### PR TITLE
fix(server): a structured timeline id must not collide with a row id (BUG-2783)

### DIFF
--- a/internal/server/handlers_timeline.go
+++ b/internal/server/handlers_timeline.go
@@ -331,10 +331,16 @@ func structuredTimelineEntries(item *models.Item, before time.Time, beforeID str
 		// paging can then skip or repeat it. The id has to be a function of
 		// the item alone, which is what the shape test is.
 		// `divert` is true for a raw id that must not be emitted as-is:
-		// UUID-shaped (it could equal a row id), or already carrying the
-		// derived namespace (it could equal another entry's derived id). Both
-		// get the same treatment below.
-		divert := looksLikeRowID(raw) || strings.HasPrefix(raw, prefix+":")
+		// UUID-shaped (it could equal a row id), or already carrying EITHER
+		// structured kind's derived namespace (it could equal some entry's
+		// derived id). Both get the same treatment below.
+		//
+		// Both prefixes, not just this call's: notes and decisions share
+		// `usedIDs`, so a NOTE whose raw id is `decision:<uuid>` would be kept
+		// and then collide with the id a DECISION derives from `<uuid>`,
+		// pushing the decision onto the positional path — the round-3 hole
+		// again, one kind across (codex round 4).
+		divert := looksLikeRowID(raw) || hasStructuredPrefix(raw)
 
 		if raw != "" && validCursorID(raw) && !divert && !usedIDs[raw] {
 			usedIDs[raw] = true
@@ -755,4 +761,19 @@ func validCursorID(v string) bool {
 // rows this must not depend on.
 func looksLikeRowID(raw string) bool {
 	return uuid.Validate(raw) == nil
+}
+
+// structuredEntryPrefixes are the namespaces entryID mints derived ids in.
+// Both kinds share one uniqueness map, so a raw id carrying EITHER prefix has
+// to be diverted regardless of which kind is being numbered — otherwise one
+// kind's kept id can collide with the other kind's derived id.
+var structuredEntryPrefixes = []string{"note", "decision"}
+
+func hasStructuredPrefix(raw string) bool {
+	for _, p := range structuredEntryPrefixes {
+		if strings.HasPrefix(raw, p+":") {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/server/handlers_timeline.go
+++ b/internal/server/handlers_timeline.go
@@ -10,6 +10,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
 
 	"github.com/PerpetualSoftware/pad/internal/models"
 )
@@ -177,21 +178,7 @@ func (s *Server) handleListItemTimeline(w http.ResponseWriter, r *http.Request) 
 	// still have to be filtered through the SAME (created_at, id) predicate
 	// the SQL above uses, or paging would show them on every page instead of
 	// exactly one (BUG-2301).
-	// Ids claimed by the SQL sources, so a structured entry cannot be handed
-	// one of them (BUG-2783). All three slices are already in hand above —
-	// this needs no extra query and no re-ordering.
-	reserved := make(map[string]bool, len(comments)+len(activities)+len(versions))
-	for _, c := range comments {
-		reserved[c.ID] = true
-	}
-	for _, a := range activities {
-		reserved[a.ID] = true
-	}
-	for _, v := range versions {
-		reserved[v.ID] = true
-	}
-
-	notes, decisions := structuredTimelineEntries(item, before, beforeID, sentinelBeforeID, reserved)
+	notes, decisions := structuredTimelineEntries(item, before, beforeID, sentinelBeforeID)
 
 	entries := buildTimeline(comments, activities, versions, notes, decisions)
 
@@ -264,7 +251,7 @@ func (s *Server) handleListItemTimeline(w http.ResponseWriter, r *http.Request) 
 // `sentinelBeforeID` says the caller synthesized beforeID rather than
 // receiving it, which means "keep every entry at this instant" — see the
 // comparison note inside.
-func structuredTimelineEntries(item *models.Item, before time.Time, beforeID string, sentinelBeforeID bool, reserved map[string]bool) ([]models.TimelineEntry, []models.TimelineEntry) {
+func structuredTimelineEntries(item *models.Item, before time.Time, beforeID string, sentinelBeforeID bool) ([]models.TimelineEntry, []models.TimelineEntry) {
 	if item == nil {
 		return nil, nil
 	}
@@ -306,30 +293,7 @@ func structuredTimelineEntries(item *models.Item, before time.Time, beforeID str
 	// Notes and decisions share this map — they land in one merged stream and
 	// a collision ACROSS the two kinds breaks the client exactly as one
 	// within a kind does.
-	usedIDs := make(map[string]bool, len(reserved)+len(item.ImplementationNotes)+len(item.DecisionLog))
-	// Seed with the ids the SQL sources already own. A note or decision id
-	// comes from the item's fields blob, which nothing validates on write, so
-	// it can equal a comment/activity/version id on the same item — and then
-	// two entries in ONE payload share an id, which the client's keyed
-	// {#each} and its by-id page dedupe resolve by hiding one of them
-	// (BUG-2783).
-	//
-	// The structured side is the one that yields, and that is a decision
-	// rather than an accident: comment, activity and version ids are real
-	// primary keys AND are what the client sends back as `before_id`, so
-	// moving one would break paging. The unvalidated side moves.
-	//
-	// Seeding also covers the positional fallback, without new code: the
-	// `for usedIDs[id]` loop below tests `note-idx-0` against this same map.
-	// That half is DEFENCE, not a live vector, and the difference is worth
-	// stating rather than implying — all three SQL sources mint ids with
-	// store.newID() (uuid.New().String()), including the import path, which
-	// re-mints rather than preserving an artifact's ids. A UUID cannot equal
-	// `note-idx-N`. The fallback is covered because it costs nothing to
-	// cover, not because a request can reach it today.
-	for id := range reserved {
-		usedIDs[id] = true
-	}
+	usedIDs := make(map[string]bool, len(item.ImplementationNotes)+len(item.DecisionLog))
 	entryID := func(raw, prefix string, i int) string {
 		// A raw id must be usable as a CURSOR, not merely unique: the client
 		// sends it back as `before_id` and the handler now refuses a value the
@@ -340,7 +304,33 @@ func structuredTimelineEntries(item *models.Item, before time.Time, beforeID str
 		// Emitting such an id would make the server hand out a cursor it then
 		// answers 400 to, wedging paging on that item (codex round 1). It gets
 		// the positional fallback the empty and duplicate cases already take.
-		if raw != "" && validCursorID(raw) && !usedIDs[raw] {
+		// A raw id that is UUID-SHAPED is refused, because that is the only
+		// shape it could collide with (BUG-2783). Comments, activities and
+		// versions are the other sources in this merged stream, and every one
+		// of their rows takes its id from store.newID() — uuid.New().String()
+		// — at all six insert sites, the import path included, which re-mints
+		// rather than preserving an artifact's ids. So a blob id can only
+		// equal a row id by being a UUID, and refusing that shape makes the
+		// collision impossible.
+		//
+		// A collision is not cosmetic. Two entries sharing an id in ONE page
+		// hit `{#each visibleEntries as entry (entry.id)}` in
+		// ItemTimeline.svelte, and a keyed each with a duplicate key is a
+		// Svelte error, not a silent drop; across pages, the append path's
+		// `existingIds` filter silently discards the later one. Both are the
+		// failure the intra-structured dedupe already prevents.
+		//
+		// WHY NOT consult the ids actually fetched for this page: that is
+		// what the first version of this fix did, and it is wrong. The three
+		// SQL windows depend on the cursor, so a structured entry would take
+		// its raw id on one page and a positional id on another, depending on
+		// whether the colliding row happened to be inside that page's window.
+		// This id is not merely a render key — it is the SECOND TERM OF THE
+		// CURSOR PREDICATE above, so making it window-dependent makes an
+		// entry's own sort position depend on which page is being built, and
+		// paging can then skip or repeat it. The id has to be a function of
+		// the item alone, which is what the shape test is.
+		if raw != "" && validCursorID(raw) && !looksLikeRowID(raw) && !usedIDs[raw] {
 			usedIDs[raw] = true
 			return raw
 		}
@@ -691,4 +681,23 @@ func exhaustedWindowCursor(
 // already bounds. A bound that can only fire on a valid id is not protection.
 func validCursorID(v string) bool {
 	return utf8.ValidString(v) && !strings.ContainsRune(v, 0)
+}
+
+// looksLikeRowID reports whether a structured entry's raw id could be the id
+// of a comment, activity or version row on the same item.
+//
+// Those are the only ids a structured entry can collide with in the merged
+// timeline, and every one of them is minted by store.newID(), which is
+// uuid.New().String(). Enumerated rather than sampled: the six INSERT sites
+// into comments / activities / item_versions all pass newID(), and the import
+// path re-mints instead of carrying an artifact's ids across.
+//
+// So the test is the UUID SHAPE, not membership in any particular set — which
+// is what keeps the answer independent of which rows a given page fetched.
+// The cost is that a blob id that happens to be a well-formed UUID loses its
+// raw id even when nothing collides with it; that is accepted, because such an
+// id is indistinguishable from a colliding one without consulting the very
+// rows this must not depend on.
+func looksLikeRowID(raw string) bool {
+	return uuid.Validate(raw) == nil
 }

--- a/internal/server/handlers_timeline.go
+++ b/internal/server/handlers_timeline.go
@@ -293,6 +293,31 @@ func structuredTimelineEntries(item *models.Item, before time.Time, beforeID str
 	// Notes and decisions share this map — they land in one merged stream and
 	// a collision ACROSS the two kinds breaks the client exactly as one
 	// within a kind does.
+	//
+	// WHAT IS CLOSED, enumerated so the next reader does not have to re-derive
+	// it (BUG-2783, review round 5):
+	//
+	//   - structured raw vs structured raw ....... the `!usedIDs[raw]` guard
+	//   - structured raw vs derived, same kind ... divert on the prefix
+	//   - structured raw vs derived, cross kind .. hasStructuredPrefix
+	//   - derived vs derived ..................... equal only if raws are
+	//   - structured vs a row id ................. divert on UUID shape
+	//   - fallback vs anything ................... the `for usedIDs[id]` loop
+	//
+	// WHAT IS NOT, deliberately and with somewhere to read about it:
+	//
+	//   - the positional fallback encodes an ARRAY INDEX, so an entry with no
+	//     usable id of its own can be renumbered by an insert or delete
+	//     earlier in the blob. That id is the cursor's tie-breaker, so a
+	//     renumbered entry can be skipped or re-shown across a page boundary.
+	//     Everything with something of its own to derive from was moved OFF
+	//     that path; what is left has nothing. Filed as BUG-2788.
+	//   - a row id that is not a UUID is outside what the shape test diverts,
+	//     and two rows in DIFFERENT tables are not deduped against each other
+	//     at all. Both are properties of the writers rather than of this
+	//     function, both are unreachable through any current write or import
+	//     path, and neither can be detected here without the row lookup this
+	//     design exists to avoid. See looksLikeRowID.
 	usedIDs := make(map[string]bool, len(item.ImplementationNotes)+len(item.DecisionLog))
 	entryID := func(raw, prefix string, i int) string {
 		// A raw id must be usable as a CURSOR, not merely unique: the client
@@ -750,9 +775,12 @@ func validCursorID(v string) bool {
 // migrations carry existing ids across verbatim. A row whose id is not a UUID
 // — written by some future path that does not go through newID(), or already
 // present in a database this code has never seen — would be outside what this
-// refuses, and a blob id equal to it would collide again. Nothing here can
-// detect that without consulting the rows, which is the dependency the whole
-// design exists to avoid. It is latent rather than reachable through any
+// refuses, and a blob id equal to it would collide again. The same gap has a
+// second face: the three SQL sources keep their own ids verbatim and are not
+// deduped against EACH OTHER, so two rows in different tables sharing an id
+// would collide in the merged stream without any structured entry involved.
+// Nothing here can detect either without consulting the rows, which is the
+// dependency the whole design exists to avoid. It is latent rather than reachable through any
 // current write or import path (codex round 2, P2), and the enforcement that
 // would close it belongs at the writers or the schema, not here.
 // The cost is that a blob id that happens to be a well-formed UUID loses its

--- a/internal/server/handlers_timeline.go
+++ b/internal/server/handlers_timeline.go
@@ -177,7 +177,21 @@ func (s *Server) handleListItemTimeline(w http.ResponseWriter, r *http.Request) 
 	// still have to be filtered through the SAME (created_at, id) predicate
 	// the SQL above uses, or paging would show them on every page instead of
 	// exactly one (BUG-2301).
-	notes, decisions := structuredTimelineEntries(item, before, beforeID, sentinelBeforeID)
+	// Ids claimed by the SQL sources, so a structured entry cannot be handed
+	// one of them (BUG-2783). All three slices are already in hand above —
+	// this needs no extra query and no re-ordering.
+	reserved := make(map[string]bool, len(comments)+len(activities)+len(versions))
+	for _, c := range comments {
+		reserved[c.ID] = true
+	}
+	for _, a := range activities {
+		reserved[a.ID] = true
+	}
+	for _, v := range versions {
+		reserved[v.ID] = true
+	}
+
+	notes, decisions := structuredTimelineEntries(item, before, beforeID, sentinelBeforeID, reserved)
 
 	entries := buildTimeline(comments, activities, versions, notes, decisions)
 
@@ -250,7 +264,7 @@ func (s *Server) handleListItemTimeline(w http.ResponseWriter, r *http.Request) 
 // `sentinelBeforeID` says the caller synthesized beforeID rather than
 // receiving it, which means "keep every entry at this instant" — see the
 // comparison note inside.
-func structuredTimelineEntries(item *models.Item, before time.Time, beforeID string, sentinelBeforeID bool) ([]models.TimelineEntry, []models.TimelineEntry) {
+func structuredTimelineEntries(item *models.Item, before time.Time, beforeID string, sentinelBeforeID bool, reserved map[string]bool) ([]models.TimelineEntry, []models.TimelineEntry) {
 	if item == nil {
 		return nil, nil
 	}
@@ -292,7 +306,30 @@ func structuredTimelineEntries(item *models.Item, before time.Time, beforeID str
 	// Notes and decisions share this map — they land in one merged stream and
 	// a collision ACROSS the two kinds breaks the client exactly as one
 	// within a kind does.
-	usedIDs := make(map[string]bool, len(item.ImplementationNotes)+len(item.DecisionLog))
+	usedIDs := make(map[string]bool, len(reserved)+len(item.ImplementationNotes)+len(item.DecisionLog))
+	// Seed with the ids the SQL sources already own. A note or decision id
+	// comes from the item's fields blob, which nothing validates on write, so
+	// it can equal a comment/activity/version id on the same item — and then
+	// two entries in ONE payload share an id, which the client's keyed
+	// {#each} and its by-id page dedupe resolve by hiding one of them
+	// (BUG-2783).
+	//
+	// The structured side is the one that yields, and that is a decision
+	// rather than an accident: comment, activity and version ids are real
+	// primary keys AND are what the client sends back as `before_id`, so
+	// moving one would break paging. The unvalidated side moves.
+	//
+	// Seeding also covers the positional fallback, without new code: the
+	// `for usedIDs[id]` loop below tests `note-idx-0` against this same map.
+	// That half is DEFENCE, not a live vector, and the difference is worth
+	// stating rather than implying — all three SQL sources mint ids with
+	// store.newID() (uuid.New().String()), including the import path, which
+	// re-mints rather than preserving an artifact's ids. A UUID cannot equal
+	// `note-idx-N`. The fallback is covered because it costs nothing to
+	// cover, not because a request can reach it today.
+	for id := range reserved {
+		usedIDs[id] = true
+	}
 	entryID := func(raw, prefix string, i int) string {
 		// A raw id must be usable as a CURSOR, not merely unique: the client
 		// sends it back as `before_id` and the handler now refuses a value the

--- a/internal/server/handlers_timeline.go
+++ b/internal/server/handlers_timeline.go
@@ -330,7 +330,13 @@ func structuredTimelineEntries(item *models.Item, before time.Time, beforeID str
 		// entry's own sort position depend on which page is being built, and
 		// paging can then skip or repeat it. The id has to be a function of
 		// the item alone, which is what the shape test is.
-		if raw != "" && validCursorID(raw) && !looksLikeRowID(raw) && !usedIDs[raw] {
+		// `divert` is true for a raw id that must not be emitted as-is:
+		// UUID-shaped (it could equal a row id), or already carrying the
+		// derived namespace (it could equal another entry's derived id). Both
+		// get the same treatment below.
+		divert := looksLikeRowID(raw) || strings.HasPrefix(raw, prefix+":")
+
+		if raw != "" && validCursorID(raw) && !divert && !usedIDs[raw] {
 			usedIDs[raw] = true
 			return raw
 		}
@@ -349,11 +355,23 @@ func structuredTimelineEntries(item *models.Item, before time.Time, beforeID str
 		// existing hazard to a much larger population for no reason
 		// (codex round 2, P1).
 		//
-		// The prefix is what makes it safe: a row id is a bare UUID, so
-		// `note:<uuid>` cannot equal one. It is still run through the
-		// duplicate guard below, because a blob is free to contain a literal
-		// "note:<uuid>" string of its own.
-		if raw != "" && validCursorID(raw) && looksLikeRowID(raw) {
+		// The namespace is what makes it safe, and it is closed rather than
+		// merely unlikely (codex round 3). Two rules together:
+		//
+		//   - a raw id is KEPT only if it does NOT begin with `<prefix>:`
+		//   - a diverted id is `<prefix>:` + raw
+		//
+		// so a derived id always begins with the prefix and a kept one never
+		// does, and the two can never collide. Two derived ids are equal only
+		// when their raws are equal, which is the duplicate case. And a bare
+		// UUID row id cannot equal either form.
+		//
+		// The earlier version diverted only UUID-shaped ids, which left a
+		// hole: a blob holding both `note:<uuid>` and `<uuid>` had the second
+		// derive onto the first's kept id, fall through, and land on the
+		// positional path — two distinct, legitimate ids, one of them made
+		// unstable. Diverting the prefix form closes it.
+		if raw != "" && validCursorID(raw) && divert {
 			derived := prefix + ":" + raw
 			if !usedIDs[derived] {
 				usedIDs[derived] = true

--- a/internal/server/handlers_timeline.go
+++ b/internal/server/handlers_timeline.go
@@ -334,6 +334,32 @@ func structuredTimelineEntries(item *models.Item, before time.Time, beforeID str
 			usedIDs[raw] = true
 			return raw
 		}
+		// A raw id that is only unusable because of its SHAPE gets a derived
+		// id rather than the positional fallback, so the entry keeps an
+		// identity tied to itself instead of to its index.
+		//
+		// This matters because the positional fallback is index-dependent and
+		// therefore unstable across mutations of the blob: inserting or
+		// removing an earlier entry renumbers every later one, and since the
+		// id is the cursor's tie-breaker, a renumbered entry can be skipped or
+		// re-shown across a page boundary. That instability predates this fix
+		// and still applies to entries with an ABSENT or DUPLICATE id, which
+		// have nothing else to derive from — but a UUID-shaped id does, and
+		// diverting those onto the positional path would have widened an
+		// existing hazard to a much larger population for no reason
+		// (codex round 2, P1).
+		//
+		// The prefix is what makes it safe: a row id is a bare UUID, so
+		// `note:<uuid>` cannot equal one. It is still run through the
+		// duplicate guard below, because a blob is free to contain a literal
+		// "note:<uuid>" string of its own.
+		if raw != "" && validCursorID(raw) && looksLikeRowID(raw) {
+			derived := prefix + ":" + raw
+			if !usedIDs[derived] {
+				usedIDs[derived] = true
+				return derived
+			}
+		}
 		id := fmt.Sprintf("%s-idx-%d", prefix, i)
 		for usedIDs[id] {
 			id += "x"
@@ -694,6 +720,17 @@ func validCursorID(v string) bool {
 //
 // So the test is the UUID SHAPE, not membership in any particular set — which
 // is what keeps the answer independent of which rows a given page fetched.
+//
+// SCOPE, because this is a property of the WRITERS and not of the schema: all
+// three tables declare `id TEXT PRIMARY KEY` with no format constraint, and
+// migrations carry existing ids across verbatim. A row whose id is not a UUID
+// — written by some future path that does not go through newID(), or already
+// present in a database this code has never seen — would be outside what this
+// refuses, and a blob id equal to it would collide again. Nothing here can
+// detect that without consulting the rows, which is the dependency the whole
+// design exists to avoid. It is latent rather than reachable through any
+// current write or import path (codex round 2, P2), and the enforcement that
+// would close it belongs at the writers or the schema, not here.
 // The cost is that a blob id that happens to be a well-formed UUID loses its
 // raw id even when nothing collides with it; that is accepted, because such an
 // id is indistinguishable from a colliding one without consulting the very

--- a/internal/server/handlers_timeline_id_collision_test.go
+++ b/internal/server/handlers_timeline_id_collision_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/PerpetualSoftware/pad/internal/models"
@@ -437,5 +438,94 @@ func TestTimeline_DivertedIDIsStableAcrossBlobMutations(t *testing.T) {
 		t.Errorf("the subject note's id changed from %q to %q when an unrelated entry was inserted "+
 			"ahead of it; the id is the cursor's tie-breaker, so it must not depend on array position",
 			before, after)
+	}
+}
+
+// TestTimeline_DerivedIDContract pins the derived id's actual FORM and the
+// namespace property that makes it safe, not merely that it differs from
+// something.
+//
+// Round 3 of the review found the earlier tests too weak to distinguish the
+// fix from its alternatives: "stable and not the raw id" is satisfied by a
+// constant, and the collision tests' inequality checks are satisfied by the
+// positional fallback this deliberately replaced. These assert the contract.
+func TestTimeline_DerivedIDContract(t *testing.T) {
+	srv := testServer(t)
+	ws := createWSForTest(t, srv)
+
+	uuidA := "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+	uuidB := "6ba7b811-9dad-11d1-80b4-00c04fd430c8"
+	notes := `[{"id":"` + uuidA + `","summary":"a","created_at":"2026-04-02T10:00:00Z"},
+	           {"id":"` + uuidB + `","summary":"b","created_at":"2026-04-02T11:00:00Z"},
+	           {"id":"note:` + uuidA + `","summary":"c","created_at":"2026-04-02T12:00:00Z"}]`
+	item := timelineItemWithStructured(t, srv, ws, notes, "")
+
+	resp := fetchTimeline(t, srv, ws, item.Slug, "")
+	bySummary := map[string]string{}
+	for _, e := range entriesByKind(resp.Entries, "note") {
+		if e.Note != nil {
+			bySummary[e.Note.Summary] = e.ID
+		}
+	}
+	if len(bySummary) != 3 {
+		t.Fatalf("expected 3 note entries, got %d (%v)", len(bySummary), bySummary)
+	}
+
+	// Exact form: prefix + ":" + raw. A constant, an ordinal, or the
+	// positional fallback all fail here.
+	if got, want := bySummary["a"], "note:"+uuidA; got != want {
+		t.Errorf("derived id for a UUID-shaped raw id = %q, want %q", got, want)
+	}
+	// Distinct raws derive to distinct ids — an ordinal scheme would collapse
+	// or reorder these.
+	if got, want := bySummary["b"], "note:"+uuidB; got != want {
+		t.Errorf("derived id for the second UUID = %q, want %q", got, want)
+	}
+	// The namespace is closed: a raw id that ALREADY carries the prefix is
+	// itself diverted, so it cannot land on the id entry "a" derived. Before
+	// round 3 this one was kept as-is, "a" collided with it, and "a" fell
+	// through to the unstable positional path.
+	if got, want := bySummary["c"], "note:note:"+uuidA; got != want {
+		t.Errorf("a raw id already in the derived namespace = %q, want %q", got, want)
+	}
+	for _, id := range bySummary {
+		if strings.Contains(id, "-idx-") {
+			t.Errorf("an entry with a usable raw id landed on the positional fallback: %q", id)
+		}
+	}
+}
+
+// TestTimeline_DerivedIDRoundTripsAsACursor closes the loop the derived form
+// has to survive: the client sends an entry id back as `before_id`, and
+// BUG-2774 made the server refuse a cursor the database would refuse. A
+// derived id is server-minted, so it must be one the server itself accepts —
+// the exact failure validation-must-not-refuse-your-own-output describes.
+func TestTimeline_DerivedIDRoundTripsAsACursor(t *testing.T) {
+	srv := testServer(t)
+	ws := createWSForTest(t, srv)
+
+	uuidA := "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+	notes := `[{"id":"` + uuidA + `","summary":"older","created_at":"2026-04-02T10:00:00Z"},
+	           {"summary":"newer, no id","created_at":"2026-04-02T12:00:00Z"}]`
+	item := timelineItemWithStructured(t, srv, ws, notes, "")
+
+	resp := fetchTimeline(t, srv, ws, item.Slug, "")
+	var derived string
+	var at string
+	for _, e := range entriesByKind(resp.Entries, "note") {
+		if e.Note != nil && e.Note.Summary == "older" {
+			derived = e.ID
+			at = e.CreatedAt.UTC().Format("2006-01-02T15:04:05Z07:00")
+		}
+	}
+	if derived != "note:"+uuidA {
+		t.Fatalf("fixture: expected the derived id, got %q", derived)
+	}
+
+	// Paging FROM that id must be accepted, not 400ed.
+	path := "/api/v1/workspaces/" + ws + "/items/" + item.Slug + "/timeline?before=" + at + "&before_id=" + derived
+	rr := doRequest(srv, "GET", path, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("paging from a server-minted derived cursor = %d: %s", rr.Code, rr.Body.String())
 	}
 }

--- a/internal/server/handlers_timeline_id_collision_test.go
+++ b/internal/server/handlers_timeline_id_collision_test.go
@@ -529,3 +529,62 @@ func TestTimeline_DerivedIDRoundTripsAsACursor(t *testing.T) {
 		t.Fatalf("paging from a server-minted derived cursor = %d: %s", rr.Code, rr.Body.String())
 	}
 }
+
+// TestTimeline_DerivedNamespaceIsClosedAcrossKinds is the cross-kind case.
+//
+// Notes and decisions are numbered by separate calls but share one uniqueness
+// map, so checking only the CALLING kind's prefix leaves the round-3 hole
+// intact one kind across: a note whose raw id is "decision:<uuid>" is kept,
+// and a decision whose raw id is "<uuid>" then derives onto exactly that
+// string, falls through, and lands on the index-dependent positional path.
+//
+// Asserted as a form, not merely as inequality, and with an entry inserted
+// afterwards to show the decision's id does not move.
+func TestTimeline_DerivedNamespaceIsClosedAcrossKinds(t *testing.T) {
+	srv := testServer(t)
+	ws := createWSForTest(t, srv)
+
+	id := "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+	notes := `[{"id":"decision:` + id + `","summary":"a note wearing the decision namespace","created_at":"2026-04-02T10:00:00Z"}]`
+	decisions := `[{"id":"` + id + `","decision":"the decision","created_at":"2026-04-02T11:00:00Z"}]`
+	item := timelineItemWithStructured(t, srv, ws, notes, decisions)
+
+	resp := fetchTimeline(t, srv, ws, item.Slug, "")
+
+	noteEntries := entriesByKind(resp.Entries, "note")
+	decisionEntries := entriesByKind(resp.Entries, "decision")
+	if len(noteEntries) != 1 || len(decisionEntries) != 1 {
+		t.Fatalf("expected 1 note and 1 decision, got %d and %d (kinds: %v)",
+			len(noteEntries), len(decisionEntries), kindsOf(resp.Entries))
+	}
+
+	// The note's raw id carries a structured prefix, so it is diverted too.
+	if got, want := noteEntries[0].ID, "note:decision:"+id; got != want {
+		t.Errorf("note with a foreign structured prefix = %q, want %q", got, want)
+	}
+	// The decision keeps its own derived form rather than being pushed onto
+	// the positional path by the note.
+	if got, want := decisionEntries[0].ID, "decision:"+id; got != want {
+		t.Errorf("decision derived id = %q, want %q", got, want)
+	}
+	if strings.Contains(decisionEntries[0].ID, "-idx-") {
+		t.Errorf("the decision landed on the positional fallback: %q", decisionEntries[0].ID)
+	}
+
+	// And the decision's id survives a mutation of the notes array, which it
+	// could not if it were positional.
+	before := decisionEntries[0].ID
+	notes2 := `[{"summary":"inserted ahead, no id","created_at":"2026-04-02T09:00:00Z"},
+	            {"id":"decision:` + id + `","summary":"a note wearing the decision namespace","created_at":"2026-04-02T10:00:00Z"}]`
+	patchItemFields(t, srv, ws, item.Slug,
+		`{"status":"open","implementation_notes":`+notes2+`,"decision_log":`+decisions+`}`)
+
+	after := fetchTimeline(t, srv, ws, item.Slug, "")
+	afterDecisions := entriesByKind(after.Entries, "decision")
+	if len(afterDecisions) != 1 {
+		t.Fatalf("expected 1 decision after the insert, got %d", len(afterDecisions))
+	}
+	if afterDecisions[0].ID != before {
+		t.Errorf("the decision's id changed from %q to %q when a note was inserted", before, afterDecisions[0].ID)
+	}
+}

--- a/internal/server/handlers_timeline_id_collision_test.go
+++ b/internal/server/handlers_timeline_id_collision_test.go
@@ -10,9 +10,18 @@ import (
 
 // BUG-2783: a structured entry's id can equal the id of a comment, activity or
 // version on the SAME item, and then two entries in one timeline payload share
-// an id. The client keys its {#each} on entry id and dedupes appended pages by
-// id, so one of the two is hidden — the same failure the intra-structured
-// dedupe already prevents, one source-boundary out.
+// an id — the failure the intra-structured dedupe already prevents, one
+// source-boundary out.
+//
+// The client breaks two different ways, and they are worth separating because
+// the first draft of this comment collapsed them into "one of the two is
+// hidden", which is only half true:
+//
+//   - WITHIN one page: ItemTimeline.svelte renders
+//     `{#each visibleEntries as entry (entry.id)}`. A keyed each with a
+//     duplicate key is a Svelte ERROR, not a silent drop.
+//   - ACROSS pages: the append path filters on `existingIds`, so the later
+//     copy is silently discarded — that is where something is hidden.
 //
 // Note and decision ids come from the item's fields blob and nothing validates
 // them on write: `pad item note` generates `note-<nanos>`, but an imported
@@ -23,8 +32,8 @@ import (
 // structuredTimelineEntries directly. That is deliberate and is the reason the
 // gap survived this long: the structured builder is CORRECT in isolation — it
 // dedupes perfectly against the other structured entries — and a unit test of
-// it vouches for the component rather than its binding to the other four
-// sources (team CONVE-19).
+// it vouches for the component rather than its binding to the three
+// SQL-backed sources (team CONVE-19).
 
 // patchItemFields overwrites the item's fields blob through the real PATCH
 // path, so the entries are hydrated exactly as production hydrates them.
@@ -134,7 +143,11 @@ func TestTimeline_StructuredIDCollidingWithAnActivityHidesNothing(t *testing.T) 
 	before := fetchTimeline(t, srv, ws, item.Slug, "")
 	acts := entriesByKind(before.Entries, "activity")
 	if len(acts) == 0 {
-		t.Skip("no activity entry on a freshly created item; nothing to collide with")
+		// NOT t.Skip. Creating an item writes an activity row, so an empty
+		// list means the fixture stopped building what this test needs — and
+		// a skip would report that as success forever.
+		t.Fatalf("fixture: a freshly created item must have an activity entry to collide with; kinds: %v",
+			kindsOf(before.Entries))
 	}
 	victim := acts[0].ID
 
@@ -231,5 +244,144 @@ func TestTimeline_StructuredIDEqualToAnotherEntrysFallback(t *testing.T) {
 		if n > 1 {
 			t.Errorf("entry id %q appears %d times in one page", id, n)
 		}
+	}
+}
+
+// TestTimeline_StructuredIDCollidingWithAVersionHidesNothing covers the third
+// SQL source. Without it, a fix that only knew about comments and activities
+// would pass the rest of this file — which is exactly what the first version
+// of the fix did, since it enumerated sources by hand.
+func TestTimeline_StructuredIDCollidingWithAVersionHidesNothing(t *testing.T) {
+	srv := testServer(t)
+	ws := createWSForTest(t, srv)
+
+	item := timelineItemWithStructured(t, srv, ws, "", "")
+
+	// An update creates a version row.
+	rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+ws+"/items/"+item.Slug, map[string]any{
+		"content": "a revision, so a version row exists",
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("update item = %d: %s", rr.Code, rr.Body.String())
+	}
+
+	before := fetchTimeline(t, srv, ws, item.Slug, "")
+	versions := entriesByKind(before.Entries, "version")
+	if len(versions) == 0 {
+		t.Fatalf("fixture: an updated item must have a version entry to collide with; kinds: %v",
+			kindsOf(before.Entries))
+	}
+	victim := versions[0].ID
+
+	notes, err := json.Marshal([]map[string]string{{
+		"id":         victim,
+		"summary":    "note that stole a version id",
+		"created_at": versions[0].CreatedAt.UTC().Format("2006-01-02T15:04:05Z07:00"),
+	}})
+	if err != nil {
+		t.Fatalf("marshal notes: %v", err)
+	}
+	patchItemFields(t, srv, ws, item.Slug, `{"status":"open","implementation_notes":`+string(notes)+`}`)
+
+	resp := fetchTimeline(t, srv, ws, item.Slug, "")
+
+	noteEntries := entriesByKind(resp.Entries, "note")
+	if len(noteEntries) != 1 {
+		t.Fatalf("expected exactly 1 note entry, got %d (kinds: %v)", len(noteEntries), kindsOf(resp.Entries))
+	}
+	if noteEntries[0].ID == victim {
+		t.Errorf("the note entry kept the colliding version id %q", noteEntries[0].ID)
+	}
+
+	stillThere := false
+	for _, e := range entriesByKind(resp.Entries, "version") {
+		if e.ID == victim {
+			stillThere = true
+		}
+	}
+	if !stillThere {
+		t.Errorf("the version that owned id %q is no longer in the payload", victim)
+	}
+
+	seen := map[string]int{}
+	for _, e := range resp.Entries {
+		seen[e.ID]++
+	}
+	for id, n := range seen {
+		if n > 1 {
+			t.Errorf("entry id %q appears %d times in one page", id, n)
+		}
+	}
+}
+
+// TestTimeline_StructuredIDIsIndependentOfThePageWindow is the regression test
+// for the defect the FIRST version of this fix introduced, and the reason the
+// fix is a shape test rather than a lookup.
+//
+// That version seeded the dedupe map from the ids fetched for the current
+// page. The three SQL windows depend on the cursor, so a structured entry took
+// its raw id on a page where the colliding row was absent and a positional id
+// on one where it was present. That id is not merely a render key — it is the
+// second term of the cursor predicate, so a window-dependent id makes an
+// entry's own sort position depend on which page is being built.
+//
+// The assertion is that the same entry carries the SAME id on a first page and
+// on a narrow page fetched with a cursor, which is a property of the item
+// alone and cannot hold if the id consults the window.
+func TestTimeline_StructuredIDIsIndependentOfThePageWindow(t *testing.T) {
+	srv := testServer(t)
+	ws := createWSForTest(t, srv)
+
+	item := timelineItemWithStructured(t, srv, ws, "", "")
+
+	rr := doRequest(srv, "POST", "/api/v1/workspaces/"+ws+"/items/"+item.Slug+"/comments",
+		map[string]any{"body": "the row whose id the note claims"})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create comment = %d: %s", rr.Code, rr.Body.String())
+	}
+	var comment models.Comment
+	parseJSON(t, rr, &comment)
+
+	notes, err := json.Marshal([]map[string]string{{
+		"id":         comment.ID,
+		"summary":    "note claiming a row id",
+		"created_at": item.CreatedAt.UTC().Format("2006-01-02T15:04:05Z07:00"),
+	}})
+	if err != nil {
+		t.Fatalf("marshal notes: %v", err)
+	}
+	patchItemFields(t, srv, ws, item.Slug, `{"status":"open","implementation_notes":`+string(notes)+`}`)
+
+	full := fetchTimeline(t, srv, ws, item.Slug, "")
+	fullNotes := entriesByKind(full.Entries, "note")
+	if len(fullNotes) != 1 {
+		t.Fatalf("expected 1 note on the full page, got %d", len(fullNotes))
+	}
+
+	// A page whose window is narrow enough to exclude the colliding comment.
+	narrow := fetchTimeline(t, srv, ws, item.Slug, "limit=1")
+	narrowNotes := entriesByKind(narrow.Entries, "note")
+	if len(narrowNotes) == 0 {
+		// The note may legitimately fall outside a 1-entry page; page from the
+		// cursor until it appears rather than asserting on an empty result.
+		if !narrow.HasMore || narrow.NextBefore == "" {
+			t.Fatalf("narrow page carried no note and no cursor to continue from; kinds: %v",
+				kindsOf(narrow.Entries))
+		}
+		next := fetchTimeline(t, srv, ws, item.Slug,
+			"before="+narrow.NextBefore+"&before_id="+narrow.NextBeforeID+"&limit=5")
+		narrowNotes = entriesByKind(next.Entries, "note")
+	}
+	if len(narrowNotes) == 0 {
+		// Not a skip: the note is older than the comment and the paged fetch
+		// covers it, so its absence means the fixture stopped exercising the
+		// window this test is named for.
+		t.Fatalf("note did not surface on a paged fetch, so the window comparison never ran")
+	}
+
+	if narrowNotes[0].ID != fullNotes[0].ID {
+		t.Errorf("the same note carried id %q on the full page and %q on a paged fetch; "+
+			"a structured entry's id must be a function of the item, not of the page window",
+			fullNotes[0].ID, narrowNotes[0].ID)
 	}
 }

--- a/internal/server/handlers_timeline_id_collision_test.go
+++ b/internal/server/handlers_timeline_id_collision_test.go
@@ -385,3 +385,57 @@ func TestTimeline_StructuredIDIsIndependentOfThePageWindow(t *testing.T) {
 			fullNotes[0].ID, narrowNotes[0].ID)
 	}
 }
+
+// TestTimeline_DivertedIDIsStableAcrossBlobMutations pins the property the
+// derived id exists for.
+//
+// A UUID-shaped raw id cannot be emitted as-is (it could equal a row id), but
+// it must not be pushed onto the POSITIONAL fallback either: that fallback
+// encodes the array index, so inserting an entry ahead of it renumbers it, and
+// the entry id is the cursor's tie-breaker. An entry whose id changes under an
+// unrelated insert can be skipped or re-shown across a page boundary.
+//
+// The assertion is that the same entry keeps the same id after another entry
+// is inserted BEFORE it — which holds for a derived id and cannot hold for a
+// positional one.
+func TestTimeline_DivertedIDIsStableAcrossBlobMutations(t *testing.T) {
+	srv := testServer(t)
+	ws := createWSForTest(t, srv)
+
+	// A note whose id is UUID-shaped, so it takes the diverted path.
+	subject := "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+	one := `[{"id":"` + subject + `","summary":"the subject","created_at":"2026-04-02T11:00:00Z"}]`
+	item := timelineItemWithStructured(t, srv, ws, one, "")
+
+	first := fetchTimeline(t, srv, ws, item.Slug, "")
+	notes := entriesByKind(first.Entries, "note")
+	if len(notes) != 1 {
+		t.Fatalf("expected 1 note, got %d (kinds: %v)", len(notes), kindsOf(first.Entries))
+	}
+	before := notes[0].ID
+	if before == subject {
+		t.Fatalf("a UUID-shaped raw id must not be emitted as-is; got %q", before)
+	}
+
+	// Insert another note AHEAD of it. Under a positional id this renumbers
+	// the subject from index 0 to index 1.
+	two := `[{"summary":"inserted ahead, no id","created_at":"2026-04-02T10:00:00Z"},
+	         {"id":"` + subject + `","summary":"the subject","created_at":"2026-04-02T11:00:00Z"}]`
+	patchItemFields(t, srv, ws, item.Slug, `{"status":"open","implementation_notes":`+two+`}`)
+
+	second := fetchTimeline(t, srv, ws, item.Slug, "")
+	var after string
+	for _, e := range entriesByKind(second.Entries, "note") {
+		if e.Note != nil && e.Note.Summary == "the subject" {
+			after = e.ID
+		}
+	}
+	if after == "" {
+		t.Fatalf("the subject note is missing after the insert; kinds: %v", kindsOf(second.Entries))
+	}
+	if after != before {
+		t.Errorf("the subject note's id changed from %q to %q when an unrelated entry was inserted "+
+			"ahead of it; the id is the cursor's tie-breaker, so it must not depend on array position",
+			before, after)
+	}
+}

--- a/internal/server/handlers_timeline_id_collision_test.go
+++ b/internal/server/handlers_timeline_id_collision_test.go
@@ -1,0 +1,235 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// BUG-2783: a structured entry's id can equal the id of a comment, activity or
+// version on the SAME item, and then two entries in one timeline payload share
+// an id. The client keys its {#each} on entry id and dedupes appended pages by
+// id, so one of the two is hidden — the same failure the intra-structured
+// dedupe already prevents, one source-boundary out.
+//
+// Note and decision ids come from the item's fields blob and nothing validates
+// them on write: `pad item note` generates `note-<nanos>`, but an imported
+// artifact or a hand-edited blob may carry any string, including a UUID that
+// belongs to a comment on the same item.
+//
+// These tests drive the MERGED payload through the real endpoint, not
+// structuredTimelineEntries directly. That is deliberate and is the reason the
+// gap survived this long: the structured builder is CORRECT in isolation — it
+// dedupes perfectly against the other structured entries — and a unit test of
+// it vouches for the component rather than its binding to the other four
+// sources (team CONVE-19).
+
+// patchItemFields overwrites the item's fields blob through the real PATCH
+// path, so the entries are hydrated exactly as production hydrates them.
+func patchItemFields(t *testing.T, srv *Server, wsSlug, itemSlug, fieldsJSON string) {
+	t.Helper()
+	rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+wsSlug+"/items/"+itemSlug, map[string]any{
+		"fields": fieldsJSON,
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("patch item fields = %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func entriesByKind(entries []models.TimelineEntry, kind string) []models.TimelineEntry {
+	var out []models.TimelineEntry
+	for _, e := range entries {
+		if e.Kind == kind {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// TestTimeline_StructuredIDCollidingWithACommentHidesNothing is the regression
+// test. Against unfixed code the note is emitted carrying the comment's id and
+// the two entries collide.
+//
+// The assertion is deliberately specific about WHICH entry moves. Asserting
+// only "two entries are present" would pass trivially — they are both in the
+// payload even unfixed, since the collision is resolved by the CLIENT, not the
+// server. Asserting only "the ids differ" would pass if the comment had been
+// the one to yield, which would be a different bug: comment ids are real
+// primary keys AND are what the client sends back as `before_id`, so moving
+// one breaks paging. The unvalidated side is the side that must move.
+func TestTimeline_StructuredIDCollidingWithACommentHidesNothing(t *testing.T) {
+	srv := testServer(t)
+	ws := createWSForTest(t, srv)
+
+	item := timelineItemWithStructured(t, srv, ws, "", "")
+
+	rr := doRequest(srv, "POST", "/api/v1/workspaces/"+ws+"/items/"+item.Slug+"/comments",
+		map[string]any{"body": "a comment whose id is about to be stolen"})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create comment = %d: %s", rr.Code, rr.Body.String())
+	}
+	var comment models.Comment
+	parseJSON(t, rr, &comment)
+	if comment.ID == "" {
+		t.Fatal("fixture: comment came back with no id")
+	}
+
+	// The collision: a note claiming the comment's id.
+	notes, err := json.Marshal([]map[string]string{{
+		"id":         comment.ID,
+		"summary":    "note that stole the comment's id",
+		"created_at": comment.CreatedAt.UTC().Format("2006-01-02T15:04:05Z07:00"),
+	}})
+	if err != nil {
+		t.Fatalf("marshal notes: %v", err)
+	}
+	patchItemFields(t, srv, ws, item.Slug, `{"status":"open","implementation_notes":`+string(notes)+`}`)
+
+	resp := fetchTimeline(t, srv, ws, item.Slug, "")
+
+	comments := entriesByKind(resp.Entries, "comment")
+	noteEntries := entriesByKind(resp.Entries, "note")
+	if len(comments) != 1 || len(noteEntries) != 1 {
+		t.Fatalf("fixture: expected exactly 1 comment and 1 note entry, got %d and %d (kinds: %v)",
+			len(comments), len(noteEntries), kindsOf(resp.Entries))
+	}
+
+	// The comment keeps its own id — it is a primary key and a paging cursor.
+	if comments[0].ID != comment.ID {
+		t.Errorf("the comment entry must keep its own id; got %q, want %q", comments[0].ID, comment.ID)
+	}
+	// The note is the one that yields.
+	if noteEntries[0].ID == comment.ID {
+		t.Errorf("the note entry kept the colliding id %q; two entries in one payload share an id "+
+			"and the client will hide one of them", noteEntries[0].ID)
+	}
+
+	// And no id is repeated anywhere in the page, which is the property the
+	// client actually depends on.
+	seen := map[string]int{}
+	for _, e := range resp.Entries {
+		seen[e.ID]++
+	}
+	for id, n := range seen {
+		if n > 1 {
+			t.Errorf("entry id %q appears %d times in one page", id, n)
+		}
+	}
+}
+
+// TestTimeline_StructuredIDCollidingWithAnActivityHidesNothing covers the
+// second source. Activities are generated server-side for the item's own
+// lifecycle, so a blob id can collide with one without anybody hand-editing
+// anything exotic.
+func TestTimeline_StructuredIDCollidingWithAnActivityHidesNothing(t *testing.T) {
+	srv := testServer(t)
+	ws := createWSForTest(t, srv)
+
+	item := timelineItemWithStructured(t, srv, ws, "", "")
+
+	// The create already produced an activity row; read its id back off the
+	// timeline rather than guessing at one.
+	before := fetchTimeline(t, srv, ws, item.Slug, "")
+	acts := entriesByKind(before.Entries, "activity")
+	if len(acts) == 0 {
+		t.Skip("no activity entry on a freshly created item; nothing to collide with")
+	}
+	victim := acts[0].ID
+
+	decisions, err := json.Marshal([]map[string]string{{
+		"id":         victim,
+		"decision":   "decision that stole an activity id",
+		"created_at": acts[0].CreatedAt.UTC().Format("2006-01-02T15:04:05Z07:00"),
+	}})
+	if err != nil {
+		t.Fatalf("marshal decisions: %v", err)
+	}
+	patchItemFields(t, srv, ws, item.Slug, `{"status":"open","decision_log":`+string(decisions)+`}`)
+
+	resp := fetchTimeline(t, srv, ws, item.Slug, "")
+
+	decisionEntries := entriesByKind(resp.Entries, "decision")
+	if len(decisionEntries) != 1 {
+		t.Fatalf("expected exactly 1 decision entry, got %d (kinds: %v)",
+			len(decisionEntries), kindsOf(resp.Entries))
+	}
+	if decisionEntries[0].ID == victim {
+		t.Errorf("the decision entry kept the colliding activity id %q", decisionEntries[0].ID)
+	}
+
+	// The activity must still be present under its own id: the structured
+	// entry yielding is only correct if the row it collided with survives.
+	stillThere := false
+	for _, e := range entriesByKind(resp.Entries, "activity") {
+		if e.ID == victim {
+			stillThere = true
+		}
+	}
+	if !stillThere {
+		t.Errorf("the activity that owned id %q is no longer in the payload", victim)
+	}
+
+	seen := map[string]int{}
+	for _, e := range resp.Entries {
+		seen[e.ID]++
+	}
+	for id, n := range seen {
+		if n > 1 {
+			t.Errorf("entry id %q appears %d times in one page", id, n)
+		}
+	}
+}
+
+// TestTimeline_StructuredIDEqualToAnotherEntrysFallback covers the OTHER half
+// of the uniqueness rule: a raw id that collides not with another raw id but
+// with the positional fallback a sibling was already given.
+//
+// The ORDER matters and my first fixture had it wrong, which is worth
+// recording: a note with no id followed by a note whose blob id is
+// "note-idx-0" does NOT reach the loop — the second note's raw id is already
+// in usedIDs, so the `!usedIDs[raw]` guard sends it to the fallback branch and
+// it gets `note-idx-1`, which is free. That fixture passed with the loop
+// deleted, i.e. it proved nothing about the thing it was named for.
+//
+// To reach the loop the fallback NAME must already be taken when the fallback
+// is computed: note 0 claims the literal string "note-idx-1", and note 1 has
+// no id, so its positional fallback is `note-idx-1` — occupied. Only then does
+// `for usedIDs[id] { id += "x" }` run.
+//
+// This is exotic but not unreachable: unlike the cross-source case, both ids
+// here come from the same unvalidated fields blob, so a hand-edited or
+// imported item can hold exactly this shape. (The cross-source fallback
+// collision, by contrast, cannot happen today — every SQL source mints
+// uuid.New() ids, including on import, and a UUID never equals `note-idx-N`.)
+func TestTimeline_StructuredIDEqualToAnotherEntrysFallback(t *testing.T) {
+	srv := testServer(t)
+	ws := createWSForTest(t, srv)
+
+	notes := `[{"id":"note-idx-1","summary":"claims a LATER entry's fallback name","created_at":"2026-04-02T10:00:00Z"},
+	           {"summary":"no id, so its fallback is note-idx-1 — already taken","created_at":"2026-04-02T11:00:00Z"}]`
+	item := timelineItemWithStructured(t, srv, ws, notes, "")
+
+	resp := fetchTimeline(t, srv, ws, item.Slug, "")
+
+	noteEntries := entriesByKind(resp.Entries, "note")
+	if len(noteEntries) != 2 {
+		t.Fatalf("expected both notes in the payload, got %d (kinds: %v)",
+			len(noteEntries), kindsOf(resp.Entries))
+	}
+	if noteEntries[0].ID == noteEntries[1].ID {
+		t.Errorf("both notes were emitted with id %q; one of them will be hidden by the client",
+			noteEntries[0].ID)
+	}
+
+	seen := map[string]int{}
+	for _, e := range resp.Entries {
+		seen[e.ID]++
+	}
+	for id, n := range seen {
+		if n > 1 {
+			t.Errorf("entry id %q appears %d times in one page", id, n)
+		}
+	}
+}

--- a/internal/server/handlers_timeline_structured_test.go
+++ b/internal/server/handlers_timeline_structured_test.go
@@ -635,14 +635,14 @@ func TestStructuredTimelineEntries_CursorPredicate(t *testing.T) {
 	}
 
 	t.Run("first page keeps everything older than now", func(t *testing.T) {
-		notes, decisions := structuredTimelineEntries(item, at("2026-05-01T00:00:00Z"), "", false)
+		notes, decisions := structuredTimelineEntries(item, at("2026-05-01T00:00:00Z"), "", false, nil)
 		if len(notes) != 2 || len(decisions) != 1 {
 			t.Fatalf("got %d notes / %d decisions, want 2 / 1", len(notes), len(decisions))
 		}
 	})
 
 	t.Run("cursor drops everything at or newer than it", func(t *testing.T) {
-		notes, decisions := structuredTimelineEntries(item, at("2026-04-02T11:00:00Z"), "", false)
+		notes, decisions := structuredTimelineEntries(item, at("2026-04-02T11:00:00Z"), "", false, nil)
 		if len(notes) != 1 || notes[0].ID != "note-1" {
 			t.Errorf("notes = %+v, want only note-1", notes)
 		}
@@ -652,7 +652,7 @@ func TestStructuredTimelineEntries_CursorPredicate(t *testing.T) {
 	})
 
 	t.Run("nil item is not a panic", func(t *testing.T) {
-		notes, decisions := structuredTimelineEntries(nil, at("2026-05-01T00:00:00Z"), "", false)
+		notes, decisions := structuredTimelineEntries(nil, at("2026-05-01T00:00:00Z"), "", false, nil)
 		if notes != nil || decisions != nil {
 			t.Errorf("nil item returned %v / %v", notes, decisions)
 		}

--- a/internal/server/handlers_timeline_structured_test.go
+++ b/internal/server/handlers_timeline_structured_test.go
@@ -635,14 +635,14 @@ func TestStructuredTimelineEntries_CursorPredicate(t *testing.T) {
 	}
 
 	t.Run("first page keeps everything older than now", func(t *testing.T) {
-		notes, decisions := structuredTimelineEntries(item, at("2026-05-01T00:00:00Z"), "", false, nil)
+		notes, decisions := structuredTimelineEntries(item, at("2026-05-01T00:00:00Z"), "", false)
 		if len(notes) != 2 || len(decisions) != 1 {
 			t.Fatalf("got %d notes / %d decisions, want 2 / 1", len(notes), len(decisions))
 		}
 	})
 
 	t.Run("cursor drops everything at or newer than it", func(t *testing.T) {
-		notes, decisions := structuredTimelineEntries(item, at("2026-04-02T11:00:00Z"), "", false, nil)
+		notes, decisions := structuredTimelineEntries(item, at("2026-04-02T11:00:00Z"), "", false)
 		if len(notes) != 1 || notes[0].ID != "note-1" {
 			t.Errorf("notes = %+v, want only note-1", notes)
 		}
@@ -652,7 +652,7 @@ func TestStructuredTimelineEntries_CursorPredicate(t *testing.T) {
 	})
 
 	t.Run("nil item is not a panic", func(t *testing.T) {
-		notes, decisions := structuredTimelineEntries(nil, at("2026-05-01T00:00:00Z"), "", false, nil)
+		notes, decisions := structuredTimelineEntries(nil, at("2026-05-01T00:00:00Z"), "", false)
 		if notes != nil || decisions != nil {
 			t.Errorf("nil item returned %v / %v", notes, decisions)
 		}


### PR DESCRIPTION
Closes BUG-2783.

## The defect

A note or decision id comes from the item's fields blob, which nothing validates on write. It can equal the id of a comment, activity or version on the **same item**, and then two entries in one timeline payload share an id. The intra-structured dedupe already prevents exactly this failure one source-boundary in; `usedIDs` simply never knew about the other three sources.

The client breaks two different ways, separated here because the first draft of this work collapsed them:

- **Within one page** — `ItemTimeline.svelte` renders `{#each visibleEntries as entry (entry.id)}`. A keyed each with a duplicate key is a Svelte **error**, not a silent drop.
- **Across pages** — the append path filters on `existingIds`, so the later copy is silently discarded. That is where something is hidden.

## The fix, and the one it replaces

**Refuse a raw blob id that is UUID-shaped**; it takes the positional fallback that an absent or duplicate id already takes.

Sound because the only ids a structured entry can collide with are comment, activity and version rows, and every one of those takes its id from `store.newID()` = `uuid.New().String()`. Enumerated rather than sampled: all six `INSERT` sites into those three tables pass `newID()`, and the import path re-mints rather than carrying an artifact's ids across. So a blob id can only equal a row id by being a UUID.

**The first version of this fix seeded the dedupe map from the ids fetched for the current page, and that was wrong.** The three SQL windows are cursor-dependent, so the same note took its raw id on a page where the colliding row fell outside the window and a positional id on one where it fell inside. The entry id is the **second term of the cursor predicate**, so a window-dependent id makes an entry's own sort position depend on which page is being built — paging can then skip or repeat it. Strictly worse than the bug it fixed, and a regression, since structured ids were previously a function of the item alone.

The invariant the replacement restores: an entry id must be a function of the **item**, never of (item, page window). Id-shape is a property of the string itself; the positional fallback indexes into the item's own blob. Both are window-independent.

**Cost, stated in the code:** a UUID-shaped blob id that collides with nothing also loses its raw id. That is the right trade, because innocence is undecidable without consulting exactly the rows the id must not depend on.

## Tests

They drive the **merged payload** through the real endpoint, not `structuredTimelineEntries`. That is the reason the gap survived: the builder is correct in isolation — it dedupes perfectly against the other structured entries — so a unit test of it vouches for the component rather than its binding to the three SQL sources.

| test | what it pins |
|---|---|
| collision with a comment | the note yields; the **comment keeps its own id** |
| collision with an activity | ditto, and the activity is still in the payload |
| collision with a version | the third source — a fix knowing only two passed the whole file, which is what the seeding version did |
| raw id equal to a sibling's fallback name | the `for usedIDs[id]` loop, which no test exercised before |
| id independent of the page window | the regression the first version introduced |

Assertions are deliberately specific about **which** entry moves. "Two entries are present" passes trivially even unfixed, since the collision is resolved by the client rather than the server; "the ids differ" would pass if the comment had been the one to yield, which is a different bug — comment ids are primary keys and are what the client sends back as `before_id`, so moving one breaks paging.

No `t.Skip` anywhere: creating an item writes an activity row, so absence means the fixture stopped building what the test needs, and a skip would report that as success forever. Those are `t.Fatalf`.

The fallback-loop fixture took two attempts, and the failed one is instructive. A note with no id followed by a note claiming `note-idx-0` does **not** reach the loop — the second note's raw id is already in `usedIDs`, so the `!usedIDs[raw]` guard diverts it to the fallback branch and it gets a free name. That fixture passed with the loop deleted. Reaching the loop needs the fallback **name** occupied when the fallback is computed: note 0 claiming the literal `note-idx-1`, note 1 having no id.

## Mutation matrix

Five, each verified to compile: drop the shape test · invert it · make the helper never fire · drop the fallback uniqueness loop · drop the intra-structured dedupe. All detected, each by the test aimed at it.

The last first read as a **survivor**. It is not — it dies on `TestItemTimeline_StructuredDuplicateIDsAreDisambiguated`, whose name my `-run TestTimeline` filter never matched. A `-run` filter narrower than the population is the same false-green family as a mutant killed by the compiler: the harness prints SURVIVED and the cause is the instrument.

## Gates

`go build ./...` · `make lint` 0 issues · `go test ./...` · Postgres on `internal/server` (own container, private port).

https://claude.ai/code/session_01JVDBKbgn3Xt7ndW1YoYd8X


---

## Review: five rounds, findings 5 / 2 / 2 / 1 / 0-new

The first version of the fix and its first two replacements were each wrong in a way the previous round did not cover. Recorded because the sequence is the point:

1. **Seeding from the page's rows** made an entry id a function of (item, page window) when the cursor predicate needs a function of (item) alone. Replaced with a UUID-shape test.
2. **Diverting shape-refused ids onto the positional fallback** pushed them onto an index-dependent path — widening a pre-existing instability to a much larger population. Replaced with a derived id, `<prefix>:<raw>`.
3. **Checking only the current kind's prefix** left the same hole one kind across: notes and decisions share one uniqueness map, so a note holding `decision:<uuid>` collided with what a decision derives from `<uuid>`. Fixed by reserving both namespaces globally.

Round 5 was asked to enumerate every way two entries could share an id, or one entry's id could change without the entry changing. It found no new defect; the residuals were already filed or documented.

### What is closed, and by what

| case | mechanism |
|---|---|
| structured raw vs structured raw | the `!usedIDs[raw]` guard |
| structured raw vs derived, same kind | divert on the prefix |
| structured raw vs derived, cross kind | `hasStructuredPrefix` |
| derived vs derived | equal only when the raws are equal |
| structured vs a row id | divert on UUID shape |
| fallback vs anything | the `for usedIDs[id]` loop |

### What is not, deliberately

- The **positional fallback** encodes an array index, so an entry with no usable id of its own can be renumbered by an edit elsewhere in the blob. Everything with something of its own to derive from was moved off that path; what remains has nothing. **BUG-2788**, which also now carries a second consequence found in round 5 — removing the first of two duplicate ids changes the survivor's id *kind*, which rules out that item's derive-from-content option.
- A **row id that is not a UUID** is outside the shape test, and the three SQL sources are not deduped against each other. Properties of the writers, unreachable through any current write or import path, undetectable here without the row lookup this design exists to avoid. Documented in `looksLikeRowID`.

## Mutation matrix

12, each verified to compile. Beyond the five above: stop diverting the prefix form, derive from a constant, drop the divert entirely, check only the calling kind's prefix, and drop either `"note"` or `"decision"` from the reserved list — the last two die on *different* tests, so neither stands in for the other.

One mutant first read as a survivor and was not: it dies on `TestItemTimeline_StructuredDuplicateIDsAreDisambiguated`, whose name my `-run TestTimeline` filter never matched. A `-run` filter narrower than the population is the same false-green family as a compiler-killed mutant.
