### PR TITLE
fix(web): an entry missing from a refreshed first page is not necessarily deleted (BUG-2773)

### DIFF
--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -629,9 +629,13 @@
 		// state being thrown away that would have survived.
 		nextCursor = null;
 		hasMore = false;
+		// This reload replaces the view; anything already in flight against
+		// the old one must not land on it.
+		const reqGen = ++viewGen;
 		try {
 			const resp: TimelineResponse = await api.timeline.list(reqWs, reqSlug);
 			if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
+			if (reqGen !== viewGen) return;
 			entries = resp.entries;
 			hasMore = resp.has_more;
 			nextCursor = cursorFrom(resp, resp.entries);
@@ -719,13 +723,13 @@
 				// round 4). Discard such a page rather than merge it — the
 				// cursor is untouched, so the button is still there and the
 				// next click fetches the same page against the current view.
-				const seqAtDispatch = sseRefreshSeq;
+				const seqAtDispatch = viewGen;
 				const resp: TimelineResponse = await api.timeline.list(reqWs, reqSlug, {
 					before: cursor.before,
 					before_id: cursor.before_id
 				});
 				if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
-				if (sseRefreshSeq !== seqAtDispatch) return;
+				if (viewGen !== seqAtDispatch) return;
 				// Deduplicate by ID to handle boundary overlap from <= queries,
 				// and because the server's cursor can deliberately re-cover rows
 				// an earlier page already rendered (see cursorFrom).
@@ -829,12 +833,22 @@
 	/** Set by onDestroy; checked by every continuation that outlives the mount. */
 	let destroyed = false;
 	/**
-	 * Monotonic id of the newest dispatched SSE refresh. A plain `let`, not
-	 * `$state`: it is read and written only inside the refresh itself, and a
-	 * `$state` written by an effect that also reads it self-invalidates
-	 * (CONVE-1688).
+	 * Monotonic id of the newest thing that may REPLACE what is on screen —
+	 * an SSE refresh or a full reload. Every continuation that writes entries
+	 * captures it before its await and drops its result if it moved, so a
+	 * response assembled against an older view can never land on a newer one.
+	 *
+	 * It counts reloads as well as refreshes deliberately: a local comment
+	 * delete calls loadTimeline, which removes the entry from page 1, and a
+	 * Load More page in flight from before that would otherwise re-add it
+	 * (codex round 6). One counter for both, because "the view was replaced"
+	 * is the same fact whichever path replaced it.
+	 *
+	 * A plain `let`, not `$state`: it is read and written inside the same
+	 * continuations, and a `$state` written by an effect that also reads it
+	 * self-invalidates (CONVE-1688).
 	 */
-	let sseRefreshSeq = 0;
+	let viewGen = 0;
 
 
 	// Named rather than inline so the failure path can re-invoke it once. The
@@ -854,12 +868,12 @@
 		// one removed, or removes one it added, and the view then disagrees
 		// with the server until something else redraws it. Only the newest
 		// dispatched refresh may write (codex round 2).
-		const reqSeq = ++sseRefreshSeq;
+		const reqSeq = ++viewGen;
 		try {
 			const resp: TimelineResponse = await api.timeline.list(reqWs, reqSlug);
 			if (destroyed) return;
 			if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
-			if (reqSeq !== sseRefreshSeq) return;
+			if (reqSeq !== viewGen) return;
 			const freshIds = new Set(resp.entries.map((e) => e.id));
 			const existingIds = new Set(entries.map((e) => e.id));
 

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -933,20 +933,36 @@
 			// nothing and therefore deletes nothing — it means every row in
 			// that window was dropped as unrenderable, not that the item's
 			// history was erased.
-			// The oldest entry the fresh page reached, found by the same
-			// ordering the server sorts by rather than by trusting the array's
-			// order.
+			// HOW FAR BACK THIS PAGE ACTUALLY LOOKED. The server's own cursor
+			// says it exactly — `next_before` is the position the next page
+			// starts strictly before, so everything at or newer than it was
+			// examined — and that is NOT the same as the oldest row it
+			// RETURNED. The handler over-fetches per source and drops what
+			// cannot render, and when one source exhausts its window while
+			// another returns an older row, the cursor sits NEWER than the
+			// oldest entry on the page. Treating the returned floor as the
+			// boundary then judges a live entry from the exhausted source —
+			// one this page never reached — as deleted (codex round 10).
+			//
+			// The fallback is that returned floor, for a server predating
+			// BUG-2765's cursor. It is the old, slightly-too-eager rule, and
+			// it is still narrower than the one this unit replaces.
 			const sortedFresh = byNewestFirst(resp.entries);
-			const coverageFloor = sortedFresh[sortedFresh.length - 1] ?? null;
+			const returnedFloor = sortedFresh[sortedFresh.length - 1] ?? null;
+			const coverageFloor =
+				resp.next_before && resp.next_before_id
+					? { created_at: resp.next_before, id: resp.next_before_id }
+					: returnedFloor;
 			const hasMoreInFresh = resp.has_more;
-			const coveredByFreshPage = (e: TimelineEntry) => {
+			const coveredByFreshPage = (e: { created_at: string; id: string }) => {
 				// A final page covers the WHOLE history: has_more false means
-				// the server returned everything, so an entry it does not
-				// contain is not out of window — it is gone, whether deleted
-				// or no longer renderable (codex round 1). This is also what
-				// makes an empty final page clear the view rather than freeze
-				// it, while an empty page with more behind it still deletes
-				// nothing.
+				// the server reached the end of the item's rows — it may have
+				// dropped some as unrenderable on the way, which is exactly
+				// why "not returned" still means "not on this timeline" — so
+				// an entry it does not contain is gone rather than out of
+				// window (codex round 1). This is also what makes an empty
+				// final page clear the view rather than freeze it, while an
+				// empty page with more behind it still deletes nothing.
 				if (!hasMoreInFresh) return true;
 				if (!coverageFloor) return false;
 				const et = new Date(e.created_at).getTime();

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -845,14 +845,50 @@
 			// order rather than prepended on the assumption (codex round 3).
 			const newEntries = resp.entries.filter((e) => !existingIds.has(e.id));
 
-			// Update existing entries from the fresh response (e.g., reaction changes).
-			// Remove entries that were previously on the first page but are now gone (deleted).
-			// Keep all entries from older pages (loaded via "Load more") untouched.
+			// Update existing entries from the fresh response (e.g., reaction
+			// changes), and drop the ones that were genuinely deleted.
+			//
+			// ABSENT FROM THE FRESH PAGE IS NOT THE SAME AS DELETED (BUG-2773).
+			// The refresh re-fetches the FIRST page, which is the newest N
+			// entries — so once enough newer entries exist, an entry that is
+			// perfectly alive ROLLS OFF that window. Treating its absence as a
+			// deletion made it disappear from the reader's view, and for
+			// anyone who had pressed Load More it vanished from the MIDDLE of
+			// a timeline whose neighbours on both sides were still shown. A
+			// full reload brought it back, which is the tell that this was
+			// display state and not data.
+			//
+			// So deletion is inferred only for a position the fresh page still
+			// COVERS: at or newer than its oldest entry, compared in the same
+			// (created_at, id) space the server's cursor uses. Anything older
+			// is out of window and left alone. An empty fresh page covers
+			// nothing and therefore deletes nothing — it means every row in
+			// that window was dropped as unrenderable, not that the item's
+			// history was erased.
+			// The oldest entry the fresh page reached, found by the same
+			// ordering the server sorts by rather than by trusting the array's
+			// order.
+			const sortedFresh = byNewestFirst(resp.entries);
+			const coverageFloor = sortedFresh[sortedFresh.length - 1] ?? null;
+			const coveredByFreshPage = (e: TimelineEntry) => {
+				if (!coverageFloor) return false;
+				const et = new Date(e.created_at).getTime();
+				const ft = new Date(coverageFloor.created_at).getTime();
+				if (et !== ft) return et > ft;
+				// Same instant: the id is the tie-break, descending, exactly as
+				// the cursor predicate orders it. The `>=` vs `>` distinction
+				// is unobservable from here — the floor is by construction one
+				// of the fresh page's own entries, so it never reaches this
+				// branch — and is written inclusive to match the ordering
+				// rather than because a case depends on it.
+				return e.id >= coverageFloor.id;
+			};
+
 			const freshById = new Map(resp.entries.map((e) => [e.id, e]));
 			const updatedExisting = entries
 				.filter((e) => {
-					if (firstPageIds.has(e.id) && !freshIds.has(e.id)) return false;
-					return true;
+					const missing = firstPageIds.has(e.id) && !freshIds.has(e.id);
+					return !(missing && coveredByFreshPage(e));
 				})
 				.map((e) => freshById.get(e.id) ?? e);
 

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -816,6 +816,13 @@
 	const SSE_REFRESH_RETRY_MS = 2000;
 	/** Set by onDestroy; checked by every continuation that outlives the mount. */
 	let destroyed = false;
+	/**
+	 * Monotonic id of the newest dispatched SSE refresh. A plain `let`, not
+	 * `$state`: it is read and written only inside the refresh itself, and a
+	 * `$state` written by an effect that also reads it self-invalidates
+	 * (CONVE-1688).
+	 */
+	let sseRefreshSeq = 0;
 
 	// Named rather than inline so the failure path can re-invoke it once. The
 	// `isRetry` flag is what bounds that to ONE extra attempt.
@@ -826,10 +833,20 @@
 		// refresh resolving late must not merge A's entries into B (TASK-2112).
 		const reqSlug = itemSlug;
 		const reqWs = wsSlug;
+		// FRESHNESS, not just identity. The item/workspace check below catches
+		// a switch, but two refreshes of the SAME item can be in flight at
+		// once — the retry path fires 2s after a failure while a newly
+		// debounced one is already running — and they can resolve out of
+		// order. An older response applying last re-adds an entry the newer
+		// one removed, or removes one it added, and the view then disagrees
+		// with the server until something else redraws it. Only the newest
+		// dispatched refresh may write (codex round 2).
+		const reqSeq = ++sseRefreshSeq;
 		try {
 			const resp: TimelineResponse = await api.timeline.list(reqWs, reqSlug);
 			if (destroyed) return;
 			if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
+			if (reqSeq !== sseRefreshSeq) return;
 			const freshIds = new Set(resp.entries.map((e) => e.id));
 			const existingIds = new Set(entries.map((e) => e.id));
 
@@ -898,6 +915,23 @@
 			// a slow leak — an entry preserved as a roll-off dropped out of
 			// the tracked set, so a later window that expanded back over it
 			// could never remove it again (codex round 1).
+			// WHAT INFERENCE CANNOT DO, stated so the next reader does not take
+			// this for a complete reconciliation (both raised by codex round 2
+			// and left open deliberately — the lead ruled option 1 for this
+			// unit and option 2, honouring deletion EVENTS, out of scope
+			// because it changes the SSE contract):
+			//
+			//   - An entry deleted BELOW a non-final page's floor is never
+			//     inspected again, so it stays on screen until a reload. The
+			//     old rule removed it — by removing every rolled-off entry
+			//     with it, which is the bug being fixed. Strictly better, not
+			//     complete.
+			//   - Whether a row renders depends on the WINDOW it was fetched
+			//     in: the cross-source drops (an activity a version or comment
+			//     stands in for) need both rows in the same fetch. So an entry
+			//     that rendered on an older page can be absent-and-covered
+			//     here and will be dropped. That matches what a fresh load
+			//     shows, which is the best any first-page comparison can do.
 			const freshById = new Map(resp.entries.map((e) => [e.id, e]));
 			const updatedExisting = entries
 				.filter((e) => !(!freshIds.has(e.id) && coveredByFreshPage(e)))

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -1032,6 +1032,11 @@
 			// a retry loop would reintroduce exactly that.
 			if (destroyed) return;
 			if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
+			// A newer refresh has already written the view, so this failure
+			// has nothing left to repair: retrying it would be traffic for a
+			// question that has been answered, and its answer would arrive
+			// staler than what is on screen (codex round 13).
+			if (ticket <= viewApplied) return;
 			console.error('[timeline] SSE-driven refresh failed', err);
 			if (isRetry) return;
 			clearTimeout(sseRefreshTimer);

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -629,8 +629,6 @@
 		// state being thrown away that would have survived.
 		nextCursor = null;
 		hasMore = false;
-		// The tombstones describe the view being replaced.
-		removedByRefresh = new Set();
 		try {
 			const resp: TimelineResponse = await api.timeline.list(reqWs, reqSlug);
 			if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
@@ -714,18 +712,25 @@
 		try {
 			for (let hop = 0; hop < MAX_EMPTY_HOPS && nextCursor; hop++) {
 				const cursor = nextCursor;
+				// A refresh applying while this page is in flight makes the
+				// page STALE: it was assembled before the refresh and can
+				// still contain an entry the refresh has since removed as
+				// deleted, which appending would put back on screen (codex
+				// round 4). Discard such a page rather than merge it — the
+				// cursor is untouched, so the button is still there and the
+				// next click fetches the same page against the current view.
+				const seqAtDispatch = sseRefreshSeq;
 				const resp: TimelineResponse = await api.timeline.list(reqWs, reqSlug, {
 					before: cursor.before,
 					before_id: cursor.before_id
 				});
 				if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
+				if (sseRefreshSeq !== seqAtDispatch) return;
 				// Deduplicate by ID to handle boundary overlap from <= queries,
 				// and because the server's cursor can deliberately re-cover rows
 				// an earlier page already rendered (see cursorFrom).
 				const existingIds = new Set(entries.map((e) => e.id));
-				const newEntries = resp.entries.filter(
-					(e) => !existingIds.has(e.id) && !removedByRefresh.has(e.id)
-				);
+				const newEntries = resp.entries.filter((e) => !existingIds.has(e.id));
 				// Merge, do not concatenate. The server's cursor deliberately
 				// re-covers ground when one source's window ran out before
 				// another's, so a later page can carry entries NEWER than the
@@ -830,15 +835,7 @@
 	 * (CONVE-1688).
 	 */
 	let sseRefreshSeq = 0;
-	/**
-	 * Entries a refresh has removed as deleted. A page fetched by Load More
-	 * can be in flight while that happens, and appending its rows verbatim
-	 * would put a deleted entry back on screen — the paging response is older
-	 * than the refresh and does not know (codex round 4). Cleared whenever
-	 * loadTimeline resets the view, so it is bounded by one mount's deletions.
-	 * A plain `let` for the same reason as sseRefreshSeq.
-	 */
-	let removedByRefresh = new Set<string>();
+
 
 	// Named rather than inline so the failure path can re-invoke it once. The
 	// `isRetry` flag is what bounds that to ONE extra attempt.
@@ -954,11 +951,7 @@
 			//     for any first-page comparison.
 			const freshById = new Map(resp.entries.map((e) => [e.id, e]));
 			const updatedExisting = entries
-				.filter((e) => {
-					if (freshIds.has(e.id) || !coveredByFreshPage(e)) return true;
-					removedByRefresh.add(e.id);
-					return false;
-				})
+				.filter((e) => !(!freshIds.has(e.id) && coveredByFreshPage(e)))
 				.map((e) => freshById.get(e.id) ?? e);
 
 			entries = byNewestFirst([...newEntries, ...updatedExisting]);

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -629,6 +629,11 @@
 		// state being thrown away that would have survived.
 		nextCursor = null;
 		hasMore = false;
+		// A paging request in flight belongs to the view being replaced. Its
+		// own cleanup is identity-guarded, so if it resolves while the reader
+		// is on another item nothing ever clears this and the button comes
+		// back permanently disabled (codex round 9).
+		loadingMore = false;
 		const ticket = ++viewDispatch;
 		// Whether this request owns the view right now: it either WROTE (in
 		// which case it also moved the high-water mark, so a bare comparison

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -610,10 +610,6 @@
 	let currentUserId = $derived(authStore.userId);
 	let isAdmin = $derived(authStore.user?.role === 'admin');
 
-	// Track IDs from the most recent first-page fetch, used by SSE merge
-	// to detect deletions without incorrectly removing older-page entries.
-	let firstPageIds = $state<Set<string>>(new Set());
-
 	async function loadTimeline() {
 		// Capture the request identity (item + workspace) BEFORE the await.
 		// ItemDetail reuses this panel across a no-{#key} item switch (its
@@ -639,7 +635,6 @@
 			entries = resp.entries;
 			hasMore = resp.has_more;
 			nextCursor = cursorFrom(resp, resp.entries);
-			firstPageIds = new Set(resp.entries.map((e) => e.id));
 		} catch (err: any) {
 			if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
 			error = err?.message ?? 'Failed to load timeline';
@@ -870,7 +865,16 @@
 			// order.
 			const sortedFresh = byNewestFirst(resp.entries);
 			const coverageFloor = sortedFresh[sortedFresh.length - 1] ?? null;
+			const hasMoreInFresh = resp.has_more;
 			const coveredByFreshPage = (e: TimelineEntry) => {
+				// A final page covers the WHOLE history: has_more false means
+				// the server returned everything, so an entry it does not
+				// contain is not out of window — it is gone, whether deleted
+				// or no longer renderable (codex round 1). This is also what
+				// makes an empty final page clear the view rather than freeze
+				// it, while an empty page with more behind it still deletes
+				// nothing.
+				if (!hasMoreInFresh) return true;
 				if (!coverageFloor) return false;
 				const et = new Date(e.created_at).getTime();
 				const ft = new Date(coverageFloor.created_at).getTime();
@@ -884,16 +888,22 @@
 				return e.id >= coverageFloor.id;
 			};
 
+			// COVERAGE REPLACES THE OLD "was it on the first page" GATE, and
+			// deliberately so. That gate existed to protect entries loaded via
+			// Load More from a first-page-shaped comparison, which coverage
+			// now does directly and better: an older-page entry sits below the
+			// floor and is left alone, while one INSIDE the fresh page's
+			// coverage that the page does not contain is gone regardless of
+			// which page first delivered it. Keeping both would also have been
+			// a slow leak — an entry preserved as a roll-off dropped out of
+			// the tracked set, so a later window that expanded back over it
+			// could never remove it again (codex round 1).
 			const freshById = new Map(resp.entries.map((e) => [e.id, e]));
 			const updatedExisting = entries
-				.filter((e) => {
-					const missing = firstPageIds.has(e.id) && !freshIds.has(e.id);
-					return !(missing && coveredByFreshPage(e));
-				})
+				.filter((e) => !(!freshIds.has(e.id) && coveredByFreshPage(e)))
 				.map((e) => freshById.get(e.id) ?? e);
 
 			entries = byNewestFirst([...newEntries, ...updatedExisting]);
-			firstPageIds = freshIds;
 		} catch (err) {
 			// A failed SSE-driven refresh is not fatal — the timeline keeps
 			// showing what it already has — but silently dropping it leaves

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -629,6 +629,8 @@
 		// state being thrown away that would have survived.
 		nextCursor = null;
 		hasMore = false;
+		// The tombstones describe the view being replaced.
+		removedByRefresh = new Set();
 		try {
 			const resp: TimelineResponse = await api.timeline.list(reqWs, reqSlug);
 			if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
@@ -721,7 +723,9 @@
 				// and because the server's cursor can deliberately re-cover rows
 				// an earlier page already rendered (see cursorFrom).
 				const existingIds = new Set(entries.map((e) => e.id));
-				const newEntries = resp.entries.filter((e) => !existingIds.has(e.id));
+				const newEntries = resp.entries.filter(
+					(e) => !existingIds.has(e.id) && !removedByRefresh.has(e.id)
+				);
 				// Merge, do not concatenate. The server's cursor deliberately
 				// re-covers ground when one source's window ran out before
 				// another's, so a later page can carry entries NEWER than the
@@ -826,6 +830,15 @@
 	 * (CONVE-1688).
 	 */
 	let sseRefreshSeq = 0;
+	/**
+	 * Entries a refresh has removed as deleted. A page fetched by Load More
+	 * can be in flight while that happens, and appending its rows verbatim
+	 * would put a deleted entry back on screen — the paging response is older
+	 * than the refresh and does not know (codex round 4). Cleared whenever
+	 * loadTimeline resets the view, so it is bounded by one mount's deletions.
+	 * A plain `let` for the same reason as sseRefreshSeq.
+	 */
+	let removedByRefresh = new Set<string>();
 
 	// Named rather than inline so the failure path can re-invoke it once. The
 	// `isRetry` flag is what bounds that to ONE extra attempt.
@@ -941,7 +954,11 @@
 			//     for any first-page comparison.
 			const freshById = new Map(resp.entries.map((e) => [e.id, e]));
 			const updatedExisting = entries
-				.filter((e) => !(!freshIds.has(e.id) && coveredByFreshPage(e)))
+				.filter((e) => {
+					if (freshIds.has(e.id) || !coveredByFreshPage(e)) return true;
+					removedByRefresh.add(e.id);
+					return false;
+				})
 				.map((e) => freshById.get(e.id) ?? e);
 
 			entries = byNewestFirst([...newEntries, ...updatedExisting]);

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -629,21 +629,35 @@
 		// state being thrown away that would have survived.
 		nextCursor = null;
 		hasMore = false;
-		// This reload replaces the view; anything already in flight against
-		// the old one must not land on it.
-		const reqGen = ++viewGen;
+		const reqGen = viewGen;
+		// Whether this request is the one that owns the view right now: it
+		// either wrote (and advanced the generation ITSELF, so a bare
+		// reqGen === viewGen check would then read as stale — the trap the
+		// first version of this fell into, blocking its own `loading = false`
+		// and leaving an empty page under a permanent spinner) or nothing else
+		// has written since it started.
+		let owned = false;
 		try {
 			const resp: TimelineResponse = await api.timeline.list(reqWs, reqSlug);
 			if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
 			if (reqGen !== viewGen) return;
+			owned = true;
+			viewGen++;
 			entries = resp.entries;
 			hasMore = resp.has_more;
 			nextCursor = cursorFrom(resp, resp.entries);
 		} catch (err: any) {
 			if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
+			// A newer load or refresh has landed since; its error state, or
+			// its success, is the one that counts.
+			if (!owned && reqGen !== viewGen) return;
 			error = err?.message ?? 'Failed to load timeline';
 		} finally {
-			if (reqSlug === itemSlug && reqWs === wsSlug) loading = false;
+			// Identity AND ownership: a stale request's cleanup must not clear
+			// the spinner a newer one owns (codex round 7).
+			if (reqSlug === itemSlug && reqWs === wsSlug && (owned || reqGen === viewGen)) {
+				loading = false;
+			}
 		}
 	}
 
@@ -833,10 +847,17 @@
 	/** Set by onDestroy; checked by every continuation that outlives the mount. */
 	let destroyed = false;
 	/**
-	 * Monotonic id of the newest thing that may REPLACE what is on screen —
-	 * an SSE refresh or a full reload. Every continuation that writes entries
-	 * captures it before its await and drops its result if it moved, so a
-	 * response assembled against an older view can never land on a newer one.
+	 * Counts REPLACEMENTS APPLIED to what is on screen — a full reload or an
+	 * SSE refresh. Every continuation that writes entries captures it before
+	 * its await and drops its result if it moved, so a response assembled
+	 * against an older view can never land on a newer one.
+	 *
+	 * Incremented where the write LANDS, not where the request is dispatched.
+	 * Dispatch-time counting made a merely-attempted refresh invalidate an
+	 * in-flight reload, so a refresh that then FAILED left the reload's good
+	 * response discarded and the view empty until something else redrew it
+	 * (codex round 7). A request that never writes must not count as a
+	 * replacement.
 	 *
 	 * It counts reloads as well as refreshes deliberately: a local comment
 	 * delete calls loadTimeline, which removes the entry from page 1, and a
@@ -868,12 +889,13 @@
 		// one removed, or removes one it added, and the view then disagrees
 		// with the server until something else redraws it. Only the newest
 		// dispatched refresh may write (codex round 2).
-		const reqSeq = ++viewGen;
+		const reqSeq = viewGen;
 		try {
 			const resp: TimelineResponse = await api.timeline.list(reqWs, reqSlug);
 			if (destroyed) return;
 			if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
 			if (reqSeq !== viewGen) return;
+			viewGen++;
 			const freshIds = new Set(resp.entries.map((e) => e.id));
 			const existingIds = new Set(entries.map((e) => e.id));
 

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -629,20 +629,20 @@
 		// state being thrown away that would have survived.
 		nextCursor = null;
 		hasMore = false;
-		const reqGen = viewGen;
-		// Whether this request is the one that owns the view right now: it
-		// either wrote (and advanced the generation ITSELF, so a bare
-		// reqGen === viewGen check would then read as stale — the trap the
-		// first version of this fell into, blocking its own `loading = false`
-		// and leaving an empty page under a permanent spinner) or nothing else
-		// has written since it started.
+		const ticket = ++viewDispatch;
+		// Whether this request owns the view right now: it either WROTE (in
+		// which case it also moved the high-water mark, so a bare comparison
+		// against that mark would read as stale — the trap the first version
+		// of this fell into, blocking its own spinner clear and leaving an
+		// empty page under a permanent one) or nothing newer has written since
+		// it started.
 		let owned = false;
 		try {
 			const resp: TimelineResponse = await api.timeline.list(reqWs, reqSlug);
 			if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
-			if (reqGen !== viewGen) return;
+			if (ticket <= viewApplied) return;
 			owned = true;
-			viewGen++;
+			viewApplied = ticket;
 			entries = resp.entries;
 			hasMore = resp.has_more;
 			nextCursor = cursorFrom(resp, resp.entries);
@@ -650,12 +650,12 @@
 			if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
 			// A newer load or refresh has landed since; its error state, or
 			// its success, is the one that counts.
-			if (!owned && reqGen !== viewGen) return;
+			if (!owned && ticket <= viewApplied) return;
 			error = err?.message ?? 'Failed to load timeline';
 		} finally {
 			// Identity AND ownership: a stale request's cleanup must not clear
 			// the spinner a newer one owns (codex round 7).
-			if (reqSlug === itemSlug && reqWs === wsSlug && (owned || reqGen === viewGen)) {
+			if (reqSlug === itemSlug && reqWs === wsSlug && (owned || ticket > viewApplied)) {
 				loading = false;
 			}
 		}
@@ -737,13 +737,13 @@
 				// round 4). Discard such a page rather than merge it — the
 				// cursor is untouched, so the button is still there and the
 				// next click fetches the same page against the current view.
-				const seqAtDispatch = viewGen;
+				const appliedAtDispatch = viewApplied;
 				const resp: TimelineResponse = await api.timeline.list(reqWs, reqSlug, {
 					before: cursor.before,
 					before_id: cursor.before_id
 				});
 				if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
-				if (viewGen !== seqAtDispatch) return;
+				if (viewApplied !== appliedAtDispatch) return;
 				// Deduplicate by ID to handle boundary overlap from <= queries,
 				// and because the server's cursor can deliberately re-cover rows
 				// an earlier page already rendered (see cursorFrom).
@@ -847,29 +847,26 @@
 	/** Set by onDestroy; checked by every continuation that outlives the mount. */
 	let destroyed = false;
 	/**
-	 * Counts REPLACEMENTS APPLIED to what is on screen — a full reload or an
-	 * SSE refresh. Every continuation that writes entries captures it before
-	 * its await and drops its result if it moved, so a response assembled
-	 * against an older view can never land on a newer one.
+	 * Request ordering for everything that can REPLACE what is on screen — a
+	 * full reload or an SSE refresh. `viewDispatch` hands each one a unique
+	 * increasing ticket at dispatch; `viewApplied` is the highest ticket that
+	 * has actually WRITTEN. A response may write only if its ticket beats
+	 * `viewApplied`, and then owns it.
 	 *
-	 * Incremented where the write LANDS, not where the request is dispatched.
-	 * Dispatch-time counting made a merely-attempted refresh invalidate an
-	 * in-flight reload, so a refresh that then FAILED left the reload's good
-	 * response discarded and the view empty until something else redrew it
-	 * (codex round 7). A request that never writes must not count as a
-	 * replacement.
+	 * Two counters rather than one, because one cannot express both halves and
+	 * each single-counter version failed a different way (codex rounds 7-8):
+	 * counting DISPATCHES let a refresh that then FAILED invalidate an
+	 * in-flight reload, leaving its good response discarded; counting APPLIES
+	 * let an OLDER response landing first claim the view and discard the newer
+	 * one behind it. Ticket-versus-high-water gives newest-wins among
+	 * concurrent responses AND costs nothing for a request that never lands.
 	 *
-	 * It counts reloads as well as refreshes deliberately: a local comment
-	 * delete calls loadTimeline, which removes the entry from page 1, and a
-	 * Load More page in flight from before that would otherwise re-add it
-	 * (codex round 6). One counter for both, because "the view was replaced"
-	 * is the same fact whichever path replaced it.
-	 *
-	 * A plain `let`, not `$state`: it is read and written inside the same
+	 * Plain `let`s, not `$state`: read and written inside the same
 	 * continuations, and a `$state` written by an effect that also reads it
 	 * self-invalidates (CONVE-1688).
 	 */
-	let viewGen = 0;
+	let viewDispatch = 0;
+	let viewApplied = 0;
 
 
 	// Named rather than inline so the failure path can re-invoke it once. The
@@ -889,13 +886,17 @@
 		// one removed, or removes one it added, and the view then disagrees
 		// with the server until something else redraws it. Only the newest
 		// dispatched refresh may write (codex round 2).
-		const reqSeq = viewGen;
+		const ticket = ++viewDispatch;
 		try {
 			const resp: TimelineResponse = await api.timeline.list(reqWs, reqSlug);
 			if (destroyed) return;
 			if (reqSlug !== itemSlug || reqWs !== wsSlug) return;
-			if (reqSeq !== viewGen) return;
-			viewGen++;
+			if (ticket <= viewApplied) return;
+			viewApplied = ticket;
+			// This refresh has produced the view, so it owns the spinner an
+			// overlapped initial load will now decline to clear (codex round
+			// 8) — otherwise an empty result sits under a permanent one.
+			loading = false;
 			const freshIds = new Set(resp.entries.map((e) => e.id));
 			const existingIds = new Set(entries.map((e) => e.id));
 

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -683,9 +683,15 @@
 	 * — the paging cursor deliberately re-covers ground, and a structured note
 	 * can carry a backdated timestamp.
 	 *
-	 * Compared as INSTANTS, not as strings: precision is not uniform — the
-	 * store writes whole seconds, a hand-written note timestamp need not — and
-	 * lexicographically `…:05.123Z` sorts BEFORE `…:05Z`.
+	 * Compared as INSTANTS, not as strings. Every timestamp this endpoint
+	 * emits is currently whole-second — the store writes RFC3339 seconds and
+	 * the handler truncates the structured kinds' hand-written ones to match —
+	 * so a string comparison would work TODAY. It is not what the ordering
+	 * means, though, and nothing enforces the uniform precision it depends on:
+	 * lexicographically `…:05.123Z` sorts BEFORE `…:05Z`, so the day one
+	 * writer stops truncating, a string sort silently reorders. Correcting a
+	 * claim this comment used to make: sub-second values are not reachable
+	 * from the current server (codex round 3 on BUG-2773).
 	 */
 	function byNewestFirst(list: TimelineEntry[]): TimelineEntry[] {
 		return [...list].sort((a, b) => {
@@ -723,13 +729,10 @@
 				// below it (codex round 1). Same order the server sorts by:
 				// created_at descending, id descending as the tie-break.
 				//
-				// Compared as INSTANTS, not as strings: these timestamps do
-				// not all carry the same precision — the store writes whole
-				// seconds, but a structured note or decision can carry a
-				// hand-written sub-second one — and lexicographically
-				// "…:05.123Z" sorts BEFORE "…:05Z", which would place the more
-				// precise entry an hour's worth of rows away from where it
-				// belongs.
+				// Ordering lives in byNewestFirst, which compares instants
+				// rather than strings — see the note there, including the
+				// correction that sub-second timestamps are not reachable from
+				// today's server.
 				entries = byNewestFirst([...entries, ...newEntries]);
 				hasMore = resp.has_more;
 				nextCursor = cursorFrom(resp, entries);
@@ -852,9 +855,10 @@
 
 			// Genuinely new entries. Normally these ARE the newest — the
 			// refresh re-fetches the newest window — but "normally" is not
-			// "always": a structured note or decision carries a hand-written
-			// created_at and can arrive backdated, so they are merged into
-			// order rather than prepended on the assumption (codex round 3).
+			// "always": the structured kinds carry a hand-written created_at
+			// and can arrive BACKDATED — truncated to whole seconds, but not
+			// forced to be recent — so they are merged into order rather than
+			// prepended on the assumption (codex round 3 on BUG-2765).
 			const newEntries = resp.entries.filter((e) => !existingIds.has(e.id));
 
 			// Update existing entries from the fresh response (e.g., reaction
@@ -926,12 +930,15 @@
 			//     old rule removed it — by removing every rolled-off entry
 			//     with it, which is the bug being fixed. Strictly better, not
 			//     complete.
-			//   - Whether a row renders depends on the WINDOW it was fetched
-			//     in: the cross-source drops (an activity a version or comment
-			//     stands in for) need both rows in the same fetch. So an entry
-			//     that rendered on an older page can be absent-and-covered
-			//     here and will be dropped. That matches what a fresh load
-			//     shows, which is the best any first-page comparison can do.
+			//   - Whether a row renders can depend on the WINDOW it was
+			//     fetched in: an `updated` activity is suppressed when a
+			//     version snapshot shares its second, and that needs both rows
+			//     in the same fetch. (Comment-linked activities are NOT such a
+			//     case — the store excludes them in SQL whether or not the
+			//     comment is in the window.) So an entry that rendered on an
+			//     older page can be absent-and-covered here and will be
+			//     dropped, which matches what a fresh load shows — the ceiling
+			//     for any first-page comparison.
 			const freshById = new Map(resp.entries.map((e) => [e.id, e]));
 			const updatedExisting = entries
 				.filter((e) => !(!freshIds.has(e.id) && coveredByFreshPage(e)))

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -889,8 +889,11 @@
 		// debounced one is already running — and they can resolve out of
 		// order. An older response applying last re-adds an entry the newer
 		// one removed, or removes one it added, and the view then disagrees
-		// with the server until something else redraws it. Only the newest
-		// dispatched refresh may write (codex round 2).
+		// with the server until something else redraws it. A response may
+		// write only if its ticket beats what has already written, so the
+		// NEWEST response wins whichever order they land in — an older one
+		// arriving first does write, and is then replaced (codex rounds 2
+		// and 8).
 		const ticket = ++viewDispatch;
 		try {
 			const resp: TimelineResponse = await api.timeline.list(reqWs, reqSlug);

--- a/web/src/lib/components/timeline/timelinePagination.svelte.test.ts
+++ b/web/src/lib/components/timeline/timelinePagination.svelte.test.ts
@@ -371,4 +371,49 @@ describe('timeline pagination past dropped windows (BUG-2765)', () => {
 		).not.toContain('A older page');
 		expect(host.textContent, 'the current view is intact').toContain('A page one');
 	});
+
+	it('re-enables Load More when a paging request resolved while away', async () => {
+		// loadMore's own cleanup is identity-guarded, so a page resolving on
+		// another item leaves loadingMore set. Coming back found the button
+		// permanently disabled (codex round 9) — a dead control, which reads
+		// as "there is nothing more" rather than as a bug.
+		pages.push({
+			entries: [entry('e-a1', '2026-01-01T00:00:09Z', 'A page one')],
+			has_more: true,
+			next_before: '2026-01-01T00:00:09Z',
+			next_before_id: 'e-a1',
+		});
+
+		app = mount(ItemTimeline, { target: host, props }) as Record<string, unknown>;
+		await settle();
+
+		let releaseStale: (r: TimelineResponse) => void = () => {};
+		const stale = new Promise<TimelineResponse>((r) => {
+			releaseStale = r;
+		});
+		timelineListMock.mockImplementationOnce(async () => stale);
+		loadMoreButton()!.click();
+		await settle();
+
+		// Away, and the paging request resolves WHILE away.
+		pages.push({ entries: [entry('e-b1', '2026-02-01T00:00:09Z', 'B page one')], has_more: false });
+		props.itemSlug = 'TASK-2';
+		await settle();
+		releaseStale({ entries: [entry('e-a2', '2026-01-01T00:00:01Z', 'A older')], has_more: false });
+		await settle();
+
+		// Back to A, which still has more behind page one.
+		pages.push({
+			entries: [entry('e-a1', '2026-01-01T00:00:09Z', 'A page one')],
+			has_more: true,
+			next_before: '2026-01-01T00:00:09Z',
+			next_before_id: 'e-a1',
+		});
+		props.itemSlug = 'TASK-1';
+		await settle();
+
+		const btn = loadMoreButton();
+		expect(btn, 'the button is offered again').not.toBeNull();
+		expect(btn!.disabled, 'and is not stuck disabled by a page that resolved elsewhere').toBe(false);
+	});
 });

--- a/web/src/lib/components/timeline/timelinePagination.svelte.test.ts
+++ b/web/src/lib/components/timeline/timelinePagination.svelte.test.ts
@@ -322,4 +322,53 @@ describe('timeline pagination past dropped windows (BUG-2765)', () => {
 		expect(calls).toHaveLength(callsDuringSwitch);
 		props.itemSlug = 'TASK-1';
 	});
+
+	it('discards a Load More page held across a switch away and BACK', async () => {
+		// The case the identity check cannot see: by the time the stale page
+		// resolves, itemSlug matches again, so only the view generation
+		// distinguishes "this page belongs to what is on screen" from "this
+		// page belongs to a view that has since been replaced twice". The same
+		// generation is what a local comment delete advances via loadTimeline
+		// (codex round 6); this is the harness-reachable form of it.
+		pages.push({
+			entries: [entry('e-a1', '2026-01-01T00:00:09Z', 'A page one')],
+			has_more: true,
+			next_before: '2026-01-01T00:00:09Z',
+			next_before_id: 'e-a1',
+		});
+
+		app = mount(ItemTimeline, { target: host, props }) as Record<string, unknown>;
+		await settle();
+
+		let releaseStale: (r: TimelineResponse) => void = () => {};
+		const stale = new Promise<TimelineResponse>((r) => {
+			releaseStale = r;
+		});
+		timelineListMock.mockImplementationOnce(async (_ws, _slug, params) => {
+			calls.push(params);
+			return stale;
+		});
+		loadMoreButton()!.click();
+		await settle();
+
+		// Away and back. Both reloads land normally.
+		pages.push({ entries: [entry('e-b1', '2026-02-01T00:00:09Z', 'B page one')], has_more: false });
+		props.itemSlug = 'TASK-2';
+		await settle();
+		pages.push({ entries: [entry('e-a1', '2026-01-01T00:00:09Z', 'A page one')], has_more: false });
+		props.itemSlug = 'TASK-1';
+		await settle();
+
+		releaseStale({
+			entries: [entry('e-a2', '2026-01-01T00:00:01Z', 'A older page')],
+			has_more: false,
+		});
+		await settle();
+
+		expect(
+			host.textContent,
+			'a page fetched two views ago must not land, even back on the same item'
+		).not.toContain('A older page');
+		expect(host.textContent, 'the current view is intact').toContain('A page one');
+	});
 });

--- a/web/src/lib/components/timeline/timelineRefreshDeletion.svelte.test.ts
+++ b/web/src/lib/components/timeline/timelineRefreshDeletion.svelte.test.ts
@@ -299,4 +299,57 @@ describe('SSE refresh: roll-off is not deletion (BUG-2773)', () => {
 
 		expect(shows('subject'), 'an empty FINAL page means the history is empty').toBe(false);
 	});
+
+	it('ignores an older refresh that resolves after a newer one', async () => {
+		// Two refreshes of the SAME item can overlap — the retry path fires
+		// while a newly debounced one is running — and resolve out of order.
+		// The older one landing last would undo the newer one's view.
+		pages.push({
+			entries: [entry('e-1', '2026-01-01T12:00:09Z', 'original')],
+			has_more: false,
+		});
+
+		app = mount(ItemTimeline, { target: host, props }) as Record<string, unknown>;
+		await settle();
+
+		let releaseOld: (r: TimelineResponse) => void = () => {};
+		let releaseNew: (r: TimelineResponse) => void = () => {};
+		const oldFlight = new Promise<TimelineResponse>((r) => {
+			releaseOld = r;
+		});
+		const newFlight = new Promise<TimelineResponse>((r) => {
+			releaseNew = r;
+		});
+		timelineListMock.mockImplementationOnce(async () => oldFlight);
+		timelineListMock.mockImplementationOnce(async () => newFlight);
+
+		// Dispatch both, each past the 500ms debounce so both are in flight.
+		itemEventCb?.({ type: 'comment_created' });
+		await new Promise((r) => setTimeout(r, 700));
+		itemEventCb?.({ type: 'comment_created' });
+		await new Promise((r) => setTimeout(r, 700));
+		expect(timelineListMock.mock.calls.length, 'both refreshes dispatched').toBeGreaterThanOrEqual(3);
+
+		// The NEWER one lands first and adds a comment...
+		releaseNew({
+			entries: [
+				entry('e-2', '2026-01-01T12:00:20Z', 'posted by someone else'),
+				entry('e-1', '2026-01-01T12:00:09Z', 'original'),
+			],
+			has_more: false,
+		});
+		await settle();
+		expect(shows('posted by someone else')).toBe(true);
+
+		// ...then the OLDER one resolves with the pre-comment view. Applying
+		// it would delete a live entry: its page is FINAL and does not contain
+		// e-2, so without the fence the coverage rule removes it.
+		releaseOld({
+			entries: [entry('e-1', '2026-01-01T12:00:09Z', 'original')],
+			has_more: false,
+		});
+		await settle();
+
+		expect(shows('posted by someone else'), 'a stale refresh must not write').toBe(true);
+	});
 });

--- a/web/src/lib/components/timeline/timelineRefreshDeletion.svelte.test.ts
+++ b/web/src/lib/components/timeline/timelineRefreshDeletion.svelte.test.ts
@@ -559,4 +559,45 @@ describe('SSE refresh: roll-off is not deletion (BUG-2773)', () => {
 
 		expect(host.querySelector('.loading'), 'the spinner must not outlive the write').toBeNull();
 	});
+
+	it('uses the server cursor as the boundary, not the oldest row returned', async () => {
+		// The shape only the server can produce: one source exhausted its
+		// over-fetch window while another returned an older rendered row, so
+		// the cursor sits NEWER than the oldest entry on the page. Everything
+		// between them was never examined — a live entry there is not deleted,
+		// it was not looked for (codex round 10).
+		pages.push({
+			entries: [
+				entry('e-top', '2026-01-01T12:00:20Z', 'top'),
+				entry('e-unexamined', '2026-01-01T12:00:05Z', 'never looked for'),
+				entry('e-inside', '2026-01-01T12:00:15Z', 'inside the window'),
+			],
+			has_more: false,
+		});
+
+		app = mount(ItemTimeline, { target: host, props }) as Record<string, unknown>;
+		await settle();
+
+		// The refresh reaches only back to 12:00:10 — its cursor says so —
+		// while still RETURNING a row from 12:00:01.
+		pages.push({
+			entries: [
+				entry('e-top', '2026-01-01T12:00:20Z', 'top'),
+				entry('e-older-returned', '2026-01-01T12:00:01Z', 'older returned'),
+			],
+			has_more: true,
+			next_before: '2026-01-01T12:00:10Z',
+			next_before_id: 'e-cursor',
+		});
+		await fireRefresh();
+
+		expect(
+			shows('never looked for'),
+			'older than the cursor: the page never reached it, so its absence means nothing'
+		).toBe(true);
+		expect(
+			shows('inside the window'),
+			'newer than the cursor and absent from a page that examined that span — deleted'
+		).toBe(false);
+	});
 });

--- a/web/src/lib/components/timeline/timelineRefreshDeletion.svelte.test.ts
+++ b/web/src/lib/components/timeline/timelineRefreshDeletion.svelte.test.ts
@@ -394,4 +394,54 @@ describe('SSE refresh: roll-off is not deletion (BUG-2773)', () => {
 		);
 		expect(shows('page one')).toBe(true);
 	});
+
+	it('a Load More response in flight cannot resurrect an entry a refresh deleted', async () => {
+		// The paging request is older than the refresh and does not know: its
+		// page still contains the deleted entry, and appending it verbatim
+		// puts it back on screen (codex round 4).
+		pages.push({
+			entries: [
+				entry('e-top', '2026-01-01T12:00:20Z', 'top'),
+				entry('e-doomed', '2026-01-01T12:00:10Z', 'about to be deleted'),
+			],
+			has_more: true,
+			next_before: '2026-01-01T12:00:10Z',
+			next_before_id: 'e-doomed',
+		});
+
+		app = mount(ItemTimeline, { target: host, props }) as Record<string, unknown>;
+		await settle();
+		expect(shows('about to be deleted')).toBe(true);
+
+		// Load More goes out and is held.
+		let releasePage: (r: TimelineResponse) => void = () => {};
+		const heldPage = new Promise<TimelineResponse>((r) => {
+			releasePage = r;
+		});
+		timelineListMock.mockImplementationOnce(async () => heldPage);
+		host.querySelector<HTMLButtonElement>('.load-more-btn')!.click();
+		await settle();
+
+		// While it is in flight, a refresh deletes the entry. Its page is
+		// FINAL, so coverage removes it.
+		pages.push({
+			entries: [entry('e-top', '2026-01-01T12:00:20Z', 'top')],
+			has_more: false,
+		});
+		await fireRefresh();
+		expect(shows('about to be deleted'), 'the refresh removed it').toBe(false);
+
+		// The paging response lands, still carrying the deleted row.
+		releasePage({
+			entries: [
+				entry('e-doomed', '2026-01-01T12:00:10Z', 'about to be deleted'),
+				entry('e-older', '2026-01-01T12:00:01Z', 'genuinely older'),
+			],
+			has_more: false,
+		});
+		await settle();
+
+		expect(shows('about to be deleted'), 'a stale page must not resurrect it').toBe(false);
+		expect(shows('genuinely older'), 'the rest of the page still lands').toBe(true);
+	});
 });

--- a/web/src/lib/components/timeline/timelineRefreshDeletion.svelte.test.ts
+++ b/web/src/lib/components/timeline/timelineRefreshDeletion.svelte.test.ts
@@ -453,4 +453,37 @@ describe('SSE refresh: roll-off is not deletion (BUG-2773)', () => {
 			'the cursor is untouched, so the reader can simply click again'
 		).not.toBeNull();
 	});
+
+	it('a FAILED refresh does not discard the load it overlapped', async () => {
+		// The generation counts writes that LANDED, not requests that were
+		// sent. Counting dispatches made a refresh that then failed invalidate
+		// an in-flight reload, so its good response was thrown away and the
+		// view stayed empty until something else redrew it (codex round 7).
+		let releaseLoad: (r: TimelineResponse) => void = () => {};
+		const heldLoad = new Promise<TimelineResponse>((r) => {
+			releaseLoad = r;
+		});
+		timelineListMock.mockImplementationOnce(async () => heldLoad);
+
+		app = mount(ItemTimeline, { target: host, props }) as Record<string, unknown>;
+		await settle();
+
+		// A refresh goes out while the first load is still in flight, and fails.
+		timelineListMock.mockImplementationOnce(async () => {
+			throw new Error('network');
+		});
+		itemEventCb?.({ type: 'comment_created' });
+		await new Promise((r) => setTimeout(r, 700));
+		await settle();
+
+		releaseLoad({
+			entries: [entry('e-1', '2026-01-01T12:00:09Z', 'the loaded entry')],
+			has_more: false,
+		});
+		await settle();
+
+		expect(shows('the loaded entry'), 'a request that never wrote must not count as a replacement').toBe(
+			true
+		);
+	});
 });

