### PR TITLE
fix(server): a malformed before_id is a 400, not a 500 (BUG-2774)

### DIFF
--- a/internal/server/handlers_timeline.go
+++ b/internal/server/handlers_timeline.go
@@ -5,7 +5,9 @@ import (
 	"net/http"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/go-chi/chi/v5"
 
@@ -97,6 +99,11 @@ func (s *Server) handleListItemTimeline(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 	if v := r.URL.Query().Get("before_id"); v != "" {
+		if !validCursorID(v) {
+			writeError(w, http.StatusBadRequest, "invalid_cursor",
+				"before_id must be valid UTF-8 with no NUL byte")
+			return
+		}
 		beforeID = v
 	}
 	if hasBefore && beforeID == "" {
@@ -581,4 +588,30 @@ func exhaustedWindowCursor(
 	}
 
 	return at, id, found
+}
+
+// validCursorID reports whether a caller-supplied `before_id` can be bound
+// into the cursor predicate at all.
+//
+// It rejects exactly what the DATABASE rejects rather than what an id
+// "should" look like. Postgres refuses a text parameter that is not valid
+// UTF-8 or that contains a NUL (SQLSTATE 22021 / 22P05), and pgx surfaces
+// that as a query error, which this handler turns into a 500 — an operator's
+// alerting reads that as the server breaking when a client sent a bad cursor.
+// SQLite accepts both and simply matches nothing, so the same request is a
+// 200 there: a dialect divergence in the failure mode, from one line of
+// unvalidated input. Same failure the BUG-1086 comment above records, whose
+// fix covered the sentinel this handler synthesizes and not the value a
+// caller supplies.
+//
+// DELIBERATELY NO LENGTH BOUND. The obvious cap is the one thing here that
+// could reject a LEGITIMATE cursor: the structured kinds' ids come from the
+// item's own fields blob (see entryID below), nothing validates them on
+// write, and an imported artifact may carry any string. Real ids are far
+// shorter — a UUID is 36 bytes, `note-<nanos>` about 24 — but "far shorter
+// than any cap I would pick" is not a guarantee, and the cost of an over-long
+// one is a single indexed comparison against a parameter the URL length limit
+// already bounds. A bound that can only fire on a valid id is not protection.
+func validCursorID(v string) bool {
+	return utf8.ValidString(v) && !strings.ContainsRune(v, 0)
 }

--- a/internal/server/handlers_timeline.go
+++ b/internal/server/handlers_timeline.go
@@ -32,7 +32,14 @@ import (
 // consumer that pages from its last visible entry therefore either cannot form
 // a cursor at all or re-requests the same window forever (BUG-2765), and one
 // that forwards only `next_before` without `next_before_id` can repeat or skip
-// entries sharing that second. Both fields, or neither.
+// entries sharing that second. Send both fields, or neither.
+//
+// The two one-sided forms are NOT symmetric, and the validation reflects that
+// rather than the slogan (BUG-2774). `before` alone is accepted: it is the
+// external-client shape the id sentinel below exists to serve, at the cost of
+// the same-second ambiguity just described. `before_id` alone is REFUSED with
+// 400 — the id is only ever the tie-break at the cursor instant, so on its own
+// it matches nothing and silently pages from the beginning.
 func (s *Server) handleListItemTimeline(w http.ResponseWriter, r *http.Request) {
 	workspaceID, ok := s.getWorkspaceID(w, r)
 	if !ok {

--- a/internal/server/handlers_timeline.go
+++ b/internal/server/handlers_timeline.go
@@ -274,7 +274,16 @@ func structuredTimelineEntries(item *models.Item, before time.Time, beforeID str
 	// within a kind does.
 	usedIDs := make(map[string]bool, len(item.ImplementationNotes)+len(item.DecisionLog))
 	entryID := func(raw, prefix string, i int) string {
-		if raw != "" && !usedIDs[raw] {
+		// A raw id must be usable as a CURSOR, not merely unique: the client
+		// sends it back as `before_id` and the handler now refuses a value the
+		// database would refuse (BUG-2774's validCursorID). These ids come
+		// from the item's fields blob and nothing validates them on write, so
+		// a JSON `\u0000` reaches here intact on SQLite — Postgres's jsonb
+		// rejects it at the door, which is why this is a one-backend hazard.
+		// Emitting such an id would make the server hand out a cursor it then
+		// answers 400 to, wedging paging on that item (codex round 1). It gets
+		// the positional fallback the empty and duplicate cases already take.
+		if raw != "" && validCursorID(raw) && !usedIDs[raw] {
 			usedIDs[raw] = true
 			return raw
 		}

--- a/internal/server/handlers_timeline.go
+++ b/internal/server/handlers_timeline.go
@@ -104,6 +104,19 @@ func (s *Server) handleListItemTimeline(w http.ResponseWriter, r *http.Request) 
 				"before_id must be valid UTF-8 with no NUL byte")
 			return
 		}
+		// The id is the tie-break AT the cursor instant, so on its own it can
+		// never match anything: `before` defaults to now+1m and no row shares
+		// that timestamp. It was therefore accepted and silently ignored, and
+		// the caller paged from the beginning believing they had a cursor
+		// (codex round 4). The documented contract is both fields or neither.
+		//
+		// The other direction stays supported on purpose: `before` alone is
+		// the external-client case the sentinel above exists for.
+		if !hasBefore {
+			writeError(w, http.StatusBadRequest, "invalid_cursor",
+				"before_id requires before — send both fields of the cursor or neither")
+			return
+		}
 		beforeID = v
 	}
 	if hasBefore && beforeID == "" {

--- a/internal/server/handlers_timeline_cursor_validation_test.go
+++ b/internal/server/handlers_timeline_cursor_validation_test.go
@@ -1,0 +1,96 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/store/storetest"
+)
+
+// BUG-2774. `before_id` went from the query string into the cursor predicate
+// unchecked. Postgres refuses a text parameter that is not valid UTF-8 or that
+// carries a NUL, so a malformed cursor came back 500 — the server announcing
+// its own failure for what is a client's bad input. SQLite accepts the same
+// bytes and matches nothing, so the identical request was a 200 there.
+//
+// The store-level test below pins that premise on Postgres; these pin the
+// handler's answer, which is the same on both backends because validation
+// happens before any query.
+
+func timelineRaw(t *testing.T, srv *Server, ws, slug, rawQuery string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("GET",
+		"/api/v1/workspaces/"+ws+"/items/"+slug+"/timeline?"+rawQuery, nil)
+	req.RemoteAddr = "192.0.2.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	return rr
+}
+
+func TestTimeline_MalformedBeforeIDIsClientError(t *testing.T) {
+	t.Parallel()
+	srv := testServer(t)
+	ws := createTestWorkspaceViaAPI(t, srv)
+	item := timelineItemWithStructured(t, srv, ws, "", "")
+	cursor := "before=" + time.Now().UTC().Format(time.RFC3339) + "&before_id="
+
+	for _, tc := range []struct {
+		name  string
+		rawID string
+		want  int
+	}{
+		// %FF is not valid UTF-8 in any encoding of it; %00 is a NUL. Both are
+		// what Postgres refuses, and both are reachable from a plain URL.
+		{name: "invalid utf-8", rawID: "%FF", want: http.StatusBadRequest},
+		{name: "embedded NUL", rawID: "note%001", want: http.StatusBadRequest},
+		{name: "invalid utf-8 mid-string", rawID: "note-%FF-1", want: http.StatusBadRequest},
+		// Controls. Without them "reject every before_id" passes the legs
+		// above, and paging would be dead rather than merely honest.
+		{name: "a uuid (control)", rawID: "0e2f3b1c-1111-4111-8111-111111111111", want: http.StatusOK},
+		{name: "a structured id (control)", rawID: "note-1775153870894988317", want: http.StatusOK},
+		// Not a shape this server emits, but valid UTF-8 with no NUL, so the
+		// database has no objection and neither does the handler. The rule is
+		// about what can be BOUND, not about what looks like an id — the
+		// deliberate absence of a length or format bound (see validCursorID).
+		{name: "long unicode id (control)", rawID: "n%C3%B8te-" + longRunOfAs(300), want: http.StatusOK},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rr := timelineRaw(t, srv, ws, item.Slug, cursor+tc.rawID)
+			if rr.Code != tc.want {
+				t.Errorf("GET timeline before_id=%s = %d, want %d: %s",
+					tc.rawID, rr.Code, tc.want, rr.Body.String())
+			}
+		})
+	}
+}
+
+func longRunOfAs(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = 'a'
+	}
+	return string(b)
+}
+
+// The premise the 400 exists to prevent, pinned where it is real: on Postgres
+// the query itself FAILS on such a parameter, which is what surfaced as a 500.
+// Skipped on SQLite, where the same call succeeds and returns nothing — the
+// divergence is the point, so both halves are asserted in the one place that
+// can see both.
+func TestListBeforeTime_InvalidUTF8CursorIsADialectDivergence(t *testing.T) {
+	pg := storetest.NewPostgres(t) // skips unless PAD_TEST_POSTGRES_URL is set
+	sqlite := storetest.NewSQLite(t)
+
+	const badID = "note-\xff-1"
+	when := time.Now().UTC().Add(time.Minute)
+
+	if _, err := sqlite.ListDocumentActivityBeforeTime("no-such-doc", when, badID, 10); err != nil {
+		t.Errorf("SQLite rejected the cursor (%v) — if this backend has started refusing it too, the handler's 400 is still right but this test's reasoning needs updating", err)
+	}
+	if _, err := pg.ListDocumentActivityBeforeTime("no-such-doc", when, badID, 10); err == nil {
+		t.Error("Postgres accepted an invalid-UTF-8 cursor: the 500 this validation prevents is no longer reachable, so either the driver changed or the premise moved")
+	}
+}

--- a/internal/server/handlers_timeline_cursor_validation_test.go
+++ b/internal/server/handlers_timeline_cursor_validation_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -60,8 +61,28 @@ func TestTimeline_MalformedBeforeIDIsClientError(t *testing.T) {
 			t.Parallel()
 			rr := timelineRaw(t, srv, ws, item.Slug, cursor+tc.rawID)
 			if rr.Code != tc.want {
-				t.Errorf("GET timeline before_id=%s = %d, want %d: %s",
+				t.Fatalf("GET timeline before_id=%s = %d, want %d: %s",
 					tc.rawID, rr.Code, tc.want, rr.Body.String())
+			}
+			if tc.want != http.StatusBadRequest {
+				return
+			}
+			// The status alone would pass for a bare 400 or the wrong code,
+			// and clients branch on the code, not the number.
+			var env struct {
+				Error struct {
+					Code    string `json:"code"`
+					Message string `json:"message"`
+				} `json:"error"`
+			}
+			if err := json.Unmarshal(rr.Body.Bytes(), &env); err != nil {
+				t.Fatalf("decode error envelope: %v (body %s)", err, rr.Body.String())
+			}
+			if env.Error.Code != "invalid_cursor" {
+				t.Errorf("error code = %q, want %q", env.Error.Code, "invalid_cursor")
+			}
+			if env.Error.Message == "" {
+				t.Error("error message is empty — the envelope has to say what was wrong")
 			}
 		})
 	}
@@ -75,24 +96,31 @@ func longRunOfAs(n int) string {
 	return string(b)
 }
 
-// The premise the 400 exists to prevent, pinned where it is real: on Postgres
-// the query itself FAILS on such a parameter, which is what surfaced as a 500.
-// Skipped on SQLite, where the same call succeeds and returns nothing — the
-// divergence is the point, so both halves are asserted in the one place that
-// can see both.
+// CHARACTERIZATION, not a regression test: it passes with or without this
+// unit's change, because it describes the BACKENDS rather than the handler.
+// That is the point — it is the premise the 400 rests on, and if it stops
+// holding the 400 needs revisiting rather than silently guarding nothing.
+//
+// The SQLite half runs everywhere; the Postgres half needs
+// PAD_TEST_POSTGRES_URL and skips without it, so an unconfigured run proves
+// only that SQLite still accepts the bytes.
 func TestListBeforeTime_InvalidUTF8CursorIsADialectDivergence(t *testing.T) {
-	pg := storetest.NewPostgres(t) // skips unless PAD_TEST_POSTGRES_URL is set
-	sqlite := storetest.NewSQLite(t)
-
 	const badID = "note-\xff-1"
 	when := time.Now().UTC().Add(time.Minute)
 
-	if _, err := sqlite.ListDocumentActivityBeforeTime("no-such-doc", when, badID, 10); err != nil {
-		t.Errorf("SQLite rejected the cursor (%v) — if this backend has started refusing it too, the handler's 400 is still right but this test's reasoning needs updating", err)
-	}
-	if _, err := pg.ListDocumentActivityBeforeTime("no-such-doc", when, badID, 10); err == nil {
-		t.Error("Postgres accepted an invalid-UTF-8 cursor: the 500 this validation prevents is no longer reachable, so either the driver changed or the premise moved")
-	}
+	t.Run("sqlite accepts it", func(t *testing.T) {
+		s := storetest.NewSQLite(t)
+		if _, err := s.ListDocumentActivityBeforeTime("no-such-doc", when, badID, 10); err != nil {
+			t.Errorf("SQLite rejected the cursor (%v) — the handler's 400 is still right, but this test's reasoning about WHY needs updating", err)
+		}
+	})
+
+	t.Run("postgres refuses it", func(t *testing.T) {
+		p := storetest.NewPostgres(t) // skips unless PAD_TEST_POSTGRES_URL is set
+		if _, err := p.ListDocumentActivityBeforeTime("no-such-doc", when, badID, 10); err == nil {
+			t.Error("Postgres accepted an invalid-UTF-8 cursor: the 500 this validation prevents is no longer reachable, so either the driver changed or the premise moved")
+		}
+	})
 }
 
 // The other direction of the same rule: the server must never EMIT a cursor it
@@ -107,13 +135,18 @@ func TestTimeline_NeverEmitsACursorItWouldRefuse(t *testing.T) {
 	srv := testServer(t)
 	ws := createTestWorkspaceViaAPI(t, srv)
 
-	// Two notes: one whose id carries a NUL, one clean, so the assertions
-	// distinguish "replaced the unusable id" from "stopped using raw ids".
-	notes := `[{"id":"note-\u0000-bad","summary":"first","created_at":"2026-04-02T10:00:00Z"},` +
-		`{"id":"note-clean","summary":"second","created_at":"2026-04-02T10:00:01Z"}]`
+	// Three notes so the NUL-bearing one can be the LAST kept entry under a
+	// truncating limit — that is what makes it the emitted next_before_id
+	// rather than merely an entry id. The clean one is the control: it
+	// distinguishes "replaced the unusable id" from "stopped using raw ids".
+	notes := `[{"id":"note-\u0000-bad","summary":"middle","created_at":"2026-04-02T10:00:01Z"},` +
+		`{"id":"note-clean","summary":"newest note","created_at":"2026-04-02T10:00:02Z"},` +
+		`{"id":"note-oldest","summary":"oldest","created_at":"2026-04-02T10:00:00Z"}]`
 	item := timelineItemWithStructured(t, srv, ws, notes, "")
 
-	resp := fetchTimeline(t, srv, ws, item.Slug, "limit=50")
+	// The item's own `created` activity plus three notes; limit=3 truncates,
+	// so the cursor is the third entry — the NUL-bearing note.
+	resp := fetchTimeline(t, srv, ws, item.Slug, "limit=3")
 	var sawClean, sawFallback bool
 	for _, e := range resp.Entries {
 		if !validCursorID(e.ID) {
@@ -126,6 +159,23 @@ func TestTimeline_NeverEmitsACursorItWouldRefuse(t *testing.T) {
 			sawFallback = true
 		}
 	}
+
+	// The cursor itself, which is what the client actually sends back.
+	if !resp.HasMore || resp.NextBeforeID == "" {
+		t.Fatalf("expected a truncated page with a cursor, got has_more=%v next_before_id=%q",
+			resp.HasMore, resp.NextBeforeID)
+	}
+	if !validCursorID(resp.NextBeforeID) {
+		t.Errorf("the server emitted next_before_id=%q, which its own validation refuses", resp.NextBeforeID)
+	}
+	// And it round-trips: the follow-up page is a 200, not the 400 this
+	// unit's other half returns for an unusable cursor.
+	rr := timelineRaw(t, srv, ws, item.Slug,
+		"limit=3&before="+resp.NextBefore+"&before_id="+resp.NextBeforeID)
+	if rr.Code != http.StatusOK {
+		t.Errorf("paging with the server's own cursor = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+
 	if !sawClean {
 		t.Error("the clean id was not used verbatim — the fallback is for unusable ids only")
 	}

--- a/internal/server/handlers_timeline_cursor_validation_test.go
+++ b/internal/server/handlers_timeline_cursor_validation_test.go
@@ -94,3 +94,42 @@ func TestListBeforeTime_InvalidUTF8CursorIsADialectDivergence(t *testing.T) {
 		t.Error("Postgres accepted an invalid-UTF-8 cursor: the 500 this validation prevents is no longer reachable, so either the driver changed or the premise moved")
 	}
 }
+
+// The other direction of the same rule: the server must never EMIT a cursor it
+// would then refuse. A structured id comes from the item's fields blob, which
+// nothing validates on write, so a JSON \u0000 escape reaches the timeline as
+// a real NUL on SQLite (Postgres's jsonb refuses it at the door — a
+// one-backend hazard). Handing that out as next_before_id would wedge paging
+// on the item: the client sends it back and gets a 400 from the validation
+// above.
+func TestTimeline_NeverEmitsACursorItWouldRefuse(t *testing.T) {
+	t.Parallel()
+	srv := testServer(t)
+	ws := createTestWorkspaceViaAPI(t, srv)
+
+	// Two notes: one whose id carries a NUL, one clean, so the assertions
+	// distinguish "replaced the unusable id" from "stopped using raw ids".
+	notes := `[{"id":"note-\u0000-bad","summary":"first","created_at":"2026-04-02T10:00:00Z"},` +
+		`{"id":"note-clean","summary":"second","created_at":"2026-04-02T10:00:01Z"}]`
+	item := timelineItemWithStructured(t, srv, ws, notes, "")
+
+	resp := fetchTimeline(t, srv, ws, item.Slug, "limit=50")
+	var sawClean, sawFallback bool
+	for _, e := range resp.Entries {
+		if !validCursorID(e.ID) {
+			t.Errorf("entry %q is not a usable cursor — a client sending it back would be refused", e.ID)
+		}
+		switch e.ID {
+		case "note-clean":
+			sawClean = true
+		case "note-idx-0":
+			sawFallback = true
+		}
+	}
+	if !sawClean {
+		t.Error("the clean id was not used verbatim — the fallback is for unusable ids only")
+	}
+	if !sawFallback {
+		t.Errorf("the NUL-bearing id did not take the positional fallback; entries: %+v", resp.Entries)
+	}
+}

--- a/internal/server/handlers_timeline_cursor_validation_test.go
+++ b/internal/server/handlers_timeline_cursor_validation_test.go
@@ -183,3 +183,52 @@ func TestTimeline_NeverEmitsACursorItWouldRefuse(t *testing.T) {
 		t.Errorf("the NUL-bearing id did not take the positional fallback; entries: %+v", resp.Entries)
 	}
 }
+
+// A cursor is a PAIR. `before_id` alone could never match anything — the id is
+// the tie-break at the cursor instant, and `before` defaults to a moment no row
+// shares — so it was accepted and silently ignored while the caller paged from
+// the beginning believing otherwise (codex round 4).
+func TestTimeline_OneSidedCursorIsRejected(t *testing.T) {
+	t.Parallel()
+	srv := testServer(t)
+	ws := createTestWorkspaceViaAPI(t, srv)
+	item := timelineItemWithStructured(t, srv, ws, "", "")
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	for _, tc := range []struct {
+		name, query string
+		want        int
+	}{
+		{
+			name:  "before_id without before",
+			query: "before_id=0e2f3b1c-1111-4111-8111-111111111111",
+			want:  http.StatusBadRequest,
+		},
+		{
+			// Deliberately supported: the sentinel exists for exactly this
+			// external-client shape, so rejecting the pair symmetrically would
+			// break a case the handler goes out of its way to serve.
+			name:  "before without before_id (control)",
+			query: "before=" + now,
+			want:  http.StatusOK,
+		},
+		{
+			name:  "both (control)",
+			query: "before=" + now + "&before_id=0e2f3b1c-1111-4111-8111-111111111111",
+			want:  http.StatusOK,
+		},
+		{
+			name:  "neither (control)",
+			query: "limit=5",
+			want:  http.StatusOK,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rr := timelineRaw(t, srv, ws, item.Slug, tc.query)
+			if rr.Code != tc.want {
+				t.Errorf("GET timeline?%s = %d, want %d: %s", tc.query, rr.Code, tc.want, rr.Body.String())
+			}
+		})
+	}
+}

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -1586,6 +1586,11 @@ export const api = {
 		 * ground. Deriving one from the last visible entry cannot advance past
 		 * such a page (BUG-2765). Send both fields or neither; the id is the
 		 * tie-break among entries sharing a second.
+		 *
+		 * The server is asymmetric about the one-sided forms (BUG-2774):
+		 * `before` alone is accepted for external clients that cannot produce
+		 * an id, while `before_id` alone is a 400 — it matches nothing on its
+		 * own and would silently page from the beginning.
 		 */
 		list: (ws: string, itemSlug: string, params?: { limit?: number; before?: string; before_id?: string }) => {
 			const qs = new URLSearchParams();


### PR DESCRIPTION
Fixes BUG-2774.

## The defect

`before_id` went from the query string into the cursor predicate unchecked. Postgres refuses a text parameter that is not valid UTF-8 or that carries a NUL (SQLSTATE 22021 / 22P05), so the store call errored and the handler answered **500** — the server announcing its own failure for a client's bad input, and SQLSTATE noise in the logs for what is an input problem. SQLite accepts the same bytes and matches nothing, so the identical request was a **200** there: the failure mode diverged by dialect from one unvalidated line.

Same SQLSTATE the file's own BUG-1086 comment records, whose fix covered the sentinel the handler synthesizes and not the value a caller supplies.

## What changed

**`validCursorID` rejects exactly what the database rejects**, not what an id "should" look like, and deliberately carries **no length or format bound**. That is the one rule here that could fire on a *legitimate* cursor: structured ids come from the item's fields blob, nothing validates them on write, and an imported artifact may carry any string. The cost of an over-long id is a single indexed comparison against a parameter the URL length limit already bounds — a bound that can only reject valid input is not protection. The comment says so, because "why isn't there a length check" is the obvious review question.

**The server never emits a cursor it would refuse** (round 1). A JSON `` escape in a note id arrives as a real NUL on SQLite — Postgres's jsonb refuses it at the door, so this is a one-backend hazard — and that id became the entry id, the entry id became `next_before_id`, and the client sending it back got the new 400. Paging would have wedged on that item. Such an id now takes the positional fallback that empty and duplicate ids already take: one condition on an existing branch.

**A one-sided cursor is a 400** (round 4). `before_id` alone could never match anything — the id is the tie-break *at* the cursor instant and `before` defaults to a moment no row shares — so it was accepted, ignored, and the caller paged from the beginning believing otherwise. `before` alone stays supported deliberately: it is the external-client shape the `"g"` sentinel exists for. The asymmetry is documented at both the handler and the TS client (round 6), because BUG-2765's "both fields or neither" was my slogan and this enforces it in one direction only.

## Review

Seven codex rounds. Rounds 1, 3, 4 and 6 produced findings, all addressed above or below; rounds 2, 5 and 7 returned CLEAN on fresh angles (every source of a cursor id; consumer impact of the new 400s; convergence).

Round 3 was about my tests, and all three of its findings were fair: status-only assertions that a bare 400 would pass, an emitted-cursor test that asserted no cursor (`limit=50` emits none), and a "both halves in one place" claim that was false in an unconfigured run where the Postgres skip took the SQLite half with it. All three fixed — the legs now decode the envelope and require `invalid_cursor`, a truncating limit makes the NUL-bearing id the actual `next_before_id` and asserts it round-trips 200, and the dialect test is split so its SQLite half runs everywhere.

## Filed, not folded

- **BUG-2782** — the same SQLSTATE through a wider door: an invalid-UTF-8 **path segment** returns 500 on Postgres and 404 on SQLite. Measured, not inferred (`ResolveItemIncludeDeleted` with an invalid-UTF-8 slug against Postgres 17 gives `SQLSTATE 22021`; the same call on SQLite returns not-found). It wants a middleware or a shared resolver helper — a cross-cutting rule, not four lines at one call site — and its filing names the three options and the search boundary of my probe.
- **BUG-2783** — a structured entry id can collide with a comment/activity/version id, because the dedupe map holds only structured ids. The client keys its `{#each}` on entry id, so one entry is hidden.

## Tests

Handler legs for three malformed shapes reachable from a plain URL (`%FF`, an embedded NUL, invalid bytes mid-string), each asserting the envelope, with three controls — a UUID, a structured note id, and a long non-ASCII id — without which "reject every `before_id`" would pass and paging would be dead rather than honest. Cursor-pair legs for all four combinations. An emitted-cursor test that drives the fallback and round-trips the server's own cursor.

A **characterization** test pins the premise where it is real: on Postgres the query itself fails, on SQLite it succeeds and returns nothing. It is labelled as characterization — it passes with or without this change, because it describes the backends rather than the handler, and if it stops holding, the 400 needs revisiting rather than silently guarding nothing.

**Mutations**, each detected: validation removed (three malformed legs); emitted ids unchecked (the fallback leg, verified twice — once after the leg was strengthened to assert the cursor rather than the entry ids); the one-sided rule removed (its leg).

## Gates (tip 3292a99a, rebased onto main 31aba0bb)

- `make lint` — 0 issues
- `go test ./...` (SQLite) — 28 ok, 0 fail
- `go test ./...` on Postgres 17 — 28 ok, 0 fail (private container on 5447, never the shared 5445)
- `npx vitest run` — 110 files, 1881 tests, 0 fail; `npx vite build` clean; `svelte-check` 0 errors (6 warnings, pre-existing, other files)

All re-run after the rebase.

## Test plan

- [x] Malformed `before_id` → 400 with the `invalid_cursor` envelope
- [x] Legitimate ids still accepted, including long non-ASCII
- [x] The server's own emitted cursor is always acceptable and round-trips
- [x] One-sided cursor rejected in the direction that is inert, accepted in the direction that works
- [x] Postgres premise measured; SQLite half runs unconfigured
- [ ] CI green on the tip

Refs: BUG-2774, BUG-2782, BUG-2783
