### PR TITLE
fix(store): compare-and-set the activity debounce merge (BUG-2770)

### DIFF
--- a/internal/store/activities.go
+++ b/internal/store/activities.go
@@ -3,6 +3,7 @@ package store
 import (
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -43,6 +44,22 @@ const ActivityDebounceCooldown = 5 * time.Minute
 // Raising it costs a longer scan on a write path; the number is a scan
 // ceiling, not a statement about how many rows the window may hold.
 // (Declined codex round 2, which read the bound as incomplete coalescing.)
+//
+// WHAT IT DOES NOT BOUND (codex rounds 5-7 on BUG-2770). It caps the rows
+// the GO loop examines. It says nothing about the work the database does to
+// produce them: no index matches this query's five filters together
+// (document_id, action, created_at, actor, user_id — and there is no index
+// on `actor` at all), so the plan is the planner's
+// choice and the rows it visits are not bounded by this constant. What is
+// bounded is the QUERY COUNT — BUG-2770's retry loop issues at most
+// debounceMergeAttempts candidate queries, each losing attempt adding one
+// UPDATE and at most one primary-key probe.
+//
+// Deliberately not claiming more than that here. The earlier version of
+// this comment asserted which index the planner would use and that the cost
+// stays small; both were guesses about a planner, and two review rounds
+// went into correcting them. If this write path ever shows up in a profile,
+// measure the plan on the dialect that hurts before adding an index.
 const maxDebounceCandidates = 10
 
 func (s *Store) CreateActivity(a models.Activity) (string, error) {
@@ -78,7 +95,6 @@ func (s *Store) CreateActivityDebounced(a models.Activity) (string, error) {
 		return s.CreateActivity(a)
 	}
 
-	ts := now()
 	cutoff := time.Now().UTC().Add(-ActivityDebounceCooldown).Format(time.RFC3339)
 
 	// Look for a recent activity of THIS WRITER's to coalesce with, newest
@@ -91,8 +107,12 @@ func (s *Store) CreateActivityDebounced(a models.Activity) (string, error) {
 	// ENDS a coalescing run; the next update starts a new one. That refusal
 	// lives in the UPDATE's own predicate and nowhere else, because a comment
 	// can link the row between this read and that write (codex round 6) — a
-	// check here would be a second guard that only looks load-bearing. What
-	// this does NOT close is the opposite order, an update that completes
+	// check here would be a second guard that only looks load-bearing. That
+	// still holds with BUG-2770's compare-and-set arm on the same UPDATE:
+	// debounceRowUnchanged runs only AFTER a refusal, asks about the
+	// metadata rather than the link, and decides a disposition — it never
+	// gates the write, so the link check is still made in exactly one
+	// place. What this does NOT close is the opposite order, an update that completes
 	// before the link is VISIBLE to it — the comment row is written in its
 	// own transaction, so on Postgres a link committing while this UPDATE's
 	// snapshot is already open is missed exactly as an unwritten one is.
@@ -123,6 +143,138 @@ func (s *Store) CreateActivityDebounced(a models.Activity) (string, error) {
 	// merge decision and the rendering in agreement.
 	incomingAgent := models.AgentNameFromMetadata(a.Metadata)
 
+	// The read and the write are separate statements, so the row can move
+	// under us between them — see debounceMergeAttempts. Each attempt
+	// re-reads the candidate, so the blob a losing attempt merges into is
+	// the winner's result rather than the stale one it first read.
+	for attempt := 0; attempt < debounceMergeAttempts; attempt++ {
+		existingID, existingMeta, ok := s.recentDebounceCandidate(a, cutoff, incomingAgent)
+		if !ok || existingID == "" {
+			// Query trouble, or nothing recent of this writer's — start a
+			// new run.
+			return s.CreateActivity(a)
+		}
+
+		// Test seam: runs between the read and the write, which is exactly
+		// the window this loop exists to survive. Nil in production.
+		if s.afterDebounceRead != nil {
+			s.afterDebounceRead()
+		}
+
+		// Merge metadata: accumulate "changes" strings from both old and new.
+		merged := mergeActivityMeta(existingMeta, a.Metadata)
+
+		// Stamped per ATTEMPT, not once before the loop (codex round 3): the
+		// merge bumps created_at because the row now carries a change that
+		// just happened, and a retry that stamped the pre-loop instant would
+		// backdate a row whose newest change is younger than that — the
+		// window this row stays coalescable in, its place in the timeline's
+		// ordering, and the backfill's chronology all read created_at. The
+		// cutoff deliberately does NOT move: it bounds which rows were
+		// eligible when the call began, and re-deriving it mid-call would
+		// let a long retry chain reach back further than the caller asked.
+		ts := now()
+
+		mergedOK, err := s.mergeIntoUnlinkedActivity(existingID, existingMeta, merged, ts)
+		if err != nil {
+			return existingID, err
+		}
+		if mergedOK {
+			return existingID, nil
+		}
+
+		// The UPDATE matched nothing, and its predicate has two arms that
+		// can do that. Ask which, rather than picking the disposition that
+		// happens to be safe for both: they want OPPOSITE handling — a
+		// frozen row must not be retried (the answer will not change), and
+		// a contended row must not start a new run (retrying merges into
+		// the winner's blob and keeps the timeline entry whole).
+		unchanged, err := s.debounceRowUnchanged(existingID, existingMeta)
+		if err != nil {
+			return existingID, err
+		}
+		if unchanged {
+			// The blob we read is still there, so the CAS arm held and the
+			// refusal was the comment link — before the read above, or
+			// since. Frozen: a fresh row starts the next run.
+			//
+			// "Frozen" is about THIS call, not forever: DeleteComment can
+			// unlink the row a moment later (codex round 8). The cost of
+			// having decided otherwise is one extra activity row, which is
+			// the same currency every other giving-up path here spends.
+			return s.CreateActivity(a)
+		}
+		// Someone else merged into this row (or deleted it) between our
+		// read and our write. Go around: re-read and merge into what they
+		// left.
+	}
+
+	// Contended past the bound. A new row costs one extra timeline entry
+	// and loses no change text, which is the direction this bug exists to
+	// prevent — unlike the alternative of overwriting a merge we know
+	// happened. See debounceMergeAttempts.
+	return s.CreateActivity(a)
+}
+
+// REFUSAL ARMS — read this before adding a predicate to
+// mergeIntoUnlinkedActivity's UPDATE. That statement refuses on exactly two
+// grounds today (the comment link, and the compare-and-set below), and
+// debounceRowUnchanged distinguishes them by asking the CAS question alone:
+// CAS still matches => it must have been the link. A THIRD arm added to the
+// UPDATE without a matching question in the probe would be classified from
+// metadata alone and silently read as "frozen".
+//
+// Left as an invariant rather than a framework because the drift is BOUNDED
+// in a way worth stating: either misclassification (frozen read as
+// contended, or the reverse) costs at most one wasted attempt or one extra
+// activity row. Neither can lose change text, which is the thing this whole
+// mechanism exists to protect. A composition layer over a two-arm predicate
+// would cost more clarity than the failure it prevents.
+//
+// debounceCASPredicate is the compare-and-set arm of the debounce merge:
+// "the row still carries the blob the caller merged from". It is ONE string
+// used by both statements that ask it — the UPDATE that enforces it and the
+// probe that decides, after a refusal, which arm refused (BUG-2770).
+//
+// Shared rather than written twice on purpose (codex round 6): if the two
+// spellings could drift, the probe would answer a question the UPDATE is
+// not asking, and the disposition it picks — retry, or start a fresh row —
+// would silently be the wrong one. This makes them the same question by
+// construction rather than by a comment asking the next editor to keep them
+// in step.
+const debounceCASPredicate = `metadata = ?`
+
+// debounceMergeAttempts bounds how many times CreateActivityDebounced will
+// re-read and retry a merge whose compare-and-set lost to a concurrent
+// writer (BUG-2770).
+//
+// It is a liveness bound, not a correctness one. An attempt that loses the
+// CAS means the row is no longer the one we merged from — because another
+// writer merged into it, or because it was deleted — so the only changes at
+// risk from giving up are the ones THIS call is carrying, and the fallback
+// (a new activity row) still records them, at the cost of one extra
+// timeline entry. Exhausting the bound therefore degrades presentation,
+// never content.
+//
+// Three because the racing pair must already be the same account, the same
+// actor kind AND the same agent name on the same item inside five minutes
+// (BUG-2763's narrowing), so contention comes from one editor's autosave
+// burst or one agent's concurrent PATCHes. A single retry clears the
+// two-writer case that BUG-2770 filed; the third is headroom for a third
+// racer arriving mid-retry. Raising it trades a longer write path for a
+// case that has to be pathological to reach; it is not load-bearing for
+// correctness in either direction.
+const debounceMergeAttempts = 3
+
+// recentDebounceCandidate reads the newest activity row of THIS WRITER's
+// inside the cooldown window, with the metadata blob it carries right now.
+// The blob is returned because it is the compare-and-set token the merge
+// UPDATE uses, not merely the input to the merge.
+//
+// ok is false when the registry could not be read at all (query or scan
+// trouble); the caller starts a new run rather than guessing. An empty id
+// with ok true means the read succeeded and this writer has no recent row.
+func (s *Store) recentDebounceCandidate(a models.Activity, cutoff, incomingAgent string) (id, metadata string, ok bool) {
 	rows, err := s.db.Query(s.q(`
 		SELECT id, metadata FROM activities
 		WHERE document_id = ? AND action = ? AND created_at >= ? AND actor = ?
@@ -130,61 +282,84 @@ func (s *Store) CreateActivityDebounced(a models.Activity) (string, error) {
 		ORDER BY created_at DESC LIMIT ?
 	`), a.DocumentID, a.Action, cutoff, a.Actor, a.UserID, a.UserID, maxDebounceCandidates)
 	if err != nil {
-		// Query error — fall back to creating a new activity.
-		return s.CreateActivity(a)
+		return "", "", false
 	}
 
-	var existingID, existingMeta string
+	var foundID, foundMeta string
 	for rows.Next() {
-		var id, meta string
-		if err := rows.Scan(&id, &meta); err != nil {
+		var rowID, meta string
+		if err := rows.Scan(&rowID, &meta); err != nil {
 			_ = rows.Close()
-			return s.CreateActivity(a)
+			return "", "", false
 		}
 		if models.AgentNameFromMetadata(meta) == incomingAgent {
-			existingID, existingMeta = id, meta
+			foundID, foundMeta = rowID, meta
 			break
 		}
 	}
 	if err := rows.Err(); err != nil {
 		_ = rows.Close()
-		return s.CreateActivity(a)
+		return "", "", false
 	}
 	if err := rows.Close(); err != nil {
-		return s.CreateActivity(a)
+		return "", "", false
 	}
+	return foundID, foundMeta, true
+}
 
-	if existingID == "" {
-		// Nothing recent of this writer's — start a new run.
-		return s.CreateActivity(a)
+// debounceRowUnchanged reports whether the row still carries the exact
+// metadata the caller read, and is the only thing that can tell the merge
+// UPDATE's two refusal arms apart after the fact.
+//
+// It asks the CAS arm's own question, so a true answer means the CAS would
+// still match and the refusal must have come from the comment-link arm. A
+// false answer covers both "another writer merged into it" and "it is gone"
+// — the caller treats them the same way (go around; a vanished row simply
+// fails to be selected next time), so nothing is served by separating them
+// here.
+//
+// It is a DISPOSITION HINT, not a guard. Nothing holds the row still
+// between this probe and the next attempt, so its answer can be stale the
+// moment it returns; the loop re-reads and re-runs the CAS rather than
+// trusting it, and the worst a stale hint costs is one wasted attempt or
+// one extra activity row (codex round 7).
+func (s *Store) debounceRowUnchanged(id, metadata string) (bool, error) {
+	var found int
+	err := s.db.QueryRow(s.q(`
+		SELECT 1 FROM activities WHERE id = ? AND `+debounceCASPredicate+`
+	`), id, metadata).Scan(&found)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
 	}
-
-	// Merge metadata: accumulate "changes" strings from both old and new.
-	merged := mergeActivityMeta(existingMeta, a.Metadata)
-
-	mergedOK, err := s.mergeIntoUnlinkedActivity(existingID, merged, ts)
 	if err != nil {
-		return existingID, err
+		return false, err
 	}
-	if !mergedOK {
-		// Comment-linked (before the read above, or since) — frozen. A
-		// fresh row starts the next run.
-		return s.CreateActivity(a)
-	}
-	return existingID, nil
+	return true, nil
 }
 
 // mergeIntoUnlinkedActivity applies a debounce merge to one activity row in a
-// single statement whose predicate refuses a row any comment links to. It
-// reports whether the row was written: false means a comment linked it after
-// the caller chose it, and the caller must not treat it as merged. See the
-// comment in CreateActivityDebounced for why the check lives in the UPDATE.
-func (s *Store) mergeIntoUnlinkedActivity(id, metadata, ts string) (bool, error) {
+// single statement whose predicate refuses the row on two grounds: a comment
+// links it, or its metadata is no longer the blob the caller merged from.
+// It reports whether the row was written; false means one of those arms
+// refused and the caller must not treat it as merged. See the comment in
+// CreateActivityDebounced for why the comment-link check lives in the UPDATE,
+// and debounceRowUnchanged for how a caller tells the two arms apart.
+//
+// expectedMetadata is the compare-and-set token (BUG-2770): the merge is a
+// read-modify-write across two statements, and without it two writers who
+// select the SAME row each merge their own change into the blob they read
+// and the second UPDATE silently erases the first one's change entry. The
+// comparison is exact-text on SQLite and jsonb equality on Postgres, where
+// the column is JSONB — both answer the only question being asked, "is this
+// still the value I merged from", because the string being compared is the
+// one that column just handed us.
+func (s *Store) mergeIntoUnlinkedActivity(id, expectedMetadata, metadata, ts string) (bool, error) {
 	res, err := s.db.Exec(s.q(`
 		UPDATE activities SET metadata = ?, created_at = ?
 		WHERE id = ?
+		  AND `+debounceCASPredicate+`
 		  AND NOT EXISTS (SELECT 1 FROM comments c WHERE c.activity_id = activities.id AND c.item_id = activities.document_id)
-	`), metadata, ts, id)
+	`), metadata, ts, id, expectedMetadata)
 	if err != nil {
 		return false, err
 	}
@@ -205,6 +380,15 @@ func mergeActivityMeta(existing, incoming string) string {
 	}
 	if err := json.Unmarshal([]byte(incoming), &newMap); err != nil {
 		newMap = make(map[string]interface{})
+	}
+	// A JSON `null` blob unmarshals with NO error and leaves the map nil,
+	// and the overlay below writes into existMap — assignment to a nil map
+	// panics (codex round 3). The error branches above cannot catch this
+	// because there is no error: `null` is valid JSON, valid JSONB on
+	// Postgres, and storable in the TEXT column on SQLite. Ranging over a
+	// nil newMap is already safe; existMap is the one that must be real.
+	if existMap == nil {
+		existMap = make(map[string]interface{})
 	}
 
 	// Accumulate changes

--- a/internal/store/activities_debounce_race_test.go
+++ b/internal/store/activities_debounce_race_test.go
@@ -1,0 +1,513 @@
+package store
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// BUG-2770. CreateActivityDebounced merges by reading a row's metadata,
+// combining it in Go, and writing the result back — two statements. Two
+// writers that select the SAME row both read the pre-merge blob, each merges
+// its own change into it, and the second UPDATE erases the first one's change
+// entry with no error and no trace.
+//
+// These tests drive that interleaving through the Store's afterDebounceRead
+// seam rather than racing goroutines: the defect needs the competing write to
+// land strictly between one call's read and its write, and two real
+// goroutines produce that ordering only sometimes. A test that reproduces a
+// race sometimes is a detector with an unknown rate, and a 1-in-10 detector
+// reads as coverage.
+//
+// What they assert is what the WRONG behaviour DOES — a change entry missing
+// from the surviving row — not the end state a correct and a broken merge
+// share (one row, still present, still recently stamped).
+
+// debounceWriter builds one writer's activity, all fields but the change text
+// held constant so every call selects the same row: same document, same
+// account, same actor kind, same agent name (BUG-2763's narrowing).
+func debounceWriter(wsID, docID, userID, changes string) models.Activity {
+	return models.Activity{
+		WorkspaceID: wsID,
+		DocumentID:  docID,
+		Action:      "updated",
+		Actor:       "agent",
+		Source:      "cli",
+		UserID:      userID,
+		Metadata:    `{"agent":"rook","changes":"` + changes + `"}`,
+	}
+}
+
+// updatedRowsFor returns the "updated" activity rows on the document, as
+// ListDocumentActivity reports them — which means a default page of 20,
+// ordered by created_at with no tie-break, NOT "every row, newest first"
+// (codex round 8). Every caller here first asserts the row COUNT it
+// expects and then reads rows without depending on their order, so neither
+// limitation is load-bearing; a future test that creates more than a
+// handful of rows, or that cares which of two same-second rows comes
+// first, must not use this helper as-is.
+func updatedRowsFor(t *testing.T, s *Store, docID string) []models.Activity {
+	t.Helper()
+	rows, err := s.ListDocumentActivity(docID, models.ActivityListParams{Action: "updated"})
+	if err != nil {
+		t.Fatalf("list document activity: %v", err)
+	}
+	return rows
+}
+
+// changesOf reads the accumulated "changes" text out of an activity's
+// metadata. Local to the test: the store writes this key through
+// mergeActivityMeta and the timeline renders it, but nothing in models
+// exposes a reader for it.
+func changesOf(t *testing.T, a models.Activity) string {
+	t.Helper()
+	if a.Metadata == "" {
+		return ""
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(a.Metadata), &m); err != nil {
+		t.Fatalf("metadata is not JSON: %q (%v)", a.Metadata, err)
+	}
+	changes, _ := m["changes"].(string)
+	return changes
+}
+
+// TestCreateActivityDebounced_ConcurrentMergeKeepsBothChanges is the
+// regression test for the lost update itself. A competing writer merges into
+// the chosen row inside the read-write window; the call under test must
+// notice its compare-and-set lost, re-read, and merge into what the winner
+// left — so the surviving row names BOTH changes.
+//
+// Against the unfixed code this fails on the competitor's change: the
+// second UPDATE overwrites the blob the competitor wrote.
+//
+// WHAT IT CANNOT DISCRIMINATE (codex round 7): an implementation that
+// re-read the row and re-merged immediately before an unconditional UPDATE
+// would also pass, because the seam fires before that re-read. The residual
+// window — a competitor landing between such a re-read and the write — is
+// not reachable without a second seam, and is the window the CAS exists to
+// close. That the token must be the merged-FROM blob rather than a fresh
+// re-read is pinned instead by the mutation matrix (M5) and by
+// TestMergeIntoUnlinkedActivity_RefusesMovedRow at the statement level.
+func TestCreateActivityDebounced_ConcurrentMergeKeepsBothChanges(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Race")
+	doc := createTestDoc(t, s, ws.ID, "Doc", "content")
+	const userID = ""
+
+	// The run this writer will try to extend.
+	if _, err := s.CreateActivityDebounced(debounceWriter(ws.ID, doc.ID, userID, "title: a → b")); err != nil {
+		t.Fatalf("seed activity: %v", err)
+	}
+
+	// One competing merge, fired between the read and the write of the call
+	// below. It runs once: the retry must then find a clear field and
+	// succeed, which is what makes the assertion about content rather than
+	// about how many times we looped.
+	fired := 0
+	var hook func()
+	hook = func() {
+		if fired > 0 {
+			return
+		}
+		fired++
+		s.afterDebounceRead = nil
+		defer func() { s.afterDebounceRead = hook }()
+		if _, err := s.CreateActivityDebounced(debounceWriter(ws.ID, doc.ID, userID, "status: open → done")); err != nil {
+			t.Errorf("competing write: %v", err)
+		}
+	}
+	s.afterDebounceRead = hook
+
+	if _, err := s.CreateActivityDebounced(debounceWriter(ws.ID, doc.ID, userID, "priority: low → high")); err != nil {
+		t.Fatalf("contended write: %v", err)
+	}
+	s.afterDebounceRead = nil
+
+	if fired != 1 {
+		t.Fatalf("seam fired %d times, want 1 — the test did not exercise the read-write window", fired)
+	}
+
+	rows := updatedRowsFor(t, s, doc.ID)
+	if len(rows) != 1 {
+		t.Fatalf("want the run coalesced into 1 row, got %d — a contended merge must retry into the winner's row, not start a new run", len(rows))
+	}
+	changes := changesOf(t, rows[0])
+	for _, want := range []string{"title", "status", "priority"} {
+		if !strings.Contains(changes, want) {
+			t.Errorf("surviving row lost the %q change: changes = %q", want, changes)
+		}
+	}
+}
+
+// TestCreateActivityDebounced_ContentionPastTheBoundKeepsTheChange pins the
+// give-up path. A competitor that wins EVERY attempt exhausts
+// debounceMergeAttempts; the call must then write its own row rather than
+// loop forever or drop the change text. Presentation degrades (an extra
+// timeline entry), content does not.
+func TestCreateActivityDebounced_ContentionPastTheBoundKeepsTheChange(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Race")
+	doc := createTestDoc(t, s, ws.ID, "Doc", "content")
+	const userID = ""
+
+	if _, err := s.CreateActivityDebounced(debounceWriter(ws.ID, doc.ID, userID, "title: a → b")); err != nil {
+		t.Fatalf("seed activity: %v", err)
+	}
+
+	fired := 0
+	var hook func()
+	hook = func() {
+		fired++
+		s.afterDebounceRead = nil
+		defer func() { s.afterDebounceRead = hook }()
+		// A different change text every time, so every attempt's
+		// compare-and-set finds a blob it has not seen.
+		if _, err := s.CreateActivityDebounced(debounceWriter(ws.ID, doc.ID, userID, "field"+string(rune('0'+fired))+": x → y")); err != nil {
+			t.Errorf("competing write %d: %v", fired, err)
+		}
+	}
+	s.afterDebounceRead = hook
+
+	if _, err := s.CreateActivityDebounced(debounceWriter(ws.ID, doc.ID, userID, "priority: low → high")); err != nil {
+		t.Fatalf("contended write: %v", err)
+	}
+	s.afterDebounceRead = nil
+
+	if fired != debounceMergeAttempts {
+		t.Errorf("seam fired %d times, want %d (one per attempt) — the loop is not bounded where it claims to be", fired, debounceMergeAttempts)
+	}
+
+	rows := updatedRowsFor(t, s, doc.ID)
+	if len(rows) != 2 {
+		t.Fatalf("want 2 rows after giving up (the contended run plus a fresh one), got %d", len(rows))
+	}
+	all := changesOf(t, rows[0]) + "; " + changesOf(t, rows[1])
+	if !strings.Contains(all, "priority") {
+		t.Error("giving up dropped the caller's change entirely; it must land on a new row")
+	}
+	// The competitors' changes must survive too. Without this, an
+	// accumulator that discarded everything it merged over would still pass
+	// on the `priority` assertion alone (codex round 7).
+	for i := 1; i <= debounceMergeAttempts; i++ {
+		want := "field" + string(rune('0'+i))
+		if !strings.Contains(all, want) {
+			t.Errorf("contention lost the competing %s change; changes across both rows = %q", want, all)
+		}
+	}
+}
+
+// TestMergeIntoUnlinkedActivity_RefusesMovedRow drives the compare-and-set
+// arm directly, on a row NO comment links — so the only thing that can refuse
+// the write is the stale expectation. The control leg (a matching
+// expectation, same row, same call) is what makes the refusal evidence of a
+// predicate rather than of a merge that no longer works at all.
+func TestMergeIntoUnlinkedActivity_RefusesMovedRow(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "CAS")
+	doc := createTestDoc(t, s, ws.ID, "Doc", "content")
+
+	id, err := s.CreateActivity(models.Activity{
+		WorkspaceID: ws.ID, DocumentID: doc.ID,
+		Action: "updated", Actor: "agent", Source: "cli",
+		Metadata: `{"agent":"rook","changes":"title: a → b"}`,
+	})
+	if err != nil {
+		t.Fatalf("create activity: %v", err)
+	}
+	metaOf := func() string {
+		var m string
+		if err := s.db.QueryRow(s.q(`SELECT metadata FROM activities WHERE id = ?`), id).Scan(&m); err != nil {
+			t.Fatalf("read metadata: %v", err)
+		}
+		return m
+	}
+	current := metaOf()
+
+	written, err := s.mergeIntoUnlinkedActivity(id, `{"agent":"rook","changes":"someone else's read"}`, `{"agent":"rook","changes":"clobber"}`, now())
+	if err != nil {
+		t.Fatalf("merge with stale expectation: %v", err)
+	}
+	if written {
+		t.Error("merge reported written despite a stale expectation")
+	}
+	if got := metaOf(); got != current {
+		t.Errorf("refused merge still wrote: metadata = %q, want %q", got, current)
+	}
+
+	written, err = s.mergeIntoUnlinkedActivity(id, current, `{"agent":"rook","changes":"title: a → c"}`, now())
+	if err != nil {
+		t.Fatalf("control merge: %v", err)
+	}
+	if !written {
+		t.Fatal("control: a matching expectation on an unlinked row was refused")
+	}
+	if got := changesOf(t, models.Activity{Metadata: metaOf()}); !strings.Contains(got, "a → c") {
+		t.Errorf("control: row not updated, changes = %q", got)
+	}
+}
+
+// TestDebounceRowUnchanged covers the classifier that tells the merge
+// UPDATE's two refusal arms apart. Its answer decides between two OPPOSITE
+// dispositions — retry, or start a fresh row — so each of its three inputs
+// gets a leg.
+func TestDebounceRowUnchanged(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Classify")
+	doc := createTestDoc(t, s, ws.ID, "Doc", "content")
+
+	id, err := s.CreateActivity(models.Activity{
+		WorkspaceID: ws.ID, DocumentID: doc.ID,
+		Action: "updated", Actor: "agent", Source: "cli",
+		Metadata: `{"agent":"rook","changes":"title: a → b"}`,
+	})
+	if err != nil {
+		t.Fatalf("create activity: %v", err)
+	}
+	var current string
+	if err := s.db.QueryRow(s.q(`SELECT metadata FROM activities WHERE id = ?`), id).Scan(&current); err != nil {
+		t.Fatalf("read metadata: %v", err)
+	}
+
+	unchanged, err := s.debounceRowUnchanged(id, current)
+	if err != nil {
+		t.Fatalf("unchanged row: %v", err)
+	}
+	if !unchanged {
+		t.Error("row carrying the exact blob reported as changed — a frozen row would be retried instead of starting a fresh run")
+	}
+
+	unchanged, err = s.debounceRowUnchanged(id, `{"agent":"rook","changes":"something else"}`)
+	if err != nil {
+		t.Fatalf("moved row: %v", err)
+	}
+	if unchanged {
+		t.Error("row carrying a different blob reported as unchanged — a contended merge would be abandoned instead of retried")
+	}
+
+	unchanged, err = s.debounceRowUnchanged("no-such-activity-id", current)
+	if err != nil {
+		t.Fatalf("missing row: %v", err)
+	}
+	if unchanged {
+		t.Error("missing row reported as unchanged")
+	}
+
+	// A store ERROR must not read as an answer. Without this leg, a
+	// classifier that swallowed errors into "unchanged" would pass every
+	// other leg here (codex round 7) — and "unchanged" is the answer that
+	// makes the caller abandon a merge it could have retried.
+	broken := testStore(t)
+	if err := broken.DB().Close(); err != nil {
+		t.Fatalf("close store db: %v", err)
+	}
+	unchanged, err = broken.debounceRowUnchanged(id, current)
+	if err == nil {
+		t.Error("a closed database produced no error from the classifier")
+	}
+	if unchanged {
+		t.Error("a failed probe reported the row as unchanged")
+	}
+}
+
+// TestCreateActivityDebounced_FrozenRowIsNotRetried pins the OTHER half of
+// the refusal classifier. A comment-linked row refuses the merge for a reason
+// that will not change no matter how many times it is asked, so the call must
+// start a fresh run on the FIRST refusal rather than spending the retry
+// budget rediscovering it.
+//
+// The end state — a new row — is the same either way, which is precisely why
+// this asserts the seam's fire COUNT: it is the only observable that
+// distinguishes "recognised the freeze" from "retried until it gave up".
+//
+// NOT a counterfactual for BUG-2770: the pre-fix code also made exactly one
+// attempt, so this test passes against it. Its target is the classifier —
+// it fails when the classifier stops distinguishing the two refusal arms
+// (matrix M3) — and it is listed here so nobody reads it as evidence for
+// the CAS.
+func TestCreateActivityDebounced_FrozenRowIsNotRetried(t *testing.T) {
+	s, item := agentNameFixture(t)
+
+	writer := models.Activity{
+		WorkspaceID: item.WorkspaceID,
+		DocumentID:  item.ID,
+		Action:      "updated",
+		Actor:       "agent",
+		Source:      "cli",
+		Metadata:    `{"agent":"rook","changes":"title: a → b"}`,
+	}
+	first, err := s.CreateActivityDebounced(writer)
+	if err != nil {
+		t.Fatalf("seed activity: %v", err)
+	}
+	if _, err := s.CreateComment(item.WorkspaceID, item.ID, "", models.CommentCreate{
+		Body: "pinned to that entry", CreatedBy: "agent", Source: "cli", ActivityID: first,
+	}); err != nil {
+		t.Fatalf("link comment: %v", err)
+	}
+
+	attempts := 0
+	s.afterDebounceRead = func() { attempts++ }
+
+	next := writer
+	next.Metadata = `{"agent":"rook","changes":"status: open → done"}`
+	second, err := s.CreateActivityDebounced(next)
+	if err != nil {
+		t.Fatalf("update after a linked row: %v", err)
+	}
+	s.afterDebounceRead = nil
+
+	if second == first {
+		t.Fatal("merged into a comment-linked row; it must be frozen")
+	}
+	if attempts != 1 {
+		t.Errorf("seam fired %d times against a comment-linked row, want 1 — a freeze is not contention and must not consume the retry budget", attempts)
+	}
+}
+
+// TestMergeActivityMeta_NullBlobDoesNotPanic covers the blob that is valid
+// JSON, valid JSONB, storable in both dialects' columns — and unmarshals to a
+// nil map. The overlay writes into that map, and assignment to a nil map
+// panics, so this is a crash on a write path rather than a bad merge.
+//
+// Both orders are exercised because only ONE of them is the defect: a nil
+// INCOMING map is merely ranged over (safe), while a nil EXISTING map is
+// assigned into. A test that only passed `null` as the incoming side would
+// go green against the unguarded code and say nothing.
+func TestMergeActivityMeta_NullBlobDoesNotPanic(t *testing.T) {
+	got := mergeActivityMeta("null", `{"agent":"rook","changes":"status: open → done"}`)
+	var m map[string]any
+	if err := json.Unmarshal([]byte(got), &m); err != nil {
+		t.Fatalf("merged blob is not JSON: %q (%v)", got, err)
+	}
+	if m["changes"] != "status: open → done" {
+		t.Errorf("null existing blob lost the incoming change: %q", got)
+	}
+	if m["agent"] != "rook" {
+		t.Errorf("null existing blob lost the incoming agent: %q", got)
+	}
+
+	// The guard must produce a REAL merge, not a null-shaped special case:
+	// same-field runs still collapse through it (codex round 7).
+	got = mergeActivityMeta("null", `{"changes":"title: a → b; title: b → c"}`)
+	if err := json.Unmarshal([]byte(got), &m); err != nil {
+		t.Fatalf("merged blob is not JSON: %q (%v)", got, err)
+	}
+	if m["changes"] != "title: a → c" {
+		t.Errorf("collapsing did not run through the null-existing path: %q", got)
+	}
+
+	got = mergeActivityMeta(`{"agent":"rook","changes":"title: a → b"}`, "null")
+	if err := json.Unmarshal([]byte(got), &m); err != nil {
+		t.Fatalf("merged blob is not JSON: %q (%v)", got, err)
+	}
+	if m["changes"] != "title: a → b" {
+		t.Errorf("null incoming blob dropped the existing change: %q", got)
+	}
+}
+
+// TestCreateActivityDebounced_NullMetadataRowSurvives drives the same blob
+// through the store, since a panic in mergeActivityMeta is only interesting
+// because a stored row can reach it. A row carrying `null` is what an older
+// or hand-written caller can leave behind: CreateActivity only substitutes
+// "{}" for the EMPTY string.
+func TestCreateActivityDebounced_NullMetadataRowSurvives(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Null")
+	doc := createTestDoc(t, s, ws.ID, "Doc", "content")
+
+	id, err := s.CreateActivity(models.Activity{
+		WorkspaceID: ws.ID, DocumentID: doc.ID,
+		Action: "updated", Actor: "user", Source: "web",
+		Metadata: "null",
+	})
+	if err != nil {
+		t.Fatalf("create activity with null metadata: %v", err)
+	}
+
+	if _, err := s.CreateActivityDebounced(models.Activity{
+		WorkspaceID: ws.ID, DocumentID: doc.ID,
+		Action: "updated", Actor: "user", Source: "web",
+		Metadata: `{"changes":"status: open → done"}`,
+	}); err != nil {
+		t.Fatalf("debounced update over a null-metadata row: %v", err)
+	}
+
+	rows := updatedRowsFor(t, s, doc.ID)
+	if len(rows) != 1 {
+		t.Fatalf("want the null row extended, got %d rows", len(rows))
+	}
+	if rows[0].ID != id {
+		t.Errorf("merged into %s, want the existing null-metadata row %s", rows[0].ID, id)
+	}
+	if got := changesOf(t, rows[0]); got != "status: open → done" {
+		t.Errorf("changes on the merged row = %q", got)
+	}
+}
+
+// TestCreateActivityDebounced_RetryStampsTheRetryTime pins that the merge's
+// timestamp is taken per ATTEMPT. A retry that reused the instant captured
+// before the loop would backdate a row whose newest change is younger than
+// that stamp — created_at is what the coalescing window, the timeline's
+// ordering and the status-transition backfill all read.
+//
+// The competing write holds the second boundary open (RFC3339 stores whole
+// seconds, so a sub-second difference is unobservable). That sleep is the
+// same device TestCreateActivityDebounced_TimestampBumped already uses, and
+// The sleep runs inside the hook, so the assertion below is only meaningful
+// if the hook actually ran — which is why `fired` is checked rather than
+// assumed (codex round 8).
+//
+// Boundary (codex round 7): an implementation with no CAS at all that
+// simply called now() at write time would also pass, so this is evidence
+// about WHERE the timestamp is taken, not that a retry happened. The retry
+// itself is pinned by the tests above; this one dies to the matrix mutation
+// that hoists ts back out of the loop (M7).
+func TestCreateActivityDebounced_RetryStampsTheRetryTime(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Stamp")
+	doc := createTestDoc(t, s, ws.ID, "Doc", "content")
+	const userID = ""
+
+	if _, err := s.CreateActivityDebounced(debounceWriter(ws.ID, doc.ID, userID, "title: a → b")); err != nil {
+		t.Fatalf("seed activity: %v", err)
+	}
+	beforeLoop := time.Now().UTC()
+
+	fired := 0
+	var hook func()
+	hook = func() {
+		if fired > 0 {
+			return
+		}
+		fired++
+		s.afterDebounceRead = nil
+		defer func() { s.afterDebounceRead = hook }()
+		if _, err := s.CreateActivityDebounced(debounceWriter(ws.ID, doc.ID, userID, "status: open → done")); err != nil {
+			t.Errorf("competing write: %v", err)
+		}
+		// Push the retry into a later whole second than the one the call
+		// started in.
+		time.Sleep(1100 * time.Millisecond)
+	}
+	s.afterDebounceRead = hook
+
+	if _, err := s.CreateActivityDebounced(debounceWriter(ws.ID, doc.ID, userID, "priority: low → high")); err != nil {
+		t.Fatalf("contended write: %v", err)
+	}
+	s.afterDebounceRead = nil
+
+	if fired != 1 {
+		t.Fatalf("seam fired %d times, want 1 — without it the sleep never ran and the timestamp assertion below proves nothing", fired)
+	}
+	rows := updatedRowsFor(t, s, doc.ID)
+	if len(rows) != 1 {
+		t.Fatalf("want 1 coalesced row, got %d", len(rows))
+	}
+	if !rows[0].CreatedAt.After(beforeLoop) {
+		t.Errorf("merged row stamped %v, which is not after the instant the contended call began (%v) — the retry reused a stale timestamp", rows[0].CreatedAt, beforeLoop)
+	}
+}

--- a/internal/store/comments_agent_name_test.go
+++ b/internal/store/comments_agent_name_test.go
@@ -368,9 +368,16 @@ func TestCreateActivityDebounced_NeverMergesIntoCommentLinkedRow(t *testing.T) {
 // Codex round 6 on TASK-2760: the debounce's read-then-write is two
 // statements, and a comment can link the chosen row between them. The write
 // itself must refuse a linked row — this drives the write directly with the
-// row already linked, the state the race produces, since the interleaving
-// cannot be scheduled from a test. The control leg pins that an unlinked row
-// is still written, so the predicate is a freeze and not a disabled merge.
+// row already linked, the state the race produces. The control leg pins that
+// an unlinked row is still written, so the predicate is a freeze and not a
+// disabled merge.
+//
+// (This comment used to say the interleaving could not be scheduled from a
+// test. BUG-2770 added the afterDebounceRead seam, so it now can — see
+// TestCreateActivityDebounced_FrozenRowIsNotRetried, which schedules exactly
+// this ordering through CreateActivityDebounced. Driving the write directly
+// is still the right shape for THIS test: it pins the predicate itself,
+// independently of any caller.)
 func TestMergeIntoUnlinkedActivity_RefusesLinkedRow(t *testing.T) {
 	s, item := agentNameFixture(t)
 	mk := func(meta string) string {
@@ -397,7 +404,11 @@ func TestMergeIntoUnlinkedActivity_RefusesLinkedRow(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("create comment: %v", err)
 	}
-	written, err := s.mergeIntoUnlinkedActivity(linked, `{"agent":"rook"}`, now())
+	// The compare-and-set arm (BUG-2770) is given the row's CURRENT blob, so
+	// it holds and the link arm is the only thing that can refuse this call.
+	// A mismatched expectation here would refuse for two reasons at once and
+	// this leg would stop discriminating.
+	written, err := s.mergeIntoUnlinkedActivity(linked, metaOf(linked), `{"agent":"rook"}`, now())
 	if err != nil {
 		t.Fatalf("merge into linked: %v", err)
 	}
@@ -409,7 +420,7 @@ func TestMergeIntoUnlinkedActivity_RefusesLinkedRow(t *testing.T) {
 	}
 
 	unlinked := mk(`{"agent":"wren"}`)
-	written, err = s.mergeIntoUnlinkedActivity(unlinked, `{"agent":"rook"}`, now())
+	written, err = s.mergeIntoUnlinkedActivity(unlinked, metaOf(unlinked), `{"agent":"rook"}`, now())
 	if err != nil {
 		t.Fatalf("merge into unlinked: %v", err)
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -46,6 +46,21 @@ type Store struct {
 	dbPath        string
 	encryptionKey []byte // 32-byte AES-256 key for encrypting sensitive fields (e.g., TOTP secrets)
 
+	// afterDebounceRead is a TEST-ONLY seam, nil in production. When set,
+	// CreateActivityDebounced calls it between reading its candidate row
+	// and issuing the merge UPDATE — the window in which a concurrent
+	// writer can move the row out from under the read (BUG-2770). A hook
+	// makes that interleaving deterministic; racing two real goroutines
+	// reproduces it only sometimes, and a test that reproduces a race
+	// sometimes is a detector with an unknown rate, not a regression test.
+	// It is a Store field rather than a package var so parallel tests
+	// cannot write each other's seam. Set it only while no request is in
+	// flight against this Store: it is READ on a write path with no
+	// synchronisation, so mutating it under live traffic is a -race
+	// finding waiting to happen (codex round 2 — latent, not current:
+	// every test that sets it does so synchronously and none is parallel).
+	afterDebounceRead func()
+
 	// stopMaint signals the background WAL checkpointer to exit; maintDone
 	// is closed once it has. Both are nil on the Postgres path (no WAL
 	// file to checkpoint) and Close() guards on nil accordingly.


### PR DESCRIPTION
Fixes BUG-2770.

## The defect

`CreateActivityDebounced` merged by reading a row's metadata, combining it in Go, and writing the result back — a read-modify-write across two statements. Two writers selecting the SAME row both read the pre-merge blob, each merged its own change into it, and the second UPDATE erased the first one's change entry. No error, no trace; the activity row simply never mentions that edit.

Since BUG-2763 the racing pair must be the same account, actor kind AND agent name — which is the ordinary case, not an exotic one: one editor's autosave burst, or one agent issuing concurrent PATCHes.

## The fix

The merge UPDATE carries the blob the caller merged from as a **compare-and-set** arm, and the caller is a bounded attempt loop that re-reads its candidate each time, so a losing attempt merges into the **winner's** blob rather than the stale one it first read.

**The part the filing didn't name.** Adding that arm gives one UPDATE two ways to affect zero rows, and they want OPPOSITE dispositions:

| Refusal | Correct disposition | Why the other one is wrong |
| --- | --- | --- |
| Comment-linked row (TASK-2760's freeze) | Start a fresh row | Retrying rediscovers the same answer; the row is frozen for this call |
| CAS lost to a concurrent merge | Retry | Starting a fresh row is how the coalescing run fragments |

`debounceRowUnchanged` asks the CAS arm's own question after a refusal to tell them apart — one primary-key probe, only on the rare refusal path. Both statements spell that arm with **one shared constant**, so they cannot drift into asking different questions. The probe is a disposition hint, not a guard: nothing holds the row still, and the loop re-runs the CAS rather than trusting it.

## Folded in (found reviewing the same code)

- **`mergeActivityMeta` panicked on a JSON `null` blob.** `null` unmarshals with no error and leaves the map nil; the overlay then assigns into it. Valid JSON, valid JSONB, storable in the TEXT column — a crash on a write path.
- **The merge timestamp is now taken per attempt.** Hoisted out of the loop, a retry backdated a row whose newest change was younger than the stamp — and `created_at` is what the cooldown window, the timeline ordering and the status-transition backfill all read.
- **Two comments corrected**: one claimed a lost CAS proves another merge landed (deletion does it too); `maxDebounceCandidates`' comment predicted a query plan it has no business predicting.

## Dual dialect

`activities.metadata` is **TEXT on SQLite, JSONB on Postgres** — the CAS is byte equality on one and jsonb equality on the other, and whether the driver types the parameter as jsonb at all is a fact about pgx, not about this code. Verified empirically on `postgres:17-alpine`, with **both discriminating legs**: a stale expectation refuses, a matching one writes. That pair is what rules out the comparison being stuck true or stuck false on that backend.

## Test strategy

The interleaving is driven by a **Store test seam** (`afterDebounceRead`, nil in production), not by racing goroutines: the defect needs the competing write to land strictly between one call's read and its write, and real goroutines produce that ordering only sometimes — a detector with an unknown rate reads as coverage without being it.

- **Counterfactual**: against the pre-fix behaviour restored exactly, the regression test fails with `changes = "title: a → b; priority: low → high"` — the competitor's `status` change silently gone, i.e. the filed symptom verbatim.
- **Mutation matrix, 8 mutations, all die** — drop the CAS predicate; make the shared constant tautological; give up on any refusal; classifier always answers "contended"; attempts bound 3→1; CAS on a fresh re-read instead of the merged-from blob (the plausible wrong version that looks equivalent); drop the nil-map guard; hoist the timestamp back out of the loop.
- **Three tests carry explicit notes naming what they cannot discriminate** — including that `FrozenRowIsNotRetried` passes against the pre-fix code, because its target is the classifier, not the CAS. Listed so nobody reads it as evidence for the CAS.

## Filed, not folded

Six pre-existing defects the review surfaced, each verified in source before filing: **BUG-2776** (item-update activity diffs a stale pre-read snapshot — a concurrent writer's change is attributed to the wrong agent), **BUG-2777** (two writers who both find no candidate insert two rows), **BUG-2778** (unordered backlink locking can deadlock on Postgres), **BUG-2779** (merge returns a stale activity id alongside its error and the handler links a comment to it), **BUG-2781** (activity feeds page over a moving dataset: offset paging can skip rows, ORDER BY has no tie-break).

## Declined

Replacing CAS+retry with a row-locking transaction. The shape was ruled from the filing's option 2; holding a row lock across a Go-side merge lengthens lock hold on an autosave-burst write path; and SQLite's `BEGIN IMMEDIATE` would serialize all writers rather than one row. Raised in review, declined with those reasons, not re-raised.

## Test plan

Gates below were run on this exact tip after rebasing onto `a2195997`; earlier greens on the pre-rebase tree are void and are not reported here.