--- a/web/src/lib/components/timeline/timelineRefreshDeletion.svelte.test.ts
+++ b/web/src/lib/components/timeline/timelineRefreshDeletion.svelte.test.ts
@@ -252,4 +252,51 @@ describe('SSE refresh: roll-off is not deletion (BUG-2773)', () => {
 			false
 		);
 	});
+
+	it('a FINAL page covers the whole history, so an older missing entry is gone', async () => {
+		// has_more false means the server returned everything it has. An entry
+		// the client holds and that page does not contain cannot have merely
+		// rolled off — there is nothing behind it to roll off into. Without
+		// this, the coverage rule would keep a genuinely deleted entry
+		// indefinitely (codex round 1).
+		pages.push({
+			entries: [
+				entry('e-keep', '2026-01-01T12:00:09Z', 'still there'),
+				entry('e-gone', '2026-01-01T12:00:01Z', 'deleted one'),
+			],
+			has_more: false,
+		});
+		pages.push({
+			entries: [entry('e-keep', '2026-01-01T12:00:09Z', 'still there')],
+			has_more: false,
+		});
+
+		app = mount(ItemTimeline, { target: host, props }) as Record<string, unknown>;
+		await settle();
+		expect(shows('deleted one')).toBe(true);
+
+		await fireRefresh();
+
+		expect(shows('deleted one'), 'below the floor but the page is FINAL — it is gone').toBe(false);
+		expect(shows('still there')).toBe(true);
+	});
+
+	it('an empty FINAL page clears the view, unlike an empty page with more behind it', async () => {
+		// The pair matters: both refreshes are empty, and only the final one
+		// means "nothing is left". Asserting either alone would let "empty
+		// always clears" or "empty never clears" pass.
+		pages.push({
+			entries: [entry('e-1', '2026-01-01T12:00:09Z', 'subject')],
+			has_more: false,
+		});
+		pages.push({ entries: [], has_more: false });
+
+		app = mount(ItemTimeline, { target: host, props }) as Record<string, unknown>;
+		await settle();
+		expect(shows('subject')).toBe(true);
+
+		await fireRefresh();
+
+		expect(shows('subject'), 'an empty FINAL page means the history is empty').toBe(false);
+	});
 });

