### PR TITLE
fix(server): diff the activity change list against the store's pre-image (BUG-2776)

### DIFF
--- a/internal/models/item.go
+++ b/internal/models/item.go
@@ -206,6 +206,27 @@ type Item struct {
 	// is deliberate: this is an internal signal for one in-process
 	// consumer, not a wire contract the API is committing to.
 	LastMutation *ItemMutationSignal `json:"-"`
+
+	// PreUpdate is the item as it stood immediately BEFORE this store call
+	// wrote it, read inside the same transaction and under the same locks as
+	// the write (BUG-2776). It exists so a caller can describe what IT
+	// changed rather than what changed since the caller last looked: the
+	// handler's own pre-read happens before permission checks and before the
+	// store's locks, so any concurrent writer's change lands between the two
+	// and, diffed naively, gets attributed to this request's author.
+	//
+	// Same contract as LastMutation above and for the same reasons: set only
+	// by UpdateItemWithParentLink, on the *models.Item it hands back, never
+	// persisted, never populated by GetItem or any list/search path, and
+	// `json:"-"` because it is an in-process signal rather than a wire
+	// contract. It is a COPY taken at re-read time, so it stays the
+	// pre-write view even though the store keeps reading `existing` after.
+	//
+	// Non-nil on every successful UpdateItemWithParentLink return. A consumer
+	// that finds it nil is looking at an item from some other path and must
+	// NOT silently fall back to its own stale snapshot — that fallback IS the
+	// defect this field exists to remove.
+	PreUpdate *Item `json:"-"`
 }
 
 // ItemMutationSignal is the race-free status/assignment delta attached to

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -916,6 +916,13 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Test seam (BUG-2776): everything from the ResolveItem above to the
+	// store's locked re-read is the window a concurrent writer can commit in.
+	// Nil in production.
+	if s.afterItemPreRead != nil {
+		s.afterItemPreRead(item.ID)
+	}
+
 	var input models.ItemUpdate
 	if err := decodeJSON(r, &input); err != nil {
 		// Surface the domain-level errors from ItemUpdate.UnmarshalJSON
@@ -1672,25 +1679,61 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 	// through the shared error handling above, so there is no remaining
 	// partial-commit window and nothing to do in this post-commit stage.
 
-	// Build rich metadata describing what changed
-	var meta string
-	if changes := diffFields(item.Fields, updated.Fields); changes != "" {
-		meta = fmt.Sprintf(`{"changes":%q}`, changes)
+	// Build rich metadata describing what changed.
+	//
+	// BUG-2776: the before-image is the store's IN-TRANSACTION pre-write
+	// view, not this handler's `item`. `item` was read at the top of this
+	// function — before the permission checks, before the store's locks —
+	// so anything a concurrent writer committed in between shows up in the
+	// difference and is attributed, with this request's actor and agent
+	// name, to whoever sent this PATCH. The store already re-reads the row
+	// under its own locks (that snapshot is what it diffs for the status and
+	// assignment signals); PreUpdate is that same snapshot, handed back.
+	//
+	// It also makes the comparisons committed-vs-committed: `updated` is
+	// what this transaction wrote, `before` is what it wrote over, so the
+	// change list describes the transaction rather than the request's
+	// intent. That is why the title arm below compares updated.Title
+	// instead of input.Title.
+	// No pre-image means no defensible change list. The obvious fallback —
+	// diff the handler's own stale `item` — is EXACTLY the defect, so a
+	// future update path that returns an item without a pre-image must lose
+	// the change list rather than quietly resume inventing wrong ones: an
+	// entry that says nothing is recoverable, an entry that names the wrong
+	// author is not, and this bug exists because the second failure is
+	// invisible. The activity row itself is still written; only its
+	// human-readable detail is dropped, and the warning names the invariant
+	// so the cause is one grep away (codex round 3).
+	before := updated.PreUpdate
+	if before == nil {
+		slog.Warn("item update returned no pre-image; writing the activity without a change list",
+			"item_id", updated.ID, "workspace_id", workspaceID,
+			"invariant", "models.Item.PreUpdate is set by UpdateItemWithParentLink on every successful update")
 	}
-	if input.Title != nil && *input.Title != item.Title {
-		if meta == "" {
-			titleChange := fmt.Sprintf("title: %s → %s", item.Title, *input.Title)
-			meta = fmt.Sprintf(`{"changes":%q}`, titleChange)
+
+	var meta string
+	if before != nil {
+		if changes := diffFields(before.Fields, updated.Fields); changes != "" {
+			meta = fmt.Sprintf(`{"changes":%q}`, changes)
 		}
 	}
-	// Track role and assignment changes
-	if updated.AgentRoleSlug != item.AgentRoleSlug {
-		roleChange := fmt.Sprintf("role: %s → %s", valueOrEmpty(item.AgentRoleName), valueOrEmpty(updated.AgentRoleName))
-		meta = appendChange(meta, roleChange)
-	}
-	if updated.AssignedUserName != item.AssignedUserName {
-		assignChange := fmt.Sprintf("assigned: %s → %s", valueOrEmpty(item.AssignedUserName), valueOrEmpty(updated.AssignedUserName))
-		meta = appendChange(meta, assignChange)
+	// appendChange, not the old "only when meta is empty" form: a PATCH that
+	// renamed the item AND changed a field used to report the field change
+	// and silently drop the rename. Adjacent to the lines this fix rewrites,
+	// so folded in rather than filed.
+	if before != nil {
+		if updated.Title != before.Title {
+			meta = appendChange(meta, fmt.Sprintf("title: %s → %s", before.Title, updated.Title))
+		}
+		// Track role and assignment changes
+		if updated.AgentRoleSlug != before.AgentRoleSlug {
+			roleChange := fmt.Sprintf("role: %s → %s", valueOrEmpty(before.AgentRoleName), valueOrEmpty(updated.AgentRoleName))
+			meta = appendChange(meta, roleChange)
+		}
+		if updated.AssignedUserName != before.AssignedUserName {
+			assignChange := fmt.Sprintf("assigned: %s → %s", valueOrEmpty(before.AssignedUserName), valueOrEmpty(updated.AssignedUserName))
+			meta = appendChange(meta, assignChange)
+		}
 	}
 	actor, source := actorFromRequest(r)
 	activityID, _ := s.logActivityWithMetaReturningID(workspaceID, updated.ID, "updated", r, meta)

--- a/internal/server/handlers_items_preimage_test.go
+++ b/internal/server/handlers_items_preimage_test.go
@@ -1,0 +1,279 @@
+package server
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// BUG-2776. The item-update handler built its activity change list by diffing
+// the item it read at the TOP of the request — before the permission checks,
+// before the store's locks — against the row the store wrote. Anything another
+// writer committed inside that window appeared in the difference and was
+// stamped with THIS request's actor and agent name: the timeline gained a
+// confident false statement about who changed what.
+//
+// The store has re-read the row under its own locks since TASK-2533; the fix
+// hands that snapshot back as models.Item.PreUpdate and diffs against it.
+//
+// The interleaving is driven through the Server's afterItemPreRead seam rather
+// than by racing goroutines: the defect needs the competing write to land
+// strictly inside that window, and two real requests produce that ordering
+// only sometimes — a detector with an unknown rate reads as coverage without
+// being it.
+
+// TestItemUpdate_ConcurrentWriteNotAttributedToThisRequest is the regression
+// test. A rival agent commits a `status` change inside the window; this
+// request only ever touched `priority`. Its activity entry must say so.
+//
+// Against the unfixed handler this fails on the `status` assertion: the stale
+// snapshot predates the rival's write, so the diff reports both fields and
+// signs them with this request's agent name.
+func TestItemUpdate_ConcurrentWriteNotAttributedToThisRequest(t *testing.T) {
+	t.Parallel()
+	srv := testServer(t)
+	token, ws, itemSlug := debounceFixture(t, srv)
+
+	fired := 0
+	var hook func(string)
+	hook = func(string) {
+		if fired > 0 {
+			return
+		}
+		fired++
+		srv.afterItemPreRead = nil
+		defer func() { srv.afterItemPreRead = hook }()
+		// A DIFFERENT agent, so BUG-2763's writer-identity split keeps the
+		// rival's entry on its own row and this assertion stays about
+		// attribution rather than about coalescing.
+		authedAgentRequest(t, srv, token, "rival", "PATCH",
+			"/api/v1/workspaces/"+ws+"/items/"+itemSlug,
+			map[string]any{"fields_patch": map[string]any{"status": "done"}})
+	}
+	srv.afterItemPreRead = hook
+
+	authedAgentRequest(t, srv, token, "mine", "PATCH",
+		"/api/v1/workspaces/"+ws+"/items/"+itemSlug,
+		map[string]any{"fields_patch": map[string]any{"priority": "high"}})
+	srv.afterItemPreRead = nil
+
+	if fired != 1 {
+		t.Fatalf("seam fired %d times, want 1 — the test did not exercise the read-to-write window", fired)
+	}
+
+	entries := updatedActivityEntries(fetchTimelineAuthed(t, srv, token, ws, itemSlug).Entries)
+	var mine *models.TimelineEntry
+	for i := range entries {
+		if entries[i].Activity != nil && strings.Contains(changesOf(t, entries[i].Activity.Metadata), "priority") {
+			mine = &entries[i]
+		}
+	}
+	if mine == nil {
+		t.Fatalf("no activity entry recorded this request's priority change; entries=%d", len(entries))
+	}
+	changes := changesOf(t, mine.Activity.Metadata)
+	if strings.Contains(changes, "status") {
+		t.Errorf("this request's change list claims a change it did not make: %q — the rival's status write was attributed to it", changes)
+	}
+}
+
+// TestItemUpdate_RenameAndFieldChangeBothRecorded pins the adjacent defect
+// folded into the same fix: the title arm only wrote metadata when the field
+// diff had produced NONE, so a PATCH that renamed the item and changed a field
+// recorded the field and silently dropped the rename.
+func TestItemUpdate_RenameAndFieldChangeBothRecorded(t *testing.T) {
+	t.Parallel()
+	srv := testServer(t)
+	token, ws, itemSlug := debounceFixture(t, srv)
+
+	rr := authedAgentRequest(t, srv, token, "mine", "PATCH",
+		"/api/v1/workspaces/"+ws+"/items/"+itemSlug,
+		map[string]any{
+			"title":        "renamed subject",
+			"fields_patch": map[string]any{"status": "done"},
+		})
+	// The rename moves the slug, so the timeline must be fetched under the
+	// NEW one — the old path 404s.
+	var updated models.Item
+	decodeAttributionBody(t, rr, &updated)
+
+	entries := updatedActivityEntries(fetchTimelineAuthed(t, srv, token, ws, updated.Slug).Entries)
+	if len(entries) != 1 {
+		t.Fatalf("want 1 updated activity, got %d", len(entries))
+	}
+	changes := changesOf(t, entries[0].Activity.Metadata)
+	if !strings.Contains(changes, "status") {
+		t.Errorf("field change missing from %q", changes)
+	}
+	if !strings.Contains(changes, "title") {
+		t.Errorf("rename missing from %q — a PATCH that renames AND edits a field must record both", changes)
+	}
+}
+
+// TestItemUpdate_SameTitleOverwritingAConcurrentRenameIsRecorded is the title
+// arm's own discriminator. A rival renames the item inside the window; this
+// request then sets the title to the value IT last saw — which, against the
+// row as committed, is a real rename back.
+//
+// The old arm compared input.Title to the handler's stale read and saw them
+// equal, so it recorded nothing and the timeline lost a rename that happened.
+// Committed-vs-committed sees it.
+func TestItemUpdate_SameTitleOverwritingAConcurrentRenameIsRecorded(t *testing.T) {
+	t.Parallel()
+	srv := testServer(t)
+	token, ws, itemSlug := debounceFixture(t, srv)
+
+	original := "debounce subject"
+	fired := 0
+	var hook func(string)
+	hook = func(string) {
+		if fired > 0 {
+			return
+		}
+		fired++
+		srv.afterItemPreRead = nil
+		defer func() { srv.afterItemPreRead = hook }()
+		authedAgentRequest(t, srv, token, "rival", "PATCH",
+			"/api/v1/workspaces/"+ws+"/items/"+itemSlug,
+			map[string]any{"title": "rival rename"})
+	}
+	srv.afterItemPreRead = hook
+
+	rr := authedAgentRequest(t, srv, token, "mine", "PATCH",
+		"/api/v1/workspaces/"+ws+"/items/"+itemSlug,
+		map[string]any{"title": original})
+	srv.afterItemPreRead = nil
+	if fired != 1 {
+		t.Fatalf("seam fired %d times, want 1", fired)
+	}
+	var updated models.Item
+	decodeAttributionBody(t, rr, &updated)
+
+	entries := updatedActivityEntries(fetchTimelineAuthed(t, srv, token, ws, updated.Slug).Entries)
+	// DIRECTION, not membership. The rival's own entry reads
+	// "title: debounce subject → rival rename" and contains both strings, so
+	// a Contains-both assertion is satisfied by the rival's row and says
+	// nothing about this request's — it survived the mutation that restores
+	// the old input-vs-stale title arm. The entry under test is the one
+	// pointing the other way.
+	want := "rival rename → " + original
+	var all []string
+	found := false
+	for _, e := range entries {
+		if e.Activity == nil {
+			continue
+		}
+		c := changesOf(t, e.Activity.Metadata)
+		all = append(all, c)
+		if strings.Contains(c, want) {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("no entry records %q; change lists were %v", want, all)
+	}
+}
+
+// TestItemUpdate_ConcurrentRenameIsNotClaimedByAnUnrelatedPatch is the same
+// arm from the other side: a request that sends NO title must never acquire a
+// title change because someone else renamed the item inside the window.
+func TestItemUpdate_ConcurrentRenameIsNotClaimedByAnUnrelatedPatch(t *testing.T) {
+	t.Parallel()
+	srv := testServer(t)
+	token, ws, itemSlug := debounceFixture(t, srv)
+
+	fired := 0
+	var hook func(string)
+	hook = func(string) {
+		if fired > 0 {
+			return
+		}
+		fired++
+		srv.afterItemPreRead = nil
+		defer func() { srv.afterItemPreRead = hook }()
+		authedAgentRequest(t, srv, token, "rival", "PATCH",
+			"/api/v1/workspaces/"+ws+"/items/"+itemSlug,
+			map[string]any{"title": "rival rename"})
+	}
+	srv.afterItemPreRead = hook
+
+	rr := authedAgentRequest(t, srv, token, "mine", "PATCH",
+		"/api/v1/workspaces/"+ws+"/items/"+itemSlug,
+		map[string]any{"fields_patch": map[string]any{"priority": "high"}})
+	srv.afterItemPreRead = nil
+	if fired != 1 {
+		t.Fatalf("seam fired %d times, want 1", fired)
+	}
+	var updated models.Item
+	decodeAttributionBody(t, rr, &updated)
+
+	entries := updatedActivityEntries(fetchTimelineAuthed(t, srv, token, ws, updated.Slug).Entries)
+	for _, e := range entries {
+		if e.Activity == nil {
+			continue
+		}
+		c := changesOf(t, e.Activity.Metadata)
+		if strings.Contains(c, "priority") && strings.Contains(c, "title") {
+			t.Errorf("a PATCH that sent no title claimed a title change: %q", c)
+		}
+	}
+}
+
+// TestItemUpdate_NoOpPatchRecordsNoChange pins that the committed-vs-committed
+// comparison did not turn writes-that-change-nothing into timeline noise: a
+// PATCH re-sending a field's current value must produce no change list, and
+// therefore no "updated" entry the timeline will render.
+func TestItemUpdate_NoOpPatchRecordsNoChange(t *testing.T) {
+	t.Parallel()
+	srv := testServer(t)
+	token, ws, itemSlug := debounceFixture(t, srv)
+
+	authedAgentRequest(t, srv, token, "mine", "PATCH",
+		"/api/v1/workspaces/"+ws+"/items/"+itemSlug,
+		map[string]any{"fields_patch": map[string]any{"status": "in-progress"}})
+	before := len(updatedActivityEntries(fetchTimelineAuthed(t, srv, token, ws, itemSlug).Entries))
+
+	authedAgentRequest(t, srv, token, "mine", "PATCH",
+		"/api/v1/workspaces/"+ws+"/items/"+itemSlug,
+		map[string]any{"fields_patch": map[string]any{"status": "in-progress"}})
+	after := updatedActivityEntries(fetchTimelineAuthed(t, srv, token, ws, itemSlug).Entries)
+
+	for _, e := range after {
+		if e.Activity != nil && changesOf(t, e.Activity.Metadata) == "" {
+			t.Errorf("a no-op PATCH produced an activity entry with an empty change list")
+		}
+	}
+	if len(after) != before {
+		t.Errorf("no-op PATCH changed the rendered entry count: %d → %d", before, len(after))
+	}
+}
+
+// TestItemUpdate_SameTitleIsNotRecordedAsARename closes the gap the previous
+// test leaves open (codex round 3): RenameAndFieldChange would also pass an
+// implementation that records a title change for EVERY non-nil input.Title,
+// including a PATCH that re-sends the title it already has.
+func TestItemUpdate_SameTitleIsNotRecordedAsARename(t *testing.T) {
+	t.Parallel()
+	srv := testServer(t)
+	token, ws, itemSlug := debounceFixture(t, srv)
+
+	authedAgentRequest(t, srv, token, "mine", "PATCH",
+		"/api/v1/workspaces/"+ws+"/items/"+itemSlug,
+		map[string]any{
+			"title":        "debounce subject", // unchanged
+			"fields_patch": map[string]any{"status": "done"},
+		})
+
+	entries := updatedActivityEntries(fetchTimelineAuthed(t, srv, token, ws, itemSlug).Entries)
+	if len(entries) != 1 {
+		t.Fatalf("want 1 updated activity, got %d", len(entries))
+	}
+	changes := changesOf(t, entries[0].Activity.Metadata)
+	if !strings.Contains(changes, "status") {
+		t.Errorf("field change missing from %q", changes)
+	}
+	if strings.Contains(changes, "title") {
+		t.Errorf("re-sending the same title was recorded as a rename: %q", changes)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -40,6 +40,23 @@ import (
 )
 
 type Server struct {
+	// afterItemPreRead is a TEST-ONLY seam, nil in production. When set, the
+	// item-update handler calls it after loading its own copy of the item and
+	// before handing the write to the store — the window in which another
+	// writer can commit a change this request did not make (BUG-2776). A hook
+	// makes that interleaving deterministic; two real goroutines produce it
+	// only sometimes, and a test that reproduces a race sometimes is a
+	// detector with an unknown rate rather than a regression test.
+	//
+	// Set it only while no other request is in flight against this Server: it
+	// is read on a request path with no synchronisation.
+	//
+	// It fires once per item-update REQUEST, so a hook that issues its own
+	// update must nil the field for the duration of that nested call or it
+	// recurses without end. Every test here does exactly that; the pattern is
+	// load-bearing, not incidental (codex round 3).
+	afterItemPreRead func(itemID string)
+
 	store                 *store.Store
 	router                *chi.Mux
 	routerOnce            sync.Once            // ensures setupRouter runs once, after all config

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -2093,6 +2093,13 @@ func (s *Store) updateItemWithParentLinkOnce(
 		return nil, nil
 	}
 
+	// Test seam (BUG-2776): the pre-lock read above is stale by exactly this
+	// window, which is why the pre-image handed to the caller comes from the
+	// in-tx re-read below and not from here. Nil in production.
+	if s.afterItemPreLockRead != nil {
+		s.afterItemPreLockRead(id)
+	}
+
 	// Validate assignment scope before writing
 	if err := s.validateAssignmentScope(existing.WorkspaceID, input.AssignedUserID, input.AgentRoleID); err != nil {
 		return nil, err
@@ -2216,6 +2223,29 @@ func (s *Store) updateItemWithParentLinkOnce(
 		}
 		existing = fresh
 	}
+
+	// BUG-2776: keep this locked pre-write view for the CALLER. Everything
+	// below already uses `existing` for its own deltas; the handler that
+	// builds the activity's human-readable change list used to have no way
+	// to reach it and diffed its own pre-permission-check read instead,
+	// which attributed a concurrent writer's change to this request's
+	// author. It now consumes this field — see the change-list block in
+	// handlers_items.go::handleUpdateItem.
+	//
+	// A COPY, not the pointer — and honestly, a DEFENSIVE one: nothing below
+	// mutates `existing` today, so a mutation replacing this copy with the
+	// pointer survives the whole suite, and no test can be written that kills
+	// it without first introducing the mutation it guards against. It stays
+	// because the cost is one struct copy per update and the failure it
+	// prevents is silent (a later edit that normalises `existing` in place
+	// would corrupt a caller's pre-image with no signal), but it is guarded
+	// by argument rather than by a test and that is worth stating. It is also
+	// SHALLOW: a future in-place mutation through a POINTER member of
+	// `existing` (AssignedUserID, AgentRoleID, ParentID, ItemNumber) would
+	// still reach the caller's pre-image. Everything the change list reads —
+	// Fields, Tags, Title, and the joined display names — is a string, and a
+	// string cannot be mutated in place, so today's consumers are covered.
+	preUpdate := *existing
 
 	// Optimistic-concurrency guard runs FIRST — before the open-children
 	// precheck — so a caller who lost the race gets the promised
@@ -2671,6 +2701,11 @@ func (s *Store) updateItemWithParentLinkOnce(
 		sig := mutSignal
 		updated.LastMutation = &sig
 	}
+	// Unconditional, unlike LastMutation above: a caller diffing against the
+	// pre-image needs it on EVERY successful update, and "nil means nothing
+	// changed" would be indistinguishable from "nil because this path forgot
+	// to set it" at exactly the call site that must not guess (BUG-2776).
+	updated.PreUpdate = &preUpdate
 
 	// The choke point (SPEC-3 / TASK-2658). Emitted here — after the in-tx
 	// read-back and after the status/assignment deltas are computed, before

--- a/internal/store/items_preimage_test.go
+++ b/internal/store/items_preimage_test.go
@@ -1,0 +1,199 @@
+package store
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// assertSameFields compares two `fields` blobs by VALUE, not by bytes.
+// The column is TEXT on SQLite — which hands back exactly what was written —
+// and JSONB on Postgres, which re-serialises it (`{"status": "done"}` with a
+// space). A byte comparison therefore passes on one dialect and fails on the
+// other while saying nothing about the property under test, which is WHICH
+// snapshot the blob came from. Found by the Postgres leg after the SQLite
+// suite was green (BUG-2776).
+func assertSameFields(t *testing.T, label, got, want, why string) {
+	t.Helper()
+	var g, w any
+	if err := json.Unmarshal([]byte(got), &g); err != nil {
+		t.Fatalf("%s is not JSON: %q (%v)", label, got, err)
+	}
+	if err := json.Unmarshal([]byte(want), &w); err != nil {
+		t.Fatalf("want value is not JSON: %q (%v)", want, err)
+	}
+	if !reflect.DeepEqual(g, w) {
+		if why != "" {
+			t.Errorf("%s = %s, want %s — %s", label, got, want, why)
+		} else {
+			t.Errorf("%s = %s, want %s", label, got, want)
+		}
+	}
+}
+
+// BUG-2776. UpdateItemWithParentLink hands back the pre-write view it read
+// under its own locks, so a caller can describe what THIS call changed rather
+// than what changed since the caller last looked.
+//
+// These are the store half of the contract; the handler half (a concurrent
+// writer's change must not reach this request's change list) lives in
+// internal/server. Wiring is a claim, so both halves are tested — a pre-image
+// that is correct but never consumed fixes nothing (CONVE-19).
+
+func TestUpdateItem_PreUpdateIsTheLockedPreWriteView(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "PreImage")
+	coll := createTestCollection(t, s, ws.ID, "Tasks")
+	item := createTestItem(t, s, ws.ID, coll.ID, "Subject", "")
+
+	first := `{"status":"open"}`
+	if _, err := s.UpdateItemWithParentLink(item.ID, models.ItemUpdate{Fields: &first}, nil, nil); err != nil {
+		t.Fatalf("seed update: %v", err)
+	}
+
+	// A second writer commits BEFORE our call — the sequential stand-in for
+	// the concurrent case: what matters is that the pre-image is read at call
+	// time under the write lock, not carried in by the caller.
+	second := `{"status":"done"}`
+	if _, err := s.UpdateItemWithParentLink(item.ID, models.ItemUpdate{Fields: &second}, nil, nil); err != nil {
+		t.Fatalf("rival update: %v", err)
+	}
+
+	third := `{"status":"done","priority":"high"}`
+	updated, err := s.UpdateItemWithParentLink(item.ID, models.ItemUpdate{Fields: &third}, nil, nil)
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if updated.PreUpdate == nil {
+		t.Fatal("PreUpdate is nil on a successful update; every caller diffing against it would silently fall back to its own stale read")
+	}
+	assertSameFields(t, "PreUpdate.Fields", updated.PreUpdate.Fields, second,
+		"the pre-image must be the row as the WRITE LOCK saw it, not an earlier snapshot")
+	assertSameFields(t, "post-write fields", updated.Fields, third, "")
+}
+
+// TestUpdateItem_PreUpdateCarriesJoinedDisplayNames pins the part a narrower
+// pre-image would have broken: the handler's change list compares the assigned
+// user's NAME and the role's slug/name, not their ids. A pre-image read
+// without the users/agent_roles joins would leave those empty and invent
+// "assigned:  → Someone" on every update — a louder version of the bug this
+// field exists to fix.
+func TestUpdateItem_PreUpdateCarriesJoinedDisplayNames(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "PreImageJoins")
+	coll := createTestCollection(t, s, ws.ID, "Tasks")
+	item := createTestItem(t, s, ws.ID, coll.ID, "Subject", "")
+
+	role, err := s.CreateAgentRole(ws.ID, models.AgentRoleCreate{Name: "Implementer", Icon: "🔨"})
+	if err != nil {
+		t.Fatalf("create role: %v", err)
+	}
+	if _, err := s.UpdateItemWithParentLink(item.ID, models.ItemUpdate{AgentRoleID: &role.ID}, nil, nil); err != nil {
+		t.Fatalf("assign role: %v", err)
+	}
+
+	title := "Subject renamed"
+	updated, err := s.UpdateItemWithParentLink(item.ID, models.ItemUpdate{Title: &title}, nil, nil)
+	if err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+	if updated.PreUpdate == nil {
+		t.Fatal("PreUpdate is nil")
+	}
+	if updated.PreUpdate.AgentRoleName != role.Name || updated.PreUpdate.AgentRoleSlug != role.Slug {
+		t.Errorf("PreUpdate role = %q/%q, want %q/%q — the pre-image lost the joined display fields the change list compares",
+			updated.PreUpdate.AgentRoleName, updated.PreUpdate.AgentRoleSlug, role.Name, role.Slug)
+	}
+	if updated.PreUpdate.Title != "Subject" {
+		t.Errorf("PreUpdate.Title = %q, want the pre-rename title", updated.PreUpdate.Title)
+	}
+}
+
+// TestUpdateItem_PreUpdateComesFromTheLockedReRead is what makes the locked
+// re-read load-bearing rather than incidental. A rival commits inside the
+// window between this call's PRE-LOCK read and its transaction; the pre-image
+// must reflect the rival's committed value, because that is the row this
+// transaction is about to write over.
+//
+// Without this test a mutation that takes the pre-image from the pre-lock
+// snapshot SURVIVES the rest of the suite: every other test's rival write
+// lands before the store call begins, so both reads see the same thing and
+// the two implementations are indistinguishable. That is why the seam exists.
+func TestUpdateItem_PreUpdateComesFromTheLockedReRead(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "PreImageLock")
+	coll := createTestCollection(t, s, ws.ID, "Tasks")
+	item := createTestItem(t, s, ws.ID, coll.ID, "Subject", "")
+
+	seed := `{"status":"open"}`
+	if _, err := s.UpdateItemWithParentLink(item.ID, models.ItemUpdate{Fields: &seed}, nil, nil); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	rival := `{"status":"done"}`
+	fired := 0
+	var hook func(string)
+	hook = func(string) {
+		if fired > 0 {
+			return
+		}
+		fired++
+		s.afterItemPreLockRead = nil
+		defer func() { s.afterItemPreLockRead = hook }()
+		if _, err := s.UpdateItemWithParentLink(item.ID, models.ItemUpdate{Fields: &rival}, nil, nil); err != nil {
+			t.Errorf("rival update: %v", err)
+		}
+	}
+	s.afterItemPreLockRead = hook
+
+	mine := `{"status":"done","priority":"high"}`
+	updated, err := s.UpdateItemWithParentLink(item.ID, models.ItemUpdate{Fields: &mine}, nil, nil)
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	s.afterItemPreLockRead = nil
+
+	if fired != 1 {
+		t.Fatalf("seam fired %d times, want 1 — the pre-lock window was not exercised", fired)
+	}
+	if updated.PreUpdate == nil {
+		t.Fatal("PreUpdate is nil")
+	}
+	assertSameFields(t, "PreUpdate.Fields", updated.PreUpdate.Fields, rival,
+		"the pre-image was taken before the lock, so it predates a write this transaction is about to overwrite")
+}
+
+// TestUpdateItem_PreUpdateCarriesTheAssignedUser is the users-join half of the
+// display-name contract. Without it, an implementation that dropped the users
+// join while keeping the agent_roles one passes every other test here (codex
+// round 3) — and would make the handler report "assigned:  → Dave" on any
+// update to an already-assigned item.
+func TestUpdateItem_PreUpdateCarriesTheAssignedUser(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "PreImageAssignee")
+	coll := createTestCollection(t, s, ws.ID, "Tasks")
+	item := createTestItem(t, s, ws.ID, coll.ID, "Subject", "")
+	user := createTestUser(t, s, "assignee@test.com", "Assignee", "hunter2hunter2")
+	if err := s.AddWorkspaceMember(ws.ID, user.ID, "editor"); err != nil {
+		t.Fatalf("add member: %v", err)
+	}
+
+	if _, err := s.UpdateItemWithParentLink(item.ID, models.ItemUpdate{AssignedUserID: &user.ID}, nil, nil); err != nil {
+		t.Fatalf("assign: %v", err)
+	}
+
+	title := "Subject renamed"
+	updated, err := s.UpdateItemWithParentLink(item.ID, models.ItemUpdate{Title: &title}, nil, nil)
+	if err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+	if updated.PreUpdate == nil {
+		t.Fatal("PreUpdate is nil")
+	}
+	if updated.PreUpdate.AssignedUserName != user.Name {
+		t.Errorf("PreUpdate.AssignedUserName = %q, want %q — a pre-image without the users join makes every update on an assigned item report a spurious assignment change",
+			updated.PreUpdate.AssignedUserName, user.Name)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -61,6 +61,23 @@ type Store struct {
 	// every test that sets it does so synchronously and none is parallel).
 	afterDebounceRead func()
 
+	// afterItemPreLockRead is a TEST-ONLY seam, nil in production. When set,
+	// updateItemWithParentLinkOnce calls it after its pre-lock GetItem and
+	// before it opens the transaction — the window in which a concurrent
+	// writer can commit a change that this call must NOT attribute to its own
+	// caller (BUG-2776). It exists because that window is what makes the
+	// locked re-read load-bearing: without it a test cannot tell a pre-image
+	// taken from the pre-lock read apart from one taken under the lock, and a
+	// mutation swapping the two survives.
+	//
+	// Same usage constraint as afterDebounceRead: set it only while no other
+	// request is in flight against this Store. It fires once per ATTEMPT, so
+	// a hook that issues its own update must nil the field for the duration
+	// of that nested call — and note that updateItemWithParentLinkOnce runs
+	// under retryOnParentSetChanged, so a retried update fires it again
+	// (codex round 3).
+	afterItemPreLockRead func(itemID string)
+
 	// stopMaint signals the background WAL checkpointer to exit; maintDone
 	// is closed once it has. Both are nil on the Postgres path (no WAL
 	// file to checkpoint) and Close() guards on nil accordingly.


### PR DESCRIPTION
Fixes BUG-2776.

## The defect

`handleUpdateItem` built the activity's change list by diffing the item it read at the **top of the request** — before the permission checks, before the store's locks — against the row the store wrote. Anything a concurrent writer committed inside that window appeared in the difference and was stamped, with this request's actor and agent name, onto whoever sent the PATCH.

Agent A sets `status`, agent B sets `priority`, and B's timeline entry reads `status: open → done; priority: low → high` under B's name.

Unlike BUG-2770 — where a change went *missing* — the timeline here **gains a confident false statement about who did what**. And BUG-2770's debounce merges that statement forward into the coalesced row, so it outlives the request that invented it.

## The fix is a carrier, not new machinery

The store has re-read the row under its own locks since TASK-2533, unconditionally, and diffs *that* snapshot for its status and assignment signals. The handler simply had no way to reach it.

`models.Item.PreUpdate` hands the same snapshot back on the returned item — `json:"-"`, transient, populated only by the update path, following the existing `LastMutation` precedent. The title, role and assignment arms move onto it too, which makes the whole list **committed-vs-committed**: what this transaction wrote over, versus what it wrote.

**A missing pre-image drops the change list** rather than falling back to the handler's stale read. That fallback is the defect wearing a warning: an entry that says nothing is recoverable, one that names the wrong author is not. The activity row is still written and a `slog.Warn` names the invariant.

## Folded in

The title arm only recorded a rename when the field diff had produced **nothing**, so a PATCH that renamed *and* edited a field silently dropped the rename. Same lines, one `appendChange`.

## Test strategy

Two seams (`Server.afterItemPreRead`, `Store.afterItemPreLockRead`), nil in production, both documenting their reentrancy requirement. The second exists because of a **mutation that survived the first matrix**: with the rival's write landing before the store call, a pre-image taken from the store's *pre-lock* read is indistinguishable from one taken under the lock — the instrument could not see the difference the fix is about. That mutation now dies.

| Mutation | Result |
| --- | --- |
| Handler diffs its own stale `item` (the pre-fix behaviour) | dies — this is the counterfactual |
| Store drops `PreUpdate` | dies (4 tests) |
| Pre-image from the pre-lock read | dies (only after the second seam) |
| Title arm back to "only when nothing else changed" | dies |
| Title arm back to input-vs-stale | dies (after fixing my own oracle, below) |
| Change list sourced from the handler's `item` | dies |
| Pre-image aliased instead of copied | **survives by design**, stated in the code |

Two things worth flagging about the tests themselves:

- **My oracle was wrong once.** The same-title test asserted that *some* entry contained both `"rival rename"` and the original title — which the rival's **own** entry satisfies. It now asserts the rename **direction**, which only this request's entry can carry.
- **The Postgres leg earned its keep.** Two store assertions compared `fields` blobs byte-wise: passes on SQLite (TEXT, exact bytes), fails on Postgres (JSONB, re-serialised with spaces) — while proving nothing either way about *which snapshot* the blob came from. They compare by value now, through a documented helper.

## Gates

Run on tree `acd453bb`, which is **byte-identical** to this commit's tree (the squash changed the SHA, not the content — verified by comparing tree hashes rather than assuming):

- `go test ./...` on SQLite — exit 0, 28 packages, zero failures
- `make lint` — exit 0, "0 issues"
- Postgres `internal/store` (348s) + `internal/server` (126s) — exit 0, on a private container (5471; the shared 5445 untouched)

## Review

Five codex rounds, converged on two fresh-angle CLEANs (error/early-return + retry semantics; dialect comparisons, struct cost, and closure-as-filed). Round 3 made one claim that was **wrong** — that a test fetched the timeline by a stale slug; it already used `updated.Slug`, checked in source rather than accepted.
