### PR TITLE
fix(store): compare-and-set the wiki-link cascade's writes (BUG-2785)

### DIFF
--- a/internal/links/links.go
+++ b/internal/links/links.go
@@ -173,9 +173,12 @@ func RewriteBracketAt(content string, position int, targetTitle, newTitle, collS
 // argued: ReplaceTitle("x [[A]] y", "A", "A]] [[A") builds `[[A]] [[A]]`, which
 // still contains `[[A]]`, and a probe against the old implementation ran for 3s
 // without terminating before being killed. The caller is inside the rename
-// transaction AND holds the workspace rename advisory lock (BUG-2778), so the
-// hang would take out every other rename in that workspace behind it, on top of
-// exhausting memory in the one that triggered it.
+// transaction, so the hang holds that transaction open indefinitely on either
+// dialect. On POSTGRES it also holds the workspace rename advisory lock
+// (BUG-2778), blocking every other rename in that workspace behind it; on
+// SQLITE that advisory lock is a no-op and the equivalent damage is the
+// database-wide write lock the transaction already holds under BEGIN IMMEDIATE.
+// Different mechanism, same outcome for everyone else.
 //
 // strings.Replace with n = -1 has the semantics that were actually wanted:
 // non-overlapping, left-to-right, over the input, so inserted text is never

--- a/internal/links/links.go
+++ b/internal/links/links.go
@@ -161,24 +161,32 @@ func RewriteBracketAt(content string, position int, targetTitle, newTitle, collS
 	return content
 }
 
+// replaceAll substitutes every occurrence of old with new, scanning the INPUT
+// once rather than re-scanning its own output.
+//
+// The previous implementation looped `find old in result; splice new in` until
+// no match remained — re-searching the string it was building, including the
+// text it had just inserted. When `new` CONTAINS `old` that never terminates
+// and the string grows without bound.
+//
+// Reachable from a user-supplied document title, and measured rather than
+// argued: ReplaceTitle("x [[A]] y", "A", "A]] [[A") builds `[[A]] [[A]]`, which
+// still contains `[[A]]`, and a probe against the old implementation ran for 3s
+// without terminating before being killed. The caller is inside the rename
+// transaction AND holds the workspace rename advisory lock (BUG-2778), so the
+// hang would take out every other rename in that workspace behind it, on top of
+// exhausting memory in the one that triggered it.
+//
+// strings.Replace with n = -1 has the semantics that were actually wanted:
+// non-overlapping, left-to-right, over the input, so inserted text is never
+// re-examined. A title that re-embeds the old token now produces one
+// substitution per original occurrence and stops.
+//
+// Found by Codex round 2 on BUG-2785 while enumerating ways the cascade's retry
+// could fail to terminate. Pre-existing — but folded into that fix rather than
+// filed, because it is three lines against a server hang, and BUG-2785's retry
+// calls this helper again per attempt, which makes it reachable more often than
+// before.
 func replaceAll(s, old, new string) string {
-	// Simple string replacement, not regex-based
-	result := s
-	for {
-		i := indexOf(result, old)
-		if i < 0 {
-			break
-		}
-		result = result[:i] + new + result[i+len(old):]
-	}
-	return result
-}
-
-func indexOf(s, substr string) int {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return i
-		}
-	}
-	return -1
+	return strings.Replace(s, old, new, -1)
 }

--- a/internal/links/replace_title_termination_test.go
+++ b/internal/links/replace_title_termination_test.go
@@ -1,0 +1,64 @@
+package links
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// ReplaceTitle used to re-scan its own output: it looped "find old in result,
+// splice new in" until no match remained, so the text it had just inserted was
+// searched again. When the NEW title contains the OLD link token that never
+// terminates and the string grows without bound.
+//
+// The caller runs inside the rename transaction while holding the workspace
+// rename advisory lock (BUG-2778), so a hang here does not merely wedge one
+// request: it holds that lock and blocks every other rename in the workspace
+// behind it while exhausting memory.
+//
+// Found by Codex round 2 on BUG-2785, while enumerating the ways the cascade's
+// retry loop could fail to terminate.
+func TestReplaceTitle_TerminatesWhenNewTitleEmbedsOldToken(t *testing.T) {
+	// `[[A]]` -> `[[A]] [[A]]`, whose output still contains `[[A]]`. Against the
+	// old implementation this grew until it was killed; a probe ran 3s without
+	// finishing.
+	cases := []struct{ name, old, new string }{
+		{"new title re-embeds the whole old token", "A", "A]] [[A"},
+		{"new title re-embeds it twice", "A", "A]] [[A]] [[A"},
+		{"old token embedded mid-title", "X", "pre A]] [[X]] [[post"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			done := make(chan string, 1)
+			go func() { done <- ReplaceTitle("x [["+tc.old+"]] y", tc.old, tc.new) }()
+
+			select {
+			case got := <-done:
+				// The property under test is TERMINATION, and specifically that
+				// the substitution happens once per occurrence in the INPUT.
+				// Asserting the exact output would pin the escape semantics of a
+				// title nobody should be able to write; asserting the count keeps
+				// the test about the loop.
+				if n := strings.Count(got, "[["+tc.new+"]]"); n != 1 {
+					t.Errorf("substituted %d times, want exactly 1 (one occurrence in the input)\n got: %q", n, got)
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("ReplaceTitle did not terminate: the replacement re-scanned its own output, " +
+					"which grows without bound when the new title contains the old link token")
+			}
+		})
+	}
+}
+
+// The ordinary path has to keep working, and this is the control that would
+// catch a "fix" that terminated by doing nothing.
+func TestReplaceTitle_StillRewritesEveryOccurrence(t *testing.T) {
+	got := ReplaceTitle("[[Old]] middle [[Old]] end", "Old", "New")
+	if want := "[[New]] middle [[New]] end"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	if strings.Contains(got, "[[Old]]") {
+		t.Errorf("an occurrence survived: %q", got)
+	}
+}