--- a/web/src/lib/components/timeline/timelineRefreshDeletion.svelte.test.ts
+++ b/web/src/lib/components/timeline/timelineRefreshDeletion.svelte.test.ts
@@ -486,4 +486,77 @@ describe('SSE refresh: roll-off is not deletion (BUG-2773)', () => {
 			true
 		);
 	});
+
+	it('the NEWER of two refreshes wins even when the older lands first', async () => {
+		// The mirror of the out-of-order test above, and the case a single
+		// applied-writes counter got backwards: the older response landing
+		// first claimed the view and discarded the newer one behind it (codex
+		// round 8).
+		pages.push({
+			entries: [entry('e-1', '2026-01-01T12:00:09Z', 'original')],
+			has_more: false,
+		});
+
+		app = mount(ItemTimeline, { target: host, props }) as Record<string, unknown>;
+		await settle();
+
+		let releaseOld: (r: TimelineResponse) => void = () => {};
+		let releaseNew: (r: TimelineResponse) => void = () => {};
+		const oldFlight = new Promise<TimelineResponse>((r) => {
+			releaseOld = r;
+		});
+		const newFlight = new Promise<TimelineResponse>((r) => {
+			releaseNew = r;
+		});
+		timelineListMock.mockImplementationOnce(async () => oldFlight);
+		timelineListMock.mockImplementationOnce(async () => newFlight);
+
+		itemEventCb?.({ type: 'comment_created' });
+		await new Promise((r) => setTimeout(r, 700));
+		itemEventCb?.({ type: 'comment_created' });
+		await new Promise((r) => setTimeout(r, 700));
+
+		// Older first...
+		releaseOld({
+			entries: [entry('e-1', '2026-01-01T12:00:09Z', 'original')],
+			has_more: false,
+		});
+		await settle();
+
+		// ...then the newer, which must still be allowed to write.
+		releaseNew({
+			entries: [
+				entry('e-2', '2026-01-01T12:00:20Z', 'the newest state'),
+				entry('e-1', '2026-01-01T12:00:09Z', 'original'),
+			],
+			has_more: false,
+		});
+		await settle();
+
+		expect(shows('the newest state'), 'an older response landing first must not lock the newer out').toBe(
+			true
+		);
+	});
+
+	it('a refresh that replaces an in-flight load clears the spinner', async () => {
+		// The overlapped load declines to clear it — a newer write has landed
+		// — so the writer must, or an empty result sits under a permanent
+		// spinner and the list never renders (codex round 8).
+		let releaseLoad: (r: TimelineResponse) => void = () => {};
+		const heldLoad = new Promise<TimelineResponse>((r) => {
+			releaseLoad = r;
+		});
+		timelineListMock.mockImplementationOnce(async () => heldLoad);
+
+		app = mount(ItemTimeline, { target: host, props }) as Record<string, unknown>;
+		await settle();
+
+		pages.push({ entries: [], has_more: false });
+		await fireRefresh();
+
+		releaseLoad({ entries: [], has_more: false });
+		await settle();
+
+		expect(host.querySelector('.loading'), 'the spinner must not outlive the write').toBeNull();
+	});
 });

