### PR TITLE
fix(store): serialize document renames and stop reading the pool inside transactions (BUG-2778)

### DIFF
--- a/internal/server/document_lock_contention_test.go
+++ b/internal/server/document_lock_contention_test.go
@@ -1,0 +1,36 @@
+package server
+
+import (
+	"errors"
+	"testing"
+)
+
+// BUG-2778. A rename serializes per workspace with a 5s lock timeout, so
+// contention surfaces as SQLSTATE 55P03 — and a deadlock Postgres chooses to
+// break surfaces as 40P01. Both mean "try again"; a generic 500 tells the
+// caller the opposite.
+//
+// This drives the classifier directly rather than manufacturing contention
+// through the HTTP stack: producing a real 55P03 needs two concurrent
+// transactions and a Postgres backend, and the property under test is which
+// errors are classified retryable — not whether Postgres emits them.
+func TestIsRetryableLockError(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"lock timeout", errors.New(`ERROR: canceling statement due to lock timeout (SQLSTATE 55P03)`), true},
+		{"deadlock detected", errors.New(`ERROR: deadlock detected (SQLSTATE 40P01)`), true},
+		// Controls: a classifier that answered true for everything would pass
+		// the two legs above on its own.
+		{"unique violation", errors.New(`ERROR: duplicate key value violates unique constraint (SQLSTATE 23505)`), false},
+		{"invalid byte sequence", errors.New(`ERROR: invalid byte sequence for encoding "UTF8" (SQLSTATE 22021)`), false},
+		{"plain error", errors.New("update document: connection refused"), false},
+		{"nil", nil, false},
+	} {
+		if got := isRetryableLockError(tc.err); got != tc.want {
+			t.Errorf("%s: isRetryableLockError = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}

--- a/internal/server/handlers_documents.go
+++ b/internal/server/handlers_documents.go
@@ -106,6 +106,20 @@ func (s *Server) handleGetDocument(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, doc)
 }
 
+// isRetryableLockError reports whether a store error is Postgres telling the
+// caller that a LOCK was not available, rather than that the request was
+// wrong. 55P03 is the lock_timeout this codebase sets on the document-rename
+// lock; 40P01 is a deadlock Postgres broke by aborting this transaction.
+// Matched on the SQLSTATE text because that is what pgx puts in the error
+// string, the same way the UNIQUE-constraint mapping above works.
+func isRetryableLockError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "SQLSTATE 55P03") || strings.Contains(msg, "SQLSTATE 40P01")
+}
+
 func (s *Server) handleUpdateDocument(w http.ResponseWriter, r *http.Request) {
 	if !requireMinRole(w, r, "editor") {
 		return
@@ -134,6 +148,19 @@ func (s *Server) handleUpdateDocument(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		if strings.Contains(err.Error(), "UNIQUE constraint") {
 			writeError(w, http.StatusConflict, "conflict", "A document with this title already exists in this workspace")
+			return
+		}
+		// Lock contention is RETRYABLE and must not look like a bug
+		// (BUG-2778, codex round 6). A rename serializes per workspace with a
+		// 5s lock timeout, so a burst produces SQLSTATE 55P03
+		// (lock_not_available); 40P01 is a deadlock Postgres chose to abort.
+		// Both mean "try again", and a generic 500 tells the caller the
+		// opposite — that the request will never succeed. Retry-After is
+		// deliberately short: the holder is one transaction, not a queue.
+		if isRetryableLockError(err) {
+			w.Header().Set("Retry-After", "1")
+			writeError(w, http.StatusServiceUnavailable, "lock_contention",
+				"The workspace is busy with another rename; retry in a moment")
 			return
 		}
 		writeInternalError(w, err)

--- a/internal/server/handlers_items_open_children_guard.go
+++ b/internal/server/handlers_items_open_children_guard.go
@@ -207,7 +207,10 @@ func (s *Server) runOpenChildrenGuard(tx *sql.Tx, ctx openChildrenGuardContext) 
 			// the collection's done-field is e.g. `resolution` with
 			// custom terminal_options). Mirrors the inclusion rule
 			// childrenDoneFiltersForParent uses (items.go ≈2165).
-			if coll, cerr := s.store.GetCollectionAnyState(child.CollectionID); cerr == nil && coll != nil {
+			// Through the guard's OWN transaction (BUG-2778): this runs
+			// inside the item-update tx, and a pool read from here needs a
+			// second connection while that tx holds the first.
+			if coll, cerr := s.store.GetCollectionAnyStateTx(tx, child.CollectionID); cerr == nil && coll != nil {
 				_ = json.Unmarshal([]byte(coll.Schema), &dc.schema)
 				if coll.Settings != "" {
 					_ = json.Unmarshal([]byte(coll.Settings), &dc.settings)

--- a/internal/server/open_children_guard_pool_test.go
+++ b/internal/server/open_children_guard_pool_test.go
@@ -1,0 +1,68 @@
+package server
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// BUG-2778 class sweep, last instance. The open-children guard runs INSIDE the
+// item-update transaction and read each child's collection through the POOL,
+// which needs a second connection while the transaction holds the first —
+// the application-level deadlock this unit is about, reached indirectly
+// through GetCollectionAnyState rather than by a query in the transaction
+// body, which is why a grep-shaped sweep missed it.
+//
+// It lives in the server package because the guard does: only a PATCH that
+// moves a PARENT into a terminal status with children attached reaches it, so
+// the store-level pool test cannot exercise this path at all. A mutation
+// sending that read back to the pool survives every store test and dies here.
+func TestOpenChildrenGuard_DoesNotReadThroughThePoolInsideTheTransaction(t *testing.T) {
+	t.Parallel()
+	srv := testServer(t)
+	slug := createTestWorkspaceViaAPI(t, srv)
+
+	planResp := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/plans/items", map[string]any{
+		"title":  "Parent plan",
+		"fields": `{"status":"active"}`,
+	})
+	if planResp.Code != http.StatusCreated {
+		t.Fatalf("create plan: %d: %s", planResp.Code, planResp.Body.String())
+	}
+	var plan models.Item
+	parseJSON(t, planResp, &plan)
+
+	childResp := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items", map[string]any{
+		"title":  "Open child",
+		"fields": `{"status":"open","parent":"` + plan.Ref + `"}`,
+	})
+	if childResp.Code != http.StatusCreated {
+		t.Fatalf("create child: %d: %s", childResp.Code, childResp.Body.String())
+	}
+
+	// One connection: any read the guard sends to the pool now waits for a
+	// connection only its own transaction could free.
+	srv.store.DB().SetMaxOpenConns(1)
+
+	done := make(chan int, 1)
+	go func() {
+		rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+plan.Slug, map[string]any{
+			"fields_patch": map[string]any{"status": "completed"},
+		})
+		done <- rr.Code
+	}()
+
+	select {
+	case code := <-done:
+		// The guard is expected to REFUSE the transition (an open child
+		// exists) — the point is that it answers at all. A 409 and a 200 are
+		// both fine here; a hang is not.
+		if code == 0 {
+			t.Fatalf("no status code")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("PATCH stalled with a one-connection pool — the open-children guard read through the pool from inside the update transaction")
+	}
+}

--- a/internal/store/attachments.go
+++ b/internal/store/attachments.go
@@ -1495,7 +1495,23 @@ func (s *Store) RemapAttachmentReferencesInWorkspace(workspaceID string, oldToNe
 	}
 	defer tx.Rollback()
 
-	rows, err := tx.Query(s.q(`SELECT id, content, fields FROM items WHERE workspace_id = ? AND deleted_at IS NULL`), workspaceID)
+	// ORDER BY id (BUG-2778 class sweep): this gathers rows and then UPDATEs
+	// them one by one inside a transaction, so the scan's order IS the lock
+	// order. Two concurrent remaps in one workspace would otherwise be free to
+	// take the same row locks in different orders — Postgres does not promise
+	// a stable seq-scan order, and synchronize_seqscans deliberately starts
+	// concurrent scans at different points.
+	//
+	// SCOPE OF THE CLAIM (codex round 6): this makes the CONTENT-ROW updates
+	// below take their locks in one order for every caller. It does not order
+	// the attachment rows stampAttachmentRefsTx locks elsewhere in the same
+	// transaction, so it is not "the whole deadlock class removed" — it
+	// removes the cycle between two concurrent remaps' own row updates, which
+	// is the one this sweep found. Unlike the rename path in documents.go,
+	// where the second stage locks the renamed row itself and ordering the
+	// cascade therefore cannot help, ordering IS sufficient for the cycle
+	// between these per-row updates.
+	rows, err := tx.Query(s.q(`SELECT id, content, fields FROM items WHERE workspace_id = ? AND deleted_at IS NULL ORDER BY id`), workspaceID)
 	if err != nil {
 		return fmt.Errorf("scan items for remap: %w", err)
 	}
@@ -1530,7 +1546,7 @@ func (s *Store) RemapAttachmentReferencesInWorkspace(workspaceID string, oldToNe
 	// while the freshly-cloned rows they should have pointed at end up
 	// referenced by nothing and eventually reclaimed (BUG-2615). Comments have
 	// no deleted_at column, hence no filter here.
-	crows, err := tx.Query(s.q(`SELECT id, body FROM comments WHERE workspace_id = ?`), workspaceID)
+	crows, err := tx.Query(s.q(`SELECT id, body FROM comments WHERE workspace_id = ? ORDER BY id`), workspaceID)
 	if err != nil {
 		return fmt.Errorf("scan comments for remap: %w", err)
 	}

--- a/internal/store/collections.go
+++ b/internal/store/collections.go
@@ -175,7 +175,14 @@ func (s *Store) scanCollectionRow(q rowQueryer, query string, args ...any) (*mod
 }
 
 func (s *Store) GetCollection(id string) (*models.Collection, error) {
-	c, err := s.scanCollectionRow(s.db, getCollectionQuery, id)
+	return s.getCollectionQ(s.db, id)
+}
+
+// getCollectionQ is GetCollection against a caller-supplied executor, so an
+// in-transaction caller reads through its own transaction instead of asking
+// the pool for a second connection while holding the first (BUG-2778).
+func (s *Store) getCollectionQ(q Queryer, id string) (*models.Collection, error) {
+	c, err := s.scanCollectionRow(q, getCollectionQuery, id)
 	if err != nil {
 		return nil, fmt.Errorf("get collection: %w", err)
 	}
@@ -194,7 +201,21 @@ func (s *Store) GetCollection(id string) (*models.Collection, error) {
 // doneFiltersForWorkspace, both of which already include soft-deleted
 // collections for exactly this reason.
 func (s *Store) GetCollectionAnyState(id string) (*models.Collection, error) {
-	c, err := s.scanCollectionRow(s.db, getCollectionAnyStateQuery, id)
+	return s.getCollectionAnyStateQ(s.db, id)
+}
+
+// GetCollectionAnyStateTx is GetCollectionAnyState through an OPEN
+// TRANSACTION. Exported for the open-children guard, which runs inside the
+// item-update transaction and must not ask the pool for a second connection
+// while that transaction holds the first (BUG-2778).
+func (s *Store) GetCollectionAnyStateTx(tx *sql.Tx, id string) (*models.Collection, error) {
+	return s.getCollectionAnyStateQ(tx, id)
+}
+
+// getCollectionAnyStateQ is GetCollectionAnyState against a caller-supplied
+// executor.
+func (s *Store) getCollectionAnyStateQ(q Queryer, id string) (*models.Collection, error) {
+	c, err := s.scanCollectionRow(q, getCollectionAnyStateQuery, id)
 	if err != nil {
 		return nil, fmt.Errorf("get collection (any state): %w", err)
 	}
@@ -396,7 +417,7 @@ func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*mod
 		if isReservedCollectionSlug(baseSlug) {
 			baseSlug = baseSlug + "-collection"
 		}
-		newSlug, err := s.uniqueSlugExcluding("collections", "workspace_id", existing.WorkspaceID, baseSlug, id)
+		newSlug, err := s.uniqueSlugExcluding(s.db, "collections", "workspace_id", existing.WorkspaceID, baseSlug, id)
 		if err != nil {
 			return nil, fmt.Errorf("unique slug: %w", err)
 		}

--- a/internal/store/documents.go
+++ b/internal/store/documents.go
@@ -214,12 +214,35 @@ func (s *Store) CreateDocument(workspaceID string, input models.DocumentCreate) 
 }
 
 func (s *Store) GetDocument(id string) (*models.Document, error) {
+	return s.getDocumentQ(s.db, id)
+}
+
+// getDocumentTx reads a document through an OPEN TRANSACTION, so the caller
+// sees the row as its own transaction sees it and needs no second pool
+// connection while the first is held (BUG-2778). Same SELECT and hydration
+// as GetDocument.
+//
+// Deliberately NOT `FOR UPDATE`. An earlier version locked the row here to
+// stop a concurrent soft-delete committing before the write at the end of the
+// rename — but the rows-affected guard on that write already makes the
+// outcome atomic (the whole transaction, cascade included, rolls back), so
+// the lock changed only WHICH writer wins, not whether the result is
+// consistent. A mutation removing it survived the suite, which is the honest
+// signal that it was a second mechanism for a window one mechanism already
+// covers; the remaining guard has its own justification and its own test.
+func (s *Store) getDocumentTx(tx *sql.Tx, id string) (*models.Document, error) {
+	return s.getDocumentQ(tx, id)
+}
+
+// getDocumentQ is the one document-row read behind GetDocument and
+// getDocumentTx, differing only in executor.
+func (s *Store) getDocumentQ(q rowQueryer, id string) (*models.Document, error) {
 	var d models.Document
 	var createdAt, updatedAt string
 	var deletedAt *string
 	var pinned bool
 
-	err := s.db.QueryRow(s.q(`
+	err := q.QueryRow(s.q(`
 		SELECT id, workspace_id, title, slug, content, doc_type, status, tags,
 		       pinned, sort_order, created_by, last_modified_by, source,
 		       created_at, updated_at, deleted_at
@@ -253,11 +276,80 @@ func (s *Store) UpdateDocument(id string, input models.DocumentUpdate) (*models.
 		return nil, nil
 	}
 
+	// Test seam (BUG-2778): the read above is stale by exactly this window,
+	// which is why the rename decision and the cascade's old title come from
+	// the re-read below. Nil in production.
+	if s.afterDocumentPreLockRead != nil {
+		s.afterDocumentPreLockRead(id)
+	}
+
 	tx, err := s.db.Begin()
 	if err != nil {
 		return nil, err
 	}
 	defer tx.Rollback()
+
+	// BUG-2778: serialize TITLE RENAMES per workspace on Postgres, before
+	// this transaction takes any row lock.
+	//
+	// A rename locks rows in two stages: updateLinksInTx writes every OTHER
+	// document whose content links the old title, and the UPDATE at the end
+	// of this function writes THIS document. Two concurrent renames of
+	// documents that link to each other therefore take the same two row locks
+	// in opposite orders — tx1 locks B then wants A, tx2 locks A then wants B
+	// — and Postgres aborts one with SQLSTATE 40P01. Measured, not argued:
+	// before this lock, a probe that renamed two mutually-linking documents
+	// concurrently deadlocked on 12 of 12 rounds.
+	//
+	// WHY NOT `ORDER BY id` ON THE CASCADE, which is what BUG-2778 proposed
+	// when it was filed from reading rather than from a repro: the cycle does
+	// not come from the ORDER of the cascade's own rows. Each transaction's
+	// cascade set here is a single row, and the cycle is cascade-then-self.
+	// Ordering the cascade leaves it exactly as reachable; only a rule that
+	// covers BOTH stages removes it.
+	//
+	// A workspace-scoped advisory lock rather than a sorted lock batch,
+	// because the two stages touch different tables and different row sets
+	// (versions, the slug-uniqueness scan) and a sorted batch would have to
+	// predict all of them. It is the same instrument BUG-2074 uses for
+	// parent-edge writes, on its own namespaced key so renames contend only
+	// with renames. No-op on SQLite, whose single writer cannot produce the
+	// cycle at all (the probe found zero deadlocks there).
+	//
+	// It fires whenever a title is SUPPLIED, not only when the supplied title
+	// differs from what we read before the lock — deciding that from the
+	// pre-lock value is precisely the staleness this block exists to remove,
+	// and a same-title PATCH is a cheap uncontended lock acquisition.
+	if input.Title != nil {
+		if err := s.acquireWorkspaceDocumentRenameLock(tx, existing.WorkspaceID); err != nil {
+			return nil, err
+		}
+		// Re-read UNDER the lock and decide from that row, not from the
+		// pre-transaction read above (codex round 1). `existing` was loaded
+		// before this transaction and before this lock, so a rename that
+		// committed in between is invisible to it — and every decision below
+		// is made from it: whether to cascade at all, and which OLD TITLE the
+		// cascade rewrites. Two concurrent renames of the SAME document could
+		// therefore leave backlinks pointing at a title nothing carries any
+		// more, or skip the cascade entirely because the stale row's title
+		// happens to equal the requested one. This is the same defect family
+		// as BUG-2776 one layer down: a decision made from a snapshot taken
+		// before the lock that protects it.
+		//
+		// The lock is taken whenever a title is SUPPLIED rather than only
+		// when it differs from the stale read — deciding that from the stale
+		// value is exactly what this block exists to stop.
+		fresh, ferr := s.getDocumentTx(tx, id)
+		if ferr != nil {
+			return nil, fmt.Errorf("re-read document under rename lock: %w", ferr)
+		}
+		if fresh == nil {
+			// Deleted between the pre-tx read and the lock; the caller's 404
+			// path handles a nil document.
+			return nil, nil
+		}
+		existing = fresh
+	}
 
 	// Stamp the incoming content's attachment references first (BUG-2614,
 	// same protocol and ordering as items and comments). Only when content is
@@ -287,7 +379,10 @@ func (s *Store) UpdateDocument(id string, input models.DocumentUpdate) (*models.
 		forceVersion := input.Title != nil && *input.Title != existing.Title
 		shouldVersion := forceVersion
 		if !shouldVersion {
-			shouldVersion, err = s.ShouldCreateVersion(id, createdBy, source)
+			// Through the transaction, not the pool (BUG-2778): this runs
+			// with the transaction open and, for a rename, with the rename
+			// lock held.
+			shouldVersion, err = s.shouldCreateVersionQ(tx, id, createdBy, source)
 			if err != nil {
 				return nil, fmt.Errorf("check version throttle: %w", err)
 			}
@@ -346,7 +441,7 @@ func (s *Store) UpdateDocument(id string, input models.DocumentUpdate) (*models.
 		if baseSlug == "" {
 			baseSlug = "untitled"
 		}
-		newSlug, err := s.uniqueSlugExcluding("documents", "workspace_id", existing.WorkspaceID, baseSlug, id)
+		newSlug, err := s.uniqueSlugExcluding(tx, "documents", "workspace_id", existing.WorkspaceID, baseSlug, id)
 		if err != nil {
 			return nil, fmt.Errorf("unique slug: %w", err)
 		}
@@ -386,11 +481,34 @@ func (s *Store) UpdateDocument(id string, input models.DocumentUpdate) (*models.
 		args = append(args, input.Source)
 	}
 
+	if s.afterDocumentPreWrite != nil {
+		s.afterDocumentPreWrite(id)
+	}
+
 	args = append(args, id)
-	query := fmt.Sprintf("UPDATE documents SET %s WHERE id = ?", strings.Join(sets, ", "))
-	_, err = tx.Exec(s.q(query), args...)
+	// deleted_at IS NULL, and the row count is CHECKED (BUG-2778): without
+	// it, a document soft-deleted since this transaction began is written
+	// anyway — and on the rename path the backlink cascade above has already
+	// rewritten every linker, so the caller is told not-found (GetDocument
+	// filters archived rows) while those rewrites stay behind. Returning
+	// early here leaves the deferred Rollback to undo the cascade with it, so
+	// the rename and its cascade land together or not at all.
+	//
+	// This is the ONLY thing standing between a concurrent soft-delete and a
+	// write to the archived row — on every path, rename or not. A
+	// content-only PATCH takes no rename lock and holds no row lock until
+	// this statement, so the delete can land at any point before it.
+	query := fmt.Sprintf("UPDATE documents SET %s WHERE id = ? AND deleted_at IS NULL", strings.Join(sets, ", "))
+	res, err := tx.Exec(s.q(query), args...)
 	if err != nil {
 		return nil, fmt.Errorf("update document: %w", err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return nil, fmt.Errorf("update document: rows affected: %w", err)
+	}
+	if affected == 0 {
+		return nil, nil
 	}
 
 	if err := tx.Commit(); err != nil {
@@ -398,6 +516,51 @@ func (s *Store) UpdateDocument(id string, input models.DocumentUpdate) (*models.
 	}
 
 	return s.GetDocument(id)
+}
+
+// acquireWorkspaceDocumentRenameLock serializes document TITLE RENAMES within
+// a workspace on Postgres (BUG-2778). Its key is namespaced so it contends
+// only with other renames — reusing acquireWorkspaceSeqLock's bare workspace
+// key would have made every rename wait behind every item-number and seq
+// write in the workspace, and vice versa, for no benefit: the cycle this
+// closes is rename-against-rename (codex round 2). Same shape and no-op
+// dialect gate as acquireWorkspaceParentLinkLock.
+func (s *Store) acquireWorkspaceDocumentRenameLock(tx *sql.Tx, workspaceID string) error {
+	if s.dialect.Driver() != DriverPostgres {
+		return nil
+	}
+	// BOUNDED WAIT (codex round 5). The transaction has already taken a pool
+	// connection by the time it waits here, so an unbounded wait converts
+	// lock contention into pool exhaustion: a burst of renames in ONE
+	// workspace can pin connections and stall unrelated work, and a client
+	// disconnecting does not cancel the wait (the HTTP context is not
+	// threaded into this call).
+	//
+	// WHAT THE 5s DOES AND DOES NOT COVER, because a bound with no receipt
+	// invites more trust than it earns: it bounds each LOCK WAIT inside this
+	// transaction once the connection is already held. It does NOT bound the
+	// transaction's total duration, and it does NOT bound the wait for a pool
+	// connection BEFORE Begin() — a saturated pool still queues callers ahead
+	// of this code. The number is a safety cap chosen to be far above any
+	// plausible uncontended acquisition, NOT a tuned value: no rename-duration
+	// or cascade-size percentile has been measured, and this comment should
+	// not be read as if one had. Measure before treating 5s as meaningful.
+	//
+	// SET LOCAL, so it dies with the transaction rather than leaking back to
+	// the pool. It also bounds the row-lock waits later in this transaction,
+	// which is intended by the same argument.
+	if _, err := tx.Exec("SET LOCAL lock_timeout = '5s'"); err != nil {
+		return fmt.Errorf("set rename lock timeout: %w", err)
+	}
+	// An operator seeing contention here sees it as wait_event_type='Lock',
+	// wait_event='advisory' in pg_stat_activity, with this query text — the
+	// 'pad:document-rename:' literal is what identifies the class. The
+	// workspace id is a bound parameter and will not appear in the text;
+	// pg_blocking_pids() on the waiter finds the holder.
+	if _, err := tx.Exec("SELECT pg_advisory_xact_lock(hashtext('pad:document-rename:' || $1))", workspaceID); err != nil {
+		return fmt.Errorf("acquire workspace document-rename lock: %w", err)
+	}
+	return nil
 }
 
 func (s *Store) updateLinksInTx(tx *sql.Tx, workspaceID, oldTitle, newTitle string) error {
@@ -430,7 +593,24 @@ func (s *Store) updateLinksInTx(tx *sql.Tx, workspaceID, oldTitle, newTitle stri
 	}
 
 	for _, du := range updates {
-		_, err = tx.Exec(s.q("UPDATE documents SET content = ? WHERE id = ?"), du.content, du.id)
+		// deleted_at IS NULL here too (codex round 4): the SELECT above filters
+		// archived linkers, but a soft-delete can land between that read and
+		// this write, and an unqualified UPDATE would then rewrite the content
+		// of a document the user has already archived. A zero-row result is
+		// the NORMAL outcome of that race and not an error — the linker is
+		// gone, so there is no link left to keep consistent.
+		//
+		// UNTESTED, and deliberately kept anyway. A mutation removing this
+		// clause survives the suite: reaching it needs a delete landing
+		// between the SELECT a few lines above and this loop, which no
+		// existing seam can schedule and which would cost a fifth one. It
+		// stays because it closes a window NOTHING else covers — the opposite
+		// of the FOR UPDATE this unit deleted, which survived its mutation
+		// because another mechanism already covered the same window. Same
+		// signal, opposite disposition, and the difference is whether the
+		// guard is redundant or merely unreachable by the current
+		// instruments.
+		_, err = tx.Exec(s.q("UPDATE documents SET content = ? WHERE id = ? AND deleted_at IS NULL"), du.content, du.id)
 		if err != nil {
 			return err
 		}

--- a/internal/store/documents_rename_deadlock_test.go
+++ b/internal/store/documents_rename_deadlock_test.go
@@ -1,0 +1,442 @@
+package store
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// BUG-2778. A document rename writes rows in two stages inside one
+// transaction: updateLinksInTx rewrites every OTHER document whose content
+// links the old title, and the final UPDATE writes the renamed document
+// itself. Two concurrent renames of documents that link to each other take
+// those two row locks in opposite orders, and Postgres aborts one of them
+// with SQLSTATE 40P01 — a 500 on an ordinary rename.
+//
+// This is a MEASURED failure, not a reasoned one. The measurement was a
+// separate throwaway probe against the unfixed code, which deadlocked on 12
+// of 12 rounds; THIS test is not that probe and does not reproduce the
+// figure — it asserts the absence of the failure over 8 rounds against the
+// fixed code, and dies to the mutations that remove or misplace the lock.
+// The distinction matters because "12 of 12" is evidence from a run nobody
+// can repeat by reading this file (codex round 6).
+//
+// The bug was originally filed (by me) as a lock-ORDERING problem in the
+// cascade loop, and reproducing it is what showed that diagnosis to be wrong
+// — each transaction's cascade set is a single row, so ordering that loop
+// changes nothing. The fix serializes renames per workspace.
+//
+// POSTGRES ONLY, and skipped loudly elsewhere rather than passing quietly:
+// SQLite's single writer cannot produce the cycle, so a green run there is
+// not evidence about this fix. Running it on SQLite would add a passing test
+// that could never fail, which reads as coverage without being it.
+func TestUpdateDocument_ConcurrentMutualRenamesDoNotDeadlock(t *testing.T) {
+	s := testStore(t)
+	if s.dialect.Driver() != DriverPostgres {
+		t.Skip("asserts a Postgres row-lock property; SQLite serializes writers and cannot exhibit the cycle")
+	}
+	ws := createTestWorkspace(t, s, "RenameDeadlock")
+
+	// Several rounds because the interleaving is scheduler-dependent. The
+	// start barrier below releases both goroutines together, which makes
+	// overlap LIKELY, not certain — nothing here can guarantee two
+	// transactions interleave at the statement that matters, which is why
+	// this runs rounds rather than asserting on one (codex round 6). Each
+	// round uses fresh titles: the (workspace_id, title) unique constraint
+	// makes reuse a different error.
+	const rounds = 8
+	for i := 0; i < rounds; i++ {
+		suffix := string(rune('A' + i))
+		ta, tb := "Alpha"+suffix, "Beta"+suffix
+		a := createTestDoc(t, s, ws.ID, ta, "links to [["+tb+"]]")
+		b := createTestDoc(t, s, ws.ID, tb, "links to [["+ta+"]]")
+
+		newA, newB := ta+"-renamed", tb+"-renamed"
+		var wg sync.WaitGroup
+		errs := make([]error, 2)
+		// Start barrier: without it the two renames can run end to end and the
+		// round proves nothing (codex round 3). Closing the channel releases
+		// both goroutines at the same instant, which makes overlap likely —
+		// it cannot make it certain, since nothing here controls when each
+		// transaction reaches the statement that takes the second lock.
+		start := make(chan struct{})
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, errs[0] = s.UpdateDocument(a.ID, models.DocumentUpdate{Title: &newA})
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			_, errs[1] = s.UpdateDocument(b.ID, models.DocumentUpdate{Title: &newB})
+		}()
+		close(start)
+		// Bounded wait so a failure reports as THIS test failing rather than
+		// as a package-wide timeout (codex round 4). Postgres aborts a
+		// detected deadlock within deadlock_timeout — a second by default —
+		// so the unfixed code fails fast rather than hanging; the bound is
+		// for the case where something holds a lock nothing releases, which
+		// is the failure mode with no other signal.
+		done := make(chan struct{})
+		go func() { wg.Wait(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(30 * time.Second):
+			t.Fatalf("round %d: renames did not finish within 30s — a lock is being held that nothing releases", i)
+		}
+
+		for j, err := range errs {
+			if err == nil {
+				continue
+			}
+			if strings.Contains(err.Error(), "deadlock") || strings.Contains(err.Error(), "40P01") {
+				t.Fatalf("round %d writer %d deadlocked: %v", i, j, err)
+			}
+			t.Fatalf("round %d writer %d failed: %v", i, j, err)
+		}
+
+		// Both renames must have actually landed — otherwise a fix that
+		// serialized by REFUSING one of them would pass the assertion above.
+		for _, want := range []struct {
+			id, title string
+		}{{a.ID, newA}, {b.ID, newB}} {
+			got, err := s.GetDocument(want.id)
+			if err != nil {
+				t.Fatalf("round %d: get document: %v", i, err)
+			}
+			if got.Title != want.title {
+				t.Errorf("round %d: title = %q, want %q — serializing must not drop a rename", i, got.Title, want.title)
+			}
+		}
+	}
+}
+
+// TestUpdateDocument_CascadeUsesTheTitleUnderTheLock is the correctness half
+// of BUG-2778's fix, and it discriminates a mutation the deadlock test cannot
+// see: keeping the re-read but continuing to DECIDE from the pre-lock
+// snapshot.
+//
+// A rename's cascade rewrites `[[oldTitle]]` in every other document. If the
+// old title comes from a read taken before the lock, a rename that commits in
+// that window makes it the wrong string: the cascade then rewrites a title
+// nothing carries any more, and every backlink is left pointing at a title
+// that no longer resolves.
+func TestUpdateDocument_CascadeUsesTheTitleUnderTheLock(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "CascadeTitle")
+	target := createTestDoc(t, s, ws.ID, "One", "the subject")
+	linker := createTestDoc(t, s, ws.ID, "Linker", "points at [[One]]")
+
+	fired := 0
+	var hook func(string)
+	hook = func(string) {
+		if fired > 0 {
+			return
+		}
+		fired++
+		s.afterDocumentPreLockRead = nil
+		defer func() { s.afterDocumentPreLockRead = hook }()
+		// A competing rename lands inside the window. It rewrites the linker
+		// to [[Two]] as it goes, so the pre-read's "One" is now a string no
+		// document contains.
+		two := "Two"
+		if _, err := s.UpdateDocument(target.ID, models.DocumentUpdate{Title: &two}); err != nil {
+			t.Errorf("competing rename: %v", err)
+		}
+	}
+	s.afterDocumentPreLockRead = hook
+
+	three := "Three"
+	if _, err := s.UpdateDocument(target.ID, models.DocumentUpdate{Title: &three}); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+	s.afterDocumentPreLockRead = nil
+
+	if fired != 1 {
+		t.Fatalf("seam fired %d times, want 1 — the pre-lock window was not exercised", fired)
+	}
+
+	got, err := s.GetDocument(linker.ID)
+	if err != nil {
+		t.Fatalf("get linker: %v", err)
+	}
+	if !strings.Contains(got.Content, "[[Three]]") {
+		t.Errorf("linker content = %q, want a [[Three]] link — the cascade rewrote the title from the pre-lock read instead of the row under the lock, so the backlink was left dangling", got.Content)
+	}
+}
+
+// TestUpdateDocument_RenameBackToTheStaleTitleStillCascades covers the case a
+// mutation exposed: gating the lock (and the re-read) on the PRE-LOCK title
+// comparison rather than on a title being supplied at all.
+//
+// A competing rename takes the document One→Two, rewriting the linker to
+// [[Two]] on its way. This request then asks for "One" — which equals the
+// title its stale read saw, so a gate written against that read concludes
+// "no rename" and skips both the lock and the cascade. The row's title column
+// is still written, so the document ends up titled One with every backlink
+// pointing at [[Two]]: a rename that silently breaks its own links.
+func TestUpdateDocument_RenameBackToTheStaleTitleStillCascades(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "RenameBack")
+	target := createTestDoc(t, s, ws.ID, "One", "the subject")
+	linker := createTestDoc(t, s, ws.ID, "Linker", "points at [[One]]")
+
+	fired := 0
+	var hook func(string)
+	hook = func(string) {
+		if fired > 0 {
+			return
+		}
+		fired++
+		s.afterDocumentPreLockRead = nil
+		defer func() { s.afterDocumentPreLockRead = hook }()
+		two := "Two"
+		if _, err := s.UpdateDocument(target.ID, models.DocumentUpdate{Title: &two}); err != nil {
+			t.Errorf("competing rename: %v", err)
+		}
+	}
+	s.afterDocumentPreLockRead = hook
+
+	// The title this request asks for is the one its stale read reported.
+	one := "One"
+	if _, err := s.UpdateDocument(target.ID, models.DocumentUpdate{Title: &one}); err != nil {
+		t.Fatalf("rename back: %v", err)
+	}
+	s.afterDocumentPreLockRead = nil
+
+	if fired != 1 {
+		t.Fatalf("seam fired %d times, want 1", fired)
+	}
+
+	got, err := s.GetDocument(target.ID)
+	if err != nil {
+		t.Fatalf("get target: %v", err)
+	}
+	if got.Title != "One" {
+		t.Fatalf("target title = %q, want One", got.Title)
+	}
+	link, err := s.GetDocument(linker.ID)
+	if err != nil {
+		t.Fatalf("get linker: %v", err)
+	}
+	if !strings.Contains(link.Content, "[[One]]") {
+		t.Errorf("linker content = %q, want [[One]] — the document is titled One, so a backlink left at [[Two]] resolves to nothing", link.Content)
+	}
+}
+
+// TestUpdateDocument_DeletedArchivedBeforeTheLockIsNotRenamed pins the
+// EARLY-RETURN half: a delete that lands before the transaction's re-read
+// makes that read return nil, and the rename must stop there.
+//
+// Precise about what it does NOT show (codex round 6): the cascade has not
+// run at this point, so this is not evidence that a cascade gets rolled
+// back. The rows-affected guard that provides that atomicity is exercised by
+// TestUpdateDocument_DeleteLandingBeforeTheWriteIsNotOverwritten, on a path
+// where it is the only mechanism.
+func TestUpdateDocument_DeletedArchivedBeforeTheLockIsNotRenamed(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "DeleteRace")
+	target := createTestDoc(t, s, ws.ID, "Doomed", "the subject")
+	linker := createTestDoc(t, s, ws.ID, "Linker", "points at [[Doomed]]")
+
+	fired := 0
+	s.afterDocumentPreLockRead = func(string) {
+		if fired > 0 {
+			return
+		}
+		fired++
+		if err := s.DeleteDocument(target.ID); err != nil {
+			t.Errorf("concurrent delete: %v", err)
+		}
+	}
+
+	renamed := "Renamed"
+	got, err := s.UpdateDocument(target.ID, models.DocumentUpdate{Title: &renamed})
+	s.afterDocumentPreLockRead = nil
+	if err != nil {
+		t.Fatalf("rename over a deleted document: %v", err)
+	}
+	if got != nil {
+		t.Errorf("rename of a soft-deleted document returned %+v, want nil (not found)", got)
+	}
+	if fired != 1 {
+		t.Fatalf("seam fired %d times, want 1", fired)
+	}
+
+	link, err := s.GetDocument(linker.ID)
+	if err != nil {
+		t.Fatalf("get linker: %v", err)
+	}
+	if !strings.Contains(link.Content, "[[Doomed]]") {
+		t.Errorf("linker content = %q — the cascade committed even though the rename did not", link.Content)
+	}
+}
+
+// TestDocumentRenameLock_DoesNotContendWithTheSeqLock pins the reason the
+// rename key is its own key. A half-fix that reused acquireWorkspaceSeqLock's
+// bare workspace key serializes renames just as well and passes every other
+// test here (codex round 2) — while also making every rename wait behind every
+// item-number and seq write in the workspace, and vice versa. The difference
+// is invisible in behaviour and visible only in contention, so this asserts
+// contention directly.
+//
+// Both legs matter: the seq key must be FREE while a rename holds its lock
+// (that is the property), and the rename key must be TAKEN (otherwise the
+// first leg passes against an implementation that acquires nothing at all).
+func TestDocumentRenameLock_DoesNotContendWithTheSeqLock(t *testing.T) {
+	s := testStore(t)
+	if s.dialect.Driver() != DriverPostgres {
+		t.Skip("advisory locks are a Postgres construct; the helper is a no-op elsewhere")
+	}
+	ws := createTestWorkspace(t, s, "LockKeys")
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer tx.Rollback()
+	if err := s.acquireWorkspaceDocumentRenameLock(tx, ws.ID); err != nil {
+		t.Fatalf("acquire rename lock: %v", err)
+	}
+
+	other, err := s.db.Begin()
+	if err != nil {
+		t.Fatalf("begin second: %v", err)
+	}
+	defer other.Rollback()
+
+	var seqFree bool
+	if err := other.QueryRow("SELECT pg_try_advisory_xact_lock(hashtext($1))", ws.ID).Scan(&seqFree); err != nil {
+		t.Fatalf("probe seq key: %v", err)
+	}
+	if !seqFree {
+		t.Error("holding the document-rename lock blocked the workspace seq key — renames would serialize against every item write in the workspace")
+	}
+
+	var renameFree bool
+	if err := other.QueryRow("SELECT pg_try_advisory_xact_lock(hashtext('pad:document-rename:' || $1))", ws.ID).Scan(&renameFree); err != nil {
+		t.Fatalf("probe rename key: %v", err)
+	}
+	if renameFree {
+		t.Error("control: the rename key was acquirable while a transaction claims to hold it — the lock is not being taken at all")
+	}
+}
+
+// TestUpdateDocument_DeleteLandingBeforeTheWriteIsNotOverwritten covers the
+// window the previous test cannot reach: a soft-delete that commits AFTER
+// this transaction's own read, with the write already prepared. The path
+// chosen is a content-only PATCH, which takes no rename lock at all — so the
+// rows-affected guard on the final UPDATE is the only thing preventing a
+// write to an archived row, and it is tested where it is the sole mechanism
+// rather than where another one would mask it.
+func TestUpdateDocument_DeleteLandingBeforeTheWriteIsNotOverwritten(t *testing.T) {
+	s := testStore(t)
+	if s.dialect.Driver() != DriverPostgres {
+		// SQLite cannot reach this interleaving at all: the open transaction
+		// holds the database's single write lock, so the delete inside the
+		// seam blocks until busy_timeout and fails. The guard is unreachable
+		// there — which is a fact about the engine, not coverage, so the skip
+		// says it rather than letting a green SQLite run imply otherwise.
+		t.Skip("the interleaving requires MVCC; SQLite's write lock blocks the concurrent delete outright")
+	}
+	ws := createTestWorkspace(t, s, "DeleteBeforeWrite")
+	doc := createTestDoc(t, s, ws.ID, "Subject", "original body")
+
+	fired := 0
+	s.afterDocumentPreWrite = func(string) {
+		if fired > 0 {
+			return
+		}
+		fired++
+		if err := s.DeleteDocument(doc.ID); err != nil {
+			t.Errorf("concurrent delete: %v", err)
+		}
+	}
+
+	body := "rewritten body"
+	got, err := s.UpdateDocument(doc.ID, models.DocumentUpdate{Content: &body})
+	s.afterDocumentPreWrite = nil
+	if err != nil {
+		t.Fatalf("update over a deleted document: %v", err)
+	}
+	if fired != 1 {
+		t.Fatalf("seam fired %d times, want 1", fired)
+	}
+	if got != nil {
+		t.Errorf("update of a soft-deleted document returned %+v, want nil (not found)", got)
+	}
+
+	// Read the archived row directly: GetDocument filters it out, so it
+	// cannot show whether the write landed on it.
+	var content string
+	var deletedAt *string
+	if err := s.db.QueryRow(s.q(`SELECT content, deleted_at FROM documents WHERE id = ?`), doc.ID).Scan(&content, &deletedAt); err != nil {
+		t.Fatalf("read archived row: %v", err)
+	}
+	if deletedAt == nil {
+		t.Fatal("document is not archived; the test did not exercise the race")
+	}
+	if content != "original body" {
+		t.Errorf("archived row content = %q, want it untouched — the update wrote over a document that had already been deleted", content)
+	}
+}
+
+// TestUpdateDocument_RenameWaitIsBounded pins the lock timeout. Without it a
+// rename waiting on the workspace lock holds its pool connection for as long
+// as the holder runs, which is how lock contention becomes pool exhaustion —
+// the failure mode is a stalled server, not an error, so nothing surfaces.
+//
+// A held lock is manufactured directly (a transaction that takes the key and
+// sits on it), because that is the only way to make the wait deterministic;
+// what is asserted is that the waiting rename FAILS, in bounded time, with
+// the SQLSTATE the handler maps to a retryable 503.
+func TestUpdateDocument_RenameWaitIsBounded(t *testing.T) {
+	s := testStore(t)
+	if s.dialect.Driver() != DriverPostgres {
+		t.Skip("advisory locks and lock_timeout are Postgres constructs; the helper is a no-op elsewhere")
+	}
+	ws := createTestWorkspace(t, s, "BoundedWait")
+	doc := createTestDoc(t, s, ws.ID, "Held", "body")
+
+	holder, err := s.db.Begin()
+	if err != nil {
+		t.Fatalf("begin holder: %v", err)
+	}
+	defer holder.Rollback()
+	if err := s.acquireWorkspaceDocumentRenameLock(holder, ws.ID); err != nil {
+		t.Fatalf("holder acquire: %v", err)
+	}
+
+	type result struct {
+		err     error
+		elapsed time.Duration
+	}
+	done := make(chan result, 1)
+	go func() {
+		started := time.Now()
+		title := "Renamed while blocked"
+		_, rerr := s.UpdateDocument(doc.ID, models.DocumentUpdate{Title: &title})
+		done <- result{err: rerr, elapsed: time.Since(started)}
+	}()
+
+	select {
+	case r := <-done:
+		if r.err == nil {
+			t.Fatal("the blocked rename succeeded while another transaction held the lock")
+		}
+		if !strings.Contains(r.err.Error(), "55P03") {
+			t.Errorf("blocked rename failed with %v, want SQLSTATE 55P03 (lock_not_available) — that is what the handler maps to a retryable 503", r.err)
+		}
+		// The bound is 5s; allow slack for scheduling, but fail if the wait
+		// was effectively unbounded.
+		if r.elapsed > 20*time.Second {
+			t.Errorf("blocked rename took %s — the lock_timeout did not bound the wait", r.elapsed)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("blocked rename never returned — the wait is unbounded and its pool connection is pinned for the holder's lifetime")
+	}
+}

--- a/internal/store/event_outbox.go
+++ b/internal/store/event_outbox.go
@@ -499,9 +499,16 @@ func (s *Store) ScrubOutboxUserRefsTx(tx *sql.Tx, userID string) error {
 		// a full-table parse for a caller bug. Refuse instead.
 		return fmt.Errorf("outbox: scrub user refs: no user id")
 	}
+	// ORDER BY id: same reason as the attachment remap (BUG-2778 class
+	// sweep) — the scan order is the lock order for the per-row UPDATEs
+	// below, and two scrubs whose LIKE matches overlap must not take those
+	// locks in opposite orders. Scoped to those per-row updates: any bulk
+	// statement elsewhere in this transaction takes its own locks in its own
+	// order (codex round 6).
 	rows, err := tx.Query(s.q(`
 		SELECT id, payload FROM event_outbox
 		WHERE subject_id = ? OR CAST(payload AS TEXT) LIKE ?
+		ORDER BY id
 	`), userID, "%"+userID+"%")
 	if err != nil {
 		return fmt.Errorf("outbox: scrub user refs: find rows: %w", err)

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -2324,7 +2324,7 @@ func (s *Store) updateItemWithParentLinkOnce(
 		forceVersion := input.ForceVersion || (input.Title != nil && *input.Title != existing.Title)
 		shouldVersion := forceVersion
 		if !shouldVersion {
-			shouldVersion, err = s.shouldCreateItemVersion(id, createdBy, source)
+			shouldVersion, err = s.shouldCreateItemVersion(tx, id, createdBy, source)
 			if err != nil {
 				return nil, fmt.Errorf("check version throttle: %w", err)
 			}
@@ -2368,7 +2368,7 @@ func (s *Store) updateItemWithParentLinkOnce(
 		if baseSlug == "" {
 			baseSlug = "untitled"
 		}
-		newSlug, err := s.uniqueSlugExcluding("items", "workspace_id", existing.WorkspaceID, baseSlug, id)
+		newSlug, err := s.uniqueSlugExcluding(tx, "items", "workspace_id", existing.WorkspaceID, baseSlug, id)
 		if err != nil {
 			return nil, fmt.Errorf("unique slug: %w", err)
 		}
@@ -2511,7 +2511,7 @@ func (s *Store) updateItemWithParentLinkOnce(
 	// see the new status and the hop would vanish.
 	var statusBefore, doneKey string
 	if input.Fields != nil {
-		doneKey = s.doneFieldKey(existing.CollectionID)
+		doneKey = s.doneFieldKeyQ(tx, existing.CollectionID)
 		statusBefore = extractFieldValue(existing.Fields, doneKey)
 	}
 
@@ -4702,7 +4702,7 @@ func (s *Store) moveItemWithPreCheckOnce(
 	// (where the item now lives and which reports group by); for a move that
 	// also crosses to a collection with a different done field, the old value
 	// read through that key may be empty, which correctly reads as "entered".
-	moveDoneKey := s.doneFieldKey(targetCollectionID)
+	moveDoneKey := s.doneFieldKeyQ(tx, targetCollectionID)
 	oldFields := existing.Fields
 
 	// preMove is the item as it stands UNDER THE LOCK, immediately before the
@@ -4898,10 +4898,20 @@ func buildItemSort(sort string, dialect Dialect) string {
 	return " ORDER BY " + strings.Join(parts, ", ")
 }
 
-// shouldCreateItemVersion mirrors ShouldCreateVersion but queries item_versions.
-func (s *Store) shouldCreateItemVersion(itemID, actor, source string) (bool, error) {
+// shouldCreateItemVersion mirrors ShouldCreateVersion but queries
+// item_versions. It takes the executor for the same reason its document twin
+// does (BUG-2778): its only caller runs inside a transaction holding the
+// workspace seq and parent-children locks, and a read sent to the POOL from
+// there needs a second connection while the first is held.
+//
+// This one was MISSED by the first sweep and found in review: the sweep
+// followed uniqueSlugExcluding's call sites and the document version check,
+// and the pool test's item leg was a TITLE-only update, which never reaches
+// this branch. A test that exercises one arm of an optional path is not
+// evidence about the other arm.
+func (s *Store) shouldCreateItemVersion(q rowQueryer, itemID, actor, source string) (bool, error) {
 	var createdBy, src, createdAt string
-	err := s.db.QueryRow(s.q(`
+	err := q.QueryRow(s.q(`
 		SELECT created_by, source, created_at
 		FROM item_versions
 		WHERE item_id = ?

--- a/internal/store/oauth_connections_backfill.go
+++ b/internal/store/oauth_connections_backfill.go
@@ -323,7 +323,8 @@ func (s *Store) backfillOneChain(requestID string, chain backfillChain) (created
 	//     the partial scope permanent. Codex review #583 round 4
 	//     caught the gap.
 	for _, slug := range explicit {
-		ws, getErr := s.GetWorkspaceBySlug(slug)
+		// Through the open transaction (BUG-2778).
+		ws, getErr := s.getWorkspaceBySlugQ(tx, slug)
 		if getErr != nil {
 			return false, 0, 0, fmt.Errorf("workspace lookup %s: %w", slug, getErr)
 		}

--- a/internal/store/pool_read_in_tx_test.go
+++ b/internal/store/pool_read_in_tx_test.go
@@ -1,0 +1,106 @@
+package store
+
+import (
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// BUG-2778, second half. A read issued against the connection POOL from
+// inside an open transaction needs a SECOND connection while the first is
+// still held. Under a saturated pool that second connection never arrives,
+// and the transaction cannot finish — so it never releases what it holds.
+// The deadlock is in the application, not the database: no SQLSTATE names it,
+// no lock timeout breaks it, and the request simply hangs.
+//
+// `uniqueSlugExcluding` was doing exactly that from two in-transaction
+// callers (the item update, under the workspace seq and parent-children
+// locks; the document rename, under the lock this bug added). It now takes
+// the executor.
+//
+// THE INSTRUMENT: a one-connection pool. That makes the hazard deterministic
+// rather than load-dependent — with a single connection, the pool is
+// saturated by definition the moment a transaction is open, so a pool read
+// inside one cannot ever succeed. Against the unfixed code these calls block
+// until the test's timeout; with the fix they use the transaction they are
+// already inside and return immediately.
+func TestPoolReadInsideTransaction_RenameAndItemUpdateDoNotStall(t *testing.T) {
+	// Runs on BOTH dialects. An earlier version skipped Postgres on the
+	// theory that the instrument was SQLite-shaped, which left the
+	// content-edit leg — the most reachable instance of the hazard — never
+	// exercised against the pool the production deployment actually uses
+	// (codex round 4). A one-connection pool is a property of database/sql,
+	// not of either driver.
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "PoolRead")
+	coll := createTestCollection(t, s, ws.ID, "Tasks")
+	item := createTestItem(t, s, ws.ID, coll.ID, "Item title", "")
+	doc := createTestDoc(t, s, ws.ID, "Doc title", "body")
+
+	// One connection: any pool read from inside a transaction now waits for a
+	// connection that only the transaction itself could free.
+	s.db.SetMaxOpenConns(1)
+
+	for _, tc := range []struct {
+		name string
+		run  func() error
+	}{
+		{"document rename", func() error {
+			title := "Doc title renamed"
+			_, err := s.UpdateDocument(doc.ID, models.DocumentUpdate{Title: &title})
+			return err
+		}},
+		{"item title update", func() error {
+			title := "Item title renamed"
+			_, err := s.UpdateItemWithParentLink(item.ID, models.ItemUpdate{Title: &title}, nil, nil)
+			return err
+		}},
+		// A title-only item update never reaches the version check, so this
+		// leg is what covers shouldCreateItemVersion — the instance the first
+		// sweep missed precisely because the leg above looked like coverage
+		// of "the item path" (codex round 7).
+		{"item content edit", func() error {
+			content := "edited item body"
+			_, err := s.UpdateItemWithParentLink(item.ID, models.ItemUpdate{Content: &content}, nil, nil)
+			return err
+		}},
+		// A FIELD update reaches doneFieldKey, which reads the collection —
+		// an INDIRECT pool read that a grep for `s.db` inside transaction
+		// bodies cannot see, and that neither leg above touches (codex round
+		// 8). Three legs on the item path, each reaching a different read.
+		{"item field update", func() error {
+			fields := `{"status":"done"}`
+			_, err := s.UpdateItemWithParentLink(item.ID, models.ItemUpdate{Fields: &fields}, nil, nil)
+			return err
+		}},
+		// A MOVE resolves the done key against the TARGET collection through
+		// the same helper, from a different transaction.
+		{"item move", func() error {
+			other := createTestCollection(t, s, ws.ID, "Archive")
+			_, err := s.MoveItem(item.ID, other.ID, `{}`)
+			return err
+		}},
+		// The version check is the MORE reachable instance of the same
+		// hazard: it fires on any content edit, not only on a rename, and the
+		// two legs above miss it entirely (codex round 3). A content-only
+		// PATCH takes no rename lock and still runs a read inside the open
+		// transaction.
+		{"document content edit", func() error {
+			body := "edited body"
+			_, err := s.UpdateDocument(doc.ID, models.DocumentUpdate{Content: &body})
+			return err
+		}},
+	} {
+		done := make(chan error, 1)
+		go func() { done <- tc.run() }()
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Errorf("%s: %v", tc.name, err)
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatalf("%s stalled with a one-connection pool — a read inside the transaction went to the pool instead of the transaction", tc.name)
+		}
+	}
+}

--- a/internal/store/status_transitions_backfill.go
+++ b/internal/store/status_transitions_backfill.go
@@ -66,7 +66,17 @@ func parseFieldChange(changes, fieldKey string) (from, to string, ok bool) {
 // field. Best-effort: any lookup/parse failure falls back to "status" so
 // capture degrades gracefully rather than dropping rows.
 func (s *Store) doneFieldKey(collectionID string) string {
-	col, err := s.GetCollection(collectionID)
+	return s.doneFieldKeyQ(s.db, collectionID)
+}
+
+// doneFieldKeyQ is doneFieldKey against a caller-supplied executor. The item
+// update and move paths call it from INSIDE their transaction, where a read
+// sent to the pool needs a second connection while the first is held
+// (BUG-2778) — an indirect instance of that class, reached through
+// GetCollection rather than by querying directly, which is why the first
+// sweep for `s.db` inside transactions did not find it.
+func (s *Store) doneFieldKeyQ(q Queryer, collectionID string) string {
+	col, err := s.getCollectionQ(q, collectionID)
 	if err != nil || col == nil {
 		return "status"
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -78,6 +78,24 @@ type Store struct {
 	// (codex round 3).
 	afterItemPreLockRead func(itemID string)
 
+	// afterDocumentPreLockRead is a TEST-ONLY seam, nil in production. When
+	// set, UpdateDocument calls it after its pre-transaction read and before
+	// it opens the transaction that takes the rename lock (BUG-2778) — the
+	// window in which another rename of the SAME document can commit, making
+	// the pre-read's title the WRONG old title for the backlink cascade.
+	//
+	// Same usage constraints as the seams above: set it only while no other
+	// request is in flight against this Store, and a hook that issues its own
+	// update must nil the field for the duration or it recurses.
+	afterDocumentPreLockRead func(documentID string)
+
+	// afterDocumentPreWrite is a TEST-ONLY seam, nil in production. When set,
+	// UpdateDocument calls it immediately before its final UPDATE — the last
+	// moment at which a concurrent soft-delete can still commit ahead of that
+	// write on a path holding no row lock (BUG-2778). Same usage constraints
+	// as the seams above.
+	afterDocumentPreWrite func(documentID string)
+
 	// stopMaint signals the background WAL checkpointer to exit; maintDone
 	// is closed once it has. Both are nil on the Postgres path (no WAL
 	// file to checkpoint) and Close() guards on nil accordingly.
@@ -856,12 +874,24 @@ func findStatementEnd(sql string) int {
 
 // uniqueSlugExcluding generates a unique slug, excluding a specific document ID
 // from the collision check. Used during title renames.
-func (s *Store) uniqueSlugExcluding(table, scopeCol, scopeVal, baseSlug, excludeID string) (string, error) {
+// It takes the executor rather than reaching for s.db, because TWO of its
+// three callers run inside a transaction that already holds locks — the item
+// update (items.go, under the workspace seq and parent-children locks) and
+// the document rename (documents.go, under the rename lock this bug added).
+// A read issued against the POOL from inside such a transaction needs a
+// SECOND connection while the first is held, and if the pool is saturated by
+// callers waiting on the very lock this transaction holds, that second
+// connection never arrives: the deadlock is then in the application rather
+// than in the database, where no SQLSTATE names it and no lock timeout breaks
+// it. The third caller (UpdateCollection) runs BEFORE its transaction opens
+// and correctly passes the pool — checked rather than assumed, after an
+// earlier version of this comment claimed all three were in-transaction.
+func (s *Store) uniqueSlugExcluding(q rowQueryer, table, scopeCol, scopeVal, baseSlug, excludeID string) (string, error) {
 	slug := baseSlug
 	for i := 2; ; i++ {
 		var count int
 		query := fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE %s = ? AND slug = ? AND id != ?", table, scopeCol)
-		err := s.db.QueryRow(s.q(query), scopeVal, slug, excludeID).Scan(&count)
+		err := q.QueryRow(s.q(query), scopeVal, slug, excludeID).Scan(&count)
 		if err != nil {
 			return "", err
 		}

--- a/internal/store/versions.go
+++ b/internal/store/versions.go
@@ -16,7 +16,17 @@ const VersionThrottleInterval = 1 * time.Hour
 // ShouldCreateVersion determines whether a new version snapshot should be created,
 // based on time since last version, actor/source changes, and content type.
 func (s *Store) ShouldCreateVersion(documentID, actor, source string) (bool, error) {
-	latest, err := s.getLatestVersionRaw(documentID)
+	return s.shouldCreateVersionQ(s.db, documentID, actor, source)
+}
+
+// shouldCreateVersionQ is ShouldCreateVersion against a caller-supplied
+// executor. UpdateDocument calls it from INSIDE its transaction, and a read
+// issued against the pool from there needs a second connection while the
+// first is held — the application-level deadlock BUG-2778's other half is
+// about. This is the more reachable instance of the two: it fires on any
+// content edit, not only a rename.
+func (s *Store) shouldCreateVersionQ(q rowQueryer, documentID, actor, source string) (bool, error) {
+	latest, err := s.getLatestVersionRawQ(q, documentID)
 	if err != nil {
 		return false, err
 	}
@@ -49,10 +59,16 @@ func (s *Store) GetLatestVersion(documentID string) (*models.Version, error) {
 
 // getLatestVersionRaw returns the most recent version without resolving diffs.
 func (s *Store) getLatestVersionRaw(documentID string) (*models.Version, error) {
+	return s.getLatestVersionRawQ(s.db, documentID)
+}
+
+// getLatestVersionRawQ is getLatestVersionRaw against a caller-supplied
+// executor, so an in-transaction caller reads through its own transaction.
+func (s *Store) getLatestVersionRawQ(q rowQueryer, documentID string) (*models.Version, error) {
 	var v models.Version
 	var createdAt string
 	var isDiff bool
-	err := s.db.QueryRow(s.q(`
+	err := q.QueryRow(s.q(`
 		SELECT id, document_id, content, change_summary, created_by, source, is_diff, created_at
 		FROM versions
 		WHERE document_id = ?

--- a/internal/store/workspaces.go
+++ b/internal/store/workspaces.go
@@ -124,11 +124,18 @@ func (s *Store) uniqueWorkspaceSlug(baseSlug string) (string, error) {
 }
 
 func (s *Store) GetWorkspaceBySlug(slug string) (*models.Workspace, error) {
+	return s.getWorkspaceBySlugQ(s.db, slug)
+}
+
+// getWorkspaceBySlugQ is GetWorkspaceBySlug against a caller-supplied
+// executor, for callers already inside a transaction (BUG-2778: a pool read
+// from inside one needs a second connection while the first is held).
+func (s *Store) getWorkspaceBySlugQ(q rowQueryer, slug string) (*models.Workspace, error) {
 	var w models.Workspace
 	var createdAt, updatedAt string
 	var deletedAt *string
 
-	err := s.db.QueryRow(s.q(`
+	err := q.QueryRow(s.q(`
 		SELECT w.id, w.name, w.slug, w.owner_id, COALESCE(ou.username, ''), w.description, w.settings, w.source, w.created_at, w.updated_at, w.deleted_at
 		FROM workspaces w
 		LEFT JOIN users ou ON ou.id = w.owner_id


### PR DESCRIPTION
Fixes BUG-2778. Two deadlocks — one in the database, one in the application.

## 1. The database deadlock (what was filed)

A rename takes row locks in **two stages** inside one transaction: `updateLinksInTx` writes every *other* document linking the old title, then the final UPDATE writes *this* document. Two concurrent renames of mutually-linking documents take those locks in opposite orders, and Postgres aborts one with SQLSTATE 40P01 — a 500 on an ordinary rename.

**Measured, not argued: a throwaway probe against the unfixed code deadlocked on 12 of 12 rounds.** (That figure is the probe's. The checked-in test asserts the *absence* of the failure over 8 rounds and dies to the mutations below; it is not a re-run of the probe.)

**Why not `ORDER BY id`** — which is what I proposed when I filed this from reading rather than from a repro: each transaction's cascade set is a **single row**, and the cycle is cascade-then-self. Run as a mutation, that fix fails the regression test. Reproducing the bug is what refuted my own diagnosis.

The fix is a dedicated per-workspace advisory key (`pad:document-rename:<ws>`), taken before any row lock, whenever a title is supplied. No-op on SQLite. `SET LOCAL lock_timeout = '5s'` bounds the wait — a transaction that waits with a pool connection already in hand turns contention into pool exhaustion — and 55P03/40P01 now map to a retryable **503 `lock_contention`** instead of a generic 500.

## 2. The application deadlock (found in review; larger)

Seven production paths read through the connection **pool** from inside an open transaction. Under a saturated pool the second connection never arrives, the transaction can't finish, and it therefore never releases what it holds. **No SQLSTATE names this, no lock timeout breaks it, and nothing errors** — the request just stops.

| Path | Read |
| --- | --- |
| document rename, item update | `uniqueSlugExcluding` |
| document content edit | `ShouldCreateVersion` |
| item content edit | `shouldCreateItemVersion` |
| item field update, item move | `doneFieldKey` → `GetCollection` *(indirect)* |
| open-children guard | `GetCollectionAnyState` *(indirect)* |
| OAuth startup backfill | `GetWorkspaceBySlug` |

All seven now take their executor. **Three were found only after asking for the true population instead of "is this instance fixed"**, and two are indirect — reached through `GetCollection`, where a grep for `s.db` inside transaction bodies finds nothing. A final sweep reports zero remaining.

The instrument is a **one-connection pool**: with a single connection the pool is saturated by definition while a transaction is open, so the hazard is deterministic rather than load-dependent.

## 3. Also fixed, adjacent

- **The rename decided from a pre-lock snapshot.** The lock made the cascade safe against another rename and then handed it a stale *old title*. It now re-reads under the lock and decides from that row. (BUG-2776's shape, one layer down — the third time in two days.)
- **A concurrent soft-delete could commit mid-rename**, leaving the cascade's rewrites behind while the caller was told not-found. The final UPDATE carries `deleted_at IS NULL` with a **checked** row count, so the rename and its cascade land together or not at all.
- **Class sweep (CONVE-18)** of the same unordered-scan-then-per-row-update shape: attachment remap (items + comments) and the outbox user-ref scrub are now ordered. Scoped claim — it orders those per-row updates, not every lock in those transactions — and **not reproduced**, unlike the rename.

## Mutations

**18 aimed, 15 die.** The three survivors have written dispositions where they live:

- **Equivalent mutant** — "lock before the cascade" ≡ "lock at the top of the transaction", because the cascade *is* the first row-locking stage. The genuinely different variant (lock *after* the cascade) dies.
- **Cascade `deleted_at` guard** — covers a window no existing seam can schedule; kept, and the code says it is untested and why. Contrast with the `FOR UPDATE` I *deleted* this unit when its mutation survived: that one was redundant with a mechanism that already covered the window, this one is merely unreachable by current instruments.
- **Remap `ORDER BY`** — the class-sweep half, no repro.

## Gates

On this exact tip: `go test ./...` SQLite exit 0 (28 packages) · `make lint` 0 issues · Postgres `internal/store` 354.865s + `internal/server` 123.757s exit 0, on a private container (5480; shared 5445 untouched, sibling's 5472 untouched).

Three tests skip loudly on SQLite (deadlock, lock-key, delete-before-write, bounded-wait) — SQLite's single writer cannot exhibit any of them, and a green default run is not evidence about them.

## Filed, not folded

**BUG-2785** — the cascade overwrites a concurrent content edit to a linker (a lost update inside `updateLinksInTx`, BUG-2770's shape one table over). Needs a compare-and-set and a seam between the cascade's read and its write.

## Caveat

The OAuth backfill fix is **untested** — it runs only at server startup for connections with explicit workspace lists, and I'd rather say so than write a test that doesn't reach it.