--- a/internal/links/replace_title_termination_test.go
+++ b/internal/links/replace_title_termination_test.go
@@ -37,9 +37,16 @@ func TestReplaceTitle_TerminatesWhenNewTitleEmbedsOldToken(t *testing.T) {
 			case got := <-done:
 				// The property under test is TERMINATION, and specifically that
 				// the substitution happens once per occurrence in the INPUT.
-				// Asserting the exact output would pin the escape semantics of a
-				// title nobody should be able to write; asserting the count keeps
-				// the test about the loop.
+				//
+				// Asserting the exact output would pin escape semantics this
+				// codebase does not have: the document API accepts these titles
+				// (handlers_documents.go validates doc_type and status, never the
+				// title), and ReplaceTitle emits them raw, so renaming to
+				// `A]] [[A` yields `[[A]] [[A]]` — two links to nothing rather
+				// than one link to the new title. That is a REAL second defect,
+				// filed as BUG-2796; it is not what this test is about, and
+				// pinning the output here would freeze the broken rendering as
+				// though it were intended.
 				if n := strings.Count(got, "[["+tc.new+"]]"); n != 1 {
 					t.Errorf("substituted %d times, want exactly 1 (one occurrence in the input)\n got: %q", n, got)
 				}

--- a/internal/links/replace_title_termination_test.go
+++ b/internal/links/replace_title_termination_test.go
@@ -11,10 +11,12 @@ import (
 // searched again. When the NEW title contains the OLD link token that never
 // terminates and the string grows without bound.
 //
-// The caller runs inside the rename transaction while holding the workspace
-// rename advisory lock (BUG-2778), so a hang here does not merely wedge one
-// request: it holds that lock and blocks every other rename in the workspace
-// behind it while exhausting memory.
+// The caller runs inside the rename transaction, so a hang here does not merely
+// wedge one request — it holds that transaction open while exhausting memory.
+// On Postgres it also holds the workspace rename advisory lock (BUG-2778) and
+// blocks every other rename in the workspace; on SQLite that lock is a no-op
+// and the transaction's own BEGIN IMMEDIATE write lock does the equivalent
+// damage.
 //
 // Found by Codex round 2 on BUG-2785, while enumerating the ways the cascade's
 // retry loop could fail to terminate.

--- a/internal/server/handlers_documents.go
+++ b/internal/server/handlers_documents.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/PerpetualSoftware/pad/internal/events"
 	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/store"
 )
 
 func (s *Server) handleListDocuments(w http.ResponseWriter, r *http.Request) {
@@ -157,10 +159,22 @@ func (s *Server) handleUpdateDocument(w http.ResponseWriter, r *http.Request) {
 		// Both mean "try again", and a generic 500 tells the caller the
 		// opposite — that the request will never succeed. Retry-After is
 		// deliberately short: the holder is one transaction, not a queue.
-		if isRetryableLockError(err) {
+		// Same disposition for a cascade that exhausted its compare-and-set
+		// retries (BUG-2785): the rename rolled back cleanly because a linking
+		// document kept being edited underneath it. Retrying can succeed, so a
+		// 500 would be actively misleading — it says the request will never
+		// work. Distinguished by sentinel rather than message text, because
+		// this one is ours to name (codex round 2).
+		if isRetryableLockError(err) || errors.Is(err, store.ErrLinkCascadeContention) {
 			w.Header().Set("Retry-After", "1")
+			// Deliberately does NOT name the holder. The previous wording said
+			// "another rename", but 55P03 here is just as likely to be an
+			// ordinary content edit holding the row — and after BUG-2785 the
+			// cascade-contention arm is definitely a content edit. Claiming a
+			// cause the server has not established sends the reader looking in
+			// the wrong place.
 			writeError(w, http.StatusServiceUnavailable, "lock_contention",
-				"The workspace is busy with another rename; retry in a moment")
+				"The workspace is busy with a concurrent edit; retry in a moment")
 			return
 		}
 		writeInternalError(w, err)

--- a/internal/store/documents.go
+++ b/internal/store/documents.go
@@ -641,7 +641,16 @@ var ErrLinkCascadeContention = errors.New("store: link cascade lost the compare-
 // drive exhaustion deterministically. Forcing exhaustion at 3 would need a
 // concurrent commit between each attempt, which needs a per-attempt hook in
 // production code; lowering the bound tests the same disposition with less
-// test-only surface. Never written outside tests.
+// test-only surface.
+//
+// Never written outside tests, and a test that writes it must not run under
+// t.Parallel() alongside anything that renames a DOCUMENT — same constraint the
+// Store's test seams carry, for the same reason: it is process-global state
+// with no synchronization. internal/store does contain parallel tests
+// (items_empty_assignment, item_mutation_signal, watches), and none of them
+// reaches this cascade today — but that is a fact about the current test
+// corpus, not an invariant, which is why the constraint is written here rather
+// than inferred from the absence of a collision.
 var cascadeRewriteAttempts = 3
 
 // rewriteLinkerCAS applies a title rewrite to one linking document, retrying

--- a/internal/store/documents.go
+++ b/internal/store/documents.go
@@ -663,6 +663,7 @@ const cascadeRewriteAttempts = 3
 //     below dies to it. Recorded here because deleting a previous unit's
 //     deliberate "this is untestable" finding is a claim in its own right,
 //     and the next reader deserves to know it was closed rather than lost.
+//
 //   - content = ? — a concurrent edit landed. The right response is the
 //     opposite: re-read, re-apply the rewrite to the NEW body, and try again.
 //

--- a/internal/store/documents.go
+++ b/internal/store/documents.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -614,6 +615,16 @@ func (s *Store) updateLinksInTx(tx *sql.Tx, workspaceID, oldTitle, newTitle stri
 	return nil
 }
 
+// ErrLinkCascadeContention reports that a rename's link cascade lost its
+// compare-and-set on the same linking document too many times in a row.
+//
+// It is a CONTENTION signal, not a fault: the rename rolled back cleanly and
+// retrying it can succeed. Exported so the HTTP layer can answer 503 with a
+// Retry-After instead of the 500 that "an internal error occurred" implies —
+// a caller told the request will never succeed will not retry, which is the
+// opposite of the truth here (codex round 2 on BUG-2785).
+var ErrLinkCascadeContention = errors.New("store: link cascade lost the compare-and-set")
+
 // cascadeRewriteAttempts bounds rewriteLinkerCAS's retry loop.
 //
 // Three, matching debounceMergeAttempts' reasoning rather than copying its
@@ -625,7 +636,13 @@ func (s *Store) updateLinksInTx(tx *sql.Tx, workspaceID, oldTitle, newTitle stri
 // It is a LIVENESS bound, not a correctness one: correctness comes from the
 // compare-and-set predicate, which cannot write a stale body however many
 // attempts it is given.
-const cascadeRewriteAttempts = 3
+// A var rather than a const — deliberately diverging from its sibling
+// debounceMergeAttempts, which is a const — so a test can lower it to 1 and
+// drive exhaustion deterministically. Forcing exhaustion at 3 would need a
+// concurrent commit between each attempt, which needs a per-attempt hook in
+// production code; lowering the bound tests the same disposition with less
+// test-only surface. Never written outside tests.
+var cascadeRewriteAttempts = 3
 
 // rewriteLinkerCAS applies a title rewrite to one linking document, retrying
 // on a lost compare-and-set.
@@ -672,6 +689,25 @@ const cascadeRewriteAttempts = 3
 // distinguishes them, the same shape BUG-2770 needed for the same reason.
 // The probe reads through tx, never the pool: a pool read from inside a
 // transaction that holds row locks is BUG-2409's deadlock.
+//
+// WHAT THIS DOES NOT FIX, named because "the cascade is now safe" is the claim
+// that would rot silently (codex round 2 enumerated both):
+//
+//   - THE MIRROR DIRECTION. This stops the cascade losing a content writer's
+//     edit. It does not stop a content writer losing the CASCADE's rewrite: a
+//     writer that read the body BEFORE this transaction, then blocked on the
+//     row lock, commits its own unconditional UPDATE afterwards and reinstates
+//     the old title. Fixing that means giving ordinary content writes a
+//     compare-and-set too, which is a much wider change than a rename cascade
+//     and belongs to whoever takes it on.
+//   - DELETE-THEN-RESTORE. The ErrNoRows arm returns without taking a row
+//     lock, so a linker soft-deleted during the cascade and RESTORED before
+//     this transaction commits comes back holding the old title. RestoreDocument
+//     takes no rename lock, so nothing serializes it against this.
+//
+// Both are pre-existing and neither is made worse here. They are recorded
+// because the next reader's question is "is the cascade correct now", and the
+// honest answer is "for the direction this bug named".
 func (s *Store) rewriteLinkerCAS(tx *sql.Tx, id, read, rewritten, oldTitle, newTitle string) error {
 	expected := read
 	next := rewritten
@@ -721,7 +757,11 @@ func (s *Store) rewriteLinkerCAS(tx *sql.Tx, id, read, rewritten, oldTitle, newT
 	// rename is atomic in intent (either the title moves and its links follow,
 	// or neither). The user can retry a failed rename; nobody goes looking for
 	// a stale wiki-link.
-	return fmt.Errorf("store: link cascade lost the compare-and-set on document %s after %d attempts: the document is being edited concurrently", id, cascadeRewriteAttempts)
+	//
+	// Wrapped around ErrLinkCascadeContention so the HTTP layer can tell this
+	// from a genuine fault. It is CONTENTION, not a bug: retrying can succeed,
+	// and a 500 would tell the caller the opposite (codex round 2).
+	return fmt.Errorf("%w: document %s after %d attempts", ErrLinkCascadeContention, id, cascadeRewriteAttempts)
 }
 
 func (s *Store) DeleteDocument(id string) error {

--- a/internal/store/documents.go
+++ b/internal/store/documents.go
@@ -576,46 +576,151 @@ func (s *Store) updateLinksInTx(tx *sql.Tx, workspaceID, oldTitle, newTitle stri
 	defer rows.Close()
 
 	type docUpdate struct {
-		id      string
-		content string
+		id string
+		// read is the body this cascade rewrote FROM, kept verbatim: it is
+		// the compare-and-set token below, so it must be the exact string
+		// the column handed us and never a normalized form of it.
+		read      string
+		rewritten string
 	}
 	var updates []docUpdate
 	for rows.Next() {
 		var du docUpdate
-		if err := rows.Scan(&du.id, &du.content); err != nil {
+		if err := rows.Scan(&du.id, &du.read); err != nil {
 			return err
 		}
-		du.content = links.ReplaceTitle(du.content, oldTitle, newTitle)
+		du.rewritten = links.ReplaceTitle(du.read, oldTitle, newTitle)
 		updates = append(updates, du)
 	}
 	if err := rows.Err(); err != nil {
 		return err
 	}
 
+	// Test seam (BUG-2785): the last moment at which a concurrent content
+	// edit to a linker can still commit ahead of the writes below, which is
+	// the whole window this function's compare-and-set exists to survive.
+	// Nil in production. No existing seam reaches here — afterDocumentPreLockRead
+	// fires before the transaction and afterDocumentPreWrite fires before the
+	// renamed document's OWN update, neither of which is this gap.
+	if s.afterLinkCascadeRead != nil {
+		s.afterLinkCascadeRead(workspaceID)
+	}
+
 	for _, du := range updates {
-		// deleted_at IS NULL here too (codex round 4): the SELECT above filters
-		// archived linkers, but a soft-delete can land between that read and
-		// this write, and an unqualified UPDATE would then rewrite the content
-		// of a document the user has already archived. A zero-row result is
-		// the NORMAL outcome of that race and not an error — the linker is
-		// gone, so there is no link left to keep consistent.
-		//
-		// UNTESTED, and deliberately kept anyway. A mutation removing this
-		// clause survives the suite: reaching it needs a delete landing
-		// between the SELECT a few lines above and this loop, which no
-		// existing seam can schedule and which would cost a fifth one. It
-		// stays because it closes a window NOTHING else covers — the opposite
-		// of the FOR UPDATE this unit deleted, which survived its mutation
-		// because another mechanism already covered the same window. Same
-		// signal, opposite disposition, and the difference is whether the
-		// guard is redundant or merely unreachable by the current
-		// instruments.
-		_, err = tx.Exec(s.q("UPDATE documents SET content = ? WHERE id = ? AND deleted_at IS NULL"), du.content, du.id)
-		if err != nil {
+		if err := s.rewriteLinkerCAS(tx, du.id, du.read, du.rewritten, oldTitle, newTitle); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// cascadeRewriteAttempts bounds rewriteLinkerCAS's retry loop.
+//
+// Three, matching debounceMergeAttempts' reasoning rather than copying its
+// number by coincidence: one attempt to lose, one to win against the writer
+// that beat it, and one of headroom for a second writer arriving mid-retry.
+// Exhausting it needs three consecutive commits to the SAME linker inside one
+// cascade, which is pathological contention rather than ordinary editing.
+//
+// It is a LIVENESS bound, not a correctness one: correctness comes from the
+// compare-and-set predicate, which cannot write a stale body however many
+// attempts it is given.
+const cascadeRewriteAttempts = 3
+
+// rewriteLinkerCAS applies a title rewrite to one linking document, retrying
+// on a lost compare-and-set.
+//
+// WHY A CAS AT ALL (BUG-2785). The cascade is a read-modify-write across two
+// statements: the SELECT above reads a linker's content, Go rewrites the
+// string, and this UPDATE writes the result. A content edit committing between
+// those two statements is silently erased by an unconditional UPDATE — the
+// same lost-update shape as BUG-2770's activity-metadata merge, one table over.
+//
+// DIALECT SCOPE, because it decides whether any test here means anything.
+// The lost update is reachable on POSTGRES only. The SQLite DSN sets
+// `_txlock=immediate` (see store.go), so UpdateDocument's db.Begin() takes the
+// write lock at BEGIN and holds it across this whole window; a concurrent
+// content edit cannot commit inside it and serializes on busy_timeout instead.
+// On Postgres under READ COMMITTED each statement takes a fresh snapshot, so
+// the edit commits between the two statements and the stale body wins. The CAS
+// is therefore a no-op on SQLite by construction — the predicate always matches,
+// because nobody else can have written — and load-bearing on Postgres.
+//
+// WHY THE ZERO-ROW RESULT NEEDS A PROBE. The UPDATE carries two predicates
+// that can each refuse it, and RowsAffected cannot say which did:
+//
+//   - deleted_at IS NULL — the linker was soft-deleted after the SELECT. That
+//     is the NORMAL outcome of a documented race (the guard predates this
+//     change): the linker is gone, so there is no link left to keep consistent,
+//     and the right response is to move on.
+//
+//     That guard used to carry a note saying it was UNTESTED and kept anyway,
+//     because reaching its window needed a seam no test could schedule "and
+//     which would cost a fifth one". This change adds that fifth seam for its
+//     own reasons, so the note is no longer true and has been removed rather
+//     than left to mislead: TestUpdateDocument_CascadeTreatsSoftDeletedLinkerAsDone
+//     now drives exactly that window, and a mutation removing the probe arm
+//     below dies to it. Recorded here because deleting a previous unit's
+//     deliberate "this is untestable" finding is a claim in its own right,
+//     and the next reader deserves to know it was closed rather than lost.
+//   - content = ? — a concurrent edit landed. The right response is the
+//     opposite: re-read, re-apply the rewrite to the NEW body, and try again.
+//
+// Treating the two alike would either retry forever against a deleted row or
+// discard a live linker's rewrite. So a refusal is followed by a probe that
+// distinguishes them, the same shape BUG-2770 needed for the same reason.
+// The probe reads through tx, never the pool: a pool read from inside a
+// transaction that holds row locks is BUG-2409's deadlock.
+func (s *Store) rewriteLinkerCAS(tx *sql.Tx, id, read, rewritten, oldTitle, newTitle string) error {
+	expected := read
+	next := rewritten
+	for attempt := 0; attempt < cascadeRewriteAttempts; attempt++ {
+		res, err := tx.Exec(s.q(`
+			UPDATE documents SET content = ?
+			WHERE id = ? AND deleted_at IS NULL AND content = ?
+		`), next, id, expected)
+		if err != nil {
+			return err
+		}
+		n, err := res.RowsAffected()
+		if err != nil {
+			return err
+		}
+		if n > 0 {
+			return nil
+		}
+
+		var current string
+		err = tx.QueryRow(s.q(`
+			SELECT content FROM documents WHERE id = ? AND deleted_at IS NULL
+		`), id).Scan(&current)
+		if err == sql.ErrNoRows {
+			// Soft-deleted between the cascade's SELECT and now. Documented
+			// normal outcome, not an error.
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+
+		// A concurrent edit won. Rewrite ITS body rather than ours: replaying
+		// the original rewrite would reintroduce the very content this bug is
+		// about losing. If that edit already removed the link, ReplaceTitle is
+		// a no-op and the next attempt writes an identical body — which still
+		// affects one row and terminates.
+		expected = current
+		next = links.ReplaceTitle(current, oldTitle, newTitle)
+	}
+
+	// Exhaustion fails the RENAME, rather than leaving this one linker holding
+	// a title that no longer exists.
+	//
+	// The alternative — log and continue — was considered and rejected: it
+	// trades a loud, retryable failure for a silent inconsistency, and a
+	// rename is atomic in intent (either the title moves and its links follow,
+	// or neither). The user can retry a failed rename; nobody goes looking for
+	// a stale wiki-link.
+	return fmt.Errorf("store: link cascade lost the compare-and-set on document %s after %d attempts: the document is being edited concurrently", id, cascadeRewriteAttempts)
 }
 
 func (s *Store) DeleteDocument(id string) error {

--- a/internal/store/documents_cascade_lost_update_test.go
+++ b/internal/store/documents_cascade_lost_update_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"errors"
 	"strings"
 	"sync"
 	"testing"
@@ -153,5 +154,78 @@ func TestUpdateDocument_CascadeTreatsSoftDeletedLinkerAsDone(t *testing.T) {
 	}
 	if got == nil || got.Title != newTitle {
 		t.Errorf("target title = %v, want %q", got, newTitle)
+	}
+}
+
+// TestUpdateDocument_CascadeExhaustionRollsBackTheWholeRename pins the
+// disposition chosen when the retry budget runs out: the rename FAILS rather
+// than leaving one linker pointing at a title that no longer exists.
+//
+// The alternative considered was log-and-continue, which trades a loud
+// retryable failure for a silent inconsistency. Without this test that choice
+// is only a comment — and the comment is exactly the kind that stays true-
+// looking after someone changes the code under it.
+//
+// Exhaustion is forced by lowering the retry bound to 1 rather than by
+// arranging three consecutive commits, which would need a per-attempt hook in
+// production code. Same disposition, less test-only surface.
+func TestUpdateDocument_CascadeExhaustionRollsBackTheWholeRename(t *testing.T) {
+	s := testStore(t)
+	if s.dialect.Driver() != DriverPostgres {
+		t.Skip("needs a write to commit inside the cascade's window, which SQLite's BEGIN IMMEDIATE prevents")
+	}
+	ws := createTestWorkspace(t, s, "CascadeExhaustion")
+
+	const originalTitle = "Epsilon"
+	target := createTestDoc(t, s, ws.ID, originalTitle, "the document being renamed")
+	linker := createTestDoc(t, s, ws.ID, "EpsilonLinker", "before [[Epsilon]] after")
+
+	restore := cascadeRewriteAttempts
+	cascadeRewriteAttempts = 1
+	defer func() { cascadeRewriteAttempts = restore }()
+
+	var once sync.Once
+	edited := "before [[Epsilon]] after — edit that beats the single attempt"
+	s.afterLinkCascadeRead = func(string) {
+		once.Do(func() {
+			if _, err := s.UpdateDocument(linker.ID, models.DocumentUpdate{Content: &edited}); err != nil {
+				t.Errorf("concurrent edit: %v", err)
+			}
+		})
+	}
+	defer func() { s.afterLinkCascadeRead = nil }()
+
+	newTitle := "Zeta"
+	_, err := s.UpdateDocument(target.ID, models.DocumentUpdate{Title: &newTitle})
+	if err == nil {
+		t.Fatal("rename succeeded after the cascade exhausted its retries; it must fail rather " +
+			"than leave a linker pointing at a title that no longer exists")
+	}
+	// The error has to be CLASSIFIABLE as contention, not just non-nil: the
+	// HTTP layer answers 503 + Retry-After on this sentinel and 500 otherwise,
+	// so losing the wrap turns a retryable outcome into "this will never work".
+	if !errors.Is(err, ErrLinkCascadeContention) {
+		t.Errorf("error does not wrap ErrLinkCascadeContention, so the HTTP layer will report an "+
+			"opaque 500 instead of a retryable 503: %v", err)
+	}
+
+	// Rollback: the target keeps its original title.
+	got, err := s.GetDocument(target.ID)
+	if err != nil {
+		t.Fatalf("GetDocument(target): %v", err)
+	}
+	if got.Title != originalTitle {
+		t.Errorf("target title = %q, want %q — the failed rename did not roll back", got.Title, originalTitle)
+	}
+
+	// And the concurrent editor's text is intact, which is the property this
+	// whole unit exists to protect. A rollback that also reverted the OTHER
+	// transaction's committed write would be a worse bug than the one fixed.
+	link, err := s.GetDocument(linker.ID)
+	if err != nil {
+		t.Fatalf("GetDocument(linker): %v", err)
+	}
+	if link.Content != edited {
+		t.Errorf("the concurrent edit did not survive the rolled-back rename.\n got: %q\nwant: %q", link.Content, edited)
 	}
 }

--- a/internal/store/documents_cascade_lost_update_test.go
+++ b/internal/store/documents_cascade_lost_update_test.go
@@ -229,3 +229,49 @@ func TestUpdateDocument_CascadeExhaustionRollsBackTheWholeRename(t *testing.T) {
 		t.Errorf("the concurrent edit did not survive the rolled-back rename.\n got: %q\nwant: %q", link.Content, edited)
 	}
 }
+
+// TestUpdateDocument_CascadeRewritesEveryLinkOnBothDialects is the only test in
+// this file that does NOT skip on SQLite, and it exists because the other three
+// do.
+//
+// The compare-and-set predicate runs on SQLite in production. The concurrency
+// tests cannot exercise it there — BEGIN IMMEDIATE closes the window they need
+// — so without this, the new UPDATE would have no coverage at all on the
+// dialect where it is claimed to be an inert no-op. "Inert" is a claim about
+// code, and it deserves a test rather than a comment: a predicate comparing
+// against the wrong string (the rewritten body instead of the body that was
+// read) affects zero rows on BOTH dialects, silently skipping the rewrite with
+// no concurrency involved.
+//
+// Multiple links in one body, and a second linker, so it also covers the loop
+// rather than a single-row happy path.
+func TestUpdateDocument_CascadeRewritesEveryLinkOnBothDialects(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "CascadeBothDialects")
+
+	target := createTestDoc(t, s, ws.ID, "Iota", "the document being renamed")
+	linkerA := createTestDoc(t, s, ws.ID, "IotaLinkerA", "a [[Iota]] b [[Iota]] c")
+	linkerB := createTestDoc(t, s, ws.ID, "IotaLinkerB", "only [[Iota]] here")
+	untouched := createTestDoc(t, s, ws.ID, "IotaStranger", "mentions Iota without brackets")
+
+	newTitle := "Kappa"
+	if _, err := s.UpdateDocument(target.ID, models.DocumentUpdate{Title: &newTitle}); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+
+	for _, tc := range []struct{ id, want string }{
+		{linkerA.ID, "a [[Kappa]] b [[Kappa]] c"},
+		{linkerB.ID, "only [[Kappa]] here"},
+		// The cascade must not touch a document that merely contains the word.
+		// Without this, a fix that widened the match would pass everything above.
+		{untouched.ID, "mentions Iota without brackets"},
+	} {
+		got, err := s.GetDocument(tc.id)
+		if err != nil {
+			t.Fatalf("GetDocument(%s): %v", tc.id, err)
+		}
+		if got.Content != tc.want {
+			t.Errorf("content = %q, want %q", got.Content, tc.want)
+		}
+	}
+}

--- a/internal/store/documents_cascade_lost_update_test.go
+++ b/internal/store/documents_cascade_lost_update_test.go
@@ -1,0 +1,157 @@
+package store
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// BUG-2785. A document rename cascades through every document whose content
+// links the old title, as a read-modify-write across two statements: the
+// cascade SELECTs each linker's content, rewrites the string in Go, then
+// UPDATEs the row. A content edit to a linker committing between those two
+// statements was silently overwritten — the cascade wrote the body it built
+// from the version it read, and the user's edit was gone with no error and no
+// version row.
+//
+// POSTGRES ONLY, and skipped loudly elsewhere rather than passing quietly.
+// SQLite's DSN sets `_txlock=immediate`, so UpdateDocument's db.Begin() takes
+// the write lock at BEGIN and holds it across the cascade's whole read→write
+// window; a concurrent content edit cannot commit inside it and serializes on
+// busy_timeout instead. The lost update is therefore unreachable on SQLite,
+// and a green run there would be a property of the DSN rather than evidence
+// about this fix. Worse than useless: driving the seam on SQLite would have
+// the concurrent write block on the lock the rename already holds, so the test
+// would stall for busy_timeout and then assert about a serialized order that
+// has nothing to do with the defect.
+//
+// That dialect split is also why the mutation matrix for this fix has to be
+// run under Postgres. Removing the compare-and-set leaves the SQLite suite
+// entirely green.
+
+// TestUpdateDocument_CascadeDoesNotOverwriteConcurrentEdit drives the exact
+// interleaving the bug describes, through the afterLinkCascadeRead seam: the
+// rename has read the linker's body and not yet written it back when an
+// ordinary content edit commits.
+//
+// The assertions are deliberately three, because each catches a different
+// wrong fix (CONVE-12 — assert what the WRONG behaviour would DO):
+//
+//   - the concurrent edit's text survives. An unconditional UPDATE erases it;
+//     this is the defect itself.
+//   - the link is rewritten to the new title. A "fix" that simply skipped a
+//     contended linker would preserve the edit and silently abandon the
+//     cascade, which is a different bug wearing this one's green test.
+//   - the old title is gone. Without it, a rewrite that APPENDED rather than
+//     replaced would pass the second assertion.
+func TestUpdateDocument_CascadeDoesNotOverwriteConcurrentEdit(t *testing.T) {
+	s := testStore(t)
+	if s.dialect.Driver() != DriverPostgres {
+		t.Skip("asserts a Postgres READ COMMITTED lost-update property; SQLite's BEGIN IMMEDIATE closes the window structurally")
+	}
+	ws := createTestWorkspace(t, s, "CascadeLostUpdate")
+
+	target := createTestDoc(t, s, ws.ID, "Alpha", "the document being renamed")
+	linker := createTestDoc(t, s, ws.ID, "Linker", "before [[Alpha]] after")
+
+	// The concurrent edit keeps the link and adds text. Keeping the link
+	// matters: it means the cascade still has work to do on the NEW body, so
+	// the test can tell "re-applied the rewrite to the winner's text" from
+	// "gave up on this linker".
+	const editMarker = "TEXT FROM THE CONCURRENT WRITER"
+	concurrentBody := "before [[Alpha]] after — " + editMarker
+
+	var once sync.Once
+	var editErr error
+	s.afterLinkCascadeRead = func(string) {
+		once.Do(func() {
+			// A content-only update: it takes no rename lock (BUG-2778's lock
+			// fires only when a title is supplied), which is precisely why it
+			// can commit inside the cascade's window.
+			_, editErr = s.UpdateDocument(linker.ID, models.DocumentUpdate{Content: &concurrentBody})
+		})
+	}
+	defer func() { s.afterLinkCascadeRead = nil }()
+
+	newTitle := "Beta"
+	if _, err := s.UpdateDocument(target.ID, models.DocumentUpdate{Title: &newTitle}); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+	if editErr != nil {
+		t.Fatalf("the concurrent content edit itself failed, so this run never "+
+			"exercised the race: %v", editErr)
+	}
+
+	got, err := s.GetDocument(linker.ID)
+	if err != nil {
+		t.Fatalf("GetDocument(linker): %v", err)
+	}
+	if got == nil {
+		t.Fatal("linker missing after the rename")
+	}
+
+	if !strings.Contains(got.Content, editMarker) {
+		t.Errorf("the concurrent edit was overwritten by the cascade — this is BUG-2785.\n got: %q\nwant it to contain: %q", got.Content, editMarker)
+	}
+	if !strings.Contains(got.Content, "[[Beta]]") {
+		t.Errorf("the cascade did not rewrite the link on the winning body; a fix that "+
+			"skips a contended linker preserves the edit but abandons the rename's job.\n got: %q", got.Content)
+	}
+	if strings.Contains(got.Content, "[[Alpha]]") {
+		t.Errorf("the old title survives the rewrite.\n got: %q", got.Content)
+	}
+}
+
+// TestUpdateDocument_CascadeTreatsSoftDeletedLinkerAsDone pins the OTHER arm of
+// the zero-row result, and is the test that makes the disambiguating probe
+// necessary rather than decorative.
+//
+// Once the UPDATE carries `content = ?` alongside `deleted_at IS NULL`, a
+// zero-row result means one of two opposite things: the linker was archived
+// (stop — there is no link left to keep consistent) or a concurrent edit landed
+// (retry against the new body). Without the probe that tells them apart, an
+// archived linker sends the loop to exhaustion and fails an otherwise valid
+// rename.
+//
+// So the assertion is that the rename SUCCEEDS, and the counterfactual is
+// specific: with the probe removed, this returns the exhaustion error.
+func TestUpdateDocument_CascadeTreatsSoftDeletedLinkerAsDone(t *testing.T) {
+	s := testStore(t)
+	if s.dialect.Driver() != DriverPostgres {
+		t.Skip("needs a write to commit inside the cascade's window, which SQLite's BEGIN IMMEDIATE prevents")
+	}
+	ws := createTestWorkspace(t, s, "CascadeDeletedLinker")
+
+	target := createTestDoc(t, s, ws.ID, "Gamma", "the document being renamed")
+	linker := createTestDoc(t, s, ws.ID, "GammaLinker", "before [[Gamma]] after")
+
+	var once sync.Once
+	var delErr error
+	s.afterLinkCascadeRead = func(string) {
+		once.Do(func() {
+			delErr = s.DeleteDocument(linker.ID)
+		})
+	}
+	defer func() { s.afterLinkCascadeRead = nil }()
+
+	newTitle := "Delta"
+	if _, err := s.UpdateDocument(target.ID, models.DocumentUpdate{Title: &newTitle}); err != nil {
+		t.Fatalf("rename failed because a linker was archived mid-cascade; an archived "+
+			"linker is a documented normal outcome, not an error: %v", err)
+	}
+	if delErr != nil {
+		t.Fatalf("the concurrent soft-delete itself failed, so this run never "+
+			"exercised the arm it exists for: %v", delErr)
+	}
+
+	// The rename itself must still have landed on the target.
+	got, err := s.GetDocument(target.ID)
+	if err != nil {
+		t.Fatalf("GetDocument(target): %v", err)
+	}
+	if got == nil || got.Title != newTitle {
+		t.Errorf("target title = %v, want %q", got, newTitle)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -96,6 +96,22 @@ type Store struct {
 	// as the seams above.
 	afterDocumentPreWrite func(documentID string)
 
+	// afterLinkCascadeRead is a TEST-ONLY seam, nil in production. When set,
+	// updateLinksInTx calls it after reading every linking document's content
+	// and before writing any of them back — the window in which a concurrent
+	// content edit to a linker is lost without a compare-and-set (BUG-2785).
+	//
+	// It is its own seam because no existing one reaches this gap:
+	// afterDocumentPreLockRead fires before the transaction opens, and
+	// afterDocumentPreWrite fires before the RENAMED document's own update,
+	// which is a different window on a different row.
+	//
+	// Same usage constraints as the seams above. Note that a test driving it
+	// only observes the defect on Postgres — SQLite's BEGIN IMMEDIATE holds
+	// the write lock across this window, so a concurrent write cannot commit
+	// inside it there.
+	afterLinkCascadeRead func(workspaceID string)
+
 	// afterDebounceRefusal is a TEST-ONLY seam, nil in production. When set,
 	// CreateActivityDebounced calls it after its merge UPDATE has affected
 	// ZERO rows and before the probe that decides which of the UPDATE's two

--- a/internal/store/wiki_links.go
+++ b/internal/store/wiki_links.go
@@ -516,13 +516,17 @@ func resolveWorkspaceSlugTx(tx *sql.Tx, s *Store, slug string) sql.NullString {
 //     their content. The renderer would no longer resolve those after
 //     the rename, breaking the user's click target. Rewrite each
 //     source's content via links.ReplaceTitle (matches the document
-//     rename behavior — see documents.go::updateLinksInTx, though NOT
-//     its concurrency behavior any more: that cascade got a
-//     compare-and-set on the source's content in BUG-2785, and this one
-//     still writes unconditionally, so a content edit committing inside
-//     its read→write window is still lost here. BUG-2795, kept separate
-//     because this cascade rewrites by POSITION and a retry has to
-//     re-derive offsets rather than re-run a search), re-stamp
+//     rename behavior — see documents.go::updateLinksInTx, though not
+//     its concurrency behavior: that cascade got a compare-and-set in
+//     BUG-2785 and this one still writes unconditionally. That is NOT
+//     the same exposure, and the difference is a lock: UpdateItem takes
+//     acquireWorkspaceSeqLock unconditionally at the top of its tx and
+//     holds it to COMMIT, so two item updates in a workspace serialize
+//     on Postgres and an ordinary content edit cannot commit inside
+//     this window at all. The one writer that can is
+//     RemapAttachmentReferencesInWorkspace, which rewrites items.content
+//     in its own transaction without that lock — narrow, and tracked as
+//     BUG-2795), re-stamp
 //     updated_at + content_flushed_at, bump the workspace seq, and
 //     re-run replaceWikiLinks so the source's own index rows refresh
 //     with the new literal AND the new target_item_id resolution.

--- a/internal/store/wiki_links.go
+++ b/internal/store/wiki_links.go
@@ -525,8 +525,11 @@ func resolveWorkspaceSlugTx(tx *sql.Tx, s *Store, slug string) sql.NullString {
 //     on Postgres and an ordinary content edit cannot commit inside
 //     this window at all. The one writer that can is
 //     RemapAttachmentReferencesInWorkspace, which rewrites items.content
-//     in its own transaction without that lock — narrow, and tracked as
-//     BUG-2795), re-stamp
+//     in its own transaction without that lock. That writer is missing a
+//     guard outright — it races ordinary item edits too, reachable during
+//     a bundle import while the workspace is already visible to its owner
+//     — so the fix belongs there, at BUG-2797, and BUG-2795 tracks this
+//     cascade's pairing as a consequence of it), re-stamp
 //     updated_at + content_flushed_at, bump the workspace seq, and
 //     re-run replaceWikiLinks so the source's own index rows refresh
 //     with the new literal AND the new target_item_id resolution.

--- a/internal/store/wiki_links.go
+++ b/internal/store/wiki_links.go
@@ -516,7 +516,13 @@ func resolveWorkspaceSlugTx(tx *sql.Tx, s *Store, slug string) sql.NullString {
 //     their content. The renderer would no longer resolve those after
 //     the rename, breaking the user's click target. Rewrite each
 //     source's content via links.ReplaceTitle (matches the document
-//     rename behavior — see documents.go::updateLinksInTx), re-stamp
+//     rename behavior — see documents.go::updateLinksInTx, though NOT
+//     its concurrency behavior any more: that cascade got a
+//     compare-and-set on the source's content in BUG-2785, and this one
+//     still writes unconditionally, so a content edit committing inside
+//     its read→write window is still lost here. BUG-2795, kept separate
+//     because this cascade rewrites by POSITION and a retry has to
+//     re-derive offsets rather than re-run a search), re-stamp
 //     updated_at + content_flushed_at, bump the workspace seq, and
 //     re-run replaceWikiLinks so the source's own index rows refresh
 //     with the new literal AND the new target_item_id resolution.


### PR DESCRIPTION
Closes BUG-2785.

## The defect

A document rename cascades through every document whose content links the old title. `Store.updateLinksInTx` does that as a read-modify-write across two statements: SELECT each linker's `content`, rewrite the string in Go, UPDATE the row.

A content edit to a linker that commits between those two statements was **silently overwritten** — the cascade's UPDATE was unconditional, so it wrote the body it built from the version it read. No error, and no version row for the loss, because the cascade does not create versions for the documents it rewrites.

Same lost-update shape as **BUG-2770**'s activity-metadata merge, one table over.

## Dialect scope — the fact that decides what any test here can prove

**Reachable on Postgres only.**

SQLite's DSN sets `_txlock=immediate` (see `store.go`), so `UpdateDocument`'s `db.Begin()` issues `BEGIN IMMEDIATE` and takes the write lock *at BEGIN*, holding it across the cascade's entire read→write window. A concurrent content edit cannot commit inside it — it serializes on `busy_timeout`. On Postgres under READ COMMITTED each statement takes a fresh snapshot, the edit commits between the two statements, and the stale body wins.

Three things follow, all acted on rather than just noted:

- **The new tests SKIP loudly on SQLite** rather than passing. A green run there would be a property of the DSN, not evidence about this fix. (Driving the seam on SQLite is worse than useless: the concurrent write would block on the lock the rename already holds, stall for `busy_timeout`, and then assert about a serialized order that has nothing to do with the defect.)
- **The mutation matrix was run under Postgres.** Removing the compare-and-set leaves the SQLite suite entirely green — a matrix run there would certify nothing while looking perfect.
- **The CAS is a no-op on SQLite by construction**: the predicate always matches, because nobody else can have written.

This is the dual-dialect foot-gun the repo warns about, arriving in the form where the SQLite side is the one that looks fine.

## The fix

`UPDATE documents SET content = ? WHERE id = ? AND deleted_at IS NULL AND content = ?`, with the body the cascade read as the compare-and-set token, and a bounded 3-attempt retry.

**The retry rewrites the winner's body, not a replay of the original.** Replaying the original rewrite would reintroduce exactly the text this bug loses. M4 in the matrix is that mutation.

**The zero-row result needs a probe.** The UPDATE now carries two predicates that can each refuse it, and `RowsAffected` cannot say which did:

| predicate | meaning | correct response |
|---|---|---|
| `deleted_at IS NULL` | linker archived after the SELECT — a documented normal outcome, guard predates this change | stop; there is no link left to keep consistent |
| `content = ?` | a concurrent edit landed | re-read, re-apply the rewrite to the new body, retry |

Treating them alike either retries forever against a deleted row or discards a live linker's rewrite. So a refusal is followed by a probe that tells them apart — the same shape BUG-2770 needed for the same reason. The probe reads through `tx`, never the pool: a pool read from inside a transaction holding row locks is BUG-2409's deadlock.

**On exhaustion the rename fails.** Considered and rejected: log-and-continue, which trades a loud retryable failure for a silent inconsistency. A rename is atomic in intent — either the title moves and its links follow, or neither — and a user can retry a failed rename, whereas nobody goes looking for a stale wiki-link. Exhausting three attempts needs three consecutive commits to the *same* linker inside one cascade, which is pathological rather than merely contended.

## The seam, and a gap it closes that a previous unit had written off

`afterLinkCascadeRead` fires after every linker's content is read and before any is written back. No existing seam reaches that gap: `afterDocumentPreLockRead` fires before the transaction, `afterDocumentPreWrite` before the *renamed* document's own update — a different window on a different row.

The `deleted_at IS NULL` guard carried a note from a previous unit calling itself **UNTESTED and deliberately kept**, because reaching its window needed a seam nothing could schedule "and which would cost a fifth one". This change adds that fifth seam for its own reasons, so the note is no longer true. It is removed and replaced by a record of the closure — `TestUpdateDocument_CascadeTreatsSoftDeletedLinkerAsDone` now drives exactly that window, and M2 dies to it. Deleting another unit's deliberate "this is untestable" finding is a claim in its own right, so it is written down rather than quietly dropped.

## Tests

Two, both Postgres-only with loud skips. The lost-update test asserts three things, each catching a different wrong fix (CONVE-12 — assert what the WRONG behaviour would DO):

- the concurrent edit's text survives — an unconditional UPDATE erases it; this is the defect
- the link is rewritten to the new title — a "fix" that simply skipped a contended linker would preserve the edit and silently abandon the cascade
- the old title is gone — without this, a rewrite that APPENDED rather than replaced would pass the second assertion

## Mutation matrix — 5 mutants, 5 detected, run under Postgres

| mutant | detected by |
|---|---|
| M1 CAS predicate removed — **literally the pre-fix code** | lost-update test |
| M2 soft-delete probe arm removed | archived-linker test |
| M3 retry budget cut to one attempt | lost-update test |
| M4 retry replays the original rewrite | lost-update test |
| M5 seam removed — control: the tests must notice they never raced | lost-update test |

M1 being the unfixed behaviour is the receipt that these tests fail against broken code rather than passing for their own reasons. M5 is the control that matters most for a concurrency test: with the seam gone no race is scheduled at all, and a test that still passed would be measuring nothing.

## Not fixed here — BUG-2795

`cascadeTitleRename`, the **item-side** cascade, has the identical defect, and no lock closes its window either (the `pg_advisory_xact_lock` calls on that path cover parent-link cycles and parent-children ordering, not title renames).

Filed rather than folded, for a reason rather than convenience: **the fix does not transfer.** The document cascade rewrites by SEARCHING for `[[oldTitle]]`, so re-applying it to a different body is just running the same search again. The item cascade rewrites by POSITION, using offsets read from `item_wiki_links` — after a concurrent edit those offsets are stale, so a retry must re-derive them from the winner's body, re-query the index inside the retry loop, and re-run `replaceWikiLinks` against the body it actually wrote. That is a redesign of the retry unit, not a predicate added to an UPDATE.

Found by this PR's CONVE-23 prose sweep: `wiki_links.go` claimed the item cascade "matches the document rename behavior — see documents.go::updateLinksInTx", which is what made the population question obvious once one of the two was fixed. That comment is corrected here to say which half no longer matches and to point at BUG-2795.

## One review finding declined, with the reasoning recorded

Codex round 6 (dimension: mixed-version rolling deployment) raised as P2 that during a rolling upgrade an old replica still runs the unconditional cascade, so the lost update remains possible until every writer is upgraded — and proposed an explicit drain / blue-green requirement before relying on the fix.

**Declined as a blocker, and the "drain requirement" declined outright:**

- The interim state is exactly the *status quo ante*. An old replica behaves as every replica has behaved for as long as this bug has existed. The rolling window makes the fix arrive unevenly; it introduces no failure mode that is not already live.
- A mixed fleet is not worse than a homogeneous old one. New-instance CAS versus old-instance unconditional write ends with the old write winning — identical to two old instances. There is no interaction that is worse than either end state.
- Unlike an *authorization* change, there is nothing here an actor can retry into. A rename either races a concurrent edit or does not; nobody can aim at an un-upgraded node to reopen the window. (That distinction is what made me correct my reasoning on IDEA-2756's equivalent finding rather than simply reusing the decline — there, a refused caller genuinely could retry until it hit an old node. Here it does not apply.)
- No schema, no migration, so rollback is clean and reverting simply restores the current behaviour.

**What is true and worth stating**: this is an ordinary behaviour change with no schema component and no sequencing requirement. Deploy it normally; protection appears per-instance as instances update. Demanding a drain or blue-green for a fix whose interim state is "what production already does" would be ceremony, not safety.

## Gates

- gofmt clean; `make lint` 0 issues; `make vuln` no vulnerabilities affecting this code
- full Go suite on **SQLite**: 28 packages, 0 failures
- full suite against **Postgres 17** on a private container (port 5463, not the shared 5445 — a sibling seat is live): 28 packages, 0 failures. `internal/store` took **346s vs 79s** on SQLite — the positive control that the PG legs ran rather than skipped, which matters more than usual here because this fix is inert on SQLite
- **Correction to this line as originally written.** It claimed all gates were re-run after the prose edits, on the tree actually pushed. That was false: after the CONVE-23 comment edits I re-ran build and the Postgres suite but NOT lint, and CI caught a gofmt violation in one of those very comments (`documents.go:665` — a list item that grew a second paragraph). Fixed in a follow-up commit; lint now 0 issues on the pushed tree, verified after the edit rather than before it.

  Worth stating plainly because it is the second time in one session, with the same cause: the previous unit's CI failure was the identical gofmt-in-a-doc-comment, and its fix commit message says "the gate has to run on the tree being pushed, not on an earlier one that resembles it". Knowing the rule did not prevent it. The reliable form is mechanical — run gofmt/lint as the last action before every push, including a comment-only one — not a rule to remember at the moment of judgement.