--- a/web/src/lib/components/timeline/timelineRefreshDeletion.svelte.test.ts
+++ b/web/src/lib/components/timeline/timelineRefreshDeletion.svelte.test.ts
@@ -229,10 +229,15 @@ describe('SSE refresh: roll-off is not deletion (BUG-2773)', () => {
 	});
 
 	it('compares instants, not strings, at the coverage boundary', async () => {
-		// Sub-second precision is reachable: a structured note carries a
-		// hand-written created_at. `12:00:05.500Z` is NEWER than `12:00:05Z`
-		// as an instant and SMALLER as a string, so a string comparison judges
-		// it out of window and keeps an entry that really was deleted.
+		// A GUARD, not a live scenario, and labelled as one after codex round
+		// 3 corrected me: every timestamp this endpoint emits is whole-second
+		// today — the store writes RFC3339 seconds and the handler truncates
+		// the structured kinds' hand-written ones — so nothing currently
+		// produces this input. It pins the comparison the ordering MEANS:
+		// `12:00:05.500Z` is NEWER than `12:00:05Z` as an instant and SMALLER
+		// as a string, so the day a writer stops truncating, a string
+		// comparison would judge it out of window and keep an entry that was
+		// really deleted.
 		pages.push({
 			entries: [entry('e-sub', '2026-01-01T12:00:05.500Z', 'sub second')],
 			has_more: false,
@@ -351,5 +356,42 @@ describe('SSE refresh: roll-off is not deletion (BUG-2773)', () => {
 		await settle();
 
 		expect(shows('posted by someone else'), 'a stale refresh must not write').toBe(true);
+	});
+
+	it('removes an entry loaded via Load More when the refreshed page is FINAL', async () => {
+		// The leg that fails against the OLD rule rather than only against an
+		// intermediate version of the new one. The old gate only ever removed
+		// entries it had seen on a first page, so an entry the reader paged
+		// back to was preserved unconditionally — including after it was
+		// deleted. Coverage on a final page removes it, and coverage is also
+		// what keeps it while the page is NOT final (the leg above).
+		pages.push({
+			entries: [entry('e-new', '2026-01-01T12:00:09Z', 'page one')],
+			has_more: true,
+			next_before: '2026-01-01T12:00:09Z',
+			next_before_id: 'e-new',
+		});
+		pages.push({
+			entries: [entry('e-older', '2026-01-01T12:00:01Z', 'paged back to')],
+			has_more: false,
+		});
+
+		app = mount(ItemTimeline, { target: host, props }) as Record<string, unknown>;
+		await settle();
+		host.querySelector<HTMLButtonElement>('.load-more-btn')!.click();
+		await settle();
+		expect(shows('paged back to'), 'the older page loaded').toBe(true);
+
+		// The refresh: a FINAL page that no longer contains it.
+		pages.push({
+			entries: [entry('e-new', '2026-01-01T12:00:09Z', 'page one')],
+			has_more: false,
+		});
+		await fireRefresh();
+
+		expect(shows('paged back to'), 'a final page contains everything — its absence is a deletion').toBe(
+			false
+		);
+		expect(shows('page one')).toBe(true);
 	});
 });

--- a/web/src/lib/components/timeline/timelineRefreshDeletion.svelte.test.ts
+++ b/web/src/lib/components/timeline/timelineRefreshDeletion.svelte.test.ts
@@ -441,7 +441,16 @@ describe('SSE refresh: roll-off is not deletion (BUG-2773)', () => {
 		});
 		await settle();
 
+		// The whole page is discarded, not filtered: it was assembled before
+		// the deletion and nothing in it can be trusted to reflect the current
+		// view. The cost is one wasted click, and the assertion below is what
+		// makes that a deliberate choice rather than a silent drop — the
+		// cursor is untouched, so Load More is still offered.
 		expect(shows('about to be deleted'), 'a stale page must not resurrect it').toBe(false);
-		expect(shows('genuinely older'), 'the rest of the page still lands').toBe(true);
+		expect(shows('genuinely older'), 'the stale page is discarded whole').toBe(false);
+		expect(
+			host.querySelector('.load-more-btn'),
+			'the cursor is untouched, so the reader can simply click again'
+		).not.toBeNull();
 	});
 });

