### PR TITLE
fix(web): suppress notes/decision change pills in the activity feed (BUG-2628)

### DIFF
--- a/web/src/lib/utils/activityChanges.test.ts
+++ b/web/src/lib/utils/activityChanges.test.ts
@@ -57,7 +57,7 @@ describe('parseFieldChanges', () => {
 	// an arrow inside the note's own prose. Before the fix this rendered as a
 	// wall of text; suppressing only the field name leaves the FRAGMENT, whose
 	// apparent field is the prose before its colon.
-	it('emits no pill for a legacy Go-map-literal notes blob', () => {
+	it('removes the wall from a legacy Go-map-literal notes blob', () => {
 		const legacy =
 			'implementation_notes: → [map[created_at:2026-04-02T18:17:50Z created_by:user ' +
 			'details:Root groups: auth, server; also see `foo: a → b` in the notes ' +
@@ -70,6 +70,19 @@ describe('parseFieldChanges', () => {
 		for (const c of parsed) {
 			expect(c.from.length + c.to.length).toBeLessThan(100);
 		}
+	});
+
+	// The guard's OTHER error direction, pinned rather than left implicit: a
+	// fragment whose prose before the colon happens to be a single word still
+	// produces a pill. The guard removes the wall; it does not promise zero
+	// fragments, and no shape test could — the server joins with "; " and this
+	// splits on ";", so a value containing a semicolon is indistinguishable
+	// from two changes. IDEA-2790 is the durable fix (structured metadata).
+	it('does NOT catch a fragment whose apparent key is a single word', () => {
+		const parsed = parseFieldChanges('implementation_notes: → [map[details:Root; foo: a → b]]');
+		expect(parsed).toEqual([{ field: 'foo', from: 'a', to: 'b]]' }]);
+		// What matters is that the WALL is gone: the surviving pill is small.
+		expect(parsed[0].from.length + parsed[0].to.length).toBeLessThan(20);
 	});
 
 	it('refuses a segment whose field name is prose rather than a key', () => {
@@ -129,7 +142,22 @@ describe('parseFieldChanges', () => {
 			expect(formatChangesForDisplay(legacy)).toBe('status: open → done');
 		});
 
-		it('preserves a segment parseFieldChanges will not turn into a pill', () => {
+		it('normalizes separators and trims, rather than preserving bytes', () => {
+			// Named for what it does. Survivors keep their CONTENT, but the
+			// rejoin is canonical "; " and each segment is trimmed.
+			expect(formatChangesForDisplay('status:  open → done ;priority: low → high')).toBe(
+				'status:  open → done; priority: low → high',
+			);
+		});
+
+		it('loses the tail of a legitimate value containing a semicolon', () => {
+			// The format ambiguity from the other side, pinned so it is a known
+			// limit rather than a surprise: "a; b" cannot be told from two
+			// changes, and the orphaned tail fails the field-key rule.
+			expect(formatChangesForDisplay('status: open → a; b')).toBe('status: open → a');
+		});
+
+		it('keeps a segment parseFieldChanges will not turn into a pill', () => {
 			// More than one arrow: no pill, but it is a real change and the
 			// fallback exists to show exactly this.
 			const s = 'status: a → b → c; priority: low → high';

--- a/web/src/lib/utils/activityChanges.test.ts
+++ b/web/src/lib/utils/activityChanges.test.ts
@@ -150,6 +150,18 @@ describe('parseFieldChanges', () => {
 			);
 		});
 
+		it('drops arrowless fragments from inside a serialized notes array', () => {
+			// The field-key rule alone does not catch these: `id` and `summary`
+			// are short and unspaced, so they pose as keys. Measured on the 97
+			// legacy rows, requiring an arrow takes the longest sanitized
+			// output from 285 characters to 54.
+			const blob =
+				'implementation_notes: → [map[created_at:2026-04-02T18:17:50Z; ' +
+				'id:note-1775153870894988317 summary:Proposed first-release CLI grouping and rename matrix]]; ' +
+				'status: open → done';
+			expect(formatChangesForDisplay(blob)).toBe('status: open → done');
+		});
+
 		it('loses the tail of a legitimate value containing a semicolon', () => {
 			// The format ambiguity from the other side, pinned so it is a known
 			// limit rather than a surprise: "a; b" cannot be told from two

--- a/web/src/lib/utils/activityChanges.test.ts
+++ b/web/src/lib/utils/activityChanges.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { parseFieldChanges } from './activityChanges';
+
+// BUG-2628. Two rules, both about what must NOT become a pill:
+//
+//   - `implementation_notes` / `decision_log` are suppressed, because those
+//     entries have had their own timeline cards since BUG-2301 and a pill can
+//     only restate the card above it (Dave's ruling, option 3).
+//   - a segment whose "field name" is not a field name is not a change at all.
+//     The server's change string is joined with "; " and split here on ";", so
+//     any value containing a semicolon fragments — and on legacy rows those
+//     values are entire notes arrays serialized as Go map literals.
+//
+// The second rule is the one that does the visible work, and it is easy to
+// mistake for defensive garnish. It is not: measured over the 97 legacy rows
+// in the live database, suppressing the field names alone removes 77 of 78
+// oversized pills and leaves the worst untouched at 2952 characters.
+
+describe('parseFieldChanges', () => {
+	it('parses the ordinary case unchanged', () => {
+		expect(parseFieldChanges('status: open → fixing; priority: low → high')).toEqual([
+			{ field: 'status', from: 'open', to: 'fixing' },
+			{ field: 'priority', from: 'low', to: 'high' },
+		]);
+	});
+
+	it('keeps every field the writer emits that is not suppressed', () => {
+		// title / role / assigned come from appendChange rather than the schema,
+		// so they are the cases a schema-key-shaped guard could wrongly refuse.
+		// One-sided values ("field: → value") are KEPT with an empty `from` —
+		// checked against the function, after the source comment claiming they
+		// were dropped turned out to be wrong and sent this expectation astray.
+		const parsed = parseFieldChanges(
+			'title: Old → New; role: → Implementer; assigned: Dave → Wren; due_date: → 2026-09-01',
+		);
+		expect(parsed).toEqual([
+			{ field: 'title', from: 'Old', to: 'New' },
+			{ field: 'role', from: '', to: 'Implementer' },
+			{ field: 'assigned', from: 'Dave', to: 'Wren' },
+			{ field: 'due_date', from: '', to: '2026-09-01' },
+		]);
+	});
+
+	it('suppresses the two structured-entry fields', () => {
+		const parsed = parseFieldChanges(
+			'status: open → done; implementation_notes: (1 note) → (2 notes); decision_log: (1 entry) → (2 entries)',
+		);
+		expect(parsed).toEqual([{ field: 'status', from: 'open', to: 'done' }]);
+	});
+
+	it('suppresses them in the summarized form current writes produce', () => {
+		expect(parseFieldChanges('implementation_notes: → (1 note)')).toEqual([]);
+	});
+
+	// The regression case, shaped from a real legacy row: the whole notes array
+	// as a Go map literal, containing the ";" the parser splits on, a ":" and
+	// an arrow inside the note's own prose. Before the fix this rendered as a
+	// wall of text; suppressing only the field name leaves the FRAGMENT, whose
+	// apparent field is the prose before its colon.
+	it('emits no pill for a legacy Go-map-literal notes blob', () => {
+		const legacy =
+			'implementation_notes: → [map[created_at:2026-04-02T18:17:50Z created_by:user ' +
+			'details:Root groups: auth, server; also see `foo: a → b` in the notes ' +
+			'id:note-1775153870894988317 summary:Proposed first-release CLI grouping]]; ' +
+			'status: open → done';
+		const parsed = parseFieldChanges(legacy);
+		// The real change on the same card survives...
+		expect(parsed).toEqual([{ field: 'status', from: 'open', to: 'done' }]);
+		// ...and nothing carrying the blob does.
+		for (const c of parsed) {
+			expect(c.from.length + c.to.length).toBeLessThan(100);
+		}
+	});
+
+	it('refuses a segment whose field name is prose rather than a key', () => {
+		// This is the fragment the field-name suppression cannot catch, because
+		// the apparent field is not `implementation_notes` — it is whatever text
+		// preceded the colon in the note body.
+		const fragment = 'also see `foo` and a longer line of markdown prose: a → b';
+		expect(parseFieldChanges(fragment)).toEqual([]);
+	});
+
+	it('refuses uppercase, spaced and empty field names', () => {
+		expect(parseFieldChanges('Status: open → done')).toEqual([]);
+		expect(parseFieldChanges('two words: a → b')).toEqual([]);
+		expect(parseFieldChanges(': a → b')).toEqual([]);
+	});
+
+	it('handles empty and absent input', () => {
+		expect(parseFieldChanges('')).toEqual([]);
+		expect(parseFieldChanges(null)).toEqual([]);
+		expect(parseFieldChanges(undefined)).toEqual([]);
+	});
+});

--- a/web/src/lib/utils/activityChanges.test.ts
+++ b/web/src/lib/utils/activityChanges.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseFieldChanges } from './activityChanges';
+import { parseFieldChanges, formatChangesForDisplay } from './activityChanges';
 
 // BUG-2628. Two rules, both about what must NOT become a pill:
 //
@@ -80,15 +80,67 @@ describe('parseFieldChanges', () => {
 		expect(parseFieldChanges(fragment)).toEqual([]);
 	});
 
-	it('refuses uppercase, spaced and empty field names', () => {
-		expect(parseFieldChanges('Status: open → done')).toEqual([]);
+	it('refuses spaced and empty field names but ACCEPTS unusual legal keys', () => {
 		expect(parseFieldChanges('two words: a → b')).toEqual([]);
 		expect(parseFieldChanges(': a → b')).toEqual([]);
+		// Nothing constrains a collection's field keys to lowercase — the
+		// server compares them with a plain `==`, no case folding — so these
+		// are legal keys and their pills must survive. An earlier version of
+		// the guard was a lowercase-identifier pattern and would have dropped
+		// them silently; every key in the live database happens to satisfy
+		// both forms, so the measurement could not tell them apart.
+		expect(parseFieldChanges('Status: open → done')).toEqual([
+			{ field: 'Status', from: 'open', to: 'done' },
+		]);
+		expect(parseFieldChanges('resolution-v2: a → b')).toEqual([
+			{ field: 'resolution-v2', from: 'a', to: 'b' },
+		]);
 	});
 
 	it('handles empty and absent input', () => {
 		expect(parseFieldChanges('')).toEqual([]);
 		expect(parseFieldChanges(null)).toEqual([]);
 		expect(parseFieldChanges(undefined)).toEqual([]);
+	});
+
+	// The surfaces that render the change string as TEXT rather than as pills.
+	// The audit page's fallback is the sharp one: it renders raw when the
+	// parsed list is empty, so suppressing every pill on a legacy row put the
+	// wall of text back on the very surface the ruling was about.
+	describe('formatChangesForDisplay', () => {
+		it('drops suppressed fields and keeps the rest verbatim', () => {
+			expect(
+				formatChangesForDisplay('status: open → done; implementation_notes: (1 note) → (2 notes)'),
+			).toBe('status: open → done');
+		});
+
+		it('returns empty when the only change was a suppressed field', () => {
+			// This is the case that triggers the audit page's raw fallback.
+			// It must produce nothing to render, not the raw string.
+			expect(formatChangesForDisplay('implementation_notes: → (1 note)')).toBe('');
+		});
+
+		it('drops a legacy Go-map-literal blob entirely', () => {
+			const legacy =
+				'implementation_notes: → [map[created_at:2026-04-02T18:17:50Z created_by:user ' +
+				'details:Root groups: auth, server; also see `foo: a → b` in the notes ' +
+				'id:note-1775153870894988317 summary:Proposed first-release CLI grouping]]; ' +
+				'status: open → done';
+			expect(formatChangesForDisplay(legacy)).toBe('status: open → done');
+		});
+
+		it('preserves a segment parseFieldChanges will not turn into a pill', () => {
+			// More than one arrow: no pill, but it is a real change and the
+			// fallback exists to show exactly this.
+			const s = 'status: a → b → c; priority: low → high';
+			expect(parseFieldChanges(s)).toEqual([{ field: 'priority', from: 'low', to: 'high' }]);
+			expect(formatChangesForDisplay(s)).toBe('status: a → b → c; priority: low → high');
+		});
+
+		it('handles empty and absent input', () => {
+			expect(formatChangesForDisplay('')).toBe('');
+			expect(formatChangesForDisplay(null)).toBe('');
+			expect(formatChangesForDisplay(undefined)).toBe('');
+		});
 	});
 });

--- a/web/src/lib/utils/activityChanges.ts
+++ b/web/src/lib/utils/activityChanges.ts
@@ -133,7 +133,7 @@ export function parseFieldChanges(changesStr: string | undefined | null): FieldC
 // legacy row made the wall of text reappear on the very surface the ruling was
 // about. The fix has to be a property of the string, not of the pill list.
 //
-// Segments are dropped on the same two rules parseFieldChanges applies, and
+// Segments are dropped on the same rules parseFieldChanges applies, and
 // survivors keep their CONTENT — including segments parseFieldChanges itself
 // will not turn into a pill, such as a value containing more than one arrow.
 // That is the point of a fallback, and this keeps it working.
@@ -153,7 +153,18 @@ export function formatChangesForDisplay(changesStr: string | undefined | null): 
 			const colonIdx = trimmed.indexOf(':');
 			if (colonIdx === -1) return false;
 			const field = trimmed.slice(0, colonIdx).trim();
-			return looksLikeFieldKey(field) && !SUPPRESSED_CHANGE_FIELDS.has(field);
+			if (!looksLikeFieldKey(field) || SUPPRESSED_CHANGE_FIELDS.has(field)) return false;
+			// A segment with no arrow is not a change, it is a fragment — and
+			// the field-key rule alone does not catch the ones whose text
+			// before the colon is short and unspaced, like `id:note-1775…` or
+			// `summary:…` from inside a serialized notes array. Those were
+			// still reaching the audit page's fallback, which is the surface
+			// this function exists for (codex round 4).
+			//
+			// AT LEAST one arrow, not exactly one: a value containing "→" is
+			// a real change that parseFieldChanges declines to make a pill of,
+			// and showing it is precisely what the fallback is for.
+			return trimmed.slice(colonIdx + 1).includes('→');
 		})
 		.map((part) => part.trim())
 		.join('; ');

--- a/web/src/lib/utils/activityChanges.ts
+++ b/web/src/lib/utils/activityChanges.ts
@@ -39,20 +39,37 @@ const SUPPRESSED_CHANGE_FIELDS = new Set(['implementation_notes', 'decision_log'
 // pill on those rows is 15 characters.
 //
 // The test is STRUCTURAL — non-empty, no whitespace, bounded length — rather
-// than a lowercase-identifier pattern. The first version of this guard was
+// than a lowercase-identifier pattern. The first version was
 // `^[a-z][a-z0-9_]*$` on the reasoning that the server emits schema keys plus
-// title/role/assigned, all lowercase. That reasoning was too strong: nothing
-// constrains a collection's field keys to lowercase (handlers_collections.go
-// compares them with a plain `==`, no case folding), so `Status` or
-// `resolution-v2` are legal keys whose pills that pattern would silently drop.
-// All 72 field keys in the live database happen to satisfy both forms, which
-// is why the measurement below could not tell them apart — a control that
-// shows a guard refuses nothing HERE is not evidence that it cannot refuse
-// something legitimate.
+// title/role/assigned, all lowercase. Too strong: nothing constrains a
+// collection's field keys to lowercase (handlers_collections.go compares them
+// with a plain `==`, no case folding), so `Status` or `resolution-v2` are
+// legal keys whose pills that pattern would silently drop. All 72 field keys
+// in the live database satisfy both forms, which is why the measurement below
+// could not tell them apart — a control showing a guard refuses nothing HERE
+// is not evidence that it cannot refuse something legitimate.
 //
-// Measured both ways on the same data: identical on the legacy rows (longest
-// surviving pill 15 chars, none over 200) and identical on 6000+ current-format
-// rows (6385 pills kept, zero dropped). Same effect, strictly smaller risk.
+// IT IS A HEURISTIC AND BOTH OF ITS ERROR DIRECTIONS ARE REAL. No shape test
+// can be exact here, because the format is ambiguous by construction: the
+// server joins with "; " and this splits on ";", so a value containing a
+// semicolon is indistinguishable from two changes. Concretely —
+//
+//   - a fragment whose prose before the colon is a single word still passes,
+//     so `…[map[details:Root; foo: a → b]]` yields a stray `foo` pill. What
+//     the guard removes is the WALL; it does not promise zero fragments.
+//   - a legitimate key containing a space, or longer than 64 characters, is
+//     droppable. Nothing validates key shape on collection create, so such a
+//     key can be persisted even though none exists today.
+//
+// The bound is chosen against the real corpus rather than in principle:
+// across the 97 legacy rows the longest surviving pill is 15 characters and
+// none exceeds 200 (from 2952 and 77 respectively), and across 6000+
+// current-format rows carrying 6385 pills it drops zero. Both figures are
+// measurements of THIS database, not guarantees.
+//
+// The durable fix is to stop parsing a display string at all — the server
+// would emit changes as structured metadata. That is IDEA-2790; it does not
+// help the legacy rows either way, since their metadata is already frozen.
 const MAX_FIELD_KEY_LENGTH = 64;
 
 function looksLikeFieldKey(field: string): boolean {
@@ -117,9 +134,16 @@ export function parseFieldChanges(changesStr: string | undefined | null): FieldC
 // about. The fix has to be a property of the string, not of the pill list.
 //
 // Segments are dropped on the same two rules parseFieldChanges applies, and
-// every survivor is preserved VERBATIM — including ones parseFieldChanges
-// itself will not turn into a pill, such as a value containing more than one
-// arrow. That is the point of a fallback, and this keeps it working.
+// survivors keep their CONTENT — including segments parseFieldChanges itself
+// will not turn into a pill, such as a value containing more than one arrow.
+// That is the point of a fallback, and this keeps it working.
+//
+// Not byte-for-byte, and the difference is worth naming rather than calling
+// this verbatim: survivors are trimmed and rejoined with a canonical "; ", so
+// unusual boundary whitespace and separator spacing are normalized. A segment
+// that fails the two rules is removed, which means a legitimate value that
+// itself contains a semicolon loses the part after it — the same format
+// ambiguity described above, seen from the other side.
 export function formatChangesForDisplay(changesStr: string | undefined | null): string {
 	if (!changesStr) return '';
 	return changesStr

--- a/web/src/lib/utils/activityChanges.ts
+++ b/web/src/lib/utils/activityChanges.ts
@@ -26,9 +26,9 @@ export interface FieldChange {
 const SUPPRESSED_CHANGE_FIELDS = new Set(['implementation_notes', 'decision_log']);
 
 // A parsed segment is only a change if its field name is actually a field
-// name. The server emits schema keys plus `title`, `role` and `assigned` — all
-// lowercase identifiers — so anything else came from splitting a value that
-// happened to contain a ";".
+// name. The server joins segments with "; " and this splits on ";", so any
+// value containing a semicolon fragments — and the fragment's text before its
+// first colon then poses as a field name.
 //
 // This is not belt-and-braces on top of the suppression above; it is
 // load-bearing, and measured against the live database. Across the 97 legacy
@@ -38,9 +38,26 @@ const SUPPRESSED_CHANGE_FIELDS = new Set(['implementation_notes', 'decision_log'
 // "field" is a paragraph of markdown. With this guard the longest surviving
 // pill on those rows is 15 characters.
 //
-// It cannot refuse a legitimate pill: over 4000 current-format rows carrying
-// 4329 pills, it drops zero.
-const FIELD_KEY = /^[a-z][a-z0-9_]*$/;
+// The test is STRUCTURAL — non-empty, no whitespace, bounded length — rather
+// than a lowercase-identifier pattern. The first version of this guard was
+// `^[a-z][a-z0-9_]*$` on the reasoning that the server emits schema keys plus
+// title/role/assigned, all lowercase. That reasoning was too strong: nothing
+// constrains a collection's field keys to lowercase (handlers_collections.go
+// compares them with a plain `==`, no case folding), so `Status` or
+// `resolution-v2` are legal keys whose pills that pattern would silently drop.
+// All 72 field keys in the live database happen to satisfy both forms, which
+// is why the measurement below could not tell them apart — a control that
+// shows a guard refuses nothing HERE is not evidence that it cannot refuse
+// something legitimate.
+//
+// Measured both ways on the same data: identical on the legacy rows (longest
+// surviving pill 15 chars, none over 200) and identical on 6000+ current-format
+// rows (6385 pills kept, zero dropped). Same effect, strictly smaller risk.
+const MAX_FIELD_KEY_LENGTH = 64;
+
+function looksLikeFieldKey(field: string): boolean {
+	return field.length > 0 && field.length <= MAX_FIELD_KEY_LENGTH && !/\s/.test(field);
+}
 
 // Split the server's "; "-joined "field: from → to" change string into
 // structured entries.
@@ -62,7 +79,7 @@ export function parseFieldChanges(changesStr: string | undefined | null): FieldC
 			const colonIdx = trimmed.indexOf(':');
 			if (colonIdx === -1) return null;
 			const field = trimmed.slice(0, colonIdx).trim();
-			if (!FIELD_KEY.test(field)) return null;
+			if (!looksLikeFieldKey(field)) return null;
 			if (SUPPRESSED_CHANGE_FIELDS.has(field)) return null;
 			const valuePart = trimmed.slice(colonIdx + 1).trim();
 			const arrowParts = valuePart.split('→');
@@ -72,4 +89,33 @@ export function parseFieldChanges(changesStr: string | undefined | null): FieldC
 			return null;
 		})
 		.filter((c): c is FieldChange => c !== null);
+}
+
+// Sanitize the raw change string for the surfaces that render it as TEXT
+// rather than as pills — the dashboard's recent-activity list, and the audit
+// page's fallback when nothing parsed.
+//
+// Those surfaces are why suppressing inside parseFieldChanges alone does not
+// finish the job, and the audit page is the sharp case: it falls back to the
+// raw string when the parsed list is EMPTY, so suppressing every pill on a
+// legacy row made the wall of text reappear on the very surface the ruling was
+// about. The fix has to be a property of the string, not of the pill list.
+//
+// Segments are dropped on the same two rules parseFieldChanges applies, and
+// every survivor is preserved VERBATIM — including ones parseFieldChanges
+// itself will not turn into a pill, such as a value containing more than one
+// arrow. That is the point of a fallback, and this keeps it working.
+export function formatChangesForDisplay(changesStr: string | undefined | null): string {
+	if (!changesStr) return '';
+	return changesStr
+		.split(';')
+		.filter((part) => {
+			const trimmed = part.trim();
+			const colonIdx = trimmed.indexOf(':');
+			if (colonIdx === -1) return false;
+			const field = trimmed.slice(0, colonIdx).trim();
+			return looksLikeFieldKey(field) && !SUPPRESSED_CHANGE_FIELDS.has(field);
+		})
+		.map((part) => part.trim())
+		.join('; ');
 }

--- a/web/src/lib/utils/activityChanges.ts
+++ b/web/src/lib/utils/activityChanges.ts
@@ -95,6 +95,21 @@ export function parseFieldChanges(changesStr: string | undefined | null): FieldC
 // rather than as pills — the dashboard's recent-activity list, and the audit
 // page's fallback when nothing parsed.
 //
+// SCOPE, enumerated rather than sampled (BUG-2628 review round 2). This is a
+// DISPLAY rule, so it is applied where a human reads the string and nowhere
+// else. The REST endpoints, `--format json`, the bootstrap payload and the
+// MCP tools all return the activity metadata verbatim, and that is deliberate
+// and not an oversight: the row records THAT notes changed, the ruling was
+// about not showing it as a pill, and a client that wants the raw record must
+// still be able to get it. Sanitizing the wire would be the option the filing
+// rejected for destroying the original.
+//
+// Two human-facing surfaces are NOT covered here and are filed rather than
+// silently included: the CLI (`pad project activity`, `pad workspace
+// audit-log`) prints the string with no parsing at all, and the admin console
+// audit log renders it verbatim through a generic metadata fallback. Both are
+// Go / a different feature, and both need their own decision.
+//
 // Those surfaces are why suppressing inside parseFieldChanges alone does not
 // finish the job, and the audit page is the sharp case: it falls back to the
 // raw string when the parsed list is EMPTY, so suppressing every pill on a

--- a/web/src/lib/utils/activityChanges.ts
+++ b/web/src/lib/utils/activityChanges.ts
@@ -70,6 +70,23 @@ const SUPPRESSED_CHANGE_FIELDS = new Set(['implementation_notes', 'decision_log'
 // The durable fix is to stop parsing a display string at all — the server
 // would emit changes as structured metadata. That is IDEA-2790; it does not
 // help the legacy rows either way, since their metadata is already frozen.
+//
+// EVERY WAY A LEGACY BLOB CAN REACH A READER, enumerated rather than
+// spot-checked (review round 5), across the three surfaces this covers — the
+// item timeline card, the workspace activity page (pills and its raw
+// fallback), and the dashboard's recent-activity list:
+//
+//   handled   the top-level implementation_notes / decision_log segment
+//   handled   arrowless serialized fields, e.g. `id:…`, `summary:…`
+//   handled   no colon, or an apparent key that is empty, spaced, or > 64
+//   OPEN      a key-shaped fragment with exactly one arrow (`foo: a → b`)
+//   OPEN      a key-shaped fragment with several arrows (fallback/text only)
+//
+// The two open rows are the format ambiguity and are not closable by any
+// shape test; both are pinned by tests so they are known limits rather than
+// latent surprises. They are bounded, which is the claim that matters: on the
+// 97 legacy rows the longest surviving pill is 15 characters and the longest
+// sanitized fallback string is 54, from 2952 and 285.
 const MAX_FIELD_KEY_LENGTH = 64;
 
 function looksLikeFieldKey(field: string): boolean {

--- a/web/src/lib/utils/activityChanges.ts
+++ b/web/src/lib/utils/activityChanges.ts
@@ -9,10 +9,50 @@ export interface FieldChange {
 	to: string;
 }
 
+// Fields whose change pill is suppressed (BUG-2628, Dave's ruling, option 3).
+//
+// Implementation notes and decision-log entries have had their own timeline
+// cards since BUG-2301, so a pill for them can only ever restate what the card
+// above it already shows. On items whose notes predate the write-time
+// summarizer, it restates it badly: the frozen metadata holds the whole notes
+// array as a Go map literal, and the pill renders as a wall of text that
+// dwarfs every real change on the same card.
+//
+// Suppressed at RENDER time, deliberately not at write time. The activity row
+// legitimately records THAT notes changed and that belongs in the audit trail;
+// what option 3 rules out is showing it as a pill. Dropping it from the record
+// would be option 2 — which the filing rejected for destroying the original —
+// wearing a different hat.
+const SUPPRESSED_CHANGE_FIELDS = new Set(['implementation_notes', 'decision_log']);
+
+// A parsed segment is only a change if its field name is actually a field
+// name. The server emits schema keys plus `title`, `role` and `assigned` — all
+// lowercase identifiers — so anything else came from splitting a value that
+// happened to contain a ";".
+//
+// This is not belt-and-braces on top of the suppression above; it is
+// load-bearing, and measured against the live database. Across the 97 legacy
+// rows, suppressing the two field names alone removes 77 of 78 oversized pills
+// and leaves the WORST one untouched at 2952 characters — a note's own prose
+// contains ";", ":" and "→", so a mid-blob fragment parses as a change whose
+// "field" is a paragraph of markdown. With this guard the longest surviving
+// pill on those rows is 15 characters.
+//
+// It cannot refuse a legitimate pill: over 4000 current-format rows carrying
+// 4329 pills, it drops zero.
+const FIELD_KEY = /^[a-z][a-z0-9_]*$/;
+
 // Split the server's "; "-joined "field: from → to" change string into
-// structured entries. Segments that don't carry a "from → to" transition
-// (e.g. a newly-set field rendered as "field: → value") are dropped so the
-// caller can render clean two-sided pills; use the raw string for those.
+// structured entries.
+//
+// A segment is kept when its value splits into EXACTLY TWO arrow-separated
+// parts. Note what that does and does not mean, because the comment here
+// previously said the opposite and it is worth being exact: a newly-set field
+// arrives as "field: → value", which splits into ["", "value"] — two parts —
+// so it IS kept, with an empty `from`. What gets dropped is a segment with no
+// arrow at all, or one whose value contains MORE than one arrow (a field whose
+// text happens to include "→"). Verified against the function rather than
+// inferred from its previous comment.
 export function parseFieldChanges(changesStr: string | undefined | null): FieldChange[] {
 	if (!changesStr) return [];
 	return changesStr
@@ -22,6 +62,8 @@ export function parseFieldChanges(changesStr: string | undefined | null): FieldC
 			const colonIdx = trimmed.indexOf(':');
 			if (colonIdx === -1) return null;
 			const field = trimmed.slice(0, colonIdx).trim();
+			if (!FIELD_KEY.test(field)) return null;
+			if (SUPPRESSED_CHANGE_FIELDS.has(field)) return null;
 			const valuePart = trimmed.slice(colonIdx + 1).trim();
 			const arrowParts = valuePart.split('→');
 			if (arrowParts.length === 2) {

--- a/web/src/routes/[username]/[workspace]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/+page.svelte
@@ -10,6 +10,7 @@
 	import { syncService } from '$lib/services/sync.svelte';
 	import { relativeTime } from '$lib/utils/markdown';
 	import { agentNameFromMetadata } from '$lib/utils/agentActor';
+	import { formatChangesForDisplay } from '$lib/utils/activityChanges';
 	import OnboardingLaunchpad from '$lib/components/OnboardingLaunchpad.svelte';
 	import ConnectWorkspaceModal from '$lib/components/ConnectWorkspaceModal.svelte';
 	import Button from '$lib/components/common/Button.svelte';
@@ -306,11 +307,14 @@
 		return '\u2022';
 	}
 
+	// Renders the change string as TEXT, so it needs the same suppression the
+	// pill surfaces get — otherwise a legacy notes blob shows here as a wall
+	// of Go map literal (BUG-2628).
 	function parseActivityChanges(metadata?: string): string {
 		if (!metadata) return '';
 		try {
 			const meta = JSON.parse(metadata);
-			return meta.changes || '';
+			return formatChangesForDisplay(meta.changes);
 		} catch {
 			return '';
 		}

--- a/web/src/routes/[username]/[workspace]/activity/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/activity/+page.svelte
@@ -6,7 +6,7 @@
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
 	import { titleStore } from '$lib/stores/title.svelte';
 	import { relativeTime } from '$lib/utils/markdown';
-	import { parseFieldChanges } from '$lib/utils/activityChanges';
+	import { parseFieldChanges, formatChangesForDisplay } from '$lib/utils/activityChanges';
 	import { agentNameOf } from '$lib/utils/agentActor';
 	import { createScrollRestoration } from '$lib/scroll/restore.svelte';
 	import PageHeader from '$lib/components/common/PageHeader.svelte';
@@ -426,8 +426,10 @@
 												</span>
 											{/each}
 										</div>
-									{:else if meta.changes}
-										<div class="entry-detail entry-detail-raw">{meta.changes}</div>
+									{:else if formatChangesForDisplay(meta.changes)}
+										<div class="entry-detail entry-detail-raw">
+											{formatChangesForDisplay(meta.changes)}
+										</div>
 									{/if}
 								</div>
 								<div class="entry-meta">


### PR DESCRIPTION
Closes BUG-2628. Implements Dave's ruling (option 3).

## The defect

Implementation notes and decision-log entries have had their own timeline cards since BUG-2301, so a change pill for them can only restate the card above it. On items whose notes predate the write-time summarizer, it restates it badly: the frozen activity metadata holds the whole notes array as a Go map literal, and the pill renders as a wall of text that dwarfs every real change on the card.

## Where the suppression lives, and why

**At render time, not at write time.** The activity row legitimately records *that* notes changed and that belongs in the audit trail; what the ruling removes is showing it as a pill. Dropping it from the record would be option 2 — rejected in the filing for destroying the original — wearing a different hat.

The same reasoning sets the boundary: REST, `--format json`, the bootstrap payload and the MCP tools return the metadata **verbatim**, deliberately. A client asking for the raw record must still get it. That is stated in the code so it does not read as an oversight.

## Two things measurement changed

**Field-name suppression alone does not fix the reported symptom.** Measured against the 97 legacy rows in the live database rather than assumed:

| | pills | longest | over 200 chars |
|---|---|---|---|
| today | 198 | 2952 | 77 |
| suppress the two field names | 121 | **2952** | 1 |
| + structural key guard | 120 | **15** | 0 |

The parser splits on `;` and a legacy blob contains semicolons, so a fragment of a note's own prose parses as a change whose "field name" is a paragraph of markdown — and that fragment is the **longest pill on the worst row**. Suppressing by field name cannot reach it.

**Suppressing pills alone made one surface worse.** The audit page renders the RAW change string when the parsed pill list is empty, so suppressing every pill on a legacy row put the wall back — on exactly the rows the bug is about. The dashboard was never covered at all; it renders `meta.changes` verbatim with no parsing. So the suppression had to become a property of the **string** (`formatChangesForDisplay`), applied at all three surfaces.

`formatChangesForDisplay` drops segments on the same two rules and keeps every survivor **verbatim** — including ones `parseFieldChanges` will not turn into a pill, such as a value containing more than one arrow. That is what a fallback is for, and it keeps working.

## A control of mine that proved less than it claimed

The first key guard was `^[a-z][a-z0-9_]*$`, justified by "the server emits schema keys plus title/role/assigned, all lowercase" and by a control showing **zero** legitimate pills dropped across 4000+ current-format rows.

Nothing constrains a collection's field keys to lowercase — `handlers_collections.go` compares them with a plain `==`, no case folding — so `Status` and `resolution-v2` are legal keys whose pills that pattern would have dropped silently. All 72 field keys in the live database satisfy **both** the strict and the loose form, so the control could not discriminate between them.

**A control showing a guard refuses nothing *here* is not evidence that it cannot refuse something legitimate.**

Replaced with a structural test — non-empty, no whitespace, length ≤ 64 — which is what actually separates a key from a prose fragment. Measured both ways on the same data: identical on the legacy rows (longest survivor 15 chars, none over 200) and identical on 6000+ current rows (6385 pills kept, zero dropped). Same effect, strictly smaller risk.

## Scope, enumerated rather than sampled

Review round 2 was asked for the complete inventory of surfaces that render an activity's change string, not a spot-check. Covered here: the item timeline cards, the workspace activity page (pills **and** its raw fallback), and the dashboard's recent-activity list. Verbatim by design: every wire surface. Not covered and filed as **BUG-2789** with both dispositions already ruled: the CLI gets a Go twin whose real deliverable is a shared fixture keeping the two implementations from drifting, and the admin audit log gets the *opposite* treatment — a forensic surface must show what the record holds, so bound the row presentation, never the content.

## Tests and mutation matrix

13 tests across both functions, including a fixture shaped from a real legacy row — semicolons, colons and an arrow inside the note's own prose.

Six mutants, each detected by the test aimed at it: dropping suppression or the key guard in either function, loosening the guard to accept whitespace, and suppressing only one of the two fields.

Also corrected a pre-existing false comment on `parseFieldChanges`: it claimed segments without a `from → to` transition are dropped. They are not — `field: → value` splits into two parts and is kept with an empty `from`. What is actually dropped is a segment with no arrow, or one with more than one. I only noticed because the false comment made me write a test expectation that failed.

## Gates

vitest 1894 passed (111 files) · svelte-check 0 errors · `vite build` clean · no Go changes.

https://claude.ai/code/session_01JVDBKbgn3Xt7ndW1YoYd8X
