### PR TITLE
fix(store): never return an activity id alongside an error (BUG-2779)

### DIFF
--- a/internal/server/handlers_comments.go
+++ b/internal/server/handlers_comments.go
@@ -114,8 +114,13 @@ func (s *Server) handleCreateComment(w http.ResponseWriter, r *http.Request) {
 
 	// Log activity first so we can link the comment to the activity record.
 	// This prevents duplicate timeline entries (one for the comment, one for the activity).
-	// Only set ActivityID on success — comments.activity_id has a FK constraint,
-	// and CreateActivity returns an ID even on insert failure.
+	// Only set ActivityID on success — comments.activity_id has a FK
+	// constraint. The guard used to be load-bearing for a second reason:
+	// CreateActivity returned an id even on insert failure. It no longer
+	// does (BUG-2779 made an empty id part of the contract for every error
+	// path), so this check is now belt on top of that contract rather than
+	// the only thing between a failed write and a dangling FK. Kept because
+	// it costs nothing and expresses the caller's own requirement.
 	//
 	// THE ORDER IS FORCED, and it leaves a window: the activity commits in its
 	// own transaction before CreateComment runs, so any CreateComment failure

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -1736,7 +1736,32 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	actor, source := actorFromRequest(r)
-	activityID, _ := s.logActivityWithMetaReturningID(workspaceID, updated.ID, "updated", r, meta)
+	// The error is CHECKED here (BUG-2779). The activity write is
+	// best-effort — a failed audit entry must not fail the user's update,
+	// which is why this logs rather than returns — but the failure has to be
+	// VISIBLE, because the comment below links to `activityID` and a silent
+	// failure means a user's comment quietly loses its link on a 200. The two
+	// comment handlers already guard the same way; this brings the third
+	// caller in line with them.
+	//
+	// The id is NOT re-zeroed here. The store's contract now guarantees an
+	// empty id beside a non-nil error, and re-zeroing it at the call site
+	// would be a second mechanism for a window the first already covers —
+	// which hides which one is load-bearing, and would keep passing if the
+	// store's contract regressed. The log is the part nothing else provides.
+	activityID, activityErr := s.logActivityWithMetaReturningID(workspaceID, updated.ID, "updated", r, meta)
+	if activityErr != nil {
+		// UNTESTED, and the reason is worth stating rather than leaving for
+		// the next reader to rediscover: asserting this line needs an
+		// activity write that FAILS while the item update SUCCEEDS, which no
+		// existing seam produces — the store-level tests induce failure by
+		// closing the database, which would fail the update too. A seam whose
+		// only purpose is to let a test read a log line is not worth a field
+		// on Server, so this is held by the store's contract plus review
+		// rather than by an assertion. A mutation deleting it survives.
+		slog.Warn("item update activity not recorded; a comment on this update will not be linked",
+			"item_id", updated.ID, "workspace_id", workspaceID, "error", activityErr)
+	}
 	actorNameForUpdate := actorNameFromRequest(r)
 	s.publishItemEventWithName(sseItemUpdated, workspaceID, updated.ID, updated.Title, updated.CollectionSlug, actor, actorNameForUpdate, source, updated.Seq)
 	s.publishWatchNotifications(workspaceID, updated, actor, actorNameForUpdate)

--- a/internal/store/activities.go
+++ b/internal/store/activities.go
@@ -73,9 +73,21 @@ func (s *Store) CreateActivity(a models.Activity) (string, error) {
 		INSERT INTO activities (id, workspace_id, document_id, action, actor, source, metadata, user_id, ip_address, user_agent, created_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`), a.ID, nilIfEmpty(a.WorkspaceID), nilIfEmpty(a.DocumentID), a.Action, a.Actor, a.Source, a.Metadata, nilIfEmpty(a.UserID), nilIfEmpty(a.IPAddress), nilIfEmpty(a.UserAgent), ts)
-	return a.ID, err
+	if err != nil {
+		// No id alongside an error (BUG-2779). The id in hand names a row
+		// that was NOT written, and a caller who ignores the error — as one
+		// did — gets a plausible-looking handle to nothing. Returning "" makes
+		// the misuse impossible instead of merely wrong.
+		return "", err
+	}
+	return a.ID, nil
 }
 
+// A non-nil error is always paired with an EMPTY id (BUG-2779). Neither this
+// function nor CreateActivity returns a usable-looking handle beside a
+// failure: the id a failed call has in hand names a row it did not write, and
+// a caller that ignores the error cannot then link anything to it.
+//
 // CreateActivityDebounced creates a new activity or updates an existing one if a
 // matching activity (same document, same action, and same WRITER — same user
 // account, same actor kind, and same agent name) was recorded within the
@@ -177,7 +189,14 @@ func (s *Store) CreateActivityDebounced(a models.Activity) (string, error) {
 
 		mergedOK, err := s.mergeIntoUnlinkedActivity(existingID, existingMeta, merged, ts)
 		if err != nil {
-			return existingID, err
+			// "" and not existingID (BUG-2779): that id names the row this
+			// call CHOSE, not one it wrote. Handing it back beside an error
+			// gave the item-update handler — which discarded the error — a
+			// real id for an OLDER activity, and a comment created in the
+			// same request linked to it. The comment then sits under an entry
+			// describing a different change, attributed by TASK-2760's
+			// agent-name rule to whoever wrote that entry.
+			return "", err
 		}
 		if mergedOK {
 			return existingID, nil
@@ -189,9 +208,21 @@ func (s *Store) CreateActivityDebounced(a models.Activity) (string, error) {
 		// frozen row must not be retried (the answer will not change), and
 		// a contended row must not start a new run (retrying merges into
 		// the winner's blob and keeps the timeline entry whole).
+		// Test seam (BUG-2779): between the refusal and the probe that
+		// classifies it. Nil in production.
+		if s.afterDebounceRefusal != nil {
+			s.afterDebounceRefusal()
+		}
+
 		unchanged, err := s.debounceRowUnchanged(existingID, existingMeta)
 		if err != nil {
-			return existingID, err
+			// Same contract as the merge failure above (BUG-2779). Reaching
+			// it needs the UPDATE to affect zero rows and THEN this probe to
+			// fail — two statements apart — which is what afterDebounceRefusal
+			// exists to schedule. An earlier version of this comment claimed
+			// no instrument could reach it; that was a fact about the seams I
+			// had written, not about the code, and review said so.
+			return "", err
 		}
 		if unchanged {
 			// The blob we read is still there, so the CAS arm held and the

--- a/internal/store/activity_id_with_error_test.go
+++ b/internal/store/activity_id_with_error_test.go
@@ -1,0 +1,230 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// BUG-2779. Both activity writers used to return a real id alongside a
+// non-nil error — CreateActivity returned the id of the row it had just
+// FAILED to insert, and the debounced path returned the id of the row it had
+// CHOSEN but not written. The item-update handler discarded that error and
+// linked a user's comment to whatever came back, so the comment appeared
+// under an activity entry describing a different change, on a 200.
+//
+// The contract is now: a non-nil error is always paired with an empty id.
+// These assert it at the source, where it can be enforced, rather than only
+// at the one caller that misused it.
+//
+// The failure is induced by closing the store's database. That is the
+// cheapest way to make every write fail deterministically, and what is under
+// test is the pairing of the two return values, not which error occurs.
+func TestActivityWriters_ErrorNeverCarriesAnID(t *testing.T) {
+	base := testStore(t)
+	ws := createTestWorkspace(t, base, "IDContract")
+	doc := createTestDoc(t, base, ws.ID, "Doc", "content")
+
+	// A row for the debounced path to find and try to merge into, written
+	// while the database still works.
+	seed := models.Activity{
+		WorkspaceID: ws.ID, DocumentID: doc.ID,
+		Action: "updated", Actor: "agent", Source: "cli",
+		Metadata: `{"agent":"rook","changes":"title: a → b"}`,
+	}
+	if _, err := base.CreateActivityDebounced(seed); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := base.DB().Close(); err != nil {
+		t.Fatalf("close db: %v", err)
+	}
+
+	t.Run("CreateActivity", func(t *testing.T) {
+		id, err := base.CreateActivity(models.Activity{
+			WorkspaceID: ws.ID, DocumentID: doc.ID,
+			Action: "updated", Actor: "agent", Source: "cli",
+		})
+		if err == nil {
+			t.Fatal("expected an error from a closed database")
+		}
+		if id != "" {
+			t.Errorf("id = %q alongside error %v — a caller that ignores the error gets a handle to a row that was never written", id, err)
+		}
+	})
+
+	t.Run("CreateActivityDebounced", func(t *testing.T) {
+		next := seed
+		next.Metadata = `{"agent":"rook","changes":"status: open → done"}`
+		id, err := base.CreateActivityDebounced(next)
+		if err == nil {
+			t.Fatal("expected an error from a closed database")
+		}
+		if id != "" {
+			t.Errorf("id = %q alongside error %v — that id names the PREVIOUS activity row, and the item-update handler linked comments to it", id, err)
+		}
+	})
+}
+
+// TestActivityWriters_SuccessStillReturnsTheID is the control: a contract
+// change that returned "" unconditionally would satisfy every assertion
+// above, and break every caller.
+func TestActivityWriters_SuccessStillReturnsTheID(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "IDContractOK")
+	doc := createTestDoc(t, s, ws.ID, "Doc", "content")
+
+	created, err := s.CreateActivity(models.Activity{
+		WorkspaceID: ws.ID, DocumentID: doc.ID,
+		Action: "created", Actor: "user", Source: "web",
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if created == "" {
+		t.Error("CreateActivity returned an empty id on success")
+	}
+
+	first := models.Activity{
+		WorkspaceID: ws.ID, DocumentID: doc.ID,
+		Action: "updated", Actor: "agent", Source: "cli",
+		Metadata: `{"agent":"rook","changes":"title: a → b"}`,
+	}
+	firstID, err := s.CreateActivityDebounced(first)
+	if err != nil {
+		t.Fatalf("debounced create: %v", err)
+	}
+	if firstID == "" {
+		t.Fatal("CreateActivityDebounced returned an empty id on success")
+	}
+
+	// The merge path returns the id of the row it extended — the value the
+	// comment link depends on.
+	second := first
+	second.Metadata = `{"agent":"rook","changes":"status: open → done"}`
+	mergedID, err := s.CreateActivityDebounced(second)
+	if err != nil {
+		t.Fatalf("debounced merge: %v", err)
+	}
+	if mergedID != firstID {
+		t.Errorf("merge returned %q, want the coalesced row %q", mergedID, firstID)
+	}
+}
+
+// TestActivityDebounce_MergeFailureCarriesNoID reaches the line the test
+// above cannot. Closing the database up front makes the CANDIDATE SELECT fail
+// first, so the call falls back to CreateActivity and the merge's own error
+// return is never executed — the assertion passed for a reason unrelated to
+// the change under test, and a mutation restoring `return existingID, err`
+// there SURVIVED because of it.
+//
+// The seam (BUG-2770's afterDebounceRead) fires between the candidate read
+// and the merge write, which is exactly the window needed: the read succeeds
+// and finds the row, then the write fails. That is the state in which the old
+// code handed back a real id for a PREVIOUS activity.
+func TestActivityDebounce_MergeFailureCarriesNoID(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "MergeFailure")
+	doc := createTestDoc(t, s, ws.ID, "Doc", "content")
+
+	seed := models.Activity{
+		WorkspaceID: ws.ID, DocumentID: doc.ID,
+		Action: "updated", Actor: "agent", Source: "cli",
+		Metadata: `{"agent":"rook","changes":"title: a → b"}`,
+	}
+	seedID, err := s.CreateActivityDebounced(seed)
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if seedID == "" {
+		t.Fatal("seed returned no id")
+	}
+
+	fired := 0
+	s.afterDebounceRead = func() {
+		if fired > 0 {
+			return
+		}
+		fired++
+		// The candidate has been read; break the write.
+		if cerr := s.DB().Close(); cerr != nil {
+			t.Errorf("close db: %v", cerr)
+		}
+	}
+
+	next := seed
+	next.Metadata = `{"agent":"rook","changes":"status: open → done"}`
+	id, err := s.CreateActivityDebounced(next)
+	s.afterDebounceRead = nil
+
+	if fired != 1 {
+		t.Fatalf("seam fired %d times, want 1 — the candidate read did not happen, so the merge error path was not reached", fired)
+	}
+	if err == nil {
+		t.Fatal("expected the merge write to fail against a closed database")
+	}
+	if id != "" {
+		t.Errorf("id = %q alongside error %v — and %q is the SEED row, which this call did not write", id, err, seedID)
+	}
+	if id == seedID {
+		t.Errorf("the returned id is the previous activity's own id (%q); that is the value the handler linked comments to", seedID)
+	}
+}
+
+// TestActivityDebounce_ClassifierFailureCarriesNoID covers the last error
+// return, and exists because review pointed out that "no instrument can reach
+// it" described the seams I had written rather than the code. The failure has
+// to land between the merge UPDATE affecting zero rows and the probe that
+// decides which of its two arms refused; afterDebounceRefusal schedules
+// exactly that.
+//
+// The zero-row refusal is produced honestly, by the mechanism that produces
+// it in production: a comment linked to the candidate row freezes it
+// (TASK-2760), so the merge's NOT EXISTS arm declines the write.
+func TestActivityDebounce_ClassifierFailureCarriesNoID(t *testing.T) {
+	s, item := agentNameFixture(t)
+
+	writer := models.Activity{
+		WorkspaceID: item.WorkspaceID,
+		DocumentID:  item.ID,
+		Action:      "updated",
+		Actor:       "agent",
+		Source:      "cli",
+		Metadata:    `{"agent":"rook","changes":"title: a → b"}`,
+	}
+	seedID, err := s.CreateActivityDebounced(writer)
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if _, err := s.CreateComment(item.WorkspaceID, item.ID, "", models.CommentCreate{
+		Body: "freezes the row", CreatedBy: "agent", Source: "cli", ActivityID: seedID,
+	}); err != nil {
+		t.Fatalf("link comment: %v", err)
+	}
+
+	fired := 0
+	s.afterDebounceRefusal = func() {
+		if fired > 0 {
+			return
+		}
+		fired++
+		if cerr := s.DB().Close(); cerr != nil {
+			t.Errorf("close db: %v", cerr)
+		}
+	}
+
+	next := writer
+	next.Metadata = `{"agent":"rook","changes":"status: open → done"}`
+	id, err := s.CreateActivityDebounced(next)
+	s.afterDebounceRefusal = nil
+
+	if fired != 1 {
+		t.Fatalf("seam fired %d times, want 1 — the merge did not refuse, so the classifier was never reached", fired)
+	}
+	if err == nil {
+		t.Fatal("expected the classifier probe to fail against a closed database")
+	}
+	if id != "" {
+		t.Errorf("id = %q alongside error %v — and %q is the frozen row this call did not write", id, err, seedID)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -96,6 +96,15 @@ type Store struct {
 	// as the seams above.
 	afterDocumentPreWrite func(documentID string)
 
+	// afterDebounceRefusal is a TEST-ONLY seam, nil in production. When set,
+	// CreateActivityDebounced calls it after its merge UPDATE has affected
+	// ZERO rows and before the probe that decides which of the UPDATE's two
+	// arms refused (BUG-2779). It exists because that probe's error return is
+	// otherwise unreachable: the failure has to land between two statements,
+	// which no other seam can schedule. Same usage constraints as the seams
+	// above.
+	afterDebounceRefusal func()
+
 	// stopMaint signals the background WAL checkpointer to exit; maintDone
 	// is closed once it has. Both are nil on the Postgres path (no WAL
 	// file to checkpoint) and Close() guards on nil accordingly.


### PR DESCRIPTION
Fixes BUG-2779.

## The defect

`CreateActivity` returned the id of the row it had just **failed to insert**. `CreateActivityDebounced` returned the id of the row it had **chosen but not written**. The item-update handler discarded the error and linked a user's comment to whatever came back — so the comment appeared under an activity entry describing a *different change*, attributed by TASK-2760's agent-name rule to whoever wrote that entry. The request answered **200**.

## The fix

**Contract:** a non-nil error is always paired with an empty id. Three error returns changed; the function's doc states the rule, so no future caller can misuse a value that looks usable.

**Caller:** the item-update handler checks the error and logs it. It deliberately does **not** re-zero the id — with the contract fixed that would be a second mechanism for a window the first already covers, it would hide which one is load-bearing, and it would keep passing if the contract regressed. The log is the part nothing else provides.

**The population the filing left open:** `logActivityWithMetaReturningID` has exactly three callers, and the two comment handlers **already guarded correctly**. This brings the third in line with its siblings rather than inventing a pattern — which is why the caller-side half is one line.

## Two instrument failures found on the way

Both are worth more than the fix, and both were caught by review rather than by me:

1. **My first fixture reached a different branch.** Closing the database made the *candidate read* fail, so the call fell back to `CreateActivity` and the merge's error return never executed. The assertion passed for a reason unrelated to the line under test, and the mutation restoring `return existingID, err` **survived**. BUG-2770's `afterDebounceRead` seam fires between the read and the write, which is the window that matters.

2. **"No instrument can reach it" was a fact about my seams, not the code.** I wrote that on the classifier's error return; review pointed at the seam I hadn't written. `afterDebounceRefusal` fires between the zero-row refusal and the probe, and that mutation now dies too.

## Mutations

**5 aimed, 4 die.** The survivor is the handler's log line, kept and documented in place: asserting it needs an activity write that *fails* while the item update *succeeds*, and a seam existing only so a test can read a log line is not worth a field on `Server`.

## Also corrected

A comment in the comment handler saying `CreateActivity` returns an id on insert failure — true when written, falsified by this change, and **missed by my own sweep** because I grepped the mechanism's name instead of the claim.

## Gates

On this exact tip (rebased onto `e4e914d3`): `go test ./...` SQLite exit 0, 28 packages · `make lint` 0 issues · Postgres `internal/store` 2539s + `internal/server` 243s exit 0.

Note on that Postgres number: an earlier run came back red with `panic: test timed out after 10m0s`. That was my ad-hoc `go test` inheriting Go's 10m per-package default — the Makefile passes `-timeout=45m` for exactly this reason — while a mutation matrix competed for CPU. Re-run with the CI timeout and nothing beside it: green. Diagnosed rather than re-run-until-green.

## Reader-facing effect

An activity write that fails now leaves the comment **unlinked** instead of linked to an older entry. Checked what that looks like: an unlinked comment renders as a plain comment (an agent one falls back to a generic label), while a wrongly-linked comment claims "commented on update" and inherits the older activity's agent metadata. The new failure mode is better for the reader, not merely better for the invariant.