--- a/web/src/lib/components/timeline/timelineRefreshDeletion.svelte.test.ts
+++ b/web/src/lib/components/timeline/timelineRefreshDeletion.svelte.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { flushSync, mount, unmount, tick } from 'svelte';
+import type { Comment, TimelineEntry, TimelineResponse } from '$lib/types';
+
+/**
+ * BUG-2773 — an entry missing from a refreshed first page is not necessarily
+ * deleted.
+ *
+ * The SSE-driven refresh re-fetches the FIRST page, which is the newest N
+ * entries, and treated anything previously on that page and now absent as
+ * deleted. Once enough newer entries exist, a perfectly alive entry ROLLS OFF
+ * that window — and disappeared from the reader's view, from the middle of a
+ * timeline whose neighbours on both sides were still shown if they had pressed
+ * Load More.
+ *
+ * Deletion is now inferred only for a position the fresh page still COVERS.
+ * Every leg below pairs a roll-off with a real deletion, because a fix that
+ * simply stopped removing anything passes the roll-off half on its own.
+ */
+
+type ListParams = { limit?: number; before?: string; before_id?: string } | undefined;
+
+const pages: TimelineResponse[] = [];
+const timelineListMock = vi.fn(async (_ws: string, _slug: string, _params: ListParams) => {
+	return pages.shift() ?? { entries: [], has_more: false };
+});
+
+vi.mock('$lib/api/client', () => ({
+	api: {
+		timeline: {
+			list: (ws: string, slug: string, params: ListParams) => timelineListMock(ws, slug, params),
+		},
+		comments: {
+			create: vi.fn(),
+			update: vi.fn(),
+			delete: vi.fn(),
+			addReaction: vi.fn(),
+			removeReaction: vi.fn(),
+		},
+		attachments: {
+			downloadUrl: (ws: string, id: string) => `/api/v1/workspaces/${ws}/attachments/${id}`,
+		},
+	},
+}));
+
+// FANS OUT rather than only recording: a mock that returns a disposer leaves
+// the component subscribed to nothing and every refresh assertion passes
+// vacuously (BUG-2509's lesson).
+let itemEventCb: ((event: { type: string }) => void) | undefined;
+vi.mock('$lib/services/sse.svelte', () => ({
+	sseService: {
+		onItemEvent: (cb: (event: { type: string }) => void) => {
+			itemEventCb = cb;
+			return () => {
+				itemEventCb = undefined;
+			};
+		},
+	},
+}));
+
+vi.mock('$lib/stores/auth.svelte', () => ({
+	authStore: { userId: 'user-1', user: { id: 'user-1', role: 'member' } },
+}));
+
+vi.mock('$lib/stores/workspace.svelte', () => ({
+	workspaceStore: { canEditItem: () => false },
+}));
+
+vi.mock('$lib/components/CommentEditor.svelte', async () => ({
+	default: (await import('./fixtures/InertCommentEditor.svelte')).default,
+}));
+
+const { default: ItemTimeline } = await import('./ItemTimeline.svelte');
+
+function entry(id: string, createdAt: string, body: string): TimelineEntry {
+	const c: Comment = {
+		id,
+		item_id: 'item-a',
+		workspace_id: 'ws-1',
+		author: 'alice',
+		body,
+		created_by: 'alice',
+		source: 'web',
+		created_at: createdAt,
+		updated_at: createdAt,
+	};
+	return { id, kind: 'comment', created_at: createdAt, actor: 'alice', source: 'web', comment: c };
+}
+
+let host: HTMLElement;
+let app: Record<string, unknown> | null = null;
+
+const props = $state({
+	wsSlug: 'ws',
+	username: 'alice',
+	itemSlug: 'TASK-1',
+	currentContent: '',
+	itemId: 'item-a',
+	collectionId: 'coll-1',
+	hostToken: 'host-1',
+	resourceGen: 0,
+	visibleKinds: undefined as Array<'comment' | 'activity' | 'version'> | undefined,
+	mutationsEnabled: false,
+});
+
+async function settle() {
+	for (let i = 0; i < 10; i++) {
+		await tick();
+		flushSync();
+	}
+}
+
+/**
+ * Fire a relevant SSE event and let the debounced refresh run. The component
+ * debounces these by 500ms, so the wait has to clear it — and the helper
+ * ASSERTS the refresh actually happened, because every expectation below is
+ * about what the refresh did and would pass vacuously if it never ran.
+ */
+async function fireRefresh() {
+	const before = timelineListMock.mock.calls.length;
+	itemEventCb?.({ type: 'comment_created' });
+	await new Promise((r) => setTimeout(r, 700));
+	await settle();
+	if (timelineListMock.mock.calls.length === before) {
+		throw new Error('the SSE refresh never fired — every assertion after this would be vacuous');
+	}
+}
+
+function shownBodies(): string[] {
+	return Array.from(host.querySelectorAll('.comment-card')).map((el) =>
+		(el.textContent ?? '').trim()
+	);
+}
+
+function shows(label: string): boolean {
+	return shownBodies().some((b) => b.includes(label));
+}
+
+beforeEach(() => {
+	host = document.createElement('div');
+	document.body.appendChild(host);
+	pages.length = 0;
+	timelineListMock.mockClear();
+});
+
+afterEach(() => {
+	if (app) unmount(app);
+	app = null;
+	host.remove();
+});
+
+describe('SSE refresh: roll-off is not deletion (BUG-2773)', () => {
+	it('keeps an entry that rolled off the first page and drops one actually deleted', async () => {
+		// Page one holds two entries.
+		pages.push({
+			entries: [
+				entry('e-new', '2026-01-01T12:00:09Z', 'newer one'),
+				entry('e-rolled', '2026-01-01T12:00:01Z', 'rolled off'),
+			],
+			has_more: false,
+		});
+		// The refresh: newer traffic pushed `e-rolled` out of the window, and
+		// `e-new` was genuinely deleted while still inside it.
+		pages.push({
+			entries: [
+				entry('e-fresh-a', '2026-01-01T12:00:20Z', 'fresh a'),
+				entry('e-fresh-b', '2026-01-01T12:00:05Z', 'fresh b'),
+			],
+			has_more: true,
+		});
+
+		app = mount(ItemTimeline, { target: host, props }) as Record<string, unknown>;
+		await settle();
+		expect(shows('rolled off')).toBe(true);
+
+		await fireRefresh();
+
+		expect(shows('rolled off'), 'an entry older than the fresh window is out of view, not deleted').toBe(
+			true
+		);
+		expect(shows('newer one'), 'an entry inside the fresh window and absent from it WAS deleted').toBe(
+			false
+		);
+		expect(shows('fresh a')).toBe(true);
+	});
+
+	it('decides the boundary case on the id, the way the cursor orders it', async () => {
+		// Both share the fresh floor's instant. `e-z` sorts at-or-newer than
+		// the floor (id greater) so it is covered; `e-a` sorts older so it is
+		// out of window. Neither is in the refreshed page.
+		pages.push({
+			entries: [
+				entry('e-z', '2026-01-01T12:00:05Z', 'same instant higher id'),
+				entry('e-a', '2026-01-01T12:00:05Z', 'same instant lower id'),
+			],
+			has_more: false,
+		});
+		pages.push({
+			entries: [entry('e-m', '2026-01-01T12:00:05Z', 'the floor')],
+			has_more: true,
+		});
+
+		app = mount(ItemTimeline, { target: host, props }) as Record<string, unknown>;
+		await settle();
+
+		await fireRefresh();
+
+		expect(shows('same instant higher id'), 'covered by the fresh page — absence means deleted').toBe(
+			false
+		);
+		expect(shows('same instant lower id'), 'sorts below the floor — out of window, kept').toBe(true);
+	});
+
+	it('deletes nothing when the refreshed page is empty', async () => {
+		// Every row in that window dropped as unrenderable. It says nothing
+		// about what still exists, so it must not wipe the view.
+		pages.push({
+			entries: [entry('e-1', '2026-01-01T12:00:09Z', 'still here')],
+			has_more: false,
+		});
+		pages.push({ entries: [], has_more: true });
+
+		app = mount(ItemTimeline, { target: host, props }) as Record<string, unknown>;
+		await settle();
+
+		await fireRefresh();
+
+		expect(shows('still here')).toBe(true);
+	});
+
+	it('compares instants, not strings, at the coverage boundary', async () => {
+		// Sub-second precision is reachable: a structured note carries a
+		// hand-written created_at. `12:00:05.500Z` is NEWER than `12:00:05Z`
+		// as an instant and SMALLER as a string, so a string comparison judges
+		// it out of window and keeps an entry that really was deleted.
+		pages.push({
+			entries: [entry('e-sub', '2026-01-01T12:00:05.500Z', 'sub second')],
+			has_more: false,
+		});
+		pages.push({
+			entries: [entry('e-floor', '2026-01-01T12:00:05Z', 'the floor')],
+			has_more: true,
+		});
+
+		app = mount(ItemTimeline, { target: host, props }) as Record<string, unknown>;
+		await settle();
+		expect(shows('sub second')).toBe(true);
+
+		await fireRefresh();
+
+		expect(shows('sub second'), 'newer than the floor as an INSTANT, so its absence is a deletion').toBe(
+			false
+		);
+	});
+});

--- a/web/src/lib/components/timeline/timelineRefreshDeletion.svelte.test.ts
+++ b/web/src/lib/components/timeline/timelineRefreshDeletion.svelte.test.ts
@@ -14,8 +14,11 @@ import type { Comment, TimelineEntry, TimelineResponse } from '$lib/types';
  * Load More.
  *
  * Deletion is now inferred only for a position the fresh page still COVERS.
- * Every leg below pairs a roll-off with a real deletion, because a fix that
- * simply stopped removing anything passes the roll-off half on its own.
+ * The first leg pairs a roll-off with a real deletion, because a fix that
+ * simply stopped removing anything passes the roll-off half on its own; the
+ * legs after it isolate one boundary each, and the later ones cover the
+ * request-ordering work that grew out of this rule rather than the rule
+ * itself.
  */
 
 type ListParams = { limit?: number; before?: string; before_id?: string } | undefined;
@@ -259,10 +262,11 @@ describe('SSE refresh: roll-off is not deletion (BUG-2773)', () => {
 	});
 
 	it('a FINAL page covers the whole history, so an older missing entry is gone', async () => {
-		// has_more false means the server returned everything it has. An entry
-		// the client holds and that page does not contain cannot have merely
-		// rolled off — there is nothing behind it to roll off into. Without
-		// this, the coverage rule would keep a genuinely deleted entry
+		// has_more false means the server reached the end of the item's rows.
+		// It may have dropped some on the way as unrenderable — which is why
+		// "not returned" still means "not on this timeline" — but there is
+		// nothing behind the page for an entry to have rolled off into.
+		// Without this, the coverage rule would keep a genuinely deleted entry
 		// indefinitely (codex round 1).
 		pages.push({
 			entries: [
@@ -287,9 +291,11 @@ describe('SSE refresh: roll-off is not deletion (BUG-2773)', () => {
 	});
 
 	it('an empty FINAL page clears the view, unlike an empty page with more behind it', async () => {
-		// The pair matters: both refreshes are empty, and only the final one
-		// means "nothing is left". Asserting either alone would let "empty
-		// always clears" or "empty never clears" pass.
+		// Reads against the leg above it: an empty NON-final refresh deletes
+		// nothing ("deletes nothing when the refreshed page is empty"), an
+		// empty FINAL one clears the view. Either leg alone would let "empty
+		// always clears" or "empty never clears" pass; the pair is what pins
+		// has_more as the thing that decides.
 		pages.push({
 			entries: [entry('e-1', '2026-01-01T12:00:09Z', 'subject')],
 			has_more: false,

--- a/web/src/lib/components/timeline/timelineRefreshDeletion.svelte.test.ts
+++ b/web/src/lib/components/timeline/timelineRefreshDeletion.svelte.test.ts
@@ -606,4 +606,40 @@ describe('SSE refresh: roll-off is not deletion (BUG-2773)', () => {
 			'newer than the cursor and absent from a page that examined that span — deleted'
 		).toBe(false);
 	});
+
+	it('does not retry a refresh that failed after a newer one succeeded', async () => {
+		// The retry exists so a transient failure does not leave the panel
+		// quietly stale (BUG-2508). Once a newer refresh has written, there is
+		// nothing stale to repair, and the retry is traffic whose answer would
+		// arrive older than the view (codex round 13).
+		pages.push({ entries: [entry('e-1', '2026-01-01T12:00:09Z', 'original')], has_more: false });
+
+		app = mount(ItemTimeline, { target: host, props }) as Record<string, unknown>;
+		await settle();
+
+		let failOld: (e: Error) => void = () => {};
+		const oldFlight = new Promise<TimelineResponse>((_, reject) => {
+			failOld = reject;
+		});
+		timelineListMock.mockImplementationOnce(async () => oldFlight);
+		timelineListMock.mockImplementationOnce(async () => ({
+			entries: [entry('e-2', '2026-01-01T12:00:20Z', 'newer state')],
+			has_more: false,
+		}));
+
+		itemEventCb?.({ type: 'comment_created' });
+		await new Promise((r) => setTimeout(r, 700));
+		itemEventCb?.({ type: 'comment_created' });
+		await new Promise((r) => setTimeout(r, 700));
+		expect(shows('newer state'), 'the newer refresh landed').toBe(true);
+
+		const before = timelineListMock.mock.calls.length;
+		failOld(new Error('network'));
+		// Past the retry backoff.
+		await new Promise((r) => setTimeout(r, 2400));
+		await settle();
+
+		expect(timelineListMock.mock.calls.length, 'no retry for a superseded refresh').toBe(before);
+		expect(shows('newer state'), 'and the newer view is untouched').toBe(true);
+	});
 });


### PR DESCRIPTION
Fixes BUG-2773.

## The defect

The timeline's SSE-driven refresh re-fetches the **first** page — the newest N entries — and treated anything previously on that page and now absent as deleted. Once enough newer entries exist, a perfectly alive entry **rolls off** that window, and it disappeared from the reader's view. For anyone who had pressed Load More it vanished from the *middle* of a timeline whose neighbours on both sides were still shown. A full reload brought it back, which is the tell that this was display state, not data.

## What changed

Per the lead's ruling (option 1), deletion is inferred only for a position the fresh page still **covers**:

- the boundary is the server's own cursor (`next_before` / `next_before_id`, from BUG-2765) — the position the next page starts before, so everything at or newer than it was examined. That is *not* the oldest row returned: when one source exhausts its over-fetch while another returns an older rendered row, the cursor sits newer, and judging by the returned floor treats a live entry from the exhausted source as deleted (round 10). The returned floor remains the fallback for a server predating the field.
- a **final** page (`has_more: false`) covers the whole history — it reached the end of the rows, dropping some as unrenderable on the way, which is why absence still means gone. This is also what lets an empty final page clear the view while an empty non-final one deletes nothing.
- `firstPageIds` is **retired**, not repaired: coverage does its job directly and better, and keeping both leaked — an entry preserved as a roll-off dropped out of the tracked set, so a later window expanding back over it could never remove it again.

Nine of the fourteen review rounds were about the request races this exposed, and the result is one ordering rule for everything that can replace the view: each request takes a **ticket** at dispatch and may write only if it beats the **high-water mark** of what has written. Newest wins whichever order responses land in, and a request that never lands costs nothing. Both single-counter versions failed — counting dispatches let a *failed* refresh discard a good reload, counting applies let an *older* response lock out the newer one behind it.

Also closed along the way: a stale Load More page could resurrect a deleted entry (discarded whole now); a refresh replacing an in-flight load left the spinner up forever; a paging request resolving while the reader was away left Load More permanently disabled; a superseded refresh still scheduled a retry.

## Deliberately not fixed

Two limits of inferring deletions from a first-page comparison, documented at the code rather than left for the next reader to discover — the lead ruled the event-based alternative (honouring deletion events) out of scope because it changes the SSE contract:

- an entry deleted **below** a non-final page's floor is never inspected again and stays until a reload. The old rule removed it — by removing every rolled-off entry with it, which is the bug being fixed. Strictly better, not complete.
- whether a row renders can depend on the **window** it was fetched in (a version snapshot sharing an activity's second needs both rows in one fetch), so an entry that rendered on an older page can be absent-and-covered here. That matches what a fresh load shows, which is the ceiling for any first-page comparison.

Also declined, twice, with the concrete harm checked: the refresh does not adopt the response's `has_more`/cursor. It re-fetches the *newest* window, which says nothing about the reader's paging frontier, and after paging to the end the reader already holds everything behind page one — so a fresh `has_more: true` strands nothing.

## Tests

14 legs in `timelineRefreshDeletion.svelte.test.ts` plus two in the pagination suite. The refresh helper **asserts the refresh actually fired** — the first version of these waited 400ms against a 500ms debounce and one leg passed vacuously on a refresh that never ran.

**Mutation matrix** — every mutation detected, each by its own leg:

| mutation | dies on |
|---|---|
| the old missing-means-deleted rule | roll-off, boundary, empty-page legs |
| never deleting anything | 5 legs |
| no final-page rule | both final-page legs |
| empty non-final page treated as covering | empty-page leg |
| id tie-break dropped | boundary leg |
| string comparison at the boundary | sub-second guard leg |
| boundary back to the oldest returned row | cursor-boundary leg |
| loadMore fence removed | switch-away-and-back, stale-page legs |
| round-7 applied-counter semantics | newest-wins leg |
| refresh not clearing the spinner | spinner leg |
| reload not advancing the generation | switch-away-and-back leg |
| dispatch-time counting | failed-refresh leg |
| loadingMore not reset on reload | disabled-button leg |
| stale-retry guard removed | retry-count leg |

Two mutations silently failed to apply on a non-unique anchor and left a green run that proved nothing; anchor counts are asserted now.

One leg that fails against the **old** rule specifically — an entry loaded via Load More, which the old gate preserved unconditionally — was added after review pointed out that the final-page legs discriminated only against an intermediate version of this fix.

## Gates (tip 0c170f2a, on main 11f67b0a)

- `make lint` — 0 issues
- `go test ./...` — 28 ok, 0 fail (no Go changed; the tree must still be green)
- `npx vitest run` — 110 files, 1881 tests, 0 fail
- `npx vite build` — clean; `svelte-check` 0 errors (6 warnings, pre-existing, other files)

## Test plan

- [x] Roll-off kept, real deletion removed, in one leg
- [x] Final page and empty final page
- [x] Cursor boundary vs oldest returned row
- [x] Request ordering: newest wins, failures cost nothing, stale pages discarded
- [x] Mutation matrix, every member detected
- [ ] CI green on the tip

Refs: BUG-2773
