### PR TITLE
fix(server): refuse a decoded NUL in a JSON request body (BUG-2803)

### DIFF
--- a/cmd/pad/cmd_attachment.go
+++ b/cmd/pad/cmd_attachment.go
@@ -264,7 +264,7 @@ func parseAttachmentFilename(disposition string) string {
 //
 // Returns "" when nothing usable survives, which the caller already handles by
 // falling back to the attachment id.
-func safeLocalFilename(name, id string) string {
+func safeLocalFilename(name string) string {
 	name = filepath.Base(strings.TrimSpace(name))
 	switch name {
 	case "", ".", "..", string(filepath.Separator):
@@ -343,7 +343,7 @@ Examples:
 				if err != nil {
 					return err
 				}
-				name := safeLocalFilename(parseAttachmentFilename(meta.ContentDisposition), id)
+				name := safeLocalFilename(parseAttachmentFilename(meta.ContentDisposition))
 				if name == "" {
 					name = id + extensionForMIME(meta.MIME)
 				} else if filepath.Ext(name) == "" {

--- a/cmd/pad/cmd_attachment.go
+++ b/cmd/pad/cmd_attachment.go
@@ -238,16 +238,6 @@ func parseAttachmentFilename(disposition string) string {
 	return filepath.Base(name)
 }
 
-// extensionForMIME returns a leading-dot extension for a MIME type,
-// or "" if the MIME isn't on our known list. Used as a last-resort
-// fallback when the Content-Disposition header is missing a filename
-// — we'd rather give the agent `<id>.png` than `<id>` with no hint
-// for downstream tooling.
-//
-// We can't use mime.ExtensionsByType here because its results depend
-// on the host's /etc/mime.types and aren't deterministic across
-// platforms (Linux/macOS/Windows all differ). The hardcoded map
-// mirrors the canonical entries in internal/attachments/mime.go.
 // safeLocalFilename reduces a SERVER-SUPPLIED filename to something safe to
 // join onto a local directory.
 //

--- a/cmd/pad/cmd_attachment.go
+++ b/cmd/pad/cmd_attachment.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/PerpetualSoftware/pad/internal/attachments"
 	goMime "mime"
 	"os"
 	"path/filepath"
@@ -247,58 +248,53 @@ func parseAttachmentFilename(disposition string) string {
 // on the host's /etc/mime.types and aren't deterministic across
 // platforms (Linux/macOS/Windows all differ). The hardcoded map
 // mirrors the canonical entries in internal/attachments/mime.go.
+// safeLocalFilename reduces a SERVER-SUPPLIED filename to something safe to
+// join onto a local directory.
+//
+// The name in Content-Disposition originates with whoever uploaded the file.
+// Treating it as a path component is how `..` turns into a write outside the
+// temp directory this command just created: filepath.Ext("..") is ".", which
+// is non-empty, so even an extension check waves it through, and
+// filepath.Join(dir, "..") is dir's PARENT (codex round 26).
+//
+// The server has its own guard, and it is being tightened for this case. This
+// one is independent on purpose: a client that builds a local path out of a
+// remote string should not be relying on the remote end to have sanitised it,
+// and this CLI talks to whatever instance it is pointed at.
+//
+// Returns "" when nothing usable survives, which the caller already handles by
+// falling back to the attachment id.
+func safeLocalFilename(name, id string) string {
+	name = filepath.Base(strings.TrimSpace(name))
+	switch name {
+	case "", ".", "..", string(filepath.Separator):
+		return ""
+	}
+	// Base() has already stripped directories; anything still carrying a
+	// separator is a name the local filesystem would read as a path.
+	if strings.ContainsAny(name, `/\`) {
+		return ""
+	}
+	// A name that is only dots ("...", "....") is not a path component worth
+	// keeping and confuses extension handling.
+	if strings.Trim(name, ".") == "" {
+		return ""
+	}
+	return name
+}
+
+// extensionForMIME delegates to the server package's mapping instead of
+// keeping a second table here.
+//
+// It used to keep its own, and the copy had drifted: it knew images and video
+// but not gzip, tar, XML, YAML, TOML, HTML, JavaScript or several document
+// types the server has always allowed. So `pad attachment view` produced an
+// extensionless temp file for those, defeating its own contract of handing a
+// path to something that opens files by extension (codex round 26).
+//
+// Two tables for one relationship is the defect; the delegation is the fix.
 func extensionForMIME(mimeType string) string {
-	if i := strings.IndexByte(mimeType, ';'); i >= 0 {
-		mimeType = mimeType[:i]
-	}
-	mimeType = strings.ToLower(strings.TrimSpace(mimeType))
-	switch mimeType {
-	case "image/png":
-		return ".png"
-	case "image/jpeg":
-		return ".jpg"
-	case "image/gif":
-		return ".gif"
-	case "image/webp":
-		return ".webp"
-	case "image/avif":
-		return ".avif"
-	case "image/heic":
-		return ".heic"
-	case "image/heif":
-		return ".heif"
-	case "video/mp4":
-		return ".mp4"
-	case "video/webm":
-		return ".webm"
-	case "video/quicktime":
-		return ".mov"
-	case "audio/mpeg":
-		return ".mp3"
-	case "audio/wav":
-		return ".wav"
-	case "audio/ogg":
-		return ".ogg"
-	case "audio/flac":
-		return ".flac"
-	case "audio/aac":
-		return ".aac"
-	case "audio/mp4":
-		return ".m4a"
-	case "application/pdf":
-		return ".pdf"
-	case "application/zip":
-		return ".zip"
-	case "application/json":
-		return ".json"
-	case "text/plain":
-		return ".txt"
-	case "text/markdown":
-		return ".md"
-	case "text/csv":
-		return ".csv"
-	}
-	return ""
+	return attachments.ExtensionForMIME(mimeType)
 }
 
 func attachmentViewCmd() *cobra.Command {
@@ -347,7 +343,7 @@ Examples:
 				if err != nil {
 					return err
 				}
-				name := parseAttachmentFilename(meta.ContentDisposition)
+				name := safeLocalFilename(parseAttachmentFilename(meta.ContentDisposition), id)
 				if name == "" {
 					name = id + extensionForMIME(meta.MIME)
 				} else if filepath.Ext(name) == "" {

--- a/cmd/pad/cmd_attachment.go
+++ b/cmd/pad/cmd_attachment.go
@@ -305,9 +305,14 @@ and save it to disk. Prints the absolute path of the saved file on
 stdout — designed for agents to use as $(pad attachment view <id>).
 
 With no -o flag, the file lands in a fresh OS temp directory. The
-filename comes from the attachment's Content-Disposition header so
-agents can hand the path to image-viewing tools without rewriting
-the extension.
+filename starts from the attachment's Content-Disposition header,
+reduced to a safe local path component (whitespace trimmed, path
+separators and dot-only or trailing-dot forms removed — stricter
+than what the server stores, because this name is written to YOUR
+filesystem); when the result has no extension, the canonical
+extension for the attachment's MIME type is appended so viewers
+that dispatch on extension still open it. An unusable name falls
+back to the attachment id, reduced the same way.
 
 With -o <path>, the file is written to that path using the same
 atomic temp-then-rename strategy as 'pad attachment download'.
@@ -341,7 +346,18 @@ Examples:
 				}
 				name := safeLocalFilename(parseAttachmentFilename(meta.ContentDisposition))
 				if name == "" {
-					name = id + extensionForMIME(meta.MIME)
+					// The id is a CLI argument, but in the documented agent
+					// flow it is harvested from item CONTENT (a
+					// "pad-attachment:" ref another workspace member wrote),
+					// so it gets the same reduction as the server-supplied
+					// name before becoming a path component — a raw
+					// traversal-shaped id joined onto the temp dir escapes
+					// it (codex closing round 3).
+					base := safeLocalFilename(id)
+					if base == "" {
+						base = "attachment"
+					}
+					name = base + extensionForMIME(meta.MIME)
 				} else if filepath.Ext(name) == "" {
 					// A stored name can be extensionless — most often the
 					// server's generic "upload" fallback, used when the

--- a/cmd/pad/cmd_attachment.go
+++ b/cmd/pad/cmd_attachment.go
@@ -280,7 +280,13 @@ func safeLocalFilename(name string) string {
 	if strings.Trim(name, ".") == "" {
 		return ""
 	}
-	return name
+	// A TRAILING dot survives every check above, and filepath.Ext("photo.")
+	// is "." — non-empty — so the caller's MIME-extension fallback never
+	// fires and the temp file dispatches on no extension; Windows cannot
+	// store the name at all. Strip the dots instead of refusing: "photo." is
+	// an ordinary name wearing one (codex closing round). Cannot empty the
+	// name — the dots-only case returned above.
+	return strings.TrimRight(name, ".")
 }
 
 // extensionForMIME delegates to the server package's mapping instead of

--- a/cmd/pad/cmd_attachment.go
+++ b/cmd/pad/cmd_attachment.go
@@ -350,6 +350,20 @@ Examples:
 				name := parseAttachmentFilename(meta.ContentDisposition)
 				if name == "" {
 					name = id + extensionForMIME(meta.MIME)
+				} else if filepath.Ext(name) == "" {
+					// A stored name can be extensionless — most often the
+					// server's generic "upload" fallback, used when the
+					// uploaded filename could not be stored as text
+					// (BUG-2803). The old check only covered an ABSENT name,
+					// so any non-empty one was taken as authoritative and the
+					// MIME fallback never ran.
+					//
+					// That matters because this command's contract is to hand
+					// the path to whatever opens files — `open "$IMG"`,
+					// `xdg-open`, an image viewer — and those dispatch on the
+					// extension. An extensionless temp file silently stops
+					// opening as an image (codex round 24).
+					name += extensionForMIME(meta.MIME)
 				}
 				dir, err := os.MkdirTemp("", "pad-attachment-")
 				if err != nil {

--- a/cmd/pad/cmd_attachment_filename_test.go
+++ b/cmd/pad/cmd_attachment_filename_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// safeLocalFilename builds a LOCAL path component out of a remote string, so
+// its contract is what keeps `pad attachment view` from writing outside its
+// temp dir or handing viewers a name they cannot dispatch on. The CLI guard
+// had no tests of its own (codex closing round, BUG-2803); each case below
+// names the failure it discriminates.
+func TestSafeLocalFilename(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"ordinary name kept", "photo.png", "photo.png"},
+		{"whitespace trimmed", "  photo.png \t", "photo.png"},
+		{"empty refused", "", ""},
+		{"dot refused", ".", ""},
+		// filepath.Ext("..") is "." — non-empty — so an extension check waves
+		// it through, and filepath.Join(dir, "..") is dir's PARENT.
+		{"dot-dot refused", "..", ""},
+		{"dots-only refused", "...", ""},
+		{"dots-only long refused", "....", ""},
+		// Base() strips directories, so a path arrives as its last segment.
+		{"path reduced to base", "a/b/photo.png", "photo.png"},
+		// A backslash is a legitimate byte in a Unix filename, but this name
+		// is written to the LOCAL filesystem, which may read it as a
+		// separator. Refusal (fall back to the attachment id) is deliberate.
+		{"backslash refused", `a\b.png`, ""},
+		{"traversal via backslash refused", `..\evil.png`, ""},
+		// A trailing dot makes filepath.Ext answer "." — non-empty — so the
+		// caller's MIME-extension fallback never fires and the temp file
+		// dispatches on no extension; Windows cannot store the name at all.
+		{"trailing dot stripped", "photo.", "photo"},
+		{"trailing dots stripped", "archive.tar..", "archive.tar"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := safeLocalFilename(tc.in); got != tc.want {
+				t.Fatalf("safeLocalFilename(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+
+	// The property the trailing-dot rule exists for, stated as the caller
+	// consumes it: a stripped name must read as EXTENSIONLESS so the
+	// MIME-extension fallback in attachmentViewCmd fires. On the unfixed
+	// code safeLocalFilename("photo.") returned "photo." whose Ext is ".",
+	// and the fallback stayed silent.
+	if got := safeLocalFilename("photo."); filepath.Ext(got) != "" {
+		t.Fatalf("safeLocalFilename(%q) = %q still carries extension %q; the MIME fallback will not fire",
+			"photo.", got, filepath.Ext(got))
+	}
+}

--- a/cmd/pad/cmd_attachment_view_test.go
+++ b/cmd/pad/cmd_attachment_view_test.go
@@ -105,6 +105,33 @@ func TestAttachmentViewNamesTheFileThroughTheCommand(t *testing.T) {
 		assertWrittenInsideTemp(t, got, body)
 	})
 
+	// image/png was in the OLD hand-rolled CLI table too, so png-only cases
+	// cannot discriminate the delegation to the shared MIME map — a stale
+	// local table would pass them (codex closing round 7). gzip is one of
+	// the types round 26 found MISSING from that table, and SVG is blocked:
+	// the shared map must answer for the first and refuse an extension for
+	// the second.
+	t.Run("delegated type the old table lacked gains its extension", func(t *testing.T) {
+		got := runAttachmentView(t,
+			attachmentViewTestHandler(`attachment; filename="dump"`, "application/gzip", body),
+			"44444444-4444-4444-4444-444444444444")
+		if filepath.Base(got) != "dump.gz" {
+			t.Fatalf("printed path %q, want basename dump.gz — the shared MIME map is not being consulted", got)
+		}
+		assertWrittenInsideTemp(t, got, body)
+	})
+
+	t.Run("blocked MIME type never gains an extension", func(t *testing.T) {
+		id := "55555555-5555-5555-5555-555555555555"
+		got := runAttachmentView(t,
+			attachmentViewTestHandler("", "image/svg+xml", body),
+			id)
+		if filepath.Base(got) != id {
+			t.Fatalf("printed path %q, want the bare id %q — a blocked type must not mint an extension", got, id)
+		}
+		assertWrittenInsideTemp(t, got, body)
+	})
+
 	t.Run("absent name falls back to the id plus extension", func(t *testing.T) {
 		got := runAttachmentView(t,
 			attachmentViewTestHandler("", "image/png", body),

--- a/cmd/pad/cmd_attachment_view_test.go
+++ b/cmd/pad/cmd_attachment_view_test.go
@@ -144,6 +144,35 @@ func TestAttachmentViewNamesTheFileThroughTheCommand(t *testing.T) {
 		}
 	})
 
+	// PathEscape leaves exact "." and ".." UNCHANGED, so they would reach
+	// the wire as live dot segments for a proxy or server to normalize
+	// away — the client refuses them before any request (codex closing
+	// round 4). A real id is a UUID; the refusal cannot fire on one.
+	t.Run("exact dot-segment id is refused before any request", func(t *testing.T) {
+		var requests int
+		record := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requests++
+			attachmentViewTestHandler("", "image/png", body).ServeHTTP(w, r)
+		})
+		server := httptest.NewServer(record)
+		t.Cleanup(server.Close)
+		t.Setenv("HOME", t.TempDir())
+		previousWorkspace, previousURL := workspaceFlag, urlFlag
+		workspaceFlag, urlFlag = "demo", server.URL+"/"
+		t.Cleanup(func() { workspaceFlag, urlFlag = previousWorkspace, previousURL })
+
+		for _, id := range []string{"..", "."} {
+			cmd := attachmentViewCmd()
+			cmd.SetArgs([]string{id})
+			if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "invalid attachment id") {
+				t.Fatalf("id %q: expected an invalid-attachment-id error, got %v", id, err)
+			}
+		}
+		if requests != 0 {
+			t.Fatalf("dot-segment ids reached the wire: %d request(s) sent", requests)
+		}
+	})
+
 	t.Run("unusable id falls back to the generic name", func(t *testing.T) {
 		got := runAttachmentView(t,
 			attachmentViewTestHandler("", "image/png", body),

--- a/cmd/pad/cmd_attachment_view_test.go
+++ b/cmd/pad/cmd_attachment_view_test.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// attachmentViewTestHandler serves HEAD/GET for any path under /attachments/,
+// with a fixed Content-Type and optional Content-Disposition. Accepting any
+// suffix is deliberate: the traversal case below needs the server to answer
+// for a hostile id the way a re-routed request would.
+func attachmentViewTestHandler(disposition, mime string, body []byte) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/attachments/") {
+			http.NotFound(w, r)
+			return
+		}
+		if disposition != "" {
+			w.Header().Set("Content-Disposition", disposition)
+		}
+		w.Header().Set("Content-Type", mime)
+		if r.Method == http.MethodHead {
+			return
+		}
+		_, _ = w.Write(body)
+	})
+}
+
+// runAttachmentView executes `pad attachment view <id>` against a stub server
+// and returns the path the command printed. The command prints via
+// fmt.Println(os.Stdout) so $(...) substitution works; the test captures it
+// the same way a shell would.
+func runAttachmentView(t *testing.T, handler http.Handler, id string) string {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	t.Setenv("HOME", t.TempDir())
+	// Sandbox the command's os.MkdirTemp so the containment assertion below
+	// has a boundary this test owns.
+	t.Setenv("TMPDIR", t.TempDir())
+
+	previousWorkspace := workspaceFlag
+	previousURL := urlFlag
+	workspaceFlag = "demo"
+	urlFlag = server.URL + "/"
+	t.Cleanup(func() {
+		workspaceFlag = previousWorkspace
+		urlFlag = previousURL
+	})
+
+	rd, wr, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	oldStdout := os.Stdout
+	os.Stdout = wr
+	defer func() { os.Stdout = oldStdout }()
+
+	cmd := attachmentViewCmd()
+	cmd.SetArgs([]string{id})
+	execErr := cmd.Execute()
+
+	_ = wr.Close()
+	os.Stdout = oldStdout
+	out := make([]byte, 4096)
+	n, _ := rd.Read(out)
+	_ = rd.Close()
+
+	if execErr != nil {
+		t.Fatalf("execute attachment view: %v", execErr)
+	}
+	return strings.TrimSpace(string(out[:n]))
+}
+
+// TestAttachmentViewNamesTheFileThroughTheCommand exercises the WIRING —
+// helper tests alone left the command's naming fallback an untested claim
+// (codex closing round 3, CONVE-19's direct-call-vouches-for-the-component
+// point).
+func TestAttachmentViewNamesTheFileThroughTheCommand(t *testing.T) {
+	body := []byte("png-bytes")
+
+	t.Run("disposition name used verbatim", func(t *testing.T) {
+		got := runAttachmentView(t,
+			attachmentViewTestHandler(`attachment; filename="shot.png"`, "image/png", body),
+			"11111111-1111-1111-1111-111111111111")
+		if filepath.Base(got) != "shot.png" {
+			t.Fatalf("printed path %q, want basename shot.png", got)
+		}
+		assertWrittenInsideTemp(t, got, body)
+	})
+
+	t.Run("extensionless stored name gains the MIME extension", func(t *testing.T) {
+		got := runAttachmentView(t,
+			attachmentViewTestHandler(`attachment; filename="upload"`, "image/png", body),
+			"22222222-2222-2222-2222-222222222222")
+		if filepath.Base(got) != "upload.png" {
+			t.Fatalf("printed path %q, want basename upload.png", got)
+		}
+		assertWrittenInsideTemp(t, got, body)
+	})
+
+	t.Run("absent name falls back to the id plus extension", func(t *testing.T) {
+		got := runAttachmentView(t,
+			attachmentViewTestHandler("", "image/png", body),
+			"33333333-3333-3333-3333-333333333333")
+		if filepath.Base(got) != "33333333-3333-3333-3333-333333333333.png" {
+			t.Fatalf("printed path %q, want id-based basename", got)
+		}
+		assertWrittenInsideTemp(t, got, body)
+	})
+
+	// The closing-round-3 defect: an id harvested from item content can be
+	// traversal-shaped. Unfixed, the fallback joined it raw onto the temp
+	// dir and the write escaped it. The stub answers for ANY attachments
+	// path, standing in for a re-routed request that answers 200.
+	t.Run("traversal-shaped id cannot escape the temp dir", func(t *testing.T) {
+		var uris []string
+		record := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			uris = append(uris, r.RequestURI)
+			attachmentViewTestHandler("", "image/png", body).ServeHTTP(w, r)
+		})
+		got := runAttachmentView(t, record, "../../escape")
+		if filepath.Base(got) != "escape.png" {
+			t.Fatalf("printed path %q, want the reduced basename escape.png", got)
+		}
+		assertWrittenInsideTemp(t, got, body)
+		// The client must PATH-ESCAPE the id so the request cannot be
+		// re-routed off the attachments route by dot segments — the wire
+		// half of the same defect. Without the escaping, this wire either
+		// carries a raw "../" or a cleaned path with the segments gone.
+		for _, uri := range uris {
+			if !strings.Contains(uri, "%2F") || strings.Contains(uri, "../") {
+				t.Fatalf("request URI %q carries unescaped dot segments; the id must be path-escaped", uri)
+			}
+		}
+		if len(uris) == 0 {
+			t.Fatal("premise failed: the stub saw no requests")
+		}
+	})
+
+	t.Run("unusable id falls back to the generic name", func(t *testing.T) {
+		got := runAttachmentView(t,
+			attachmentViewTestHandler("", "image/png", body),
+			"....")
+		if filepath.Base(got) != "attachment.png" {
+			t.Fatalf("printed path %q, want attachment.png", got)
+		}
+		assertWrittenInsideTemp(t, got, body)
+	})
+}
+
+// assertWrittenInsideTemp asserts the consequence a wrong join would produce:
+// a file OUTSIDE the sandboxed TMPDIR (or none at the printed path at all).
+func assertWrittenInsideTemp(t *testing.T, printed string, want []byte) {
+	t.Helper()
+	tmp, err := filepath.EvalSymlinks(os.Getenv("TMPDIR"))
+	if err != nil {
+		t.Fatalf("resolve TMPDIR: %v", err)
+	}
+	resolved, err := filepath.EvalSymlinks(printed)
+	if err != nil {
+		t.Fatalf("printed path %q does not resolve: %v", printed, err)
+	}
+	if !strings.HasPrefix(resolved, tmp+string(filepath.Separator)) {
+		t.Fatalf("file %q landed outside the sandboxed temp dir %q", resolved, tmp)
+	}
+	data, err := os.ReadFile(printed)
+	if err != nil {
+		t.Fatalf("read written file: %v", err)
+	}
+	if string(data) != string(want) {
+		t.Fatalf("written bytes = %q, want %q", data, want)
+	}
+}

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -168,8 +168,22 @@ your backup — it is the import applying a rule the write path now applies too
 (BUG-2803): a NUL cannot be stored in a text or JSON column, and PostgreSQL
 refuses it outright.
 
-It can only affect data written **before** that rule existed, and only on
-SQLite, which accepted it. A PostgreSQL instance never stored such a value.
+**The rule lives in the binary, not in the database**, so "before the rule
+existed" is a statement about which build served the write, not about a date.
+On SQLite, any window in which an older binary serves the same database can
+still create such rows: a rollback to the previous version, a staged rollout
+where an old and a new instance share a database, or a second older instance
+pointed at the same file. Once that window closes the guard is back, but the
+rows are already stored, and they behave exactly like genuinely old ones.
+
+Only SQLite is affected. PostgreSQL refuses a NUL in a text or JSON column
+itself, at every binary version, so a PostgreSQL instance never stored such a
+value regardless of which build wrote it.
+
+If you want the guarantee rather than the guard, drain writes from older
+binaries before the new one starts serving, or roll forward rather than back.
+Enforcing the invariant below the HTTP layer, so the running build stops
+mattering, is tracked as BUG-2813.
 
 The same limitation applies to `pad db migrate-to-pg`, which copies rows
 directly and does not go through the import guard: a row carrying a NUL will

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -194,8 +194,11 @@ reported up front.
 
 If you hit either, the affected value has to be repaired at the source before
 the import or migration will go through — the export itself succeeds either
-way, as described above. A preflight check and a repair path
-are tracked as BUG-2810; until then the failing row is named in the error.
+way, as described above. A preflight check and a repair path are tracked as
+BUG-2810. Until then, neither error names the exact row: the import answers
+400 naming the rule it refused on, and `pad db migrate-to-pg` reports which
+workspace's copy failed — locating the offending value inside it is manual
+today.
 
 
 This format is database-agnostic and can be used to:

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -160,6 +160,27 @@ pad workspace import < my-workspace.json
 pad workspace import --name "imported-workspace" < my-workspace.json
 ```
 
+### One case where an export is not importable
+
+A workspace whose stored data contains a **NUL character** exports fine and is
+refused on import, with a 400 naming the cause. This is not a corruption of
+your backup — it is the import applying a rule the write path now applies too
+(BUG-2803): a NUL cannot be stored in a text or JSON column, and PostgreSQL
+refuses it outright.
+
+It can only affect data written **before** that rule existed, and only on
+SQLite, which accepted it. A PostgreSQL instance never stored such a value.
+
+The same limitation applies to `pad db migrate-to-pg`, which copies rows
+directly and does not go through the import guard: a row carrying a NUL will
+fail against PostgreSQL's JSONB parser during the copy rather than being
+reported up front.
+
+If you hit either, the affected value has to be repaired at the source before
+the export or migration will go through. A preflight check and a repair path
+are tracked as BUG-2810; until then the failing row is named in the error.
+
+
 This format is database-agnostic and can be used to:
 - Transfer workspaces between Pad instances
 - Create workspace templates

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -193,7 +193,8 @@ fail against PostgreSQL's JSONB parser during the copy rather than being
 reported up front.
 
 If you hit either, the affected value has to be repaired at the source before
-the export or migration will go through. A preflight check and a repair path
+the import or migration will go through — the export itself succeeds either
+way, as described above. A preflight check and a repair path
 are tracked as BUG-2810; until then the failing row is named in the error.
 
 

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -165,8 +165,10 @@ pad workspace import --name "imported-workspace" < my-workspace.json
 A workspace whose stored data contains a **NUL character** exports fine and is
 refused on import, with a 400 naming the cause. This is not a corruption of
 your backup — it is the import applying a rule the write path now applies too
-(BUG-2803): a NUL cannot be stored in a text or JSON column, and PostgreSQL
-refuses it outright.
+(BUG-2803): Pad does not accept a NUL in a text or JSON value. That is an
+application rule, not a universal storage fact — PostgreSQL does refuse a NUL
+outright, but SQLite accepts one in a TEXT column, which is why the rule has to
+be enforced rather than assumed, and why the paragraphs below matter.
 
 **The rule lives in the binary, not in the database**, so "before the rule
 existed" is a statement about which build served the write, not about a date.

--- a/internal/attachments/mime.go
+++ b/internal/attachments/mime.go
@@ -290,10 +290,6 @@ type uploadError struct{ msg string }
 
 func (e *uploadError) Error() string { return e.msg }
 
-// mimeForExt is a minimal extension → entry mapping used only for the
-// extension-vs-sniff sanity check. Keeping it small and deliberate means
-// unrecognized extensions just skip the cross-check (instead of forcing
-// us to enumerate every extension on the planet).
 // ExtensionForMIME returns the canonical file extension for a MIME type, or ""
 // when there is no mapping.
 //

--- a/internal/attachments/mime.go
+++ b/internal/attachments/mime.go
@@ -294,6 +294,63 @@ func (e *uploadError) Error() string { return e.msg }
 // extension-vs-sniff sanity check. Keeping it small and deliberate means
 // unrecognized extensions just skip the cross-check (instead of forcing
 // us to enumerate every extension on the planet).
+// ExtensionForMIME returns the canonical file extension for a MIME type, or ""
+// when there is no mapping.
+//
+// Exported so a client need not keep its OWN table. The CLI did, and it had
+// drifted: it knew images and video but not gzip, tar, XML, YAML, TOML, HTML,
+// JavaScript or several document types this map has always allowed — so
+// `pad attachment view` silently produced an extensionless file for them,
+// defeating its contract of handing a path to something that opens files by
+// extension (codex round 26). Two tables for one relationship was the defect.
+func ExtensionForMIME(mimeType string) string {
+	if ext, ok := canonicalExtForMIME[NormalizeMIME(mimeType)]; ok {
+		return ext
+	}
+	return ""
+}
+
+// canonicalExtForMIME reverses extMIMEMap with one deliberate choice per MIME
+// type, since several extensions map to the same type. Held to the forward map
+// by TestCanonicalExtForMIMECoversTheMap.
+var canonicalExtForMIME = buildCanonicalExtForMIME()
+
+// preferredExtensions names the spelling to use where a type has several.
+//
+// Every key MUST be a value that extMIMEMap actually uses, or the entry is a
+// line that cannot fire. One of them was exactly that on first writing —
+// "text/yaml", where this map says application/yaml — so the preference never
+// applied and .yaml won on length. The test asserts the property rather than
+// trusting the next reader to notice.
+func preferredExtensions() map[string]string {
+	return map[string]string{
+		"image/jpeg":       ".jpg",  // over .jpeg
+		"text/markdown":    ".md",   // over .markdown
+		"application/yaml": ".yml",  // over .yaml
+		"text/html":        ".html", // over .htm, which shortest-wins would pick
+	}
+}
+
+func buildCanonicalExtForMIME() map[string]string {
+	preferred := preferredExtensions()
+	out := make(map[string]string, len(extMIMEMap))
+	for ext, mimeStr := range extMIMEMap {
+		m := NormalizeMIME(mimeStr)
+		if want, ok := preferred[m]; ok {
+			out[m] = want
+			continue
+		}
+		// Anything unlisted takes the shortest extension, then alphabetical,
+		// so the result does not depend on Go's randomised map order. A helper
+		// that answered differently per process would be worse than none.
+		cur, seen := out[m]
+		if !seen || len(ext) < len(cur) || (len(ext) == len(cur) && ext < cur) {
+			out[m] = ext
+		}
+	}
+	return out
+}
+
 // SafeFallbackExtension reports whether ext (with its leading dot, any case)
 // may be carried into a generic fallback filename when the original name was
 // unstorable.

--- a/internal/attachments/mime.go
+++ b/internal/attachments/mime.go
@@ -294,6 +294,48 @@ func (e *uploadError) Error() string { return e.msg }
 // extension-vs-sniff sanity check. Keeping it small and deliberate means
 // unrecognized extensions just skip the cross-check (instead of forcing
 // us to enumerate every extension on the planet).
+// SafeFallbackExtension reports whether ext (with its leading dot, any case)
+// may be carried into a generic fallback filename when the original name was
+// unstorable.
+//
+// The bar is deliberately higher than "storable text". A fallback name is
+// SYNTHESISED by the server, so anything kept from the caller's input has to
+// earn its place:
+//
+//   - it must be a known extension, so an arbitrary suffix cannot ride along
+//     and later drive MIME or viewer behaviour that the bytes do not support;
+//   - it must map to an ALLOWED type, so the blocklist cannot be sidestepped
+//     by arriving through the fallback path instead of the ordinary one;
+//
+// A control-obfuscated suffix is excluded by the SAME map lookup rather than
+// by a separate charset test, and that is a deliberate choice recorded here
+// because a mutation exposed it. ".s<VT>vg" is storable (a vertical tab is
+// valid UTF-8 and not a NUL) but matches no key, so it is already refused.
+// I first wrote an explicit alphanumeric loop as well; removing it changed
+// nothing, because no key in extMIMEMap contains a non-alphanumeric character.
+// Keeping a guard that cannot fire, with a comment claiming it stops control
+// characters, would have misdescribed which line does the work — so the loop
+// is gone and TestExtMIMEMapKeysArePlain enforces the property it relied on.
+//
+// That divergence — storable here, stripped by Content-Disposition sanitising,
+// so ".s<VT>vg" reaches the client as ".svg" past a blocklist that never
+// evaluated it — is a pre-existing hazard on the ORDINARY upload path, where
+// the name is not synthesised at all. Tracked as BUG-2818; this predicate only
+// refuses to add a second door to it.
+//
+// Anything else is dropped and the fallback stays extensionless.
+func SafeFallbackExtension(ext string) bool {
+	if len(ext) < 2 || len(ext) > 16 || ext[0] != '.' {
+		return false
+	}
+	mimeStr, ok := extMIMEMap[strings.ToLower(ext)]
+	if !ok {
+		return false
+	}
+	_, allowed := LookupMIME(NormalizeMIME(mimeStr))
+	return allowed
+}
+
 var extMIMEMap = map[string]string{
 	".png":  "image/png",
 	".jpg":  "image/jpeg",

--- a/internal/attachments/mime.go
+++ b/internal/attachments/mime.go
@@ -16,9 +16,12 @@ const (
 	// (image, audio, video). Content-Disposition is "inline".
 	RenderInline RenderMode = iota
 	// RenderChip means the editor displays a download chip instead of
-	// embedding the bytes (PDFs, archives, office docs). The HTTP layer
-	// still serves these inline so the browser can preview if it wants
-	// to (PDF in particular); the Content-Disposition stays "inline".
+	// embedding the bytes (PDFs, archives, office docs). Content-Disposition
+	// for these is decided by the read path's explicit ServeInline allowlist
+	// (BUG-2413), NOT by this mode: most chip types are served as
+	// "attachment", with only the audited exceptions (PDF, say) inline. An
+	// earlier version of this comment said the HTTP layer served every chip
+	// inline, which described the pre-BUG-2413 policy (codex closing round 8).
 	RenderChip
 	// RenderForceDownload means we set Content-Disposition: attachment
 	// to keep the browser from interpreting the bytes inline. This is

--- a/internal/attachments/mime.go
+++ b/internal/attachments/mime.go
@@ -321,9 +321,12 @@ var canonicalExtForMIME = buildCanonicalExtForMIME()
 func preferredExtensions() map[string]string {
 	return map[string]string{
 		"image/jpeg":       ".jpg",  // over .jpeg
-		"text/markdown":    ".md",   // over .markdown
 		"application/yaml": ".yml",  // over .yaml
 		"text/html":        ".html", // over .htm, which shortest-wins would pick
+		// text/markdown is NOT here: .md is its only extMIMEMap spelling, so
+		// a preference had nothing to choose against — a line that cannot
+		// fire, the same class this map's doc warns about (codex closing
+		// round 5). The test now asserts every entry has a real competitor.
 	}
 }
 

--- a/internal/attachments/mime.go
+++ b/internal/attachments/mime.go
@@ -331,6 +331,30 @@ func preferredExtensions() map[string]string {
 	}
 }
 
+// aliasExtensions covers allowed MIME spellings that NO extension in
+// extMIMEMap maps to, so reversing the forward table alone leaves them
+// without an extension: the forward table picks one spelling per extension
+// (.xml says application/xml, .js says text/javascript, .webm says
+// video/webm), while the allowlist accepts the alias spellings too. An
+// attachment stored under an alias type with an unstorable filename came out
+// of `pad attachment view` extensionless — the exact failure the delegation
+// to this package was built to end (codex closing round).
+//
+// Every key MUST be an allowed type with no forward-derived reverse mapping,
+// and every value MUST be an extension the forward map sends to an ALLOWED
+// type — an alias must never mint an extension the product refuses (the
+// BUG-2818 door the blocked-type filter above closes). Both properties are
+// asserted by test, alongside the closing property this table exists for:
+// every allowed MIME type has a reverse extension.
+func aliasExtensions() map[string]string {
+	return map[string]string{
+		"text/xml":               ".xml",  // forward map spells it application/xml
+		"text/yaml":              ".yml",  // forward map spells it application/yaml; .yml matches its preference
+		"application/javascript": ".js",   // forward map spells it text/javascript
+		"audio/webm":             ".webm", // forward map spells it video/webm; the container is the same
+	}
+}
+
 func buildCanonicalExtForMIME() map[string]string {
 	preferred := preferredExtensions()
 	out := make(map[string]string, len(extMIMEMap))
@@ -362,6 +386,13 @@ func buildCanonicalExtForMIME() map[string]string {
 		if !seen || len(ext) < len(cur) || (len(ext) == len(cur) && ext < cur) {
 			out[m] = ext
 		}
+	}
+	// Alias spellings last. Unconditional on purpose: an alias key that the
+	// forward loop ALSO produced would mean two sources disagree about one
+	// type, and the test asserting alias keys have no forward-derived mapping
+	// fails loudly rather than letting this line silently pick a winner.
+	for m, ext := range aliasExtensions() {
+		out[NormalizeMIME(m)] = ext
 	}
 	return out
 }

--- a/internal/attachments/mime.go
+++ b/internal/attachments/mime.go
@@ -336,6 +336,21 @@ func buildCanonicalExtForMIME() map[string]string {
 	out := make(map[string]string, len(extMIMEMap))
 	for ext, mimeStr := range extMIMEMap {
 		m := NormalizeMIME(mimeStr)
+		// BLOCKED types get no reverse mapping. extMIMEMap is the forward
+		// table used to REFUSE uploads — it deliberately lists .svg, .exe and
+		// friends so their extensions can be recognised and rejected.
+		// Reversing it wholesale turned that refusal list into a SOURCE of
+		// extensions: ExtensionForMIME("image/svg+xml") answered ".svg", and
+		// `pad attachment view` names a local file with it. The old CLI table
+		// answered nothing for those, so this was a regression, and it
+		// reopened the same hazard BUG-2818 describes through a different
+		// door (codex round 27).
+		//
+		// A caller asking "what should I call a file of this type" must only
+		// ever be told about types this product actually accepts.
+		if _, ok := LookupMIME(m); !ok {
+			continue
+		}
 		if want, ok := preferred[m]; ok {
 			out[m] = want
 			continue

--- a/internal/attachments/mime_test.go
+++ b/internal/attachments/mime_test.go
@@ -306,3 +306,35 @@ func TestValidateUpload_RejectsExeByExtensionAlone(t *testing.T) {
 		t.Errorf("code = %q, want extension_blocked", code)
 	}
 }
+
+// TestExtMIMEMapKeysArePlain enforces the property SafeFallbackExtension
+// relies on instead of restating it as a comment.
+//
+// That predicate has no charset test of its own: a control-obfuscated suffix
+// like ".s<VT>vg" is refused because it matches no key here, not because
+// anything inspects its bytes. I originally wrote an explicit alphanumeric
+// loop too, and removing it changed no behaviour — a guard that cannot fire,
+// carrying a comment about what it protects against, misdescribes which line
+// does the work.
+//
+// So the loop is gone and this test holds the invariant up. If a key with a
+// dash, a space, or a control byte is ever added, this fails and whoever adds
+// it has to decide whether SafeFallbackExtension needs its own charset test
+// back.
+func TestExtMIMEMapKeysArePlain(t *testing.T) {
+	if len(extMIMEMap) == 0 {
+		t.Fatal("premise failed: the extension map is empty, so this test asserts nothing")
+	}
+	for ext := range extMIMEMap {
+		if len(ext) < 2 || ext[0] != '.' {
+			t.Errorf("extension key %q must start with a dot and have a body", ext)
+			continue
+		}
+		for _, r := range ext[1:] {
+			if (r < '0' || r > '9') && (r < 'a' || r > 'z') {
+				t.Errorf("extension key %q contains %q, which is not lowercase alphanumeric; "+
+					"SafeFallbackExtension has no charset test of its own and relies on this", ext, r)
+			}
+		}
+	}
+}

--- a/internal/attachments/mime_test.go
+++ b/internal/attachments/mime_test.go
@@ -412,14 +412,27 @@ func TestCanonicalExtForMIMECoversTheMap(t *testing.T) {
 
 	// Stability: the reverse map is built by iterating a Go map, whose order
 	// is randomised. A helper that answered differently per process would be
-	// worse than none, so the choice must be deterministic.
-	// Every preference is pinned, not just JPEG — the point of the list is
-	// that each of these types has several spellings and one was chosen.
+	// worse than none, so the choice must be deterministic — for EVERY entry,
+	// not only the preferred ones. The first version of this loop compared
+	// just the preference list, so a non-preferred mapping could have
+	// regressed to map-order selection while it stayed green (codex closing
+	// round 2). Now every rebuild must equal the first, and the preferences
+	// are additionally pinned to their declared spellings.
+	first := buildCanonicalExtForMIME()
+	for m, want := range preferredExtensions() {
+		if got := first[m]; got != want {
+			t.Fatalf("wrong reverse mapping for %s: got %q want %q", m, got, want)
+		}
+	}
 	for i := 0; i < 20; i++ {
 		built := buildCanonicalExtForMIME()
-		for m, want := range preferredExtensions() {
+		if len(built) != len(first) {
+			t.Fatalf("reverse map size changed across rebuilds: %d vs %d on iteration %d",
+				len(built), len(first), i)
+		}
+		for m, want := range first {
 			if got := built[m]; got != want {
-				t.Fatalf("unstable or wrong reverse mapping for %s: got %q want %q on iteration %d",
+				t.Fatalf("unstable reverse mapping for %s: got %q want %q on iteration %d",
 					m, got, want, i)
 			}
 		}

--- a/internal/attachments/mime_test.go
+++ b/internal/attachments/mime_test.go
@@ -338,3 +338,56 @@ func TestExtMIMEMapKeysArePlain(t *testing.T) {
 		}
 	}
 }
+
+// TestCanonicalExtForMIMECoversTheMap holds the reverse map to the forward one
+// so the two cannot drift.
+//
+// The CLI used to keep its own MIME-to-extension table, which had fallen
+// behind this package's — it knew images and video but not gzip, tar, XML,
+// YAML, TOML, HTML, JavaScript or several documents, so `pad attachment view`
+// silently produced extensionless files for them. The CLI now delegates here,
+// which removes the second table; this test stops the reverse map growing the
+// same gap against the forward one.
+func TestCanonicalExtForMIMECoversTheMap(t *testing.T) {
+	if len(extMIMEMap) == 0 {
+		t.Fatal("premise failed: the forward map is empty, so this asserts nothing")
+	}
+	for ext, mimeStr := range extMIMEMap {
+		m := NormalizeMIME(mimeStr)
+		got := ExtensionForMIME(m)
+		if got == "" {
+			t.Errorf("%s (from %q) has no reverse mapping; a client asking for its extension gets "+
+				"nothing and writes an extensionless file", m, ext)
+			continue
+		}
+		if back, ok := extMIMEMap[got]; !ok || NormalizeMIME(back) != m {
+			t.Errorf("ExtensionForMIME(%q) = %q, which does not map back to it", m, got)
+		}
+	}
+
+	// Every preferred spelling must name a MIME type this map actually uses.
+	// A preference for a type that is not here is a line that cannot fire,
+	// and one of them was: "text/yaml", where the map says application/yaml.
+	values := map[string]bool{}
+	for _, m := range extMIMEMap {
+		values[NormalizeMIME(m)] = true
+	}
+	for m, ext := range preferredExtensions() {
+		if !values[m] {
+			t.Errorf("preferred extension %q is declared for %q, which no entry in extMIMEMap uses; "+
+				"the preference can never apply", ext, m)
+		}
+		if back, ok := extMIMEMap[ext]; !ok || NormalizeMIME(back) != m {
+			t.Errorf("preferred extension %q for %q does not map back to it", ext, m)
+		}
+	}
+
+	// Stability: the reverse map is built by iterating a Go map, whose order
+	// is randomised. A helper that answered differently per process would be
+	// worse than none, so the choice must be deterministic.
+	for i := 0; i < 20; i++ {
+		if got := buildCanonicalExtForMIME()["image/jpeg"]; got != ".jpg" {
+			t.Fatalf("unstable reverse mapping for image/jpeg: %q on iteration %d", got, i)
+		}
+	}
+}

--- a/internal/attachments/mime_test.go
+++ b/internal/attachments/mime_test.go
@@ -352,9 +352,25 @@ func TestCanonicalExtForMIMECoversTheMap(t *testing.T) {
 	if len(extMIMEMap) == 0 {
 		t.Fatal("premise failed: the forward map is empty, so this asserts nothing")
 	}
+	var sawBlocked bool
 	for ext, mimeStr := range extMIMEMap {
 		m := NormalizeMIME(mimeStr)
 		got := ExtensionForMIME(m)
+
+		// A BLOCKED type must have no reverse mapping. extMIMEMap is the
+		// refusal table — it lists .svg and .exe so uploads carrying them can
+		// be rejected — and reversing it wholesale turned a refusal list into
+		// a source of extensions that `pad attachment view` then names local
+		// files with (codex round 27).
+		if _, allowed := LookupMIME(m); !allowed {
+			sawBlocked = true
+			if got != "" {
+				t.Errorf("%s is BLOCKED but ExtensionForMIME returns %q; a client would name a local "+
+					"file with an extension this product refuses to accept", m, got)
+			}
+			continue
+		}
+
 		if got == "" {
 			t.Errorf("%s (from %q) has no reverse mapping; a client asking for its extension gets "+
 				"nothing and writes an extensionless file", m, ext)
@@ -363,6 +379,18 @@ func TestCanonicalExtForMIMECoversTheMap(t *testing.T) {
 		if back, ok := extMIMEMap[got]; !ok || NormalizeMIME(back) != m {
 			t.Errorf("ExtensionForMIME(%q) = %q, which does not map back to it", m, got)
 		}
+	}
+
+	// Premise: the map must actually CONTAIN a blocked type, or the blocked
+	// branch above asserts nothing and would pass against a reverse map that
+	// happily emitted .svg.
+	if !sawBlocked {
+		t.Fatal("premise failed: no blocked MIME type found in extMIMEMap, so the blocked-type " +
+			"assertion never ran")
+	}
+	if got := ExtensionForMIME("image/svg+xml"); got != "" {
+		t.Errorf("image/svg+xml is the named reason the extension blocklist exists; "+
+			"ExtensionForMIME returned %q", got)
 	}
 
 	// Every preferred spelling must name a MIME type this map actually uses.
@@ -385,9 +413,15 @@ func TestCanonicalExtForMIMECoversTheMap(t *testing.T) {
 	// Stability: the reverse map is built by iterating a Go map, whose order
 	// is randomised. A helper that answered differently per process would be
 	// worse than none, so the choice must be deterministic.
+	// Every preference is pinned, not just JPEG — the point of the list is
+	// that each of these types has several spellings and one was chosen.
 	for i := 0; i < 20; i++ {
-		if got := buildCanonicalExtForMIME()["image/jpeg"]; got != ".jpg" {
-			t.Fatalf("unstable reverse mapping for image/jpeg: %q on iteration %d", got, i)
+		built := buildCanonicalExtForMIME()
+		for m, want := range preferredExtensions() {
+			if got := built[m]; got != want {
+				t.Fatalf("unstable or wrong reverse mapping for %s: got %q want %q on iteration %d",
+					m, got, want, i)
+			}
 		}
 	}
 }

--- a/internal/attachments/mime_test.go
+++ b/internal/attachments/mime_test.go
@@ -408,6 +408,20 @@ func TestCanonicalExtForMIMECoversTheMap(t *testing.T) {
 		if back, ok := extMIMEMap[ext]; !ok || NormalizeMIME(back) != m {
 			t.Errorf("preferred extension %q for %q does not map back to it", ext, m)
 		}
+		// A preference must have something to choose AGAINST: with a single
+		// forward-map spelling the entry cannot fire — text/markdown sat
+		// here that way, "preferring" .md over a .markdown that was never in
+		// the map (codex closing round 5).
+		var spellings int
+		for _, mv := range extMIMEMap {
+			if NormalizeMIME(mv) == m {
+				spellings++
+			}
+		}
+		if spellings < 2 {
+			t.Errorf("preferred extension %q for %q has no competitor (%d spelling in extMIMEMap); "+
+				"the preference cannot fire", ext, m, spellings)
+		}
 	}
 
 	// Stability: the reverse map is built by iterating a Go map, whose order

--- a/internal/attachments/mime_test.go
+++ b/internal/attachments/mime_test.go
@@ -425,3 +425,65 @@ func TestCanonicalExtForMIMECoversTheMap(t *testing.T) {
 		}
 	}
 }
+
+// TestEveryAllowedMIMEHasAnExtension is the closing property the alias table
+// exists for: reversing extMIMEMap alone left four ALLOWED spellings
+// (text/xml, text/yaml, application/javascript, audio/webm) with no reverse
+// extension, because the forward map picks one spelling per extension and the
+// allowlist accepts more spellings than the forward map uses. The population
+// is asserted over the allowlist itself, not the four known cases, so a
+// future allowlist entry without a reverse extension fails here instead of
+// shipping another extensionless `pad attachment view` file (codex closing
+// round, BUG-2803).
+func TestEveryAllowedMIMEHasAnExtension(t *testing.T) {
+	if len(allowed) == 0 {
+		t.Fatal("premise failed: the allowlist is empty, so this asserts nothing")
+	}
+	for m := range allowed {
+		got := ExtensionForMIME(m)
+		if got == "" {
+			t.Errorf("%s is ALLOWED but has no reverse extension; `pad attachment view` writes an "+
+				"extensionless file for it", m)
+			continue
+		}
+		// Whatever extension is handed out, the forward map must know it and
+		// send it to an ALLOWED type — the reverse map must never mint an
+		// extension the product refuses (the BUG-2818 door).
+		back, ok := extMIMEMap[got]
+		if !ok {
+			t.Errorf("ExtensionForMIME(%q) = %q, an extension extMIMEMap does not know", m, got)
+			continue
+		}
+		if _, backAllowed := LookupMIME(back); !backAllowed {
+			t.Errorf("ExtensionForMIME(%q) = %q, which the forward map sends to BLOCKED type %q", m, got, back)
+		}
+	}
+
+	// Alias-table hygiene: each key must be an allowed type the forward loop
+	// produces NO mapping for (the alias application is unconditional, so a
+	// forward-derived key here would be silently overridden — this assertion
+	// is what makes that loud instead).
+	values := map[string]bool{}
+	for _, mv := range extMIMEMap {
+		values[NormalizeMIME(mv)] = true
+	}
+	for m, ext := range aliasExtensions() {
+		nm := NormalizeMIME(m)
+		if nm != m {
+			t.Errorf("alias key %q is not in normalized form (want %q)", m, nm)
+		}
+		if _, ok := LookupMIME(nm); !ok {
+			t.Errorf("alias %q is not on the allowlist; an alias for a refused type is a line that "+
+				"cannot legitimately fire", m)
+		}
+		if values[nm] {
+			t.Errorf("alias %q is a value extMIMEMap already uses — the forward loop derives its "+
+				"mapping and the alias would override it", m)
+		}
+		if back, ok := extMIMEMap[ext]; !ok {
+			t.Errorf("alias extension %q for %q is unknown to extMIMEMap", ext, m)
+		} else if _, backAllowed := LookupMIME(back); !backAllowed {
+			t.Errorf("alias extension %q for %q maps to BLOCKED type %q", ext, m, back)
+		}
+	}
+}

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -1727,7 +1727,12 @@ func (c *Client) UploadAttachment(wsSlug, itemRef, filename string, body io.Read
 // silently falls back to the original if the derived row doesn't exist
 // (TASK-872 / TASK-878 contract).
 func (c *Client) DownloadAttachment(wsSlug, attachmentID, variant string, w io.Writer) (mime string, size int64, err error) {
-	path := "/workspaces/" + wsSlug + "/attachments/" + attachmentID
+	// PathEscape: the id reaches this URL from item content ("pad-attachment:"
+	// refs other workspace members wrote). Raw concatenation let a
+	// traversal-shaped id ("../items/x") re-route the request to a DIFFERENT
+	// endpoint whose 200 then vouched for the id downstream — the view
+	// command builds a local filename from it (codex closing round 3).
+	path := "/workspaces/" + wsSlug + "/attachments/" + url.PathEscape(attachmentID)
 	if variant != "" {
 		path += "?variant=" + url.QueryEscape(variant)
 	}
@@ -1772,7 +1777,12 @@ type AttachmentMetadata struct {
 // structured metadata. Variant is forwarded the same way as
 // DownloadAttachment — empty string for the original blob.
 func (c *Client) HeadAttachment(wsSlug, attachmentID, variant string) (*AttachmentMetadata, error) {
-	path := "/workspaces/" + wsSlug + "/attachments/" + attachmentID
+	// PathEscape: the id reaches this URL from item content ("pad-attachment:"
+	// refs other workspace members wrote). Raw concatenation let a
+	// traversal-shaped id ("../items/x") re-route the request to a DIFFERENT
+	// endpoint whose 200 then vouched for the id downstream — the view
+	// command builds a local filename from it (codex closing round 3).
+	path := "/workspaces/" + wsSlug + "/attachments/" + url.PathEscape(attachmentID)
 	if variant != "" {
 		path += "?variant=" + url.QueryEscape(variant)
 	}

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -1719,6 +1719,22 @@ func (c *Client) UploadAttachment(wsSlug, itemRef, filename string, body io.Read
 	return &result, nil
 }
 
+// attachmentIDPathSegment renders an attachment id as a single, inert URL
+// path segment. The id reaches these URLs from item content
+// ("pad-attachment:" refs other workspace members wrote), so it is treated
+// as hostile: PathEscape stops a slash-carrying id from re-routing the
+// request to a different endpoint whose 200 would then vouch for it
+// downstream (codex closing round 3), and the exact dot segments "." and
+// ".." — which PathEscape leaves UNCHANGED, so a proxy or server can still
+// normalize them away — are refused outright rather than sent (codex
+// closing round 4). A real id is a UUID; neither refusal can fire on one.
+func attachmentIDPathSegment(id string) (string, error) {
+	if id == "." || id == ".." {
+		return "", fmt.Errorf("invalid attachment id %q", id)
+	}
+	return url.PathEscape(id), nil
+}
+
 // DownloadAttachment streams the bytes of an attachment into w. Returns
 // the Content-Type the server set and the number of bytes copied so
 // callers can verify size or render with the right MIME hint.
@@ -1727,12 +1743,11 @@ func (c *Client) UploadAttachment(wsSlug, itemRef, filename string, body io.Read
 // silently falls back to the original if the derived row doesn't exist
 // (TASK-872 / TASK-878 contract).
 func (c *Client) DownloadAttachment(wsSlug, attachmentID, variant string, w io.Writer) (mime string, size int64, err error) {
-	// PathEscape: the id reaches this URL from item content ("pad-attachment:"
-	// refs other workspace members wrote). Raw concatenation let a
-	// traversal-shaped id ("../items/x") re-route the request to a DIFFERENT
-	// endpoint whose 200 then vouched for the id downstream — the view
-	// command builds a local filename from it (codex closing round 3).
-	path := "/workspaces/" + wsSlug + "/attachments/" + url.PathEscape(attachmentID)
+	p, err := attachmentIDPathSegment(attachmentID)
+	if err != nil {
+		return "", 0, err
+	}
+	path := "/workspaces/" + wsSlug + "/attachments/" + p
 	if variant != "" {
 		path += "?variant=" + url.QueryEscape(variant)
 	}
@@ -1777,12 +1792,11 @@ type AttachmentMetadata struct {
 // structured metadata. Variant is forwarded the same way as
 // DownloadAttachment — empty string for the original blob.
 func (c *Client) HeadAttachment(wsSlug, attachmentID, variant string) (*AttachmentMetadata, error) {
-	// PathEscape: the id reaches this URL from item content ("pad-attachment:"
-	// refs other workspace members wrote). Raw concatenation let a
-	// traversal-shaped id ("../items/x") re-route the request to a DIFFERENT
-	// endpoint whose 200 then vouched for the id downstream — the view
-	// command builds a local filename from it (codex closing round 3).
-	path := "/workspaces/" + wsSlug + "/attachments/" + url.PathEscape(attachmentID)
+	p, err := attachmentIDPathSegment(attachmentID)
+	if err != nil {
+		return nil, err
+	}
+	path := "/workspaces/" + wsSlug + "/attachments/" + p
 	if variant != "" {
 		path += "?variant=" + url.QueryEscape(variant)
 	}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -376,10 +376,17 @@ type Metrics struct {
 	//
 	// Cardinality note for MCPToolCallsTotal: the user_id label is
 	// bounded by the cloud-deployment user count (target hundreds-to-
-	// low-thousands during alpha) and the tool label is bounded by the
-	// catalog (~7 tools today). 1000 users × 7 tools × 4 statuses =
-	// 28k series, well within Prometheus' comfort zone. If we ever
-	// open the surface to a much larger user set, drop the user_id
+	// low-thousands during alpha).
+	//
+	// THE TOOL LABEL IS NOT BOUNDED BY THE CATALOG, and this comment
+	// used to say it was. The value is whatever the caller put in
+	// params.name (or the JSON-RPC method), recorded even when dispatch
+	// later rejects it, so an authenticated caller can mint a new
+	// series per request. The "~7 tools today" arithmetic below
+	// describes well-behaved traffic, not a bound. Tracked as BUG-2817;
+	// the fix is to map anything outside the catalog to a single
+	// bucket. If we ever open the surface to a much larger user set,
+	// drop the user_id
 	// label and lean on the audit log for per-user forensics — the
 	// audit row already carries that data without a series-explosion
 	// risk.

--- a/internal/server/artifact_import.go
+++ b/internal/server/artifact_import.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -57,18 +59,26 @@ var ErrArtifactUnsafeYAML = errors.New("artifact import: frontmatter rejected by
 var ErrArtifactUnbindableText = errors.New("artifact import: body contains invalid UTF-8 or a NUL byte")
 
 // parseArtifactRequest is the guarded HTTP-boundary parse used by the import
-// handler. It applies three checks IN ORDER:
+// handler. It applies five steps IN ORDER:
 //
 //  1. Byte cap on the raw body (http.MaxBytesReader), so an oversized body is
 //     rejected before full materialization.
-//  2. YAML-bomb guard: the frontmatter region is parsed into a yaml.Node tree
+//  2. Raw text validity (bindableText), so invalid UTF-8 or a NUL BYTE is
+//     refused before anything parses it.
+//  3. YAML-bomb guard: the frontmatter region is parsed into a yaml.Node tree
 //     and walked, enforcing maxFrontmatterNodes / maxFrontmatterDepth /
 //     maxFrontmatterAliases. This runs BEFORE the struct decode so an alias-
 //     storm or deep-nesting document never reaches the expanding unmarshaler.
-//  3. artifact.Decode, which produces the typed Artifact.
+//  4. artifact.Decode, which produces the typed Artifact.
+//  5. Decoded text validity, because YAML manufactures a NUL from \0 that
+//     step 2 cannot see in the request bytes.
+//
+// Steps 2 and 5 arrived with BUG-2803; this list said "three checks" until
+// codex round 8 pointed out it was describing the version before them.
 //
 // Returns the decoded Artifact or a typed error: ErrArtifactTooLarge,
-// ErrArtifactUnsafeYAML, or an artifact.* sentinel (ErrMalformed /
+// ErrArtifactUnbindableText, ErrArtifactUnsafeYAML, or an artifact.*
+// sentinel (ErrMalformed /
 // ErrUnknownKind / ErrUnsupportedVersion) wrapped for context. The import
 // handler maps these to HTTP statuses.
 func parseArtifactRequest(w http.ResponseWriter, r *http.Request, maxBytes int64) (artifact.Artifact, error) {
@@ -90,7 +100,7 @@ func parseArtifactRequest(w http.ResponseWriter, r *http.Request, maxBytes int64
 		return artifact.Artifact{}, fmt.Errorf("artifact import: read body: %w", err)
 	}
 
-	// (2a) The artifact body is TEXT bound for text columns, and this
+	// (2) The artifact body is TEXT bound for text columns, and this
 	// handler reads it directly rather than through decodeJSON, so it
 	// inherits neither BUG-2803's refusal nor the path/query rule (a body is
 	// neither). A raw NUL or invalid UTF-8 here reaches the store and
@@ -101,19 +111,19 @@ func parseArtifactRequest(w http.ResponseWriter, r *http.Request, maxBytes int64
 		return artifact.Artifact{}, ErrArtifactUnbindableText
 	}
 
-	// (2) YAML-bomb guard on the frontmatter region only.
+	// (3) YAML-bomb guard on the frontmatter region only.
 	if err := guardArtifactFrontmatter(data); err != nil {
 		return artifact.Artifact{}, err
 	}
 
-	// (3) Typed decode.
+	// (4) Typed decode.
 	art, err := artifact.Decode(data)
 	if err != nil {
 		return artifact.Artifact{}, err
 	}
 
-	// (4) The DECODED artifact must be bindable text too — the raw check in
-	// (2a) is not sufficient on its own. YAML has its own escape vocabulary:
+	// (5) The DECODED artifact must be bindable text too — the raw check in
+	// (2) is not sufficient on its own. YAML has its own escape vocabulary:
 	// a double-quoted scalar `title: "a\0b"` carries no NUL in the request
 	// bytes, passes (2a), and manufactures one during the YAML decode.
 	// Measured before this check: such an artifact imported 201 with a NUL in
@@ -225,43 +235,40 @@ func extractFrontmatterRegion(s string) (string, bool) {
 	}
 }
 
-// artifactIsBindableText reports whether every string a decoded artifact would
-// carry into the store is text the database can be asked to hold. Title, body
-// and every frontmatter field value are checked; field values are walked
-// because a playbook's `arguments` is a nested structure, not a scalar.
+// artifactIsBindableText reports whether a decoded artifact carries a NUL in
+// any string it would take into the store.
 //
-// Keys are checked as well as values, on the same precautionary grounds
-// ValidateQuery states for query parameter names: no failure was observed
-// through a key, and why it would survive is unread, so it is checked rather
-// than assumed safe.
+// It works by MARSHALLING the artifact and searching the result, rather than
+// walking its fields by type. The hand-written walk this replaces missed two
+// things a reviewer found immediately (codex round 8): Provenance, whose
+// strings are rendered into a Markdown footer appended to the stored content,
+// and Arguments, whose declared type is []map[string]any — a concrete slice
+// type the walk's `[]any` case never matched. Both were reachable. A type
+// switch over a struct that grows is a list that goes stale in silence, which
+// is the same objection this file's jsonEncodedFieldKeys has to answer for
+// and can only answer with a derivation test. Marshalling has no such gap:
+// every exported field is covered, including ones added later.
+//
+// encoding/json escapes a NUL as the six-character sequence, so a decoded NUL
+// anywhere in the artifact appears in the output. The search is for that
+// sequence in bytes the MARSHALLER produced, not in caller-supplied text, so
+// the ambiguity bodyDecodesNUL has to resolve — a doubled backslash meaning
+// literal text — cannot arise here: a literal backslash in a value marshals
+// to a doubled one.
+//
+// SCOPE, stated because marshalling hides one thing: invalid UTF-8 in a Go
+// string marshals to U+FFFD rather than surviving, so this cannot detect it.
+// It does not need to. Step (2a) rejects invalid UTF-8 in the request bytes
+// before the decode, and YAML cannot manufacture it from valid input — its
+// escapes name code points (\xff is U+00FF, a valid rune), where \0 names a
+// NUL. NUL is the class that survives the decode, and it is the class this
+// checks.
 func artifactIsBindableText(art artifact.Artifact) bool {
-	if !bindableText(art.Title) || !bindableText(art.Body) {
+	encoded, err := json.Marshal(art)
+	if err != nil {
+		// An artifact that cannot be marshalled cannot be reasoned about;
+		// refuse rather than pass it on unexamined.
 		return false
 	}
-	for k, v := range art.Fields {
-		if !bindableText(k) || !anyValueIsBindableText(v) {
-			return false
-		}
-	}
-	return true
-}
-
-func anyValueIsBindableText(v any) bool {
-	switch t := v.(type) {
-	case string:
-		return bindableText(t)
-	case map[string]any:
-		for k, sub := range t {
-			if !bindableText(k) || !anyValueIsBindableText(sub) {
-				return false
-			}
-		}
-	case []any:
-		for _, sub := range t {
-			if !anyValueIsBindableText(sub) {
-				return false
-			}
-		}
-	}
-	return true
+	return !bytes.Contains(encoded, []byte{'\\', 'u', '0', '0', '0', '0'})
 }

--- a/internal/server/artifact_import.go
+++ b/internal/server/artifact_import.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -270,5 +269,21 @@ func artifactIsBindableText(art artifact.Artifact) bool {
 		// refuse rather than pass it on unexamined.
 		return false
 	}
-	return !bytes.Contains(encoded, []byte{'\\', 'u', '0', '0', '0', '0'})
+	// Searching the marshalled BYTES for the escape is wrong, and this
+	// function did it until codex round 9: a value holding the six LITERAL
+	// characters marshals to a doubled backslash, which still contains the
+	// six-character sequence as a substring, so valid content was refused.
+	// That is the same doubled-backslash trap bodyDecodesNUL exists to
+	// resolve — and an earlier version of this comment asserted it "cannot
+	// arise here", which was simply wrong.
+	//
+	// So the marshalled form is decoded again and walked with the same
+	// machinery, as caller data (no wire-key list applies to an artifact).
+	// The round trip is what makes every field reachable without a type
+	// switch; the walk is what makes the answer exact.
+	var v any
+	if err := json.Unmarshal(encoded, &v); err != nil {
+		return false
+	}
+	return !valueDecodesNUL(v, true)
 }

--- a/internal/server/artifact_import.go
+++ b/internal/server/artifact_import.go
@@ -62,7 +62,7 @@ var ErrArtifactUnsafeYAML = errors.New("artifact import: frontmatter rejected by
 // rule Pad applies on both dialects, not a storage limit it inherits from
 // either. Stating it as a capability would tell the next reader that SQLite
 // enforces something it does not.
-var ErrArtifactUnbindableText = errors.New("artifact import: body contains invalid UTF-8 or a NUL byte")
+var ErrArtifactUnbindableText = errors.New("artifact import: body contains invalid UTF-8 or a NUL character")
 
 // parseArtifactRequest is the guarded HTTP-boundary parse used by the import
 // handler. It applies five steps IN ORDER:

--- a/internal/server/artifact_import.go
+++ b/internal/server/artifact_import.go
@@ -111,6 +111,18 @@ func parseArtifactRequest(w http.ResponseWriter, r *http.Request, maxBytes int64
 	if err != nil {
 		return artifact.Artifact{}, err
 	}
+
+	// (4) The DECODED artifact must be bindable text too — the raw check in
+	// (2a) is not sufficient on its own. YAML has its own escape vocabulary:
+	// a double-quoted scalar `title: "a\0b"` carries no NUL in the request
+	// bytes, passes (2a), and manufactures one during the YAML decode.
+	// Measured before this check: such an artifact imported 201 with a NUL in
+	// the item title (codex round 4, BUG-2803). Same shape as the JSON half —
+	// a value that only becomes dangerous after a SECOND parse — so it gets
+	// the same answer, at the layer that can see it.
+	if !artifactIsBindableText(art) {
+		return artifact.Artifact{}, ErrArtifactUnbindableText
+	}
 	return art, nil
 }
 
@@ -211,4 +223,45 @@ func extractFrontmatterRegion(s string) (string, bool) {
 		}
 		offset += nl + 1
 	}
+}
+
+// artifactIsBindableText reports whether every string a decoded artifact would
+// carry into the store is text the database can be asked to hold. Title, body
+// and every frontmatter field value are checked; field values are walked
+// because a playbook's `arguments` is a nested structure, not a scalar.
+//
+// Keys are checked as well as values, on the same precautionary grounds
+// ValidateQuery states for query parameter names: no failure was observed
+// through a key, and why it would survive is unread, so it is checked rather
+// than assumed safe.
+func artifactIsBindableText(art artifact.Artifact) bool {
+	if !bindableText(art.Title) || !bindableText(art.Body) {
+		return false
+	}
+	for k, v := range art.Fields {
+		if !bindableText(k) || !anyValueIsBindableText(v) {
+			return false
+		}
+	}
+	return true
+}
+
+func anyValueIsBindableText(v any) bool {
+	switch t := v.(type) {
+	case string:
+		return bindableText(t)
+	case map[string]any:
+		for k, sub := range t {
+			if !bindableText(k) || !anyValueIsBindableText(sub) {
+				return false
+			}
+		}
+	case []any:
+		for _, sub := range t {
+			if !anyValueIsBindableText(sub) {
+				return false
+			}
+		}
+	}
+	return true
 }

--- a/internal/server/artifact_import.go
+++ b/internal/server/artifact_import.go
@@ -255,12 +255,13 @@ func extractFrontmatterRegion(s string) (string, bool) {
 // and can only answer with a derivation test. Marshalling has no such gap:
 // every exported field is covered, including ones added later.
 //
-// encoding/json escapes a NUL as the six-character sequence, so a decoded NUL
-// anywhere in the artifact appears in the output. The search is for that
-// sequence in bytes the MARSHALLER produced, not in caller-supplied text, so
-// the ambiguity bodyDecodesNUL has to resolve — a doubled backslash meaning
-// literal text — cannot arise here: a literal backslash in a value marshals
-// to a doubled one.
+// The marshalled form is then DECODED AGAIN and walked with the same
+// machinery as caller data — not byte-searched for the escape sequence. An
+// earlier version of this paragraph claimed a byte search was safe because
+// "the ambiguity cannot arise here"; the body comment below records why that
+// was simply wrong (codex round 9, re-caught contradicting itself in the
+// closing rounds): a value holding the six LITERAL characters marshals to a
+// doubled backslash that still contains the sequence as a substring.
 //
 // SCOPE, stated because marshalling hides one thing: invalid UTF-8 in a Go
 // string marshals to U+FFFD rather than surviving, so this cannot detect it.

--- a/internal/server/artifact_import.go
+++ b/internal/server/artifact_import.go
@@ -49,6 +49,13 @@ var ErrArtifactTooLarge = errors.New("artifact import: body exceeds size limit")
 // the YAML-bomb guard limits (node count, nesting depth, or anchors/aliases).
 var ErrArtifactUnsafeYAML = errors.New("artifact import: frontmatter rejected by safety limits")
 
+// ErrArtifactUnbindableText is returned when the artifact body is not text the
+// database can be asked to store — invalid UTF-8, or carrying a NUL. It is a
+// client error (400), not a 500, for the reason BUG-2782 gives: the value
+// cannot be stored under any encoding this product supports, so the caller
+// sent something that cannot mean anything here.
+var ErrArtifactUnbindableText = errors.New("artifact import: body contains invalid UTF-8 or a NUL byte")
+
 // parseArtifactRequest is the guarded HTTP-boundary parse used by the import
 // handler. It applies three checks IN ORDER:
 //
@@ -81,6 +88,17 @@ func parseArtifactRequest(w http.ResponseWriter, r *http.Request, maxBytes int64
 			return artifact.Artifact{}, ErrArtifactTooLarge
 		}
 		return artifact.Artifact{}, fmt.Errorf("artifact import: read body: %w", err)
+	}
+
+	// (2a) The artifact body is TEXT bound for text columns, and this
+	// handler reads it directly rather than through decodeJSON, so it
+	// inherits neither BUG-2803's refusal nor the path/query rule (a body is
+	// neither). A raw NUL or invalid UTF-8 here reaches the store and
+	// Postgres answers 22021, which the handler turns into a 500 for what is
+	// a client error. Same predicate as ValidatePath and ValidateQuery.
+	// Found by the codex round 3 sweep over body readers (BUG-2803).
+	if !bindableText(string(data)) {
+		return artifact.Artifact{}, ErrArtifactUnbindableText
 	}
 
 	// (2) YAML-bomb guard on the frontmatter region only.

--- a/internal/server/artifact_import.go
+++ b/internal/server/artifact_import.go
@@ -52,9 +52,16 @@ var ErrArtifactUnsafeYAML = errors.New("artifact import: frontmatter rejected by
 
 // ErrArtifactUnbindableText is returned when the artifact body is not text the
 // database can be asked to store — invalid UTF-8, or carrying a NUL. It is a
-// client error (400), not a 500, for the reason BUG-2782 gives: the value
-// cannot be stored under any encoding this product supports, so the caller
-// sent something that cannot mean anything here.
+// client error (400), not a 500, for the reason BUG-2782 gives: this is a
+// value Pad refuses to store, so the caller sent something that cannot mean
+// anything here.
+//
+// "Refuses", not "cannot" — the distinction matters and the earlier wording
+// blurred it (codex round 20). PostgreSQL rejects a NUL in a text or JSON
+// column outright; SQLite would accept one in TEXT. So this is an application
+// rule Pad applies on both dialects, not a storage limit it inherits from
+// either. Stating it as a capability would tell the next reader that SQLite
+// enforces something it does not.
 var ErrArtifactUnbindableText = errors.New("artifact import: body contains invalid UTF-8 or a NUL byte")
 
 // parseArtifactRequest is the guarded HTTP-boundary parse used by the import

--- a/internal/server/decode_json_nul_test.go
+++ b/internal/server/decode_json_nul_test.go
@@ -1127,3 +1127,57 @@ func TestBodyDecodesNULKnownMapModelDisagreements(t *testing.T) {
 		}
 	})
 }
+
+// TestUnknownFieldRefusalThroughTheHandler is the WIRING leg for release-note
+// item 10 (CONVE-19: a direct-call test vouches for the component, not its
+// binding). TestBodyDecodesNULKnownMapModelDisagreements proves the scan
+// RETURNS true for an unknown field carrying a NUL escape; the release note
+// claims the API answers 400. Those are different claims, and only this one
+// is the one an operator or client author reads.
+//
+// The control leg is what makes the 400 mean something: the SAME unknown
+// field with an ordinary value must still be ACCEPTED, so this pins "refused
+// for the NUL" rather than "refused for being unknown" — the handler does not
+// reject unknown fields, and if it ever started to, the release note's
+// explanation of the change would be wrong even though its status code
+// stayed right.
+func TestUnknownFieldRefusalThroughTheHandler(t *testing.T) {
+	srv := testServer(t)
+
+	rr := rawJSONRequest(srv, "POST", "/api/v1/workspaces/",
+		`{"name":"Unknown field probe","slug":"unkprobe","template":"startup"}`)
+	if rr.Code != http.StatusOK && rr.Code != http.StatusCreated {
+		t.Fatalf("fixture workspace: %d %s", rr.Code, rr.Body.String())
+	}
+	rr = rawJSONRequest(srv, "POST", "/api/v1/workspaces/unkprobe/collections/",
+		`{"name":"Probes","slug":"probes"}`)
+	if rr.Code != http.StatusOK && rr.Code != http.StatusCreated {
+		t.Fatalf("fixture collection: %d %s", rr.Code, rr.Body.String())
+	}
+
+	const itemsPath = "/api/v1/workspaces/unkprobe/collections/probes/items"
+
+	// Control: an unknown field is ordinarily IGNORED, not refused. On main
+	// this is the only behaviour there is — decodeJSONWithLimit unmarshals
+	// straight into the typed value, which drops the key.
+	control := rawJSONRequest(srv, "POST", itemsPath,
+		`{"title":"ok","future_field":"harmless"}`)
+	if control.Code != http.StatusCreated && control.Code != http.StatusOK {
+		t.Fatalf("an unknown field with an ordinary value must still be accepted, got %d: %s",
+			control.Code, control.Body.String())
+	}
+
+	// Release-note item 10: the same unknown field carrying a NUL escape is
+	// now refused, though the value reaches nothing. The scan has no
+	// destination type by design and cannot tell a forward-compatible field
+	// from a real one.
+	got := rawJSONRequest(srv, "POST", itemsPath,
+		`{"title":"ok","future_field":"a`+escNULLiteral+`b"}`)
+	if got.Code != http.StatusBadRequest {
+		t.Fatalf("release note item 10 says an unknown field carrying a NUL escape answers 400; "+
+			"got %d: %s — update the note or the check", got.Code, got.Body.String())
+	}
+	if !strings.Contains(got.Body.String(), "NUL") {
+		t.Errorf("the 400 should name the cause, got: %s", got.Body.String())
+	}
+}

--- a/internal/server/decode_json_nul_test.go
+++ b/internal/server/decode_json_nul_test.go
@@ -237,15 +237,54 @@ func TestDecodeJSONKeepsEmptyBodyEOF(t *testing.T) {
 // the list cannot rot into a set of stale excuses that quietly permits a
 // future reader added to the same file.
 func TestEveryRequestBodyReaderIsAccountedFor(t *testing.T) {
-	accounted := map[string]string{
+	// Each entry records HOW MANY reader expressions the file had when it was
+	// reviewed, not just that it was reviewed.
+	//
+	// Per-FILE accounting alone is not a safety property: once a file is
+	// listed, a NEW reader added to it is covered by the existing entry and
+	// this test stays green (codex round 29 made the point that this is what
+	// makes over-flagging expensive rather than cheap — a false positive does
+	// not cost one review, it permanently blinds the list for that file).
+	//
+	// The count closes that. Adding a reader to an accounted file changes the
+	// number and fails here, so the entry has to be re-read and its reason
+	// re-justified. It churns exactly when a body reader is added or removed,
+	// which is precisely when a human should look.
+	type entry struct {
+		readers int
+		why     string
+	}
+	accountedWhy := map[string]string{
 		"middleware_request_text.go": "the chokepoint itself: readBodyForDecode reads the body under the caller's cap so bodyDecodesNUL can scan it",
 		"handlers_import_bundle.go":  "tar.gz bundle import — streams the body through gzip, and its pad-export.json is checked with bodyDecodesNUL before ImportWorkspace",
 		"handlers_attachments.go":    "multipart upload — the body is binary blob content, not text, and must NOT be scanned for text validity",
 		"artifact_import.go":         "raw artifact TEXT (not JSON) — checked with bindableText, the same predicate ValidatePath and ValidateQuery apply",
 		"handlers_cloud.go":          "bodyHasCloudSecret PEEKS at the body and restores it; the real decode still happens through decodeJSON downstream",
 		"middleware_mcp_audit.go":    "audit capture — parses the body ITSELF and binds the decoded method / params.name to mcp_audit_log.tool_name, so it is a second READER, not a pass-through. That the MCP dispatcher decodes the body again is true and says nothing about what this middleware persists — the earlier rationale here made exactly that mistake and certified it safe (codex round 20). parseMCPRequestBody now runs both caller-derived returns through sanitiseStoredText",
-		"handlers_tokens.go":         "a nil/ContentLength check only — it never reads the body",
+		"handlers_tokens.go":         "guards on r.Body != nil && r.ContentLength != 0, then decodes THROUGH decodeJSON — so the body is read by the chokepoint, which applies the cap and the NUL rule. The earlier reason here said it never reads the body, which was simply false (codex round 29): a wrong reason in this list is the same defect as a missing entry, since both let a reader pass as reviewed",
 		"handlers_oauth.go":          "KNOWN GAP, tracked as BUG-2811: the OAuth handlers read FORM-encoded bodies (r.Form/FormValue), which no rule in this family covers — the transport rules see the query half of r.Form and not the body half. Listed so this test states the gap instead of being blind to it; measuring it needs a fosite-backed fixture.",
+	}
+
+	// Reader counts as reviewed. A mismatch means this file gained or lost a
+	// body reader since someone last justified it.
+	// MEASURED, not estimated. I first wrote plausible-looking numbers here
+	// and every one of them was wrong; the test reported the real counts on
+	// the first run. Recording that because it is the same habit this branch
+	// keeps catching — a figure written from expectation reads exactly like a
+	// figure that was counted.
+	accountedCount := map[string]int{
+		"middleware_request_text.go": 4,
+		"handlers_import_bundle.go":  3,
+		"handlers_attachments.go":    8,
+		"artifact_import.go":         1,
+		"handlers_cloud.go":          3,
+		"middleware_mcp_audit.go":    7,
+		"handlers_tokens.go":         1,
+		"handlers_oauth.go":          13,
+	}
+	accounted := map[string]entry{}
+	for name, why := range accountedWhy {
+		accounted[name] = entry{readers: accountedCount[name], why: why}
 	}
 
 	// FormValue/PostFormValue/ParseForm/ParseMultipartForm read the request
@@ -258,7 +297,7 @@ func TestEveryRequestBodyReaderIsAccountedFor(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read package dir: %v", err)
 	}
-	touches := map[string]bool{}
+	touches := map[string]int{}
 	scanned := 0
 	for _, e := range entries {
 		name := e.Name()
@@ -266,8 +305,8 @@ func TestEveryRequestBodyReaderIsAccountedFor(t *testing.T) {
 			continue
 		}
 		scanned++
-		if scanFileForRequestBodyReads(t, filepath.Join(".", name)) {
-			touches[name] = true
+		if n := scanFileForRequestBodyReads(t, filepath.Join(".", name)); n > 0 {
+			touches[name] = n
 		}
 	}
 
@@ -288,8 +327,14 @@ func TestEveryRequestBodyReaderIsAccountedFor(t *testing.T) {
 				"the reason it is safe.", name)
 		}
 	}
-	for name, why := range accounted {
-		if !touches[name] {
+	for name, ent := range accounted {
+		if got := touches[name]; got != 0 && got != ent.readers {
+			t.Errorf("%s has %d request-body readers but was reviewed with %d (%q). A reader was "+
+				"added or removed since someone justified this entry — re-read it and update the "+
+				"count, or the entry silently covers code nobody reviewed.", name, got, ent.readers, ent.why)
+		}
+		why := ent.why
+		if touches[name] == 0 {
 			t.Errorf("%s is accounted for here (%q) but no longer reads a request body — remove the entry "+
 				"so it cannot silently cover a future reader added to that file", name, why)
 		}
@@ -1529,8 +1574,8 @@ func h(r *http.Request) int { return 1 }`},
 			if err := os.WriteFile(path, []byte(src), 0o600); err != nil {
 				t.Fatalf("write probe: %v", err)
 			}
-			if got := scanFileForRequestBodyReads(t, path); got != tc.want {
-				t.Errorf("scan = %v, want %v\n--- source ---\n%s", got, tc.want, src)
+			if got := scanFileForRequestBodyReads(t, path) > 0; got != tc.want {
+				t.Errorf("scan detected a reader = %v, want %v\n--- source ---\n%s", got, tc.want, src)
 			}
 		})
 	}
@@ -1566,12 +1611,17 @@ func h(r *http.Request) int { return 1 }`},
 // for the whole file. Still invisible, and NOT in the safe direction: a request
 // reached only through a struct field, a context value, or a type alias, since
 // this matches the literal http.Request spelling.
-func scanFileForRequestBodyReads(t *testing.T, path string) bool {
+func scanFileForRequestBodyReads(t *testing.T, path string) int {
 	t.Helper()
 
 	readerSelectors := map[string]bool{
 		"Body": true, "FormValue": true, "PostFormValue": true, "ParseForm": true,
 		"ParseMultipartForm": true, "MultipartForm": true, "PostForm": true,
+		// MultipartReader STREAMS the body, and FormFile triggers multipart
+		// parsing of it. Both were missing (codex round 29) — and FormFile is
+		// used in production, in handlers_attachments.go, so the list was
+		// incomplete against code that exists rather than hypothetically.
+		"MultipartReader": true, "FormFile": true,
 	}
 
 	// Both *http.Request and http.Request count. A VALUE copy still shares the
@@ -1644,20 +1694,22 @@ func scanFileForRequestBodyReads(t *testing.T, path string) bool {
 		})
 	}
 	if len(reqNames) == 0 {
-		return false
+		return 0
 	}
 
-	// Pass 2: any reader selector on any of those names, anywhere in the file.
-	found := false
+	// Pass 2: COUNT reader selectors on those names. A count rather than a
+	// yes/no, so an accounting entry cannot silently absorb a reader added to
+	// a file that was already reviewed.
+	readers := 0
 	ast.Inspect(f, func(n ast.Node) bool {
 		sel, ok := n.(*ast.SelectorExpr)
 		if !ok || !readerSelectors[sel.Sel.Name] {
 			return true
 		}
 		if id, ok := sel.X.(*ast.Ident); ok && reqNames[id.Name] {
-			found = true
+			readers++
 		}
 		return true
 	})
-	return found
+	return readers
 }

--- a/internal/server/decode_json_nul_test.go
+++ b/internal/server/decode_json_nul_test.go
@@ -240,7 +240,7 @@ func TestEveryRequestBodyReaderIsAccountedFor(t *testing.T) {
 		"handlers_attachments.go":    "multipart upload — the body is binary blob content, not text, and must NOT be scanned for text validity",
 		"artifact_import.go":         "raw artifact TEXT (not JSON) — checked with bindableText, the same predicate ValidatePath and ValidateQuery apply",
 		"handlers_cloud.go":          "bodyHasCloudSecret PEEKS at the body and restores it; the real decode still happens through decodeJSON downstream",
-		"middleware_mcp_audit.go":    "audit capture — records the body for the MCP audit log and restores it; decoding still happens in the MCP dispatcher",
+		"middleware_mcp_audit.go":    "audit capture — parses the body ITSELF and binds the decoded method / params.name to mcp_audit_log.tool_name, so it is a second READER, not a pass-through. That the MCP dispatcher decodes the body again is true and says nothing about what this middleware persists — the earlier rationale here made exactly that mistake and certified it safe (codex round 20). parseMCPRequestBody now runs both caller-derived returns through sanitiseStoredText",
 		"handlers_tokens.go":         "a nil/ContentLength check only — it never reads the body",
 		"handlers_oauth.go":          "KNOWN GAP, tracked as BUG-2811: the OAuth handlers read FORM-encoded bodies (r.Form/FormValue), which no rule in this family covers — the transport rules see the query half of r.Form and not the body half. Listed so this test states the gap instead of being blind to it; measuring it needs a fosite-backed fixture.",
 	}

--- a/internal/server/decode_json_nul_test.go
+++ b/internal/server/decode_json_nul_test.go
@@ -288,6 +288,78 @@ func TestEveryRequestBodyReaderIsAccountedFor(t *testing.T) {
 		pkg, ok := sel.X.(*ast.Ident)
 		return ok && pkg.Name == "http"
 	}
+	// The scan walks a SCOPE at a time rather than a whole function, because
+	// a single flat name-set is wrong in both directions (codex round 26):
+	//
+	//   - a function literal inside a handler was scanned with the OUTER
+	//     function's request names, so an unrelated inner variable that
+	//     happened to be called `r` was falsely flagged;
+	//   - a request that arrives only as a function literal's own parameter
+	//     was invisible, because literals were never given their own names.
+	//
+	// So each scope inherits its parent's request names, drops any the scope
+	// shadows with a parameter of a different type, and adds its own. Local
+	// aliases (`req := r`) are picked up too, since that is an ordinary thing
+	// for a handler to do and the alias reads the same body.
+	var scanScope func(body *ast.BlockStmt, params *ast.FieldList, inherited map[string]bool) bool
+	scanScope = func(body *ast.BlockStmt, params *ast.FieldList, inherited map[string]bool) bool {
+		if body == nil {
+			return false
+		}
+		reqNames := make(map[string]bool, len(inherited))
+		for k := range inherited {
+			reqNames[k] = true
+		}
+		// A parameter SHADOWS an inherited name whatever its type: if it is a
+		// request the name stays, otherwise the outer meaning is gone.
+		if params != nil {
+			for _, fld := range params.List {
+				isReq := isRequestPtr(fld.Type)
+				for _, nm := range fld.Names {
+					if isReq {
+						reqNames[nm.Name] = true
+					} else {
+						delete(reqNames, nm.Name)
+					}
+				}
+			}
+		}
+
+		found := false
+		var walk func(n ast.Node) bool
+		walk = func(n ast.Node) bool {
+			switch node := n.(type) {
+			case *ast.FuncLit:
+				// Its own scope; do not let the outer names leak in as-is.
+				if scanScope(node.Body, node.Type.Params, reqNames) {
+					found = true
+				}
+				return false
+			case *ast.AssignStmt:
+				// `req := r` and `req = r` alias the same request.
+				for i, rhs := range node.Rhs {
+					id, ok := rhs.(*ast.Ident)
+					if !ok || !reqNames[id.Name] || i >= len(node.Lhs) {
+						continue
+					}
+					if lhs, ok := node.Lhs[i].(*ast.Ident); ok {
+						reqNames[lhs.Name] = true
+					}
+				}
+			case *ast.SelectorExpr:
+				if !readerSelectors[node.Sel.Name] {
+					return true
+				}
+				if id, ok := node.X.(*ast.Ident); ok && reqNames[id.Name] {
+					found = true
+				}
+			}
+			return true
+		}
+		ast.Inspect(body, walk)
+		return found
+	}
+
 	fileReadsRequestBody := func(path string) bool {
 		fset := token.NewFileSet()
 		f, err := parser.ParseFile(fset, path, nil, 0)
@@ -295,42 +367,26 @@ func TestEveryRequestBodyReaderIsAccountedFor(t *testing.T) {
 			t.Fatalf("parse %s: %v", path, err)
 		}
 		found := false
-		ast.Inspect(f, func(n ast.Node) bool {
-			fn, ok := n.(*ast.FuncDecl)
+		for _, decl := range f.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
 			if !ok || fn.Body == nil {
-				return true
+				continue
 			}
-			reqNames := map[string]bool{}
-			collect := func(fl *ast.FieldList) {
-				if fl == nil {
-					return
-				}
-				for _, fld := range fl.List {
+			seed := map[string]bool{}
+			if fn.Recv != nil {
+				for _, fld := range fn.Recv.List {
 					if !isRequestPtr(fld.Type) {
 						continue
 					}
 					for _, nm := range fld.Names {
-						reqNames[nm.Name] = true
+						seed[nm.Name] = true
 					}
 				}
 			}
-			collect(fn.Type.Params)
-			collect(fn.Recv)
-			if len(reqNames) == 0 {
-				return true
+			if scanScope(fn.Body, fn.Type.Params, seed) {
+				found = true
 			}
-			ast.Inspect(fn.Body, func(m ast.Node) bool {
-				sel, ok := m.(*ast.SelectorExpr)
-				if !ok || !readerSelectors[sel.Sel.Name] {
-					return true
-				}
-				if id, ok := sel.X.(*ast.Ident); ok && reqNames[id.Name] {
-					found = true
-				}
-				return true
-			})
-			return true
-		})
+		}
 		return found
 	}
 
@@ -383,9 +439,15 @@ func TestEveryRequestBodyReaderIsAccountedFor(t *testing.T) {
 	//     NEW reader added to it is covered by the existing entry and this
 	//     test stays green. The reason strings are what a reviewer checks
 	//     against; they are not permanent exemptions.
-	//  2. Only signature-declared requests are seen. A request stashed in a
-	//     struct field or captured by a closure is not a parameter, so this
-	//     scan does not find it.
+	//  2. Only requests reachable by NAME are seen. Closure parameters and
+	//     local aliases (`req := r`) are now covered, and a variable that
+	//     shadows a request name is correctly ignored — all three are pinned
+	//     by controls run against this scanner. Still invisible: a request
+	//     stored in a STRUCT FIELD, one obtained from a context, and one whose
+	//     type reaches http.Request through an alias or an embedded field,
+	//     since this matches the literal `*http.Request` spelling rather than
+	//     resolving types (codex round 26). Closing those means running the
+	//     type checker, not the parser.
 	//
 	// Both want per-call-site accounting, which is a different instrument.
 }

--- a/internal/server/decode_json_nul_test.go
+++ b/internal/server/decode_json_nul_test.go
@@ -226,9 +226,13 @@ func TestDecodeJSONKeepsEmptyBodyEOF(t *testing.T) {
 // package — and to any alias, helper or future spelling. A completeness test
 // that misses a live example is worse than none: it reads as coverage.
 //
-// So it now scans for the thing that cannot be spelled around — a reference to
-// the request body at all — and requires every FILE that touches one to be
-// accounted for here with a reason. A new body reader fails this test until
+// So it now scans for something much harder to spell around — a NAME-visible
+// reference to the request body — and requires every FILE that touches one to
+// be accounted for here with a reason. Not impossible to spell around: a
+// request reached through a struct field, a context value, or a type alias is
+// invisible to it, exactly as the KNOWN LIMITS block at the bottom states —
+// an earlier version of this sentence claimed more than the scanner delivers
+// (codex closing round). A new body reader fails this test until
 // someone writes down what it does, which is the point: the decision becomes
 // deliberate instead of invisible.
 //
@@ -259,7 +263,7 @@ func TestEveryRequestBodyReaderIsAccountedFor(t *testing.T) {
 		"handlers_import_bundle.go":  "tar.gz bundle import — streams the body through gzip, and its pad-export.json is checked with bodyDecodesNUL before ImportWorkspace",
 		"handlers_attachments.go":    "multipart upload — the body is binary blob content, not text, and must NOT be scanned for text validity",
 		"artifact_import.go":         "raw artifact TEXT (not JSON) — checked with bindableText, the same predicate ValidatePath and ValidateQuery apply",
-		"handlers_cloud.go":          "bodyHasCloudSecret PEEKS at the body and restores it; the real decode still happens through decodeJSON downstream",
+		"handlers_cloud.go":          "bodyHasCloudSecret PEEKS at the body and restores the first 64 KiB of it — a larger body loses its tail, a bound that file documents and accepts; the real decode still happens through decodeJSON downstream",
 		"middleware_mcp_audit.go":    "audit capture — parses the body ITSELF and binds the decoded method / params.name to mcp_audit_log.tool_name, so it is a second READER, not a pass-through. That the MCP dispatcher decodes the body again is true and says nothing about what this middleware persists — the earlier rationale here made exactly that mistake and certified it safe (codex round 20). parseMCPRequestBody now runs both caller-derived returns through sanitiseStoredText",
 		"handlers_tokens.go":         "guards on r.Body != nil && r.ContentLength != 0, then decodes THROUGH decodeJSON — so the body is read by the chokepoint, which applies the cap and the NUL rule. The earlier reason here said it never reads the body, which was simply false (codex round 29): a wrong reason in this list is the same defect as a missing entry, since both let a reader pass as reviewed",
 		"handlers_oauth.go":          "KNOWN GAP, tracked as BUG-2811: the OAuth handlers read FORM-encoded bodies (r.Form/FormValue), which no rule in this family covers — the transport rules see the query half of r.Form and not the body half. Listed so this test states the gap instead of being blind to it; measuring it needs a fosite-backed fixture.",

--- a/internal/server/decode_json_nul_test.go
+++ b/internal/server/decode_json_nul_test.go
@@ -1281,7 +1281,6 @@ func TestUnknownFieldRefusalThroughTheHandler(t *testing.T) {
 // EOF (or the playbook contract breaks), and non-JSON whitespace must NOT (or
 // the divergence is still there).
 func TestDecodeJSONTrimsOnlyJSONWhitespace(t *testing.T) {
-	srv := testServer(t)
 
 	for _, tc := range []struct {
 		name    string
@@ -1314,7 +1313,6 @@ func TestDecodeJSONTrimsOnlyJSONWhitespace(t *testing.T) {
 			}
 		})
 	}
-	_ = srv
 }
 
 // independentDecodesNUL is a SECOND implementation of the walker's contract,

--- a/internal/server/decode_json_nul_test.go
+++ b/internal/server/decode_json_nul_test.go
@@ -13,6 +13,8 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/artifact"
 )
 
 // rawJSONRequest sends a RAW body string. A test cannot marshal a Go map
@@ -765,5 +767,67 @@ func TestDocumentActivityStoresBindableUserAgent(t *testing.T) {
 	}
 	if seenSanitised == 0 {
 		t.Error("no activity carries the sanitised header; the call site is not wired to requestUserAgent")
+	}
+}
+
+// TestBodyDecodesNULUnderAJSONEncodedKeyChecksBothWays is codex round 9's P1,
+// which was a REGRESSION this branch introduced in its round-8 restructure.
+//
+// Taking the JSON-encoded branch for a listed key used to skip the plain
+// "does this string contain a NUL" check, so a direct NUL in a `fields` value
+// — the very first door this change closed — was accepted again. The two
+// questions are different and both must be asked: does the string ITSELF
+// carry a NUL, and does the document it carries contain an escape.
+func TestBodyDecodesNULUnderAJSONEncodedKeyChecksBothWays(t *testing.T) {
+	esc := escNULLiteral
+
+	// A direct escape in the fields STRING (not inside a nested document):
+	// the outer decode turns it into a real NUL in that string.
+	direct := `{"title":"x","fields":"a` + esc + `b"}`
+	if !bodyDecodesNUL([]byte(direct)) {
+		t.Error("a NUL in the fields string itself must be refused")
+	}
+
+	// And the nested form still is, so this is not just the plain check.
+	nested := `{"title":"x","fields":` + jsonEncode(t, `{"k":"a`+esc+`b"}`) + `}`
+	if !bodyDecodesNUL([]byte(nested)) {
+		t.Error("an escape inside the fields document must be refused")
+	}
+
+	// Control: an ordinary fields string is accepted, so the legs above are
+	// not passing because everything under a listed key is refused.
+	if bodyDecodesNUL([]byte(`{"title":"x","fields":"plain"}`)) {
+		t.Error("an ordinary fields string must be accepted")
+	}
+}
+
+// TestArtifactBindableTextAcceptsLiteralEscapeText is codex round 9's P2: the
+// artifact check searched the MARSHALLED bytes for the escape, and a value
+// holding the six LITERAL characters marshals to a doubled backslash which
+// still contains that sequence — so valid content was refused. Artifacts are
+// documentation; text about a JSON escape is exactly what one carries.
+func TestArtifactBindableTextAcceptsLiteralEscapeText(t *testing.T) {
+	esc := escNULLiteral
+	ok := artifact.Artifact{
+		Title: "Escapes",
+		Body:  "write a NUL as " + esc + " in JSON",
+		Fields: map[string]any{
+			"note": "also " + esc + " here",
+		},
+	}
+	if !artifactIsBindableText(ok) {
+		t.Error("literal escape TEXT in an artifact is valid content and must be accepted")
+	}
+
+	// The counterfactual: a real NUL in the same places is still refused, so
+	// the leg above is not passing because the check does nothing.
+	for name, bad := range map[string]artifact.Artifact{
+		"title":  {Title: "a\x00b"},
+		"body":   {Title: "t", Body: "a\x00b"},
+		"fields": {Title: "t", Fields: map[string]any{"k": "a\x00b"}},
+	} {
+		if artifactIsBindableText(bad) {
+			t.Errorf("a real NUL in %s must be refused", name)
+		}
 	}
 }

--- a/internal/server/decode_json_nul_test.go
+++ b/internal/server/decode_json_nul_test.go
@@ -370,7 +370,10 @@ func TestEveryRequestBodyReaderIsAccountedFor(t *testing.T) {
 	//     Closing the class means running the type checker, not another
 	//     parser patch — tracked as BUG-2820, which enumerates these forms.
 	//
-	// Both want per-call-site accounting, which is a different instrument.
+	// Both want per-call-site accounting, which is a different instrument —
+	// BUG-2820's go/types rewrite is filed to provide exactly that (each
+	// reader expression individually justified), retiring the per-file
+	// count workaround along with the name-resolution blind spots.
 }
 
 // jsonEncode returns s as a JSON string literal — the wire form of a field
@@ -1523,6 +1526,13 @@ func h(r *http.Request) { c := *r; io.ReadAll(c.Body) }`},
 func h(r *http.Request) { f := func(c http.Request) { io.ReadAll(c.Body) }; f(*r) }`},
 		{"form reader", true, `
 func h(r *http.Request) { _ = r.FormValue("x") }`},
+		// MultipartReader and FormFile are in the selector list but had no
+		// control here, so their removal from that list would have gone
+		// undetected (codex closing round 7).
+		{"multipart streaming reader", true, `
+func h(r *http.Request) { _, _ = r.MultipartReader() }`},
+		{"form file reader", true, `
+func h(r *http.Request) { _, _, _ = r.FormFile("f") }`},
 		{"reassigned through WithContext", true, `
 func h(r *http.Request) {
 	r = r.WithContext(context.Background())

--- a/internal/server/decode_json_nul_test.go
+++ b/internal/server/decode_json_nul_test.go
@@ -1421,7 +1421,7 @@ func TestBodyDecodesNULAgainstAnIndependentOracle(t *testing.T) {
 }
 
 // probeFileHeader is the preamble every synthetic probe file shares.
-var probeFileHeader = "package probe\n\nimport (\n\t\"io\"\n\t\"net/http\"\n)\n\nvar _ = io.ReadAll\n\n"
+var probeFileHeader = "package probe\n\nimport (\n\t\"context\"\n\t\"io\"\n\t\"net/http\"\n)\n\nvar _ = io.ReadAll\nvar _ = context.Background\n\n"
 
 // TestBodyReaderScanDiscriminates feeds the accounting scan SYNTHETIC source
 // covering the cases that have broken it, instead of only pointing it at the
@@ -1454,6 +1454,23 @@ func h(orig *http.Request) { req := orig; io.ReadAll(req.Body) }`},
 func h(r *http.Request) { f := func(c http.Request) { io.ReadAll(c.Body) }; f(*r) }`},
 		{"form reader", true, `
 func h(r *http.Request) { _ = r.FormValue("x") }`},
+		{"reassigned through WithContext", true, `
+func h(r *http.Request) {
+	r = r.WithContext(context.Background())
+	io.ReadAll(r.Body)
+}`},
+		{"reader inside an if body", true, `
+func h(r *http.Request) {
+	if r.Method == "POST" {
+		io.ReadAll(r.Body)
+	}
+}`},
+		{"reader inside a for body", true, `
+func h(r *http.Request) {
+	for i := 0; i < 1; i++ {
+		io.ReadAll(r.Body)
+	}
+}`},
 
 		{"no request at all", false, `
 type payload struct{ Body string }
@@ -1590,9 +1607,19 @@ func scanFileForRequestBodyReads(t *testing.T, path string) bool {
 						reqNames[lhs.Name] = true
 						continue
 					}
-					// Binding the name to anything else takes it over for the
-					// rest of this scope.
-					delete(reqNames, lhs.Name)
+					// Only a DEFINE can take the name over. Go is statically
+					// typed, so a plain `=` cannot change a variable's type:
+					// if it held a request before, it holds one after.
+					//
+					// Deleting on `=` as well was a FALSE NEGATIVE, and on the
+					// most idiomatic line in Go HTTP code — `r = r.WithContext(ctx)`
+					// has a call on the right, so the name was dropped and
+					// every later r.Body read went unseen. Measured before the
+					// fix: MISSED. That is the dangerous direction for a test
+					// whose job is to say nothing is invisible.
+					if node.Tok == token.DEFINE {
+						delete(reqNames, lhs.Name)
+					}
 				}
 			case *ast.SelectorExpr:
 				if !readerSelectors[node.Sel.Name] {

--- a/internal/server/decode_json_nul_test.go
+++ b/internal/server/decode_json_nul_test.go
@@ -328,21 +328,70 @@ func TestBodyDecodesNULNestedDocuments(t *testing.T) {
 	}
 }
 
-// TestBodyDecodesNULOverRefusesWholeJSONValues pins a DECISION, not an
-// accident. The nesting test is structural rather than destination-typed, so
-// a plain-text field whose ENTIRE value is a valid JSON document carrying the
-// escape is refused even though its column would have stored it happily.
+// TestBodyDecodesNULLeavesTextFieldsAlone is codex round 2's finding on
+// BUG-2803, pinned so it cannot come back.
 //
-// It is here so that the trade is visible and a future change to it is a
-// deliberate act: if someone makes the check destination-typed, this test
-// should be updated, not deleted in passing. See stringIsJSONDocument for why
-// the allow-list alternative was declined.
-func TestBodyDecodesNULOverRefusesWholeJSONValues(t *testing.T) {
-	body := `{"content":` + jsonEncode(t, `{"k":"a`+escNULLiteral+`b"}`) + `}`
-	if !bodyDecodesNUL([]byte(body)) {
-		t.Error("a text field whose whole value is a JSON document carrying the escape " +
-			"is refused by design; if this changed deliberately, update the reasoning at " +
-			"stringIsJSONDocument rather than only this test")
+// The first version of the nesting check recursed into ANY string that parsed
+// as a JSON document. That refused a plain-text `content` value holding a
+// JSON snippet which merely MENTIONS the escape — a value this server
+// accepted before the fix, stores in a text column that has no problem with
+// it, and emits again in an export. Refusing input the server itself produced
+// is a worse failure than the narrow door the unscoped recursion closed, so
+// the recursion is now scoped to the keys that actually carry JSON documents.
+func TestBodyDecodesNULLeavesTextFieldsAlone(t *testing.T) {
+	doc := `{"k":"a` + escNULLiteral + `b"}`
+	for _, key := range []string{"content", "title", "summary", "body", "description"} {
+		body := `{"` + key + `":` + jsonEncode(t, doc) + `}`
+		if bodyDecodesNUL([]byte(body)) {
+			t.Errorf("%s is a text field: a JSON document in its value must not be re-parsed "+
+				"(codex round 2 — the server emits such values in exports and must accept them back)", key)
+		}
+	}
+	// The same document under a JSON-ENCODED key is still refused, so the
+	// legs differ only in the key and this is not just "recursion removed".
+	if !bodyDecodesNUL([]byte(`{"fields":` + jsonEncode(t, doc) + `}`)) {
+		t.Error("under a JSON-encoded key the same document must still be refused")
+	}
+}
+
+// TestJSONEncodedFieldKeysCoversTheModels keeps jsonEncodedFieldKeys from
+// going stale in silence, which is the whole objection to a list-based rule.
+// It derives the set from the wire model — a Go string field with a json tag
+// whose comment says it holds JSON — and fails when one is not covered. A key
+// missing from the list reopens a door; an extra key is harmless (see the
+// over-inclusion note at jsonEncodedFieldKeys), so this asserts one direction
+// only, deliberately.
+func TestJSONEncodedFieldKeysCoversTheModels(t *testing.T) {
+	entries, err := os.ReadDir("../models")
+	if err != nil {
+		t.Fatalf("read models dir: %v", err)
+	}
+	// A string field, a json tag, and a trailing comment mentioning JSON.
+	decl := regexp.MustCompile("string\\s+`json:\"([a-z_]+)[\",][^`]*`\\s*//[^\\n]*JSON")
+	found := map[string]string{}
+	scanned := 0
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		scanned++
+		src, err := os.ReadFile(filepath.Join("../models", name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		for _, m := range decl.FindAllStringSubmatch(string(src), -1) {
+			found[m[1]] = name
+		}
+	}
+	if scanned < 10 || len(found) < 5 {
+		t.Fatalf("derivation looks broken: scanned %d files, found %d JSON-encoded fields", scanned, len(found))
+	}
+	for key, file := range found {
+		if !jsonEncodedFieldKeys[key] {
+			t.Errorf("%s declares %q as a JSON-encoded string, but it is not in jsonEncodedFieldKeys — "+
+				"a NUL escape nested inside it would reach the database unchecked (BUG-2803)", file, key)
+		}
 	}
 }
 
@@ -351,10 +400,14 @@ func TestBodyDecodesNULOverRefusesWholeJSONValues(t *testing.T) {
 // so the body is refused rather than passed uninspected.
 func TestBodyDecodesNULDepthBound(t *testing.T) {
 	// Wrap a NUL-bearing document deeper than the limit allows.
+	// Nested under a JSON-ENCODED key at every level, since that is the only
+	// path the walk descends: nesting under an ordinary key would never start
+	// the recursion and the test would pass for the wrong reason.
 	doc := `{"k":"a` + escNULLiteral + `b"}`
 	for i := 0; i < maxJSONDocumentNesting+2; i++ {
-		doc = `{"n":` + jsonEncode(t, doc) + `}`
+		doc = `{"fields":` + jsonEncode(t, doc) + `}`
 	}
+	doc = `{"fields":` + jsonEncode(t, doc) + `}`
 	if !bodyDecodesNUL([]byte(doc)) {
 		t.Error("a body nested past maxJSONDocumentNesting must be refused, not passed uninspected")
 	}

--- a/internal/server/decode_json_nul_test.go
+++ b/internal/server/decode_json_nul_test.go
@@ -1476,11 +1476,16 @@ func h(r *http.Request) {
 type payload struct{ Body string }
 
 func h(p payload) int { return len(p.Body) }`},
-		{"shadowed by a closure parameter", false, `
+		// These two are OVER-FLAGGED on purpose, and asserted as such so the
+		// bias is a decision on the record rather than a surprise. The file
+		// binds `r` to a request, and the scanner does not model the scope
+		// that rebinds it. Erring this way is what makes the false-negative
+		// classes from rounds 24-28 structurally impossible.
+		{"shadowed by a closure parameter (conservatively flagged)", true, `
 type other struct{ Body string }
 
 func h(r *http.Request) int { f := func(r other) int { return len(r.Body) }; return f(other{}) }`},
-		{"redefined inside a nested block", false, `
+		{"rebound in a nested block (conservatively flagged)", true, `
 type resp struct{ Body string }
 
 func h(r *http.Request) int {
@@ -1490,6 +1495,28 @@ func h(r *http.Request) int {
 		n = len(r.Body)
 	}
 	return n
+}`},
+		{"mixed short declaration reusing the request", true, `
+func getReq() (*http.Request, bool) { return nil, false }
+
+func h(r *http.Request) {
+	r, ok := getReq()
+	_ = ok
+	io.ReadAll(r.Body)
+}`},
+		{"reader in a switch case", true, `
+func h(r *http.Request) {
+	switch r.Method {
+	case "POST":
+		io.ReadAll(r.Body)
+	}
+}`},
+		{"reader after an if-initialiser shadow", true, `
+func h(r *http.Request) {
+	if r := 1; r > 0 {
+		_ = r
+	}
+	io.ReadAll(r.Body)
 }`},
 		{"mentioned only in a comment", false, `
 // This function does not read r.Body, it only talks about it.
@@ -1509,23 +1536,36 @@ func h(r *http.Request) int { return 1 }`},
 	}
 }
 
-// scanFileForRequestBodyReads reports whether path contains a function that
-// reads the HTTP request body.
+// scanFileForRequestBodyReads reports whether path contains code that reads the
+// HTTP request body.
 //
-// Package-level so the accounting test and TestBodyReaderScanDiscriminates
-// drive the SAME scanner. The controls were previously throwaway probes, so
-// nothing in the suite held this to them (codex round 27).
+// DELIBERATELY CONSERVATIVE: it over-approximates. Any identifier bound to an
+// http.Request anywhere in the file is treated as a request for the whole file,
+// and a reader selector on such a name counts. Names are never un-bound.
 //
-// AST, not a regex. The lexical version was wrong three ways, all in the
-// direction that matters for a test whose job is to say nothing is invisible:
-// it recognised only the names r and req; it matched inside COMMENTS; and
-// broadening it to any identifier matched every unrelated .Body field, whose
-// only route to green would have been accounting entries for files that read
-// no request body — and an accounting entry HIDES future readers in its file.
+// That is a decision, not an oversight, and it was made after five review
+// rounds found successive FALSE NEGATIVES in a scope-modelling version of this
+// scanner: a value-copied request, a plain `r = r.WithContext(ctx)`
+// reassignment, a mixed `r, ok := ...` short declaration that reuses an
+// existing variable, and if/for/switch initialisers and case clauses whose
+// scopes it did not model. Each fix closed one case and left another.
 //
-// Scope-aware, because one flat name-set per function is wrong in both
-// directions: a nested scope that rebinds the name was falsely flagged, and a
-// request arriving as a function literal's own parameter was invisible.
+// The two error directions are not symmetric for this test. A false NEGATIVE
+// hides a body reader, which is the entire thing this test exists to prevent.
+// A false POSITIVE costs one human review and an accounting entry with a
+// reason attached. So the scanner is biased to over-flag, and the residual
+// imprecision is stated below rather than chased.
+//
+// Getting this EXACT means resolving types, not parsing them — go/types with
+// a real package load. That is a bigger instrument than this test warrants
+// today; if the accounted list ever grows entries whose reason is "the scan
+// over-flagged", that is the signal to build it.
+//
+// Known imprecision, all in the safe direction: a name shadowed by a
+// non-request of the same spelling, or rebound in a nested scope, still counts
+// for the whole file. Still invisible, and NOT in the safe direction: a request
+// reached only through a struct field, a context value, or a type alias, since
+// this matches the literal http.Request spelling.
 func scanFileForRequestBodyReads(t *testing.T, path string) bool {
 	t.Helper()
 
@@ -1535,9 +1575,7 @@ func scanFileForRequestBodyReads(t *testing.T, path string) bool {
 	}
 
 	// Both *http.Request and http.Request count. A VALUE copy still shares the
-	// Body — it is an interface holding the same reader — so a literal taking
-	// http.Request reads the same body, and the shadowing rule would otherwise
-	// delete the name and MISS it.
+	// Body — it is an interface holding the same reader.
 	isRequestType := func(e ast.Expr) bool {
 		if star, ok := e.(*ast.StarExpr); ok {
 			e = star.X
@@ -1550,115 +1588,76 @@ func scanFileForRequestBodyReads(t *testing.T, path string) bool {
 		return ok && pkg.Name == "http"
 	}
 
-	var scanScope func(body *ast.BlockStmt, params *ast.FieldList, inherited map[string]bool) bool
-	scanScope = func(body *ast.BlockStmt, params *ast.FieldList, inherited map[string]bool) bool {
-		if body == nil {
-			return false
-		}
-		reqNames := make(map[string]bool, len(inherited))
-		for k := range inherited {
-			reqNames[k] = true
-		}
-		// A parameter SHADOWS an inherited name whatever its type: if it is a
-		// request the name stays, otherwise the outer meaning is gone.
-		if params != nil {
-			for _, fld := range params.List {
-				isReq := isRequestType(fld.Type)
-				for _, nm := range fld.Names {
-					if isReq {
-						reqNames[nm.Name] = true
-					} else {
-						delete(reqNames, nm.Name)
-					}
-				}
-			}
-		}
-
-		found := false
-		ast.Inspect(body, func(n ast.Node) bool {
-			switch node := n.(type) {
-			case *ast.FuncLit:
-				if scanScope(node.Body, node.Type.Params, reqNames) {
-					found = true
-				}
-				return false
-			case *ast.BlockStmt:
-				// A nested block is its own scope. Without this a := inside it
-				// leaked outward, and an inner rebinding such as
-				// { r := &http.Response{}; r.Body.Read(nil) } was FALSELY
-				// flagged as a request read.
-				if node != body {
-					if scanScope(node, nil, reqNames) {
-						found = true
-					}
-					return false
-				}
-			case *ast.AssignStmt:
-				for i, rhs := range node.Rhs {
-					if i >= len(node.Lhs) {
-						break
-					}
-					lhs, ok := node.Lhs[i].(*ast.Ident)
-					if !ok {
-						continue
-					}
-					if id, isIdent := rhs.(*ast.Ident); isIdent && reqNames[id.Name] {
-						// req := r / req = r alias the same request.
-						reqNames[lhs.Name] = true
-						continue
-					}
-					// Only a DEFINE can take the name over. Go is statically
-					// typed, so a plain `=` cannot change a variable's type:
-					// if it held a request before, it holds one after.
-					//
-					// Deleting on `=` as well was a FALSE NEGATIVE, and on the
-					// most idiomatic line in Go HTTP code — `r = r.WithContext(ctx)`
-					// has a call on the right, so the name was dropped and
-					// every later r.Body read went unseen. Measured before the
-					// fix: MISSED. That is the dangerous direction for a test
-					// whose job is to say nothing is invisible.
-					if node.Tok == token.DEFINE {
-						delete(reqNames, lhs.Name)
-					}
-				}
-			case *ast.SelectorExpr:
-				if !readerSelectors[node.Sel.Name] {
-					return true
-				}
-				if id, ok := node.X.(*ast.Ident); ok && reqNames[id.Name] {
-					found = true
-				}
-			}
-			return true
-		})
-		return found
-	}
-
 	fset := token.NewFileSet()
 	f, err := parser.ParseFile(fset, path, nil, 0)
 	if err != nil {
 		t.Fatalf("parse %s: %v", path, err)
 	}
-	found := false
-	for _, decl := range f.Decls {
-		fn, ok := decl.(*ast.FuncDecl)
-		if !ok || fn.Body == nil {
-			continue
+
+	// Pass 1: every name ever bound to a request, from any signature in the
+	// file — declarations, literals, receivers — plus aliases of those.
+	reqNames := map[string]bool{}
+	collectParams := func(fl *ast.FieldList) {
+		if fl == nil {
+			return
 		}
-		seed := map[string]bool{}
-		if fn.Recv != nil {
-			for _, fld := range fn.Recv.List {
-				if !isRequestType(fld.Type) {
-					continue
-				}
-				for _, nm := range fld.Names {
-					seed[nm.Name] = true
-				}
+		for _, fld := range fl.List {
+			if !isRequestType(fld.Type) {
+				continue
+			}
+			for _, nm := range fld.Names {
+				reqNames[nm.Name] = true
 			}
 		}
-		if scanScope(fn.Body, fn.Type.Params, seed) {
+	}
+	ast.Inspect(f, func(n ast.Node) bool {
+		switch node := n.(type) {
+		case *ast.FuncDecl:
+			collectParams(node.Type.Params)
+			collectParams(node.Recv)
+		case *ast.FuncLit:
+			collectParams(node.Type.Params)
+		}
+		return true
+	})
+	// Aliases, to a fixed point: `req := r`, `r2 = req`, and chains of them.
+	for changed := true; changed; {
+		changed = false
+		ast.Inspect(f, func(n ast.Node) bool {
+			as, ok := n.(*ast.AssignStmt)
+			if !ok {
+				return true
+			}
+			for i, rhs := range as.Rhs {
+				if i >= len(as.Lhs) {
+					break
+				}
+				id, isIdent := rhs.(*ast.Ident)
+				lhs, isLhsIdent := as.Lhs[i].(*ast.Ident)
+				if !isIdent || !isLhsIdent || !reqNames[id.Name] || reqNames[lhs.Name] {
+					continue
+				}
+				reqNames[lhs.Name] = true
+				changed = true
+			}
+			return true
+		})
+	}
+	if len(reqNames) == 0 {
+		return false
+	}
+
+	// Pass 2: any reader selector on any of those names, anywhere in the file.
+	found := false
+	ast.Inspect(f, func(n ast.Node) bool {
+		sel, ok := n.(*ast.SelectorExpr)
+		if !ok || !readerSelectors[sel.Sel.Name] {
+			return true
+		}
+		if id, ok := sel.X.(*ast.Ident); ok && reqNames[id.Name] {
 			found = true
 		}
-	}
+		return true
+	})
 	return found
 }

--- a/internal/server/decode_json_nul_test.go
+++ b/internal/server/decode_json_nul_test.go
@@ -1230,3 +1230,127 @@ func TestDecodeJSONTrimsOnlyJSONWhitespace(t *testing.T) {
 	}
 	_ = srv
 }
+
+// independentDecodesNUL is a SECOND implementation of the walker's contract,
+// written for the test and deliberately not calling valueDecodesNUL.
+//
+// It exists because TestBodyDecodesNULGateAgreesWithAnUngatedWalk compares the
+// gated function against an "ungated" reference that calls the SAME production
+// walker (codex round 22). That comparison is valid for what it claims - it
+// pins the raw-prefix GATE - but it cannot see a defect in the walker itself,
+// because a walker bug is present identically on both sides and cancels.
+//
+// The two share encoding/json and jsonEncodedFieldKeys. They deliberately do
+// not share traversal, descent, or key-matching code, which is where every
+// walker defect in this unit actually lived (rounds 1, 2, 4, 16, 17).
+func independentDecodesNUL(t *testing.T, raw []byte) bool {
+	t.Helper()
+	var root any
+	if err := json.Unmarshal(raw, &root); err != nil {
+		return false
+	}
+
+	hasNUL := func(s string) bool { return strings.ContainsRune(s, 0) }
+
+	// Iterative, explicit stack - a different shape from the production
+	// recursion, so a recursion-shaped bug cannot reproduce here by accident.
+	type frame struct {
+		v      any
+		nested bool // already inside a re-parsed document; do not descend again
+	}
+	stack := []frame{{root, false}}
+	for len(stack) > 0 {
+		f := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+
+		switch cur := f.v.(type) {
+		case string:
+			if hasNUL(cur) {
+				return true
+			}
+		case []any:
+			for _, e := range cur {
+				stack = append(stack, frame{e, f.nested})
+			}
+		case map[string]any:
+			for k, v := range cur {
+				if hasNUL(k) {
+					return true
+				}
+				if sv, ok := v.(string); ok {
+					if hasNUL(sv) {
+						return true
+					}
+					// One level of descent into a listed key's JSON document,
+					// and only when not already nested. Matched case-folded,
+					// the way encoding/json matches a wire key to a field.
+					if !f.nested {
+						for listed := range jsonEncodedFieldKeys {
+							if !strings.EqualFold(k, listed) {
+								continue
+							}
+							var inner any
+							if json.Unmarshal([]byte(sv), &inner) == nil {
+								stack = append(stack, frame{inner, true})
+							}
+							break
+						}
+					}
+					continue
+				}
+				stack = append(stack, frame{v, f.nested})
+			}
+		}
+	}
+	return false
+}
+
+// TestBodyDecodesNULAgainstAnIndependentOracle checks the WALKER, which the
+// gate differential structurally cannot (codex round 22: shared-oracle blind
+// spot). Disagreement means one of the two is wrong and both get read - the
+// point is that a single shared bug can no longer hide.
+func TestBodyDecodesNULAgainstAnIndependentOracle(t *testing.T) {
+	esc := escNULLiteral
+	bs := string([]byte{'\\', 'u', '0', '0', '5', 'c'})
+	doubled := `\\` + "u0000"
+
+	corpus := []string{
+		`{"title":"plain"}`,
+		`{"title":"quotes \" and a backslash \\ but no escape"}`,
+		`{"fields":"{\"k\":\"plain\"}"}`,
+		`{"fields":"{\"k\":\"a` + esc + `b\"}"}`,
+		`{"fields":"{\"k\":\"a` + bs + `u0000b\"}"}`,
+		`{"fields":"{\"k\":\"a` + doubled + `b\"}"}`,
+		`{"title":"a` + esc + `b"}`,
+		`{"a` + esc + `b":"key"}`,
+		`{"tags":["ok","a` + esc + `b"]}`,
+		`{"fields":"[1,2,\"a` + esc + `b\"]"}`,
+		`{"Fields":"{\"k\":\"a` + esc + `b\"}"}`,
+		`{"content":"{\"k\":\"a` + esc + `b\"}"}`,
+		`{"title":"unicode é 中"}`,
+		`{"nested":{"deep":{"deeper":"a` + esc + `b"}}}`,
+		`{"title":"a control escape that is not a NUL: \\u0001"}`,
+	}
+
+	var sawTrue, sawFalse bool
+	for i, body := range corpus {
+		got := bodyDecodesNUL([]byte(body))
+		want := independentDecodesNUL(t, []byte(body))
+		if got != want {
+			t.Errorf("corpus[%d] %s\n  production=%v independent=%v — one of the two walkers is "+
+				"wrong; read both before assuming it is the oracle", i, body, got, want)
+		}
+		if want {
+			sawTrue = true
+		} else {
+			sawFalse = true
+		}
+	}
+
+	// The corpus must contain BOTH answers, or agreement proves nothing: two
+	// walkers that always say false agree perfectly.
+	if !sawTrue || !sawFalse {
+		t.Fatalf("corpus is one-sided (sawTrue=%v sawFalse=%v); agreement over it is vacuous",
+			sawTrue, sawFalse)
+	}
+}

--- a/internal/server/decode_json_nul_test.go
+++ b/internal/server/decode_json_nul_test.go
@@ -1054,3 +1054,76 @@ func TestBodyDecodesNULMatchesKeysLikeTheDecoder(t *testing.T) {
 		t.Error("an unlisted key must not be treated as JSON-encoded whatever its casing")
 	}
 }
+
+// TestBodyDecodesNULKnownMapModelDisagreements pins the four measured
+// disagreements between this scan's map[string]any model and encoding/json's
+// typed decode (BUG-2803 rounds 16-17, lead ruling day-68: land-and-follow).
+// They are documented on bodyDecodesNUL; this is the instrument that keeps
+// that documentation and the release note from going stale.
+//
+// Two of the four are ACCEPTED over-refusals. The other two are KNOWN GAPS
+// whose fix is the BUG-2812 token-walk unit — so those legs assert the WRONG
+// answer on purpose. That is deliberate and it is the point: when BUG-2812
+// lands, this test FAILS, which is the signal to update the doc comment, the
+// release note and this test together rather than discovering months later
+// that the note describes a version of the check that no longer exists.
+func TestBodyDecodesNULKnownMapModelDisagreements(t *testing.T) {
+	t.Run("accepted over-refusals", func(t *testing.T) {
+		// (3) An unknown field is scanned though no handler reads it. The
+		// scan has no destination type by design, so it cannot tell a
+		// forward-compatible field from a real one. Observable compatibility
+		// change; stated in the release note.
+		unknown := `{"title":"valid","future_field":"a` + escNULLiteral + `b"}`
+		if !bodyDecodesNUL([]byte(unknown)) {
+			t.Error("(3) an unknown field carrying a NUL escape is refused today; if that changed, " +
+				"update the disposition on bodyDecodesNUL and the release note's compatibility line")
+		}
+
+		// (4) Case-variant duplicates: the typed decode keeps the LAST
+		// spelling and discards the NUL, the map scan sees both and refuses.
+		// Same root as (1), opposite direction.
+		caseDup := `{"title":"a` + escNULLiteral + `b","TITLE":"safe"}`
+		if !bodyDecodesNUL([]byte(caseDup)) {
+			t.Error("(4) a case-variant duplicate is refused today even though the decode drops the " +
+				"NUL spelling; if that changed, update the disposition on bodyDecodesNUL")
+		}
+	})
+
+	t.Run("known gaps owned by BUG-2812", func(t *testing.T) {
+		// (1) Duplicate keys: map[string]any REPLACES, encoding/json MERGES
+		// into an already-populated map field. The scan structurally cannot
+		// see the shadowed first occurrence.
+		dupKey := `{"fields_patch":{"orphan":"a` + escNULLiteral + `b"},"fields_patch":{"status":"open"}}`
+		if bodyDecodesNUL([]byte(dupKey)) {
+			t.Error("(1) now DETECTED — the map-model duplicate-key gap is closed. That is the " +
+				"BUG-2812 token walk landing: update bodyDecodesNUL's disposition block, the " +
+				"release note's filed-residuals line, and delete this leg")
+		}
+
+		// (2) A scan failure lets a known-bad value through: the overflowing
+		// number fails the `any` unmarshal, this function returns false so the
+		// caller's decode owns the "invalid JSON" message, and the typed
+		// decode then SKIPS the unknown field and accepts the NUL title.
+		scanFail := `{"title":"a` + escNULLiteral + `b","ignored":1e999}`
+		if bodyDecodesNUL([]byte(scanFail)) {
+			t.Error("(2) now DETECTED — the scan-failure passthrough is closed. That is the " +
+				"BUG-2812 token walk landing: update bodyDecodesNUL's disposition block, the " +
+				"release note's filed-residuals line, and delete this leg")
+		}
+
+		// Premise for both legs above: the SAME bodies with their
+		// disagreement mechanism removed ARE detected. Without this, the two
+		// assertions would pass against a bodyDecodesNUL that detected
+		// nothing at all, and would prove nothing about the gaps they name.
+		singleKey := `{"fields_patch":{"orphan":"a` + escNULLiteral + `b"}}`
+		if !bodyDecodesNUL([]byte(singleKey)) {
+			t.Fatal("premise failed: the duplicate-key body's payload is not detectable even when " +
+				"spelled once, so the (1) leg above is vacuous")
+		}
+		parseable := `{"title":"a` + escNULLiteral + `b","ignored":1}`
+		if !bodyDecodesNUL([]byte(parseable)) {
+			t.Fatal("premise failed: the scan-failure body's payload is not detectable even when " +
+				"the body parses, so the (2) leg above is vacuous")
+		}
+	})
+}

--- a/internal/server/decode_json_nul_test.go
+++ b/internal/server/decode_json_nul_test.go
@@ -897,3 +897,130 @@ func TestTestEmailRefusesUnusableBody(t *testing.T) {
 			rr.Code, rr.Body.String())
 	}
 }
+
+// TestTextSafeHelpersAreUsedAtEveryCallSite closes the gap codex round 14
+// named: reverting a single call site back to the unsafe form leaves every
+// behavioural test green, because the surviving fixtures are ASCII and the
+// helpers' own unit tests do not care who calls them.
+//
+// Testing each site behaviourally would need a fixture per site (an OAuth
+// connection, a cloud login, four audit paths). This asserts the WIRING
+// statically instead — the same technique as
+// TestEveryRequestBodyReaderIsAccountedFor, and the same bargain: a reverted
+// call site fails here immediately, and a new one has to be decided on
+// deliberately rather than added invisibly.
+//
+// It asserts in both directions: an unsafe form anywhere fails, and finding
+// none of the safe form also fails, so a scan that silently matched nothing
+// cannot pass forever.
+func TestTextSafeHelpersAreUsedAtEveryCallSite(t *testing.T) {
+	// A plain byte slice of a caller string can split a rune and produce
+	// invalid UTF-8; truncateBindableText is the only allowed form.
+	unsafeTruncate := regexp.MustCompile(`\b(name|suggested|input\.Name|Name)\s*=\s*\w+(\.\w+)*\[:\d+\]`)
+	// The raw header reaches a text column; requestUserAgent is the allowed
+	// form. The two HASH sites are exempt and named below.
+	unsafeUA := regexp.MustCompile(`(r|req)\.UserAgent\(\)|(r|req)\.Header\.Get\("User-Agent"\)`)
+	// Exempt sites, with counts, so a NEW raw read in one of these files
+	// still fails rather than hiding behind a blanket exemption.
+	uaHashExempt := map[string]int{
+		// All four reads here feed a HASH, not a text column: one
+		// session-fingerprint comparison plus three CreateSession calls,
+		// and store.CreateSession hashes the header (sessions.ua_hash) and
+		// stores no text. sha256 over arbitrary bytes is well defined, and
+		// sanitising before hashing would be actively harmful — login would
+		// store sha256(sanitised) while the comparison still hashes the RAW
+		// header, so every session from a client with a non-UTF-8
+		// User-Agent would fail validation.
+		"handlers_auth.go": 4,
+		// The same fingerprint comparison on the session-validation path.
+		"middleware_auth.go": 1,
+		// requestUserAgent itself: this is the one read that is allowed to
+		// be raw, because it is the thing doing the sanitising.
+		"middleware_request_text.go": 1,
+	}
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read package dir: %v", err)
+	}
+	var safeTruncateUses, safeUAUses int
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		src, err := os.ReadFile(filepath.Join(".", name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		text := string(src)
+		safeTruncateUses += strings.Count(text, "truncateBindableText(")
+		safeUAUses += strings.Count(text, "requestUserAgent(")
+
+		for _, m := range unsafeTruncate.FindAllString(text, -1) {
+			t.Errorf("%s: %q slices a caller string by BYTES, which can split a rune and produce "+
+				"invalid UTF-8 downstream of validation — use truncateBindableText (BUG-2803)", name, m)
+		}
+		found := len(unsafeUA.FindAllString(text, -1))
+		if allowed := uaHashExempt[name]; found > allowed {
+			t.Errorf("%s: %d raw User-Agent read(s), %d exempt. A raw header reaching a text column "+
+				"must go through requestUserAgent; only the session-hash comparisons are exempt (BUG-2803)",
+				name, found, allowed)
+		}
+	}
+
+	if safeTruncateUses < 4 {
+		t.Errorf("found only %d truncateBindableText call sites; the scan or the wiring is broken", safeTruncateUses)
+	}
+	if safeUAUses < 4 {
+		t.Errorf("found only %d requestUserAgent call sites; the scan or the wiring is broken", safeUAUses)
+	}
+}
+
+// TestOAuthRegisterRefusesNULBody is the last of codex round 14's three
+// unwired-call-site findings. Reverting handlers_oauth.go to a bare
+// json.NewDecoder — losing both the refusal and the size cap — would
+// otherwise leave the suite green, and the static body-reader scan cannot
+// catch it because that file is already listed for its FORM-body reads.
+//
+// It also pins the message split: a body carrying a NUL is valid JSON, so
+// answering "Request body must be JSON" sends a client hunting a syntax error
+// it does not have.
+func TestOAuthRegisterRefusesNULBody(t *testing.T) {
+	srv := testServer(t)
+	srv.SetCloudMode("cloud-secret-for-test")
+	o, err := newTestOAuthServer(t, srv)
+	if err != nil {
+		t.Fatalf("oauth.NewServer: %v", err)
+	}
+	srv.SetOAuthServer(o)
+
+	post := func(t *testing.T, body string) *httptest.ResponseRecorder {
+		t.Helper()
+		req := httptest.NewRequest("POST", "/oauth/register", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.RemoteAddr = "192.0.2.7:1234"
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+		return rr
+	}
+
+	// Control: a well-formed registration must still be accepted, so a 400
+	// below cannot be the endpoint refusing everything.
+	control := post(t, `{"redirect_uris":["https://example.com/cb"],"client_name":"Probe"}`)
+	if control.Code >= 400 {
+		t.Fatalf("control registration must succeed, got %d: %s", control.Code, control.Body.String())
+	}
+
+	rr := post(t, `{"redirect_uris":["https://example.com/cb"],"client_name":"a`+escNULLiteral+`b"}`)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("a NUL-bearing registration must answer 400, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if strings.Contains(rr.Body.String(), "must be JSON") {
+		t.Errorf("the body IS valid JSON; the message must not send the client after a syntax error: %s",
+			rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "NUL") {
+		t.Errorf("the refusal should name the cause, got %s", rr.Body.String())
+	}
+}

--- a/internal/server/decode_json_nul_test.go
+++ b/internal/server/decode_json_nul_test.go
@@ -1,0 +1,263 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// rawJSONRequest sends a RAW body string. A test cannot marshal a Go map
+// here: marshalling would escape the backslash and send the literal text
+// instead of the escape, so every probe would be testing the harmless case.
+func rawJSONRequest(srv *Server, method, path, body string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(method, path, bytes.NewReader([]byte(body)))
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = "192.0.2.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	return rr
+}
+
+// escNULLiteral is the six-character JSON escape that decodes to a NUL,
+// assembled from bytes. Written as a Go literal it is one backslash away from
+// being the NUL itself, and every layer between an editor and the compiler is
+// a chance for that to happen silently — which is the whole subject here.
+var escNULLiteral = string([]byte{'\\', 'u', '0', '0', '0', '0'})
+
+func TestBodyDecodesNUL(t *testing.T) {
+	esc := escNULLiteral
+	cases := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"plain body, no escape anywhere", `{"title":"hello"}`, false},
+		{"escape in a string value", `{"title":"a` + esc + `b"}`, true},
+		{"escape as the whole value", `{"title":"` + esc + `"}`, true},
+		{"escape in an OBJECT KEY", `{"a` + esc + `b":"v"}`, true},
+		{"escape nested in a fields map", `{"fields":{"k":"a` + esc + `b"}}`, true},
+		{"escape inside an array element", `{"tags":["ok","a` + esc + `b"]}`, true},
+
+		// The reason this is not a substring search. A doubled backslash is
+		// an escaped BACKSLASH followed by the literal characters u0000, so
+		// the decoded string holds no NUL. This product stores markdown, and
+		// a document explaining JSON escapes is an ordinary thing to write.
+		{"doubled backslash decodes to literal text, NOT a NUL",
+			`{"content":"write it as \\` + "u0000" + ` in JSON"}`, false},
+		{"doubled backslash twice", `{"a":"\\` + "u0000" + `","b":"\\` + "u0000" + `"}`, false},
+
+		// A NUL escape that follows an escaped backslash IS real: the first
+		// two backslashes consume each other, so the third begins a fresh
+		// escape. The doubled-backslash cases above must not be read as
+		// "any preceding backslash makes it safe".
+		{"escaped backslash then a REAL escape", `{"a":"\\` + esc + `"}`, true},
+
+		{"other escapes are untouched", `{"a":"tab\there é \n"}`, false},
+		{"base64-looking payload with no escape", `{"b":"AQACAAAA"}`, false},
+
+		// Malformed input answers false: the caller's decode reports the JSON
+		// error, so this function never has to phrase one.
+		{"malformed JSON carrying the escape", `{"a":"` + esc, false},
+		{"empty body", ``, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := bodyDecodesNUL([]byte(tc.body)); got != tc.want {
+				t.Errorf("bodyDecodesNUL(%q) = %v, want %v", tc.body, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBodyDecodesNULAgreesWithTheDecoder is the differential check: for every
+// case above, the verdict must match what actually lands in a decoded Go
+// value. Asserting the function against hand-written expectations pins my
+// reading of JSON escaping; asserting it against encoding/json pins the
+// property the fix depends on.
+func TestBodyDecodesNULAgreesWithTheDecoder(t *testing.T) {
+	esc := escNULLiteral
+	bodies := []string{
+		`{"title":"hello"}`,
+		`{"title":"a` + esc + `b"}`,
+		`{"a` + esc + `b":"v"}`,
+		`{"fields":{"k":"a` + esc + `b"}}`,
+		`{"tags":["ok","a` + esc + `b"]}`,
+		`{"content":"write it as \\` + "u0000" + ` in JSON"}`,
+		`{"a":"\\` + esc + `"}`,
+		`{"a":"tab\there é \n"}`,
+	}
+	for _, body := range bodies {
+		var v any
+		if err := json.Unmarshal([]byte(body), &v); err != nil {
+			t.Fatalf("fixture %q does not decode: %v", body, err)
+		}
+		want := anyHasNUL(v)
+		if got := bodyDecodesNUL([]byte(body)); got != want {
+			t.Errorf("bodyDecodesNUL(%q) = %v, but the decoded value %s a NUL",
+				body, got, map[bool]string{true: "CONTAINS", false: "does not contain"}[want])
+		}
+	}
+}
+
+func anyHasNUL(v any) bool {
+	switch t := v.(type) {
+	case string:
+		return strings.ContainsRune(t, 0)
+	case map[string]any:
+		for k, sub := range t {
+			if strings.ContainsRune(k, 0) || anyHasNUL(sub) {
+				return true
+			}
+		}
+	case []any:
+		for _, sub := range t {
+			if anyHasNUL(sub) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// TestDecodeJSONRefusesNULThroughTheHandler exercises the BINDING, not the
+// predicate: a real request through the real router, so the test has an
+// opinion about whether decodeJSON is what handlers actually call. Its
+// control leg is the same request with an ordinary value — without one, a 400
+// proves nothing, since a malformed body would produce the same status
+// (this filing's original measurement made exactly that mistake).
+//
+// Runs on SQLite, where the underlying insert would SUCCEED with a truncated
+// value rather than error. That is deliberate: on SQLite the refusal can only
+// come from this fix, so a green here cannot be the database doing the work.
+func TestDecodeJSONRefusesNULThroughTheHandler(t *testing.T) {
+	srv := testServer(t)
+
+	rr := rawJSONRequest(srv, "POST", "/api/v1/workspaces/",
+		`{"name":"NUL probe","slug":"nulprobe","template":"startup"}`)
+	if rr.Code != http.StatusOK && rr.Code != http.StatusCreated {
+		t.Fatalf("fixture workspace: %d %s", rr.Code, rr.Body.String())
+	}
+	rr = rawJSONRequest(srv, "POST", "/api/v1/workspaces/nulprobe/collections/",
+		`{"name":"Probes","slug":"probes"}`)
+	if rr.Code != http.StatusOK && rr.Code != http.StatusCreated {
+		t.Fatalf("fixture collection: %d %s", rr.Code, rr.Body.String())
+	}
+
+	const itemsPath = "/api/v1/workspaces/nulprobe/collections/probes/items"
+	esc := escNULLiteral
+
+	control := rawJSONRequest(srv, "POST", itemsPath, `{"title":"a-plain-b"}`)
+	if control.Code != http.StatusCreated && control.Code != http.StatusOK {
+		t.Fatalf("control leg must succeed, got %d: %s", control.Code, control.Body.String())
+	}
+
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{"title", `{"title":"a` + esc + `b"}`},
+		{"content", `{"title":"ok","content":"a` + esc + `b"}`},
+		{"fields value", `{"title":"ok","fields":{"k":"a` + esc + `b"}}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := rawJSONRequest(srv, "POST", itemsPath, tc.body)
+			if rr.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d: %s", rr.Code, rr.Body.String())
+			}
+			if !strings.Contains(rr.Body.String(), "NUL") {
+				t.Errorf("400 body should name the cause, got: %s", rr.Body.String())
+			}
+		})
+	}
+
+	// The doubled-backslash body must still be ACCEPTED end to end. This is
+	// the leg that fails if anyone ever "simplifies" the check into a
+	// substring search.
+	ok := rawJSONRequest(srv, "POST", itemsPath,
+		`{"title":"escapes","content":"write it as \\`+"u0000"+` in JSON"}`)
+	if ok.Code != http.StatusCreated && ok.Code != http.StatusOK {
+		t.Fatalf("literal escape text must be accepted, got %d: %s", ok.Code, ok.Body.String())
+	}
+}
+
+// TestDecodeJSONKeepsEmptyBodyEOF pins a contract a caller depends on:
+// handlers_playbooks.go treats errors.Is(err, io.EOF) as "no arguments
+// supplied" and runs the playbook anyway. json.Decoder answered io.EOF on an
+// empty body; json.Unmarshal answers a SyntaxError, which that check cannot
+// see. Without this, an empty-body playbook run starts returning 400.
+func TestDecodeJSONKeepsEmptyBodyEOF(t *testing.T) {
+	for _, body := range []string{"", "   ", "\n\t "} {
+		req := httptest.NewRequest("POST", "/", strings.NewReader(body))
+		var v map[string]any
+		err := decodeJSON(req, &v)
+		if err == nil {
+			t.Fatalf("empty body %q: expected an error", body)
+		}
+		if !errors.Is(err, io.EOF) {
+			t.Errorf("empty body %q: error must wrap io.EOF, got %v", body, err)
+		}
+	}
+}
+
+// TestNoJSONBodyDecoderOutsideTheChokepoint is the completeness claim, made
+// ENFORCEABLE rather than asserted.
+//
+// The fix works because every JSON request body in this package reaches the
+// store through decodeJSON/decodeJSONWithLimit. That was true of 65 call
+// sites and false of six, which decoded straight off r.Body and inherited
+// neither the NUL check nor the size cap decodeJSON has always applied. A
+// seventh added later would silently reopen both, and nothing in a diff would
+// point at it — so the invariant is checked here instead of remembered.
+func TestNoJSONBodyDecoderOutsideTheChokepoint(t *testing.T) {
+	// The chokepoint itself reads the body; nothing else in the package may.
+	allowed := map[string]bool{"middleware_request_text.go": true}
+
+	pattern := regexp.MustCompile(`json\.NewDecoder\((r|req)\.Body\)|io\.ReadAll\((r|req)\.Body\)`)
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read package dir: %v", err)
+	}
+	var offenders []string
+	scanned := 0
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		scanned++
+		if allowed[name] {
+			continue
+		}
+		src, err := os.ReadFile(filepath.Join(".", name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		for i, line := range strings.Split(string(src), "\n") {
+			if pattern.MatchString(line) {
+				offenders = append(offenders, name+":"+strconv.Itoa(i+1)+": "+strings.TrimSpace(line))
+			}
+		}
+	}
+
+	// Assert the scan actually looked at something. A test whose search
+	// silently matched no files would pass forever.
+	if scanned < 20 {
+		t.Fatalf("scan looked at only %d non-test .go files; the package is much larger, so the scan is broken", scanned)
+	}
+	if len(offenders) > 0 {
+		t.Errorf("request bodies must be decoded through decodeJSON/decodeJSONWithLimit "+
+			"(BUG-2803: they apply the NUL refusal and the size cap). Found %d direct decoder(s):\n  %s",
+			len(offenders), strings.Join(offenders, "\n  "))
+	}
+}

--- a/internal/server/decode_json_nul_test.go
+++ b/internal/server/decode_json_nul_test.go
@@ -340,8 +340,18 @@ func TestBodyDecodesNULNestedDocuments(t *testing.T) {
 		// check.
 		{"escape spelled obliquely, via an escaped backslash",
 			`{"fields":"{\"k\":\"a` + string([]byte{'\\', 'u', '0', '0', '5', 'c'}) + `u0000b\"}"}`, true},
-		{"twice-encoded — a document inside a document",
-			`{"fields":` + jsonEncode(t, `{"inner":`+jsonEncode(t, innerWithNUL)+`}`) + `}`, true},
+		// Depth 2 under an ORDINARY key is ACCEPTED, and that is a measured
+		// decision rather than a gap: the handler parses `fields` once, so
+		// the inner text is re-escaped when the blob is written and Postgres
+		// never sees an escape. Probed on Postgres 17 with the check
+		// disabled — the same body imports 201. Only the document Postgres
+		// itself parses can carry a fatal one (codex round 7).
+		{"twice-encoded under an ordinary key is safe",
+			`{"fields":` + jsonEncode(t, `{"inner":`+jsonEncode(t, innerWithNUL)+`}`) + `}`, false},
+		// ...but a JSON-ENCODED key INSIDE the document still recurses, so
+		// this is a key rule applied at every level, not a depth limit.
+		{"twice-encoded under a JSON-encoded key still refuses",
+			`{"fields":` + jsonEncode(t, `{"schema":`+jsonEncode(t, innerWithNUL)+`}`) + `}`, true},
 
 		// Controls. These must stay ACCEPTED: the recursion must not turn
 		// "contains the six characters somewhere" into a refusal.

--- a/internal/server/decode_json_nul_test.go
+++ b/internal/server/decode_json_nul_test.go
@@ -850,3 +850,50 @@ func TestArtifactBindableTextAcceptsLiteralEscapeText(t *testing.T) {
 		}
 	}
 }
+
+// TestTestEmailRefusesUnusableBody is the handler-level leg codex round 13
+// found missing. Reverting handlers_admin.go to `err != nil || input.To == ""`
+// — which defaulted EVERY decode failure to the admin's own address — passed
+// every other test in this file, because they only exercise decodeJSON.
+//
+// The distinction being pinned is between two things that used to collapse
+// into one: an ABSENT body legitimately means "send it to me", while a body
+// that is present and REFUSED must not be reinterpreted as that default.
+func TestTestEmailRefusesUnusableBody(t *testing.T) {
+	srv := testServer(t)
+	token := bootstrapFirstUser(t, srv, "admin-mail@example.com", "Admin")
+	mock := mockMailerooEndpoint(t, http.StatusOK, true)
+	configureEmailForTest(srv, mock.URL, "http://localhost:7777")
+
+	post := func(t *testing.T, body string) *httptest.ResponseRecorder {
+		t.Helper()
+		var r io.Reader
+		if body != "" {
+			r = strings.NewReader(body)
+		}
+		req := httptest.NewRequest("POST", "/api/v1/admin/test-email", r)
+		if body != "" {
+			req.Header.Set("Content-Type", "application/json")
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.RemoteAddr = "127.0.0.1:1234"
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+		return rr
+	}
+
+	// Control 1: no body at all still means "send it to me".
+	if rr := post(t, ""); rr.Code != http.StatusOK {
+		t.Fatalf("absent body must still send, got %d: %s", rr.Code, rr.Body.String())
+	}
+	// Control 2: an ordinary body still works.
+	if rr := post(t, `{"to":"someone@example.com"}`); rr.Code != http.StatusOK {
+		t.Fatalf("ordinary body must send, got %d: %s", rr.Code, rr.Body.String())
+	}
+	// The case: a body that is valid JSON but carries an unusable value.
+	rr := post(t, `{"to":"a`+escNULLiteral+`b@example.com"}`)
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("a refused body must answer 400, not be reinterpreted as the default recipient; got %d: %s",
+			rr.Code, rr.Body.String())
+	}
+}

--- a/internal/server/decode_json_nul_test.go
+++ b/internal/server/decode_json_nul_test.go
@@ -254,142 +254,6 @@ func TestEveryRequestBodyReaderIsAccountedFor(t *testing.T) {
 	// BUG-2811 tracks, were entirely invisible to it (codex round 13). A
 	// completeness test with a blind spot is worse than none, because it
 	// reads as coverage.
-	// AST, not a regex. Three defects in the lexical version, all found by
-	// codex round 22, all in the direction that matters for a test whose job
-	// is to say nothing is invisible:
-	//
-	//   - it recognised only the names `r` and `req`, so a handler holding
-	//     its request as `httpReq` or `orig` was INVISIBLE;
-	//   - it matched inside COMMENTS, so prose could make a file look scanned;
-	//   - broadening it to any identifier (my first attempt at this fix)
-	//     matched every unrelated `.Body` field — input.Body, comment.Body,
-	//     fetched.Body — and the only route to green was listing five files
-	//     that read no request body at all, which would then have HIDDEN real
-	//     readers later added to them. A false accounting entry is worse than
-	//     a missing one, so that attempt was abandoned rather than tuned.
-	//
-	// Keying on the TYPE fixes all three: find every identifier declared as
-	// *http.Request in a function signature, then look for reader selectors on
-	// exactly those identifiers. Names are irrelevant, comments are not part
-	// of the AST, and `.Body` on anything else is not a match.
-	readerSelectors := map[string]bool{
-		"Body": true, "FormValue": true, "PostFormValue": true, "ParseForm": true,
-		"ParseMultipartForm": true, "MultipartForm": true, "PostForm": true,
-	}
-	isRequestPtr := func(e ast.Expr) bool {
-		star, ok := e.(*ast.StarExpr)
-		if !ok {
-			return false
-		}
-		sel, ok := star.X.(*ast.SelectorExpr)
-		if !ok || sel.Sel.Name != "Request" {
-			return false
-		}
-		pkg, ok := sel.X.(*ast.Ident)
-		return ok && pkg.Name == "http"
-	}
-	// The scan walks a SCOPE at a time rather than a whole function, because
-	// a single flat name-set is wrong in both directions (codex round 26):
-	//
-	//   - a function literal inside a handler was scanned with the OUTER
-	//     function's request names, so an unrelated inner variable that
-	//     happened to be called `r` was falsely flagged;
-	//   - a request that arrives only as a function literal's own parameter
-	//     was invisible, because literals were never given their own names.
-	//
-	// So each scope inherits its parent's request names, drops any the scope
-	// shadows with a parameter of a different type, and adds its own. Local
-	// aliases (`req := r`) are picked up too, since that is an ordinary thing
-	// for a handler to do and the alias reads the same body.
-	var scanScope func(body *ast.BlockStmt, params *ast.FieldList, inherited map[string]bool) bool
-	scanScope = func(body *ast.BlockStmt, params *ast.FieldList, inherited map[string]bool) bool {
-		if body == nil {
-			return false
-		}
-		reqNames := make(map[string]bool, len(inherited))
-		for k := range inherited {
-			reqNames[k] = true
-		}
-		// A parameter SHADOWS an inherited name whatever its type: if it is a
-		// request the name stays, otherwise the outer meaning is gone.
-		if params != nil {
-			for _, fld := range params.List {
-				isReq := isRequestPtr(fld.Type)
-				for _, nm := range fld.Names {
-					if isReq {
-						reqNames[nm.Name] = true
-					} else {
-						delete(reqNames, nm.Name)
-					}
-				}
-			}
-		}
-
-		found := false
-		var walk func(n ast.Node) bool
-		walk = func(n ast.Node) bool {
-			switch node := n.(type) {
-			case *ast.FuncLit:
-				// Its own scope; do not let the outer names leak in as-is.
-				if scanScope(node.Body, node.Type.Params, reqNames) {
-					found = true
-				}
-				return false
-			case *ast.AssignStmt:
-				// `req := r` and `req = r` alias the same request.
-				for i, rhs := range node.Rhs {
-					id, ok := rhs.(*ast.Ident)
-					if !ok || !reqNames[id.Name] || i >= len(node.Lhs) {
-						continue
-					}
-					if lhs, ok := node.Lhs[i].(*ast.Ident); ok {
-						reqNames[lhs.Name] = true
-					}
-				}
-			case *ast.SelectorExpr:
-				if !readerSelectors[node.Sel.Name] {
-					return true
-				}
-				if id, ok := node.X.(*ast.Ident); ok && reqNames[id.Name] {
-					found = true
-				}
-			}
-			return true
-		}
-		ast.Inspect(body, walk)
-		return found
-	}
-
-	fileReadsRequestBody := func(path string) bool {
-		fset := token.NewFileSet()
-		f, err := parser.ParseFile(fset, path, nil, 0)
-		if err != nil {
-			t.Fatalf("parse %s: %v", path, err)
-		}
-		found := false
-		for _, decl := range f.Decls {
-			fn, ok := decl.(*ast.FuncDecl)
-			if !ok || fn.Body == nil {
-				continue
-			}
-			seed := map[string]bool{}
-			if fn.Recv != nil {
-				for _, fld := range fn.Recv.List {
-					if !isRequestPtr(fld.Type) {
-						continue
-					}
-					for _, nm := range fld.Names {
-						seed[nm.Name] = true
-					}
-				}
-			}
-			if scanScope(fn.Body, fn.Type.Params, seed) {
-				found = true
-			}
-		}
-		return found
-	}
-
 	entries, err := os.ReadDir(".")
 	if err != nil {
 		t.Fatalf("read package dir: %v", err)
@@ -402,7 +266,7 @@ func TestEveryRequestBodyReaderIsAccountedFor(t *testing.T) {
 			continue
 		}
 		scanned++
-		if fileReadsRequestBody(filepath.Join(".", name)) {
+		if scanFileForRequestBodyReads(t, filepath.Join(".", name)) {
 			touches[name] = true
 		}
 	}
@@ -1442,8 +1306,22 @@ func independentDecodesNUL(t *testing.T, raw []byte) bool {
 							if !strings.EqualFold(k, listed) {
 								continue
 							}
+							// Production only descends into a DOCUMENT — a
+							// string whose trimmed form starts with "{" or
+							// "[" (stringIsJSONDocument). A JSON scalar such
+							// as "\"a<escape>b\"" is valid JSON and is NOT a
+							// document, so production leaves it alone. The
+							// oracle unmarshalled anything valid and so said
+							// true where production said false (codex round
+							// 27) — closer to production is not the same as
+							// identical, and only identical is a usable
+							// oracle.
+							trimmed := strings.TrimSpace(sv)
+							if trimmed == "" || (trimmed[0] != '{' && trimmed[0] != '[') {
+								break
+							}
 							var inner any
-							if json.Unmarshal([]byte(sv), &inner) == nil {
+							if json.Unmarshal([]byte(trimmed), &inner) == nil {
 								stack = append(stack, frame{inner, true})
 							}
 							break
@@ -1512,6 +1390,10 @@ func TestBodyDecodesNULAgainstAnIndependentOracle(t *testing.T) {
 		// And its counterpart, where the listed key's value IS a string and
 		// the descent is correct. Both sides must answer TRUE.
 		`{"fields":"{\"k\":\"a` + esc + `b\"}"}`,
+		// A JSON SCALAR under a listed key. Valid JSON, but not a document,
+		// so production does not descend and the escape stays literal text.
+		// Both sides must answer FALSE. The oracle used to say true here.
+		`{"fields":"\"a` + doubled + `b\""}`,
 		`{"title":"a control escape that is not a NUL: \\u0001"}`,
 	}
 
@@ -1536,4 +1418,220 @@ func TestBodyDecodesNULAgainstAnIndependentOracle(t *testing.T) {
 		t.Fatalf("corpus is one-sided (sawTrue=%v sawFalse=%v); agreement over it is vacuous",
 			sawTrue, sawFalse)
 	}
+}
+
+// probeFileHeader is the preamble every synthetic probe file shares.
+var probeFileHeader = "package probe\n\nimport (\n\t\"io\"\n\t\"net/http\"\n)\n\nvar _ = io.ReadAll\n\n"
+
+// TestBodyReaderScanDiscriminates feeds the accounting scan SYNTHETIC source
+// covering the cases that have broken it, instead of only pointing it at the
+// package and trusting the result.
+//
+// Round 27 was right to flag this: the earlier controls were run as throwaway
+// probes and deleted, so nothing in the suite held the scanner to them. A scan
+// whose whole value is a completeness claim needs its own discrimination
+// pinned, or the next rewrite silently loses a case.
+//
+// Both directions matter, and for a reason specific to this instrument. A
+// false NEGATIVE hides a reader. A false POSITIVE is arguably worse: the only
+// way to green a false flag is to add the file to the accounted list, and an
+// accounting entry then hides every FUTURE reader in that file.
+func TestBodyReaderScanDiscriminates(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		want bool
+		src  string
+	}{
+		{"plain handler", true, `
+func h(w http.ResponseWriter, r *http.Request) { io.ReadAll(r.Body) }`},
+		{"unconventional parameter name", true, `
+func h(w http.ResponseWriter, httpReq *http.Request) { io.ReadAll(httpReq.Body) }`},
+		{"closure parameter", true, `
+func h() func(*http.Request) { return func(hr *http.Request) { io.ReadAll(hr.Body) } }`},
+		{"local alias", true, `
+func h(orig *http.Request) { req := orig; io.ReadAll(req.Body) }`},
+		{"value copy still shares the body", true, `
+func h(r *http.Request) { f := func(c http.Request) { io.ReadAll(c.Body) }; f(*r) }`},
+		{"form reader", true, `
+func h(r *http.Request) { _ = r.FormValue("x") }`},
+
+		{"no request at all", false, `
+type payload struct{ Body string }
+
+func h(p payload) int { return len(p.Body) }`},
+		{"shadowed by a closure parameter", false, `
+type other struct{ Body string }
+
+func h(r *http.Request) int { f := func(r other) int { return len(r.Body) }; return f(other{}) }`},
+		{"redefined inside a nested block", false, `
+type resp struct{ Body string }
+
+func h(r *http.Request) int {
+	n := 0
+	{
+		r := resp{}
+		n = len(r.Body)
+	}
+	return n
+}`},
+		{"mentioned only in a comment", false, `
+// This function does not read r.Body, it only talks about it.
+func h(r *http.Request) int { return 1 }`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "probe.go")
+			src := probeFileHeader + tc.src + "\n"
+			if err := os.WriteFile(path, []byte(src), 0o600); err != nil {
+				t.Fatalf("write probe: %v", err)
+			}
+			if got := scanFileForRequestBodyReads(t, path); got != tc.want {
+				t.Errorf("scan = %v, want %v\n--- source ---\n%s", got, tc.want, src)
+			}
+		})
+	}
+}
+
+// scanFileForRequestBodyReads reports whether path contains a function that
+// reads the HTTP request body.
+//
+// Package-level so the accounting test and TestBodyReaderScanDiscriminates
+// drive the SAME scanner. The controls were previously throwaway probes, so
+// nothing in the suite held this to them (codex round 27).
+//
+// AST, not a regex. The lexical version was wrong three ways, all in the
+// direction that matters for a test whose job is to say nothing is invisible:
+// it recognised only the names r and req; it matched inside COMMENTS; and
+// broadening it to any identifier matched every unrelated .Body field, whose
+// only route to green would have been accounting entries for files that read
+// no request body — and an accounting entry HIDES future readers in its file.
+//
+// Scope-aware, because one flat name-set per function is wrong in both
+// directions: a nested scope that rebinds the name was falsely flagged, and a
+// request arriving as a function literal's own parameter was invisible.
+func scanFileForRequestBodyReads(t *testing.T, path string) bool {
+	t.Helper()
+
+	readerSelectors := map[string]bool{
+		"Body": true, "FormValue": true, "PostFormValue": true, "ParseForm": true,
+		"ParseMultipartForm": true, "MultipartForm": true, "PostForm": true,
+	}
+
+	// Both *http.Request and http.Request count. A VALUE copy still shares the
+	// Body — it is an interface holding the same reader — so a literal taking
+	// http.Request reads the same body, and the shadowing rule would otherwise
+	// delete the name and MISS it.
+	isRequestType := func(e ast.Expr) bool {
+		if star, ok := e.(*ast.StarExpr); ok {
+			e = star.X
+		}
+		sel, ok := e.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "Request" {
+			return false
+		}
+		pkg, ok := sel.X.(*ast.Ident)
+		return ok && pkg.Name == "http"
+	}
+
+	var scanScope func(body *ast.BlockStmt, params *ast.FieldList, inherited map[string]bool) bool
+	scanScope = func(body *ast.BlockStmt, params *ast.FieldList, inherited map[string]bool) bool {
+		if body == nil {
+			return false
+		}
+		reqNames := make(map[string]bool, len(inherited))
+		for k := range inherited {
+			reqNames[k] = true
+		}
+		// A parameter SHADOWS an inherited name whatever its type: if it is a
+		// request the name stays, otherwise the outer meaning is gone.
+		if params != nil {
+			for _, fld := range params.List {
+				isReq := isRequestType(fld.Type)
+				for _, nm := range fld.Names {
+					if isReq {
+						reqNames[nm.Name] = true
+					} else {
+						delete(reqNames, nm.Name)
+					}
+				}
+			}
+		}
+
+		found := false
+		ast.Inspect(body, func(n ast.Node) bool {
+			switch node := n.(type) {
+			case *ast.FuncLit:
+				if scanScope(node.Body, node.Type.Params, reqNames) {
+					found = true
+				}
+				return false
+			case *ast.BlockStmt:
+				// A nested block is its own scope. Without this a := inside it
+				// leaked outward, and an inner rebinding such as
+				// { r := &http.Response{}; r.Body.Read(nil) } was FALSELY
+				// flagged as a request read.
+				if node != body {
+					if scanScope(node, nil, reqNames) {
+						found = true
+					}
+					return false
+				}
+			case *ast.AssignStmt:
+				for i, rhs := range node.Rhs {
+					if i >= len(node.Lhs) {
+						break
+					}
+					lhs, ok := node.Lhs[i].(*ast.Ident)
+					if !ok {
+						continue
+					}
+					if id, isIdent := rhs.(*ast.Ident); isIdent && reqNames[id.Name] {
+						// req := r / req = r alias the same request.
+						reqNames[lhs.Name] = true
+						continue
+					}
+					// Binding the name to anything else takes it over for the
+					// rest of this scope.
+					delete(reqNames, lhs.Name)
+				}
+			case *ast.SelectorExpr:
+				if !readerSelectors[node.Sel.Name] {
+					return true
+				}
+				if id, ok := node.X.(*ast.Ident); ok && reqNames[id.Name] {
+					found = true
+				}
+			}
+			return true
+		})
+		return found
+	}
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, path, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	found := false
+	for _, decl := range f.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+		seed := map[string]bool{}
+		if fn.Recv != nil {
+			for _, fld := range fn.Recv.List {
+				if !isRequestType(fld.Type) {
+					continue
+				}
+				for _, nm := range fld.Names {
+					seed[nm.Name] = true
+				}
+			}
+		}
+		if scanScope(fn.Body, fn.Type.Params, seed) {
+			found = true
+		}
+	}
+	return found
 }

--- a/internal/server/decode_json_nul_test.go
+++ b/internal/server/decode_json_nul_test.go
@@ -5,6 +5,9 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -251,7 +254,85 @@ func TestEveryRequestBodyReaderIsAccountedFor(t *testing.T) {
 	// BUG-2811 tracks, were entirely invisible to it (codex round 13). A
 	// completeness test with a blind spot is worse than none, because it
 	// reads as coverage.
-	pattern := regexp.MustCompile(`\b(r|req)\.(Body|FormValue|PostFormValue|ParseForm|ParseMultipartForm|MultipartForm|PostForm)\b`)
+	// AST, not a regex. Three defects in the lexical version, all found by
+	// codex round 22, all in the direction that matters for a test whose job
+	// is to say nothing is invisible:
+	//
+	//   - it recognised only the names `r` and `req`, so a handler holding
+	//     its request as `httpReq` or `orig` was INVISIBLE;
+	//   - it matched inside COMMENTS, so prose could make a file look scanned;
+	//   - broadening it to any identifier (my first attempt at this fix)
+	//     matched every unrelated `.Body` field — input.Body, comment.Body,
+	//     fetched.Body — and the only route to green was listing five files
+	//     that read no request body at all, which would then have HIDDEN real
+	//     readers later added to them. A false accounting entry is worse than
+	//     a missing one, so that attempt was abandoned rather than tuned.
+	//
+	// Keying on the TYPE fixes all three: find every identifier declared as
+	// *http.Request in a function signature, then look for reader selectors on
+	// exactly those identifiers. Names are irrelevant, comments are not part
+	// of the AST, and `.Body` on anything else is not a match.
+	readerSelectors := map[string]bool{
+		"Body": true, "FormValue": true, "PostFormValue": true, "ParseForm": true,
+		"ParseMultipartForm": true, "MultipartForm": true, "PostForm": true,
+	}
+	isRequestPtr := func(e ast.Expr) bool {
+		star, ok := e.(*ast.StarExpr)
+		if !ok {
+			return false
+		}
+		sel, ok := star.X.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "Request" {
+			return false
+		}
+		pkg, ok := sel.X.(*ast.Ident)
+		return ok && pkg.Name == "http"
+	}
+	fileReadsRequestBody := func(path string) bool {
+		fset := token.NewFileSet()
+		f, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		found := false
+		ast.Inspect(f, func(n ast.Node) bool {
+			fn, ok := n.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				return true
+			}
+			reqNames := map[string]bool{}
+			collect := func(fl *ast.FieldList) {
+				if fl == nil {
+					return
+				}
+				for _, fld := range fl.List {
+					if !isRequestPtr(fld.Type) {
+						continue
+					}
+					for _, nm := range fld.Names {
+						reqNames[nm.Name] = true
+					}
+				}
+			}
+			collect(fn.Type.Params)
+			collect(fn.Recv)
+			if len(reqNames) == 0 {
+				return true
+			}
+			ast.Inspect(fn.Body, func(m ast.Node) bool {
+				sel, ok := m.(*ast.SelectorExpr)
+				if !ok || !readerSelectors[sel.Sel.Name] {
+					return true
+				}
+				if id, ok := sel.X.(*ast.Ident); ok && reqNames[id.Name] {
+					found = true
+				}
+				return true
+			})
+			return true
+		})
+		return found
+	}
 
 	entries, err := os.ReadDir(".")
 	if err != nil {
@@ -265,11 +346,7 @@ func TestEveryRequestBodyReaderIsAccountedFor(t *testing.T) {
 			continue
 		}
 		scanned++
-		src, err := os.ReadFile(filepath.Join(".", name))
-		if err != nil {
-			t.Fatalf("read %s: %v", name, err)
-		}
-		if pattern.Match(src) {
+		if fileReadsRequestBody(filepath.Join(".", name)) {
 			touches[name] = true
 		}
 	}
@@ -297,6 +374,20 @@ func TestEveryRequestBodyReaderIsAccountedFor(t *testing.T) {
 				"so it cannot silently cover a future reader added to that file", name, why)
 		}
 	}
+
+	// KNOWN LIMITS, stated because this test's whole value is a completeness
+	// claim, and an unqualified one is how the MCP audit reader came to be
+	// certified safe while persisting a decoded NUL (codex round 20).
+	//
+	//  1. Accounting is per FILE, not per call site. Once a file is listed, a
+	//     NEW reader added to it is covered by the existing entry and this
+	//     test stays green. The reason strings are what a reviewer checks
+	//     against; they are not permanent exemptions.
+	//  2. Only signature-declared requests are seen. A request stashed in a
+	//     struct field or captured by a closure is not a parameter, so this
+	//     scan does not find it.
+	//
+	// Both want per-call-site accounting, which is a different instrument.
 }
 
 // jsonEncode returns s as a JSON string literal — the wire form of a field

--- a/internal/server/decode_json_nul_test.go
+++ b/internal/server/decode_json_nul_test.go
@@ -242,9 +242,16 @@ func TestEveryRequestBodyReaderIsAccountedFor(t *testing.T) {
 		"handlers_cloud.go":          "bodyHasCloudSecret PEEKS at the body and restores it; the real decode still happens through decodeJSON downstream",
 		"middleware_mcp_audit.go":    "audit capture — records the body for the MCP audit log and restores it; decoding still happens in the MCP dispatcher",
 		"handlers_tokens.go":         "a nil/ContentLength check only — it never reads the body",
+		"handlers_oauth.go":          "KNOWN GAP, tracked as BUG-2811: the OAuth handlers read FORM-encoded bodies (r.Form/FormValue), which no rule in this family covers — the transport rules see the query half of r.Form and not the body half. Listed so this test states the gap instead of being blind to it; measuring it needs a fosite-backed fixture.",
 	}
 
-	pattern := regexp.MustCompile(`\b(r|req)\.Body\b`)
+	// FormValue/PostFormValue/ParseForm/ParseMultipartForm read the request
+	// BODY too, and the first version of this scan looked only for .Body — so
+	// it reported full coverage while the OAuth form-body handlers, which
+	// BUG-2811 tracks, were entirely invisible to it (codex round 13). A
+	// completeness test with a blind spot is worse than none, because it
+	// reads as coverage.
+	pattern := regexp.MustCompile(`\b(r|req)\.(Body|FormValue|PostFormValue|ParseForm|ParseMultipartForm|MultipartForm|PostForm)\b`)
 
 	entries, err := os.ReadDir(".")
 	if err != nil {
@@ -562,6 +569,18 @@ func TestTruncateBindableText(t *testing.T) {
 			}
 			if !strings.HasPrefix(tc.s, got) {
 				t.Errorf("result %q is not a prefix of the input", got)
+			}
+			// And it must keep as much as the limit allows. Without this,
+			// an implementation returning "" for every input passes every
+			// assertion above — it is bindable, within the limit, and a
+			// prefix (codex round 13).
+			if len(tc.s) <= tc.limit {
+				if got != tc.s {
+					t.Errorf("input fits the limit and must be returned unchanged, got %q", got)
+				}
+			} else if lost := tc.limit - len(got); lost >= 4 {
+				t.Errorf("dropped %d bytes to respect a %d-byte limit; at most one rune (max 4 bytes) "+
+					"should be lost to the boundary", lost, tc.limit)
 			}
 		})
 	}

--- a/internal/server/decode_json_nul_test.go
+++ b/internal/server/decode_json_nul_test.go
@@ -350,8 +350,11 @@ func TestBodyDecodesNULNestedDocuments(t *testing.T) {
 			`{"fields":` + jsonEncode(t, `{"inner":`+jsonEncode(t, innerWithNUL)+`}`) + `}`, false},
 		// ...but a JSON-ENCODED key INSIDE the document still recurses, so
 		// this is a key rule applied at every level, not a depth limit.
-		{"twice-encoded under a JSON-encoded key still refuses",
-			`{"fields":` + jsonEncode(t, `{"schema":`+jsonEncode(t, innerWithNUL)+`}`) + `}`, true},
+		// ...and a key that LOOKS like a wire key inside caller data is not
+		// one: a collection may declare a user field named `schema`, so the
+		// list is consulted only outside caller data (codex round 8).
+		{"a user field named like a wire key does not restart the descent",
+			`{"fields":` + jsonEncode(t, `{"schema":`+jsonEncode(t, innerWithNUL)+`}`) + `}`, false},
 
 		// Controls. These must stay ACCEPTED: the recursion must not turn
 		// "contains the six characters somewhere" into a refusal.
@@ -453,21 +456,38 @@ func TestJSONEncodedFieldKeysCoversTheModels(t *testing.T) {
 	}
 }
 
-// TestBodyDecodesNULDepthBound pins the behaviour AT the recursion limit:
-// past it the escape is known to be present and the walk has stopped looking,
-// so the body is refused rather than passed uninspected.
-func TestBodyDecodesNULDepthBound(t *testing.T) {
-	// Wrap a NUL-bearing document deeper than the limit allows.
-	// Nested under a JSON-ENCODED key at every level, since that is the only
-	// path the walk descends: nesting under an ordinary key would never start
-	// the recursion and the test would pass for the wrong reason.
-	doc := `{"k":"a` + escNULLiteral + `b"}`
-	for i := 0; i < maxJSONDocumentNesting+2; i++ {
-		doc = `{"fields":` + jsonEncode(t, doc) + `}`
+// TestBodyDecodesNULDescendsExactlyOneLevel replaces an earlier depth-bound
+// test. The walk no longer carries a depth counter, because it no longer
+// needs one: the key list is consulted only outside caller data, so a
+// document reached through a listed key is walked with the list disabled and
+// nothing below it can start a second descent.
+//
+// This pins that property directly rather than pinning a bound, and it is the
+// test that fails if someone reintroduces flag inheritance: an escape one
+// level below the parsed document must be ACCEPTED (measured safe on Postgres
+// — the inner text is re-escaped when the blob is written), while the same
+// escape IN that document must be refused.
+func TestBodyDecodesNULDescendsExactlyOneLevel(t *testing.T) {
+	inner := `{"k":"a` + escNULLiteral + `b"}`
+
+	atTheParsedLayer := `{"fields":` + jsonEncode(t, inner) + `}`
+	if !bodyDecodesNUL([]byte(atTheParsedLayer)) {
+		t.Error("an escape in the document Postgres parses must be refused")
 	}
-	doc = `{"fields":` + jsonEncode(t, doc) + `}`
-	if !bodyDecodesNUL([]byte(doc)) {
-		t.Error("a body nested past maxJSONDocumentNesting must be refused, not passed uninspected")
+
+	oneDeeper := `{"fields":` + jsonEncode(t, `{"inner":`+jsonEncode(t, inner)+`}`) + `}`
+	if bodyDecodesNUL([]byte(oneDeeper)) {
+		t.Error("an escape BELOW the parsed document is safe and must be accepted")
+	}
+
+	// A user field named like a wire key must not restart the descent.
+	shadowed := `{"fields":` + jsonEncode(t, `{"schema":`+jsonEncode(t, inner)+`}`) + `}`
+	if bodyDecodesNUL([]byte(shadowed)) {
+		t.Error("a user field named `schema` inside a fields blob is caller data, not a wire key")
+	}
+	natural := `{"fields":{"schema":` + jsonEncode(t, inner) + `}}`
+	if bodyDecodesNUL([]byte(natural)) {
+		t.Error("a user field named `schema` in a NATURAL fields object is caller data too")
 	}
 }
 
@@ -622,7 +642,7 @@ func TestBodyDecodesNULGateAgreesWithAnUngatedWalk(t *testing.T) {
 		if err := json.Unmarshal(raw, &v); err != nil {
 			return false
 		}
-		return valueDecodesNUL(v, false, 0)
+		return valueDecodesNUL(v, false)
 	}
 
 	esc := escNULLiteral                                     // the six-character NUL escape

--- a/internal/server/decode_json_nul_test.go
+++ b/internal/server/decode_json_nul_test.go
@@ -1389,7 +1389,30 @@ func independentDecodesNUL(t *testing.T, raw []byte) bool {
 					}
 					continue
 				}
-				stack = append(stack, frame{v, f.nested})
+				// A NATURAL object or array under a listed key is USER DATA:
+				// the server marshals it itself and nothing re-parses it, so
+				// a listed key appearing INSIDE it is an ordinary field name,
+				// not a document marker. Production expresses this by passing
+				// inUserData=true; this oracle must too, or the two disagree
+				// on {"fields":{"schema":"...escape text..."}} — production
+				// correctly says no, and an oracle that says yes would fail
+				// the comparison and blame the production walker.
+				//
+				// Measured: before this, production=false / oracle=true on
+				// exactly that body. My corpus omitted it, so the oracle
+				// passed while being wrong (codex round 26). A one-sidedness
+				// check that only asks whether BOTH answers appear does not
+				// catch a corpus that misses a whole branch of the contract.
+				nested := f.nested
+				if !f.nested {
+					for listed := range jsonEncodedFieldKeys {
+						if strings.EqualFold(k, listed) {
+							nested = true
+							break
+						}
+					}
+				}
+				stack = append(stack, frame{v, nested})
 			}
 		}
 	}
@@ -1420,6 +1443,13 @@ func TestBodyDecodesNULAgainstAnIndependentOracle(t *testing.T) {
 		`{"content":"{\"k\":\"a` + esc + `b\"}"}`,
 		`{"title":"unicode é 中"}`,
 		`{"nested":{"deep":{"deeper":"a` + esc + `b"}}}`,
+		// The branch the corpus used to miss entirely: a NATURAL object under
+		// a listed key, carrying escape TEXT that never becomes a NUL because
+		// nothing re-parses it. Both sides must answer FALSE here.
+		`{"fields":{"schema":"{\"k\":\"a` + doubled + `b\"}"}}`,
+		// And its counterpart, where the listed key's value IS a string and
+		// the descent is correct. Both sides must answer TRUE.
+		`{"fields":"{\"k\":\"a` + esc + `b\"}"}`,
 		`{"title":"a control escape that is not a NUL: \\u0001"}`,
 	}
 

--- a/internal/server/decode_json_nul_test.go
+++ b/internal/server/decode_json_nul_test.go
@@ -352,15 +352,18 @@ func TestEveryRequestBodyReaderIsAccountedFor(t *testing.T) {
 	//     NEW reader added to it is covered by the existing entry and this
 	//     test stays green. The reason strings are what a reviewer checks
 	//     against; they are not permanent exemptions.
-	//  2. Only requests reachable by NAME are seen. Closure parameters and
-	//     local aliases (`req := r`) are now covered, and a variable that
-	//     shadows a request name is correctly ignored — all three are pinned
-	//     by controls run against this scanner. Still invisible: a request
-	//     stored in a STRUCT FIELD, one obtained from a context, and one whose
-	//     type reaches http.Request through an alias or an embedded field,
-	//     since this matches the literal `*http.Request` spelling rather than
-	//     resolving types (codex round 26). Closing those means running the
-	//     type checker, not the parser.
+	//  2. Only requests reachable by NAME are seen. Closure parameters, local
+	//     aliases (`req := r`), and dereferenced copies (`c := *r`) are
+	//     covered; a variable that SHADOWS a request name is conservatively
+	//     over-flagged, not ignored — an earlier sentence here claimed the
+	//     opposite while the controls asserted the flagging (codex closing
+	//     round 2). All are pinned by controls run against this scanner.
+	//     Still invisible: a request stored in a STRUCT FIELD, one obtained
+	//     from a context, and one whose type reaches http.Request through an
+	//     alias or an embedded field, since this matches the literal
+	//     `*http.Request` spelling rather than resolving types (codex round
+	//     26). Closing those means running the type checker, not the parser —
+	//     tracked as BUG-2820.
 	//
 	// Both want per-call-site accounting, which is a different instrument.
 }
@@ -1499,6 +1502,8 @@ func h(w http.ResponseWriter, httpReq *http.Request) { io.ReadAll(httpReq.Body) 
 func h() func(*http.Request) { return func(hr *http.Request) { io.ReadAll(hr.Body) } }`},
 		{"local alias", true, `
 func h(orig *http.Request) { req := orig; io.ReadAll(req.Body) }`},
+		{"dereferenced local copy still shares the body", true, `
+func h(r *http.Request) { c := *r; io.ReadAll(c.Body) }`},
 		{"value copy still shares the body", true, `
 func h(r *http.Request) { f := func(c http.Request) { io.ReadAll(c.Body) }; f(*r) }`},
 		{"form reader", true, `
@@ -1686,7 +1691,15 @@ func scanFileForRequestBodyReads(t *testing.T, path string) int {
 				if i >= len(as.Lhs) {
 					break
 				}
-				id, isIdent := rhs.(*ast.Ident)
+				// `req := r` aliases the pointer; `c := *r` copies the VALUE,
+				// and the copy still shares the Body (an interface holding the
+				// same reader) — the second form was invisible until the
+				// closing rounds caught it (codex closing round 2).
+				src := rhs
+				if star, ok := rhs.(*ast.StarExpr); ok {
+					src = star.X
+				}
+				id, isIdent := src.(*ast.Ident)
 				lhs, isLhsIdent := as.Lhs[i].(*ast.Ident)
 				if !isIdent || !isLhsIdent || !reqNames[id.Name] || reqNames[lhs.Name] {
 					continue

--- a/internal/server/decode_json_nul_test.go
+++ b/internal/server/decode_json_nul_test.go
@@ -261,3 +261,134 @@ func TestNoJSONBodyDecoderOutsideTheChokepoint(t *testing.T) {
 			len(offenders), strings.Join(offenders, "\n  "))
 	}
 }
+
+// jsonEncode returns s as a JSON string literal — the wire form of a field
+// that crosses as a JSON-ENCODED STRING (an item's fields, a collection's
+// schema, a workspace's settings). Using encoding/json to build it, rather
+// than hand-writing the backslashes, is deliberate: the escaping rules are
+// the subject under test and hand-written fixtures would pin my reading of
+// them instead of the real ones.
+func jsonEncode(t *testing.T, s string) string {
+	t.Helper()
+	b, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("encode %q: %v", s, err)
+	}
+	return string(b)
+}
+
+// TestBodyDecodesNULNestedDocuments covers codex round 1's P1 on BUG-2803:
+// several fields arrive as JSON-ENCODED STRINGS, so the escape survives the
+// OUTER decode as literal text and reappears when the destination re-parses
+// the string as JSON. Postgres refuses that with SQLSTATE 22P05 (unsupported
+// Unicode escape sequence) rather than the 22021 the rest of this family
+// produces — a different error precisely because the outer string is pure
+// ASCII and never trips the text-encoding check.
+func TestBodyDecodesNULNestedDocuments(t *testing.T) {
+	esc := escNULLiteral
+
+	innerWithNUL := `{"k":"a` + esc + `b"}`       // decodes to a NUL when parsed
+	innerLiteral := `{"k":"a\\` + "u0000" + `b"}` // a doubled backslash: literal text
+	innerPlain := `{"k":"plain"}`
+
+	cases := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"fields as a JSON-encoded string carrying the escape",
+			`{"title":"x","fields":` + jsonEncode(t, innerWithNUL) + `}`, true},
+		{"schema as a JSON-encoded string carrying the escape",
+			`{"name":"c","schema":` + jsonEncode(t, innerWithNUL) + `}`, true},
+		{"settings as a JSON-encoded string carrying the escape",
+			`{"name":"w","settings":` + jsonEncode(t, innerWithNUL) + `}`, true},
+		{"a JSON-encoded ARRAY carrying the escape",
+			`{"tags":` + jsonEncode(t, `["ok","a`+esc+`b"]`) + `}`, true},
+		{"twice-encoded — a document inside a document",
+			`{"fields":` + jsonEncode(t, `{"inner":`+jsonEncode(t, innerWithNUL)+`}`) + `}`, true},
+
+		// Controls. These must stay ACCEPTED: the recursion must not turn
+		// "contains the six characters somewhere" into a refusal.
+		{"fields as a JSON-encoded string, ordinary content",
+			`{"title":"x","fields":` + jsonEncode(t, innerPlain) + `}`, false},
+		{"nested document whose escape is a DOUBLED backslash",
+			`{"fields":` + jsonEncode(t, innerLiteral) + `}`, false},
+		{"a string that starts like JSON but does not parse",
+			`{"content":` + jsonEncode(t, `{"k":"a`+esc+`b"`) + `}`, false},
+		{"prose mentioning the escape is not a JSON document",
+			`{"content":` + jsonEncode(t, `write a NUL as `+esc+` in JSON`) + `}`, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := bodyDecodesNUL([]byte(tc.body)); got != tc.want {
+				t.Errorf("bodyDecodesNUL(%s) = %v, want %v", tc.body, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBodyDecodesNULOverRefusesWholeJSONValues pins a DECISION, not an
+// accident. The nesting test is structural rather than destination-typed, so
+// a plain-text field whose ENTIRE value is a valid JSON document carrying the
+// escape is refused even though its column would have stored it happily.
+//
+// It is here so that the trade is visible and a future change to it is a
+// deliberate act: if someone makes the check destination-typed, this test
+// should be updated, not deleted in passing. See stringIsJSONDocument for why
+// the allow-list alternative was declined.
+func TestBodyDecodesNULOverRefusesWholeJSONValues(t *testing.T) {
+	body := `{"content":` + jsonEncode(t, `{"k":"a`+escNULLiteral+`b"}`) + `}`
+	if !bodyDecodesNUL([]byte(body)) {
+		t.Error("a text field whose whole value is a JSON document carrying the escape " +
+			"is refused by design; if this changed deliberately, update the reasoning at " +
+			"stringIsJSONDocument rather than only this test")
+	}
+}
+
+// TestBodyDecodesNULDepthBound pins the behaviour AT the recursion limit:
+// past it the escape is known to be present and the walk has stopped looking,
+// so the body is refused rather than passed uninspected.
+func TestBodyDecodesNULDepthBound(t *testing.T) {
+	// Wrap a NUL-bearing document deeper than the limit allows.
+	doc := `{"k":"a` + escNULLiteral + `b"}`
+	for i := 0; i < maxJSONDocumentNesting+2; i++ {
+		doc = `{"n":` + jsonEncode(t, doc) + `}`
+	}
+	if !bodyDecodesNUL([]byte(doc)) {
+		t.Error("a body nested past maxJSONDocumentNesting must be refused, not passed uninspected")
+	}
+}
+
+// TestDecodeJSONRefusesNestedNULThroughTheHandler is the wiring leg for the
+// nested case, on SQLite for the same reason as the single-layer one: there
+// the write would SUCCEED, so a green cannot be the database doing the work.
+func TestDecodeJSONRefusesNestedNULThroughTheHandler(t *testing.T) {
+	srv := testServer(t)
+
+	rr := rawJSONRequest(srv, "POST", "/api/v1/workspaces/",
+		`{"name":"Nested","slug":"nested","template":"startup"}`)
+	if rr.Code != http.StatusOK && rr.Code != http.StatusCreated {
+		t.Fatalf("fixture workspace: %d %s", rr.Code, rr.Body.String())
+	}
+	rr = rawJSONRequest(srv, "POST", "/api/v1/workspaces/nested/collections/",
+		`{"name":"Probes","slug":"probes"}`)
+	if rr.Code != http.StatusOK && rr.Code != http.StatusCreated {
+		t.Fatalf("fixture collection: %d %s", rr.Code, rr.Body.String())
+	}
+
+	const itemsPath = "/api/v1/workspaces/nested/collections/probes/items"
+
+	control := rawJSONRequest(srv, "POST", itemsPath,
+		`{"title":"nested control","fields":`+jsonEncode(t, `{"k":"plain"}`)+`}`)
+	if control.Code != http.StatusCreated && control.Code != http.StatusOK {
+		t.Fatalf("control leg must succeed, got %d: %s", control.Code, control.Body.String())
+	}
+
+	bad := rawJSONRequest(srv, "POST", itemsPath,
+		`{"title":"nested probe","fields":`+jsonEncode(t, `{"k":"a`+escNULLiteral+`b"}`)+`}`)
+	if bad.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for a JSON-encoded fields string carrying the escape, got %d: %s",
+			bad.Code, bad.Body.String())
+	}
+}

--- a/internal/server/decode_json_nul_test.go
+++ b/internal/server/decode_json_nul_test.go
@@ -1057,7 +1057,7 @@ func TestBodyDecodesNULMatchesKeysLikeTheDecoder(t *testing.T) {
 
 // TestBodyDecodesNULKnownMapModelDisagreements pins the four measured
 // disagreements between this scan's map[string]any model and encoding/json's
-// typed decode (BUG-2803 rounds 16-17, lead ruling day-68: land-and-follow).
+// typed decode (BUG-2803 rounds 16-17; lead ruling: land-and-follow).
 // They are documented on bodyDecodesNUL; this is the instrument that keeps
 // that documentation and the release note from going stale.
 //

--- a/internal/server/decode_json_nul_test.go
+++ b/internal/server/decode_json_nul_test.go
@@ -480,3 +480,97 @@ func TestDecodeJSONRefusesNestedNULThroughTheHandler(t *testing.T) {
 			bad.Code, bad.Body.String())
 	}
 }
+
+// TestTruncateBindableText covers codex round 5's second class on BUG-2803:
+// a value that PASSED the body check becomes unbindable on its way to the
+// store, because a plain s[:n] can split a rune and leave a partial sequence.
+//
+// The failure is invisible with ASCII fixtures, which is why four review
+// rounds aimed at the input side did not reach it — so these cases are built
+// from multi-byte runes deliberately, and each asserts the OUTPUT is valid
+// UTF-8 rather than merely short.
+func TestTruncateBindableText(t *testing.T) {
+	// é is 2 bytes, 中 is 3, 𝄞 is 4 — one case per continuation length, so a
+	// walk-back that is off by one cannot pass them all.
+	for _, tc := range []struct {
+		name  string
+		s     string
+		limit int
+	}{
+		{"two-byte rune straddling the cut", strings.Repeat("é", 80), 121},
+		{"three-byte rune straddling the cut", strings.Repeat("中", 80), 121},
+		{"four-byte rune straddling the cut", strings.Repeat("𝄞", 80), 121},
+		{"cut exactly on a boundary", strings.Repeat("é", 80), 120},
+		{"ascii", strings.Repeat("a", 300), 120},
+		{"shorter than the limit", "café", 120},
+		{"limit of zero", "café", 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := truncateBindableText(tc.s, tc.limit)
+			if len(got) > tc.limit {
+				t.Errorf("result is %d bytes, over the %d limit", len(got), tc.limit)
+			}
+			// The point of the whole helper: the RESULT must still be
+			// storable. A plain slice fails exactly here.
+			if !bindableText(got) {
+				t.Errorf("result is not bindable text: %q", got)
+			}
+			if !strings.HasPrefix(tc.s, got) {
+				t.Errorf("result %q is not a prefix of the input", got)
+			}
+		})
+	}
+
+	// The counterfactual, stated as a test rather than as a comment: the
+	// naive slice this replaces really does produce unbindable output for the
+	// same input. Without this leg the cases above would pass against an
+	// implementation that simply returned the input unchanged when short —
+	// they would never demonstrate that anything was wrong.
+	s := strings.Repeat("é", 80)
+	if bindableText(s[:121]) {
+		t.Fatal("the fixture cannot reproduce the defect: a plain byte slice of it is still valid UTF-8, " +
+			"so this test would pass against a broken implementation")
+	}
+}
+
+// TestRequestUserAgentIsBindableText covers codex round 5's third class on
+// BUG-2803: the User-Agent header reaches activities.user_agent and
+// sessions.user_agent as text, and no rule in this file sees a header.
+//
+// The disposition here is SANITISE, not refuse — a header is metadata this
+// server chose to record, not something the caller asked for, so a malformed
+// one must not turn a fine request into a 400. That difference from every
+// other check in this file is the thing worth pinning.
+func TestRequestUserAgentIsBindableText(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		ua   string
+		want string
+	}{
+		{"ordinary", "pad-cli/1.0", "pad-cli/1.0"},
+		{"non-ascii is preserved", "café/1.0 中", "café/1.0 中"},
+		{"invalid UTF-8 is dropped", "pad\xffcli", "padcli"},
+		{"NUL is dropped", "pad\x00cli", "padcli"},
+		{"empty stays empty", "", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/", nil)
+			req.Header.Set("User-Agent", tc.ua)
+			got := requestUserAgent(req)
+			if got != tc.want {
+				t.Errorf("requestUserAgent = %q, want %q", got, tc.want)
+			}
+			if !bindableText(got) {
+				t.Errorf("result is not bindable text: %q", got)
+			}
+		})
+	}
+
+	// The counterfactual: the raw header really is unbindable, so these cases
+	// would not pass against a helper that simply returned it unchanged.
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("User-Agent", "pad\xffcli")
+	if bindableText(req.Header.Get("User-Agent")) {
+		t.Fatal("the fixture cannot reproduce the defect: the raw header is already bindable text")
+	}
+}

--- a/internal/server/decode_json_nul_test.go
+++ b/internal/server/decode_json_nul_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"io"
@@ -348,6 +349,18 @@ func TestBodyDecodesNULNestedDocuments(t *testing.T) {
 			`{"title":"x","fields":` + jsonEncode(t, innerPlain) + `}`, false},
 		{"nested document whose escape is a DOUBLED backslash",
 			`{"fields":` + jsonEncode(t, innerLiteral) + `}`, false},
+		// codex round 6: these fields also accept their NATURAL shape, in
+		// which the elements are ordinary strings the server marshals itself.
+		// Nothing re-parses them, so an element that merely LOOKS like a
+		// document must not be treated as one — this refused a free-form tag
+		// whose whole value happened to be JSON.
+		{"tags as a natural ARRAY whose element is a JSON document",
+			`{"title":"x","tags":["release",` + jsonEncode(t, innerWithNUL) + `]}`, false},
+		{"fields as a natural OBJECT whose value is a JSON document",
+			`{"title":"x","fields":{"k":` + jsonEncode(t, innerWithNUL) + `}}`, false},
+		// ...while the JSON-ENCODED spelling of the same field still is.
+		{"tags as a JSON-encoded STRING carrying the escape",
+			`{"title":"x","tags":` + jsonEncode(t, `["a`+esc+`b"]`) + `}`, true},
 		{"a string that starts like JSON but does not parse",
 			`{"content":` + jsonEncode(t, `{"k":"a`+esc+`b"`) + `}`, false},
 		{"prose mentioning the escape is not a JSON document",
@@ -572,5 +585,155 @@ func TestRequestUserAgentIsBindableText(t *testing.T) {
 	req.Header.Set("User-Agent", "pad\xffcli")
 	if bindableText(req.Header.Get("User-Agent")) {
 		t.Fatal("the fixture cannot reproduce the defect: the raw header is already bindable text")
+	}
+}
+
+// TestBodyDecodesNULGateAgreesWithAnUngatedWalk is the instrument that keeps
+// the fast path honest.
+//
+// The gate is an argument, not an observation: to manufacture the
+// six-character NUL escape inside a decoded string, every one of its
+// characters must arrive either literally from the raw bytes — in which case
+// the raw contains the escape, which begins with \u00 — or from a \u escape
+// of its own, and the three characters involved (backslash U+005C, 'u'
+// U+0075, '0' U+0030) all sit below U+0100, so every such escape also begins
+// with \u00. Hence: no \u00 in the raw bytes, no NUL at any depth, however
+// spelled.
+//
+// The FIRST version of that argument was wrong in exactly this way — it said
+// "the escape has only one spelling", which is true inside a decoded string
+// and false of the raw bytes, and codex round 4 turned that into a live
+// bypass. So the argument does not get to stand on its own reasoning: this
+// test runs the gated function against an UNGATED walk over a corpus built to
+// attack it, and any disagreement is a bypass.
+func TestBodyDecodesNULGateAgreesWithAnUngatedWalk(t *testing.T) {
+	ungated := func(raw []byte) bool {
+		var v any
+		if err := json.Unmarshal(raw, &v); err != nil {
+			return false
+		}
+		return valueDecodesNUL(v, false, 0)
+	}
+
+	esc := escNULLiteral                                     // the six-character NUL escape
+	bs := string([]byte{'\\', 'u', '0', '0', '5', 'c'})      // escapes to a BACKSLASH
+	bsUpper := string([]byte{'\\', 'u', '0', '0', '5', 'C'}) // same, upper-case hex
+	uEsc := string([]byte{'\\', 'u', '0', '0', '7', '5'})    // escapes to the letter u
+	zero := string([]byte{'\\', 'u', '0', '0', '3', '0'})    // escapes to the digit 0
+	doubled := `\\` + "u0000"                                // literal text, no NUL
+
+	corpus := []string{
+		`{"title":"plain"}`,
+		`{"title":"quotes \" and a backslash \\ but no escape"}`,
+		`{"fields":"{\"k\":\"plain\"}"}`,
+		`{"fields":"{\"k\":\"a` + esc + `b\"}"}`,
+		`{"fields":"{\"k\":\"a` + bs + `u0000b\"}"}`,
+		`{"fields":"{\"k\":\"a` + bsUpper + `u0000b\"}"}`,
+		`{"fields":"{\"k\":\"a\\` + uEsc + `0000b\"}"}`,
+		`{"fields":"{\"k\":\"a\\u00` + zero + `0b\"}"}`,
+		`{"fields":"{\"k\":\"a` + doubled + `b\"}"}`,
+		`{"content":"{\"k\":\"a` + esc + `b\"}"}`,
+		`{"title":"a` + esc + `b"}`,
+		`{"a` + esc + `b":"key"}`,
+		`{"tags":["ok","a` + esc + `b"]}`,
+		`{"fields":"[1,2,\"a` + esc + `b\"]"}`,
+		`{"title":"unicode é 中"}`,
+		`{"title":"a control escape that is not a NUL: \\u0001"}`,
+		`{"fields":"{\"k\":\"ab\"}"}`,
+	}
+
+	for i, body := range corpus {
+		got, want := bodyDecodesNUL([]byte(body)), ungated([]byte(body))
+		if got != want {
+			t.Errorf("corpus[%d] %s\n  gated=%v ungated=%v — the fast path is a BYPASS for this input",
+				i, body, got, want)
+		}
+	}
+
+	// The corpus must contain both answers, or agreement proves nothing.
+	var trues, falses int
+	for _, body := range corpus {
+		if ungated([]byte(body)) {
+			trues++
+		} else {
+			falses++
+		}
+	}
+	if trues < 3 || falses < 3 {
+		t.Fatalf("corpus is one-sided (%d refuse, %d accept); agreement would be vacuous", trues, falses)
+	}
+}
+
+// TestDocumentActivityStoresBindableUserAgent is the WIRING leg for the
+// User-Agent sanitiser (CONVE-19, and codex round 6's second finding: a unit
+// test vouches for the helper, not for anything calling it).
+//
+// It drives a real request through the router with a malformed header and
+// reads the STORED value out of the activities row, so reverting the
+// production call site fails this even though the helper still works.
+//
+// It targets the ACTIVITY sink deliberately. The round-5 enumeration also
+// named "sessions.user_agent", and I wired the three login paths to the
+// sanitiser before reading store.CreateSession — which HASHES the header and
+// stores no text at all. That change was reverted: login would have stored
+// sha256(sanitised) while middleware_auth still compares sha256(RAW),
+// breaking session validation for any client with a non-UTF-8 User-Agent.
+// A sink named in a review is a pointer to verify, not a finding.
+func TestDocumentActivityStoresBindableUserAgent(t *testing.T) {
+	srv := testServer(t)
+	ws := createWSForTest(t, srv)
+
+	post := func(t *testing.T, ua, title string) {
+		t.Helper()
+		body, _ := json.Marshal(map[string]any{"title": title})
+		req := httptest.NewRequest("POST", "/api/v1/workspaces/"+ws+"/documents/", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("User-Agent", ua)
+		req.RemoteAddr = "192.0.2.1:1234"
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+		if rr.Code != http.StatusOK && rr.Code != http.StatusCreated {
+			t.Fatalf("create document = %d: %s", rr.Code, rr.Body.String())
+		}
+	}
+
+	// Control first: an ordinary header must be stored VERBATIM, so a
+	// sanitiser that mangled everything would fail here rather than pass.
+	post(t, "pad-cli/1.0 café", "control doc")
+	post(t, "pad-cli/1.0 bad\xffbyte\x00here", "probe doc")
+
+	rows, err := srv.store.DB().Query(`SELECT user_agent FROM activities WHERE user_agent IS NOT NULL`)
+	if err != nil {
+		t.Fatalf("read activities: %v", err)
+	}
+	defer rows.Close()
+
+	var seenControl, seenSanitised int
+	for rows.Next() {
+		var ua sql.NullString
+		if err := rows.Scan(&ua); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		if !ua.Valid {
+			continue
+		}
+		if !bindableText(ua.String) {
+			t.Errorf("a stored activity user_agent is not bindable text: %q", ua.String)
+		}
+		switch ua.String {
+		case "pad-cli/1.0 café":
+			seenControl++
+		case "pad-cli/1.0 badbytehere":
+			seenSanitised++
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows: %v", err)
+	}
+	if seenControl == 0 {
+		t.Error("the control header was not stored verbatim — the sanitiser is doing too much")
+	}
+	if seenSanitised == 0 {
+		t.Error("no activity carries the sanitised header; the call site is not wired to requestUserAgent")
 	}
 }

--- a/internal/server/decode_json_nul_test.go
+++ b/internal/server/decode_json_nul_test.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"strconv"
 	"strings"
 	"testing"
 )
@@ -209,26 +208,46 @@ func TestDecodeJSONKeepsEmptyBodyEOF(t *testing.T) {
 	}
 }
 
-// TestNoJSONBodyDecoderOutsideTheChokepoint is the completeness claim, made
-// ENFORCEABLE rather than asserted.
+// TestEveryRequestBodyReaderIsAccountedFor is the completeness claim, made
+// ENFORCEABLE rather than asserted — and made honest after codex round 3
+// showed the first version could not see past two exact call shapes.
 //
-// The fix works because every JSON request body in this package reaches the
-// store through decodeJSON/decodeJSONWithLimit. That was true of 65 call
-// sites and false of six, which decoded straight off r.Body and inherited
-// neither the NUL check nor the size cap decodeJSON has always applied. A
-// seventh added later would silently reopen both, and nothing in a diff would
-// point at it — so the invariant is checked here instead of remembered.
-func TestNoJSONBodyDecoderOutsideTheChokepoint(t *testing.T) {
-	// The chokepoint itself reads the body; nothing else in the package may.
-	allowed := map[string]bool{"middleware_request_text.go": true}
+// The fix works because a JSON request body reaches the store through
+// decodeJSON/decodeJSONWithLimit, which refuse a decoded NUL and apply a size
+// cap. The first version of this test scanned for `json.NewDecoder(r.Body)`
+// and `io.ReadAll(r.Body)` only, so it was blind to
+// `io.ReadAll(io.LimitReader(r.Body, n))` — a shape ALREADY PRESENT in the
+// package — and to any alias, helper or future spelling. A completeness test
+// that misses a live example is worse than none: it reads as coverage.
+//
+// So it now scans for the thing that cannot be spelled around — a reference to
+// the request body at all — and requires every FILE that touches one to be
+// accounted for here with a reason. A new body reader fails this test until
+// someone writes down what it does, which is the point: the decision becomes
+// deliberate instead of invisible.
+//
+// It asserts BOTH directions. An unaccounted file fails, because a door may
+// have opened. An accounted file that no longer touches a body ALSO fails, so
+// the list cannot rot into a set of stale excuses that quietly permits a
+// future reader added to the same file.
+func TestEveryRequestBodyReaderIsAccountedFor(t *testing.T) {
+	accounted := map[string]string{
+		"middleware_request_text.go": "the chokepoint itself: readBodyForDecode reads the body under the caller's cap so bodyDecodesNUL can scan it",
+		"handlers_import_bundle.go":  "tar.gz bundle import — streams the body through gzip, and its pad-export.json is checked with bodyDecodesNUL before ImportWorkspace",
+		"handlers_attachments.go":    "multipart upload — the body is binary blob content, not text, and must NOT be scanned for text validity",
+		"artifact_import.go":         "raw artifact TEXT (not JSON) — checked with bindableText, the same predicate ValidatePath and ValidateQuery apply",
+		"handlers_cloud.go":          "bodyHasCloudSecret PEEKS at the body and restores it; the real decode still happens through decodeJSON downstream",
+		"middleware_mcp_audit.go":    "audit capture — records the body for the MCP audit log and restores it; decoding still happens in the MCP dispatcher",
+		"handlers_tokens.go":         "a nil/ContentLength check only — it never reads the body",
+	}
 
-	pattern := regexp.MustCompile(`json\.NewDecoder\((r|req)\.Body\)|io\.ReadAll\((r|req)\.Body\)`)
+	pattern := regexp.MustCompile(`\b(r|req)\.Body\b`)
 
 	entries, err := os.ReadDir(".")
 	if err != nil {
 		t.Fatalf("read package dir: %v", err)
 	}
-	var offenders []string
+	touches := map[string]bool{}
 	scanned := 0
 	for _, e := range entries {
 		name := e.Name()
@@ -236,29 +255,37 @@ func TestNoJSONBodyDecoderOutsideTheChokepoint(t *testing.T) {
 			continue
 		}
 		scanned++
-		if allowed[name] {
-			continue
-		}
 		src, err := os.ReadFile(filepath.Join(".", name))
 		if err != nil {
 			t.Fatalf("read %s: %v", name, err)
 		}
-		for i, line := range strings.Split(string(src), "\n") {
-			if pattern.MatchString(line) {
-				offenders = append(offenders, name+":"+strconv.Itoa(i+1)+": "+strings.TrimSpace(line))
-			}
+		if pattern.Match(src) {
+			touches[name] = true
 		}
 	}
 
-	// Assert the scan actually looked at something. A test whose search
-	// silently matched no files would pass forever.
+	// The scan must have looked at something, and must have FOUND something.
+	// A pattern that silently matched nothing would pass forever.
 	if scanned < 20 {
 		t.Fatalf("scan looked at only %d non-test .go files; the package is much larger, so the scan is broken", scanned)
 	}
-	if len(offenders) > 0 {
-		t.Errorf("request bodies must be decoded through decodeJSON/decodeJSONWithLimit "+
-			"(BUG-2803: they apply the NUL refusal and the size cap). Found %d direct decoder(s):\n  %s",
-			len(offenders), strings.Join(offenders, "\n  "))
+	if len(touches) < 3 {
+		t.Fatalf("scan found only %d files touching a request body; the pattern is broken", len(touches))
+	}
+
+	for name := range touches {
+		if _, ok := accounted[name]; !ok {
+			t.Errorf("%s reads the request body but is not accounted for in this test. "+
+				"A body carrying JSON must go through decodeJSON/decodeJSONWithLimit, which apply "+
+				"BUG-2803's NUL refusal and the size cap. If this reader is legitimate, add it here WITH "+
+				"the reason it is safe.", name)
+		}
+	}
+	for name, why := range accounted {
+		if !touches[name] {
+			t.Errorf("%s is accounted for here (%q) but no longer reads a request body — remove the entry "+
+				"so it cannot silently cover a future reader added to that file", name, why)
+		}
 	}
 }
 

--- a/internal/server/decode_json_nul_test.go
+++ b/internal/server/decode_json_nul_test.go
@@ -331,6 +331,14 @@ func TestBodyDecodesNULNestedDocuments(t *testing.T) {
 			`{"name":"w","settings":` + jsonEncode(t, innerWithNUL) + `}`, true},
 		{"a JSON-encoded ARRAY carrying the escape",
 			`{"tags":` + jsonEncode(t, `["ok","a`+esc+`b"]`) + `}`, true},
+		// codex round 4: the BACKSLASH itself can be written as an escape, so
+		// the raw body carries no literal six-character sequence anywhere
+		// while the outer decode manufactures one inside the nested document.
+		// This is the case the old substring fast path let through — measured
+		// as a 201 through the real router before the gate became a backslash
+		// check.
+		{"escape spelled obliquely, via an escaped backslash",
+			`{"fields":"{\"k\":\"a` + string([]byte{'\\', 'u', '0', '0', '5', 'c'}) + `u0000b\"}"}`, true},
 		{"twice-encoded — a document inside a document",
 			`{"fields":` + jsonEncode(t, `{"inner":`+jsonEncode(t, innerWithNUL)+`}`) + `}`, true},
 

--- a/internal/server/decode_json_nul_test.go
+++ b/internal/server/decode_json_nul_test.go
@@ -267,6 +267,7 @@ func TestEveryRequestBodyReaderIsAccountedFor(t *testing.T) {
 		"middleware_mcp_audit.go":    "audit capture — parses the body ITSELF and binds the decoded method / params.name to mcp_audit_log.tool_name, so it is a second READER, not a pass-through. That the MCP dispatcher decodes the body again is true and says nothing about what this middleware persists — the earlier rationale here made exactly that mistake and certified it safe (codex round 20). parseMCPRequestBody now runs both caller-derived returns through sanitiseStoredText",
 		"handlers_tokens.go":         "guards on r.Body != nil && r.ContentLength != 0, then decodes THROUGH decodeJSON — so the body is read by the chokepoint, which applies the cap and the NUL rule. The earlier reason here said it never reads the body, which was simply false (codex round 29): a wrong reason in this list is the same defect as a missing entry, since both let a reader pass as reviewed",
 		"handlers_oauth.go":          "KNOWN GAP, tracked as BUG-2811: the OAuth handlers read FORM-encoded bodies (r.Form/FormValue), which no rule in this family covers — the transport rules see the query half of r.Form and not the body half. Listed so this test states the gap instead of being blind to it; measuring it needs a fosite-backed fixture.",
+		"handlers_watches.go":        "guards on r.Body != nil && r.ContentLength != 0, then decodes THROUGH decodeJSON — the closing-round-4 fix for the chunked-body drop; the one reader expression is the nil check itself, and the body bytes flow through the chokepoint",
 	}
 
 	// Reader counts as reviewed. A mismatch means this file gained or lost a
@@ -285,6 +286,7 @@ func TestEveryRequestBodyReaderIsAccountedFor(t *testing.T) {
 		"middleware_mcp_audit.go":    7,
 		"handlers_tokens.go":         1,
 		"handlers_oauth.go":          13,
+		"handlers_watches.go":        1,
 	}
 	accounted := map[string]entry{}
 	for name, why := range accountedWhy {
@@ -670,8 +672,11 @@ func TestTruncateBindableText(t *testing.T) {
 }
 
 // TestRequestUserAgentIsBindableText covers codex round 5's third class on
-// BUG-2803: the User-Agent header reaches activities.user_agent and
-// sessions.user_agent as text, and no rule in this file sees a header.
+// BUG-2803: the User-Agent header reaches activities.user_agent as text, and
+// no rule in this file sees a header. (Sessions are NOT a text sink — they
+// store only ua_hash, which is why the accounting list above exempts those
+// reads; an earlier version of this sentence claimed sessions.user_agent
+// stored text, contradicting that exemption — codex closing round 4.)
 //
 // The disposition here is SANITISE, not refuse — a header is metadata this
 // server chose to record, not something the caller asked for, so a malformed

--- a/internal/server/decode_json_nul_test.go
+++ b/internal/server/decode_json_nul_test.go
@@ -1035,7 +1035,11 @@ func TestOAuthRegisterRefusesNULBody(t *testing.T) {
 // Measured before the fix: `fields` refused, `Fields` and `FIELDS` accepted.
 func TestBodyDecodesNULMatchesKeysLikeTheDecoder(t *testing.T) {
 	inner := `{"k":"a` + escNULLiteral + `b"}`
-	for _, key := range []string{"fields", "Fields", "FIELDS", "fIeLdS", "Schema", "TAGS"} {
+	// The last two are Unicode simple-fold spellings: encoding/json matches
+	// them to the same struct field, and lower-casing does NOT (codex round
+	// 17). U+017F LONG S folds to 's'; U+212A KELVIN SIGN folds to 'k'.
+	for _, key := range []string{"fields", "Fields", "FIELDS", "fIeLdS", "Schema", "TAGS",
+		"\u017Fchema", "\u017FCHEMA"} {
 		body := `{"title":"x","` + key + `":` + jsonEncode(t, inner) + `}`
 		if !bodyDecodesNUL([]byte(body)) {
 			t.Errorf("key %q reaches the same struct field as its lower-case spelling and must be "+

--- a/internal/server/decode_json_nul_test.go
+++ b/internal/server/decode_json_nul_test.go
@@ -1024,3 +1024,29 @@ func TestOAuthRegisterRefusesNULBody(t *testing.T) {
 		t.Errorf("the refusal should name the cause, got %s", rr.Body.String())
 	}
 }
+
+// TestBodyDecodesNULMatchesKeysLikeTheDecoder is codex round 16: encoding/json
+// matches an incoming key to a struct field by an exact match first and a
+// CASE-INSENSITIVE one otherwise, so `{"Fields":...}` lands in
+// ItemCreate.Fields exactly as `{"fields":...}` does. A case-sensitive lookup
+// in the walk skipped the nested check for a body the handler then accepted,
+// and the database answered the original 500.
+//
+// Measured before the fix: `fields` refused, `Fields` and `FIELDS` accepted.
+func TestBodyDecodesNULMatchesKeysLikeTheDecoder(t *testing.T) {
+	inner := `{"k":"a` + escNULLiteral + `b"}`
+	for _, key := range []string{"fields", "Fields", "FIELDS", "fIeLdS", "Schema", "TAGS"} {
+		body := `{"title":"x","` + key + `":` + jsonEncode(t, inner) + `}`
+		if !bodyDecodesNUL([]byte(body)) {
+			t.Errorf("key %q reaches the same struct field as its lower-case spelling and must be "+
+				"walked the same way", key)
+		}
+	}
+
+	// Control: a key that is not a wire key in ANY casing stays caller data,
+	// so this is case-insensitive matching rather than matching everything.
+	notAKey := `{"title":"x","Notes":` + jsonEncode(t, inner) + `}`
+	if bodyDecodesNUL([]byte(notAKey)) {
+		t.Error("an unlisted key must not be treated as JSON-encoded whatever its casing")
+	}
+}

--- a/internal/server/decode_json_nul_test.go
+++ b/internal/server/decode_json_nul_test.go
@@ -359,11 +359,14 @@ func TestEveryRequestBodyReaderIsAccountedFor(t *testing.T) {
 	//     opposite while the controls asserted the flagging (codex closing
 	//     round 2). All are pinned by controls run against this scanner.
 	//     Still invisible: a request stored in a STRUCT FIELD, one obtained
-	//     from a context, and one whose type reaches http.Request through an
-	//     alias or an embedded field, since this matches the literal
-	//     `*http.Request` spelling rather than resolving types (codex round
-	//     26). Closing those means running the type checker, not the parser —
-	//     tracked as BUG-2820.
+	//     from a context, one whose type reaches http.Request through an
+	//     alias or an embedded field, and the ordinary alias forms the
+	//     fixed-point does not walk — a `var req = r` declaration, a
+	//     call-derived alias (`req := r.WithContext(ctx)`), named results,
+	//     and range bindings — since this matches literal spellings rather
+	//     than resolving types (codex rounds 26/29, closing round 3).
+	//     Closing the class means running the type checker, not another
+	//     parser patch — tracked as BUG-2820, which enumerates these forms.
 	//
 	// Both want per-call-site accounting, which is a different instrument.
 }
@@ -1038,11 +1041,20 @@ func TestTextSafeHelpersAreUsedAtEveryCallSite(t *testing.T) {
 		}
 	}
 
-	if safeTruncateUses < 4 {
-		t.Errorf("found only %d truncateBindableText call sites; the scan or the wiring is broken", safeTruncateUses)
+	// Exact counts, not lower bounds — a floor let a real call site vanish
+	// while the threshold stayed satisfied (codex closing round 3). Each
+	// total includes the helper's own declaration (the scan counts raw
+	// occurrences), so today that is 1 declaration + 4 call sites for each.
+	// MEASURED against this package, same discipline as the reader counts
+	// above: a changed number is the signal to re-justify, in either
+	// direction.
+	if safeTruncateUses != 5 {
+		t.Errorf("truncateBindableText occurrences = %d, want 5 (1 declaration + 4 call sites); "+
+			"a site was added or removed — re-justify and re-pin", safeTruncateUses)
 	}
-	if safeUAUses < 4 {
-		t.Errorf("found only %d requestUserAgent call sites; the scan or the wiring is broken", safeUAUses)
+	if safeUAUses != 5 {
+		t.Errorf("requestUserAgent occurrences = %d, want 5 (1 declaration + 4 call sites); "+
+			"a site was added or removed — re-justify and re-pin", safeUAUses)
 	}
 }
 

--- a/internal/server/decode_json_nul_test.go
+++ b/internal/server/decode_json_nul_test.go
@@ -1181,3 +1181,52 @@ func TestUnknownFieldRefusalThroughTheHandler(t *testing.T) {
 		t.Errorf("the 400 should name the cause, got: %s", got.Body.String())
 	}
 }
+
+// TestDecodeJSONTrimsOnlyJSONWhitespace pins that the empty-body shortcut uses
+// JSON's whitespace set, not Go's (codex round 22).
+//
+// bytes.TrimSpace uses unicode.IsSpace, which strips \v, \f, U+00A0 and more.
+// encoding/json accepts none of those. So a body of just "\v" trimmed to
+// EMPTY here and returned io.EOF, and an EOF-tolerant caller — playbook run
+// treats errors.Is(err, io.EOF) as "no arguments supplied" and runs anyway —
+// took a syntactically invalid body for an ABSENT one.
+//
+// The four legs matter in pairs: real JSON whitespace must still shortcut to
+// EOF (or the playbook contract breaks), and non-JSON whitespace must NOT (or
+// the divergence is still there).
+func TestDecodeJSONTrimsOnlyJSONWhitespace(t *testing.T) {
+	srv := testServer(t)
+
+	for _, tc := range []struct {
+		name    string
+		body    string
+		wantEOF bool
+	}{
+		{"space and tab and newline", " \t\r\n", true},
+		{"empty", "", true},
+		{"vertical tab", "\v", false},
+		{"form feed", "\f", false},
+		{"non-breaking space", "\u00a0", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var v map[string]any
+			req := httptest.NewRequest("POST", "/x", strings.NewReader(tc.body))
+			err := decodeJSON(req, &v)
+			if err == nil {
+				t.Fatalf("expected an error for body %q", tc.body)
+			}
+			gotEOF := errors.Is(err, io.EOF)
+			if gotEOF != tc.wantEOF {
+				if tc.wantEOF {
+					t.Errorf("body %q is JSON whitespace and must read as an ABSENT body (io.EOF), "+
+						"or the playbook-run empty-body contract breaks; got %v", tc.body, err)
+				} else {
+					t.Errorf("body %q is NOT JSON whitespace — encoding/json would reject it — so it "+
+						"must NOT be reported as an absent body; an EOF-tolerant caller would proceed "+
+						"on invalid input. got io.EOF", tc.body)
+				}
+			}
+		})
+	}
+	_ = srv
+}

--- a/internal/server/handlers_admin.go
+++ b/internal/server/handlers_admin.go
@@ -2,7 +2,9 @@ package server
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 
 	"github.com/PerpetualSoftware/pad/internal/models"
@@ -182,7 +184,19 @@ func (s *Server) handleTestEmail(w http.ResponseWriter, r *http.Request) {
 	var input struct {
 		To string `json:"to"`
 	}
-	if err := decodeJSON(r, &input); err != nil || input.To == "" {
+	// An ABSENT or empty body means "send it to me" — the endpoint is
+	// deliberately callable with no payload. A body that is present and
+	// REFUSED is a different thing and must not be silently reinterpreted as
+	// that default: collapsing the two swallowed BUG-2803's refusal, so a
+	// request carrying a NUL answered 200 (codex round 3).
+	if err := decodeJSON(r, &input); err != nil {
+		if !errors.Is(err, io.EOF) {
+			writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+			return
+		}
+		input.To = ""
+	}
+	if input.To == "" {
 		// Default to the admin's own email
 		input.To = user.Email
 	}

--- a/internal/server/handlers_artifact_import.go
+++ b/internal/server/handlers_artifact_import.go
@@ -341,8 +341,11 @@ func writeArtifactParseError(w http.ResponseWriter, err error) {
 		writeError(w, http.StatusRequestEntityTooLarge, "too_large",
 			"Artifact body exceeds the size limit")
 	case errors.Is(err, ErrArtifactUnbindableText):
+		// "character", not "byte": the same refusal fires for a NUL
+		// manufactured by a YAML escape during parsing, where no raw NUL
+		// byte exists in the body (codex closing round 4).
 		writeError(w, http.StatusBadRequest, "invalid_body",
-			"Artifact body contains invalid UTF-8 or a NUL byte")
+			"Artifact body contains invalid UTF-8 or a NUL character")
 	case errors.Is(err, ErrArtifactUnsafeYAML):
 		writeError(w, http.StatusBadRequest, "unsafe_yaml",
 			"Artifact frontmatter was rejected by the import safety limits")

--- a/internal/server/handlers_artifact_import.go
+++ b/internal/server/handlers_artifact_import.go
@@ -340,6 +340,9 @@ func writeArtifactParseError(w http.ResponseWriter, err error) {
 	case errors.Is(err, ErrArtifactTooLarge):
 		writeError(w, http.StatusRequestEntityTooLarge, "too_large",
 			"Artifact body exceeds the size limit")
+	case errors.Is(err, ErrArtifactUnbindableText):
+		writeError(w, http.StatusBadRequest, "invalid_body",
+			"Artifact body contains invalid UTF-8 or a NUL byte")
 	case errors.Is(err, ErrArtifactUnsafeYAML):
 		writeError(w, http.StatusBadRequest, "unsafe_yaml",
 			"Artifact frontmatter was rejected by the import safety limits")

--- a/internal/server/handlers_artifact_test.go
+++ b/internal/server/handlers_artifact_test.go
@@ -603,6 +603,13 @@ func TestImportArtifactUnbindableTextRejected(t *testing.T) {
 	}{
 		{"NUL byte in the body", []byte(strings.Replace(good, "body", "bo\x00dy", 1))},
 		{"invalid UTF-8 in the body", append([]byte(strings.Replace(good, "body", "bo", 1)), 0xff, '\n')},
+		// codex round 4: YAML has its own escape vocabulary. A double-quoted
+		// scalar carries no NUL in the request bytes — the raw check passes —
+		// and manufactures one during the YAML decode. Measured before the
+		// post-decode check existed: this imported 201 with a NUL in the
+		// title. Same shape as the JSON half, where a value only becomes
+		// dangerous after a SECOND parse.
+		{"YAML-escaped NUL in the title", []byte("---\npad_artifact: convention\nformat_version: 1\ntitle: \"a" + string([]byte{'\\', '0'}) + "b\"\n---\n\nbody\n")},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			rr := doArtifactRequest(srv, "POST", "/api/v1/workspaces/"+ws+"/import-artifact", tc.body)

--- a/internal/server/handlers_artifact_test.go
+++ b/internal/server/handlers_artifact_test.go
@@ -609,6 +609,18 @@ func TestImportArtifactUnbindableTextRejected(t *testing.T) {
 		// post-decode check existed: this imported 201 with a NUL in the
 		// title. Same shape as the JSON half, where a value only becomes
 		// dangerous after a SECOND parse.
+		// codex round 8: the first version of the post-decode check walked
+		// the artifact by TYPE and missed two reachable fields — arguments,
+		// whose declared type []map[string]any never matched the walk's
+		// []any case, and provenance, whose strings are rendered into a
+		// footer appended to the stored content. The check now marshals the
+		// artifact and searches the output, so every field is covered.
+		{"YAML-escaped NUL inside a playbook argument", []byte(
+			"---\npad_artifact: playbook\nformat_version: 1\ntitle: Args\narguments:\n  - name: \"a" +
+				string([]byte{'\\', '0'}) + "b\"\n    type: string\n---\n\nbody\n")},
+		{"YAML-escaped NUL in provenance", []byte(
+			"---\npad_artifact: convention\nformat_version: 1\ntitle: Prov\nprovenance:\n  workspace: \"a" +
+				string([]byte{'\\', '0'}) + "b\"\n  author: someone\n---\n\nbody\n")},
 		{"YAML-escaped NUL in the title", []byte("---\npad_artifact: convention\nformat_version: 1\ntitle: \"a" + string([]byte{'\\', '0'}) + "b\"\n---\n\nbody\n")},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/server/handlers_artifact_test.go
+++ b/internal/server/handlers_artifact_test.go
@@ -573,3 +573,45 @@ func fieldString(t *testing.T, fieldsJSON, key string) string {
 	s, _ := m[key].(string)
 	return s
 }
+
+// TestImportArtifactUnbindableTextRejected covers the last body reader the
+// BUG-2803 sweep turned up (codex round 3). The artifact endpoint takes RAW
+// TEXT, not JSON, so it never went through decodeJSON and inherited neither
+// the NUL refusal nor the path/query rule — a body is neither a path nor a
+// query. A raw NUL or invalid UTF-8 reached the store, and Postgres answered
+// SQLSTATE 22021, which the handler turned into a 500 for what is a client
+// error.
+//
+// Note the shape difference from the JSON half: here a RAW byte is the vector,
+// because there is no JSON decoder in the way to reject it. The predicate is
+// the same bindableText the path and query middlewares apply.
+func TestImportArtifactUnbindableTextRejected(t *testing.T) {
+	srv := testServer(t)
+	ws := createWSForTest(t, srv)
+
+	good := "---\npad_artifact: convention\nformat_version: 1\ntitle: Fine\n---\n\nbody\n"
+
+	// Control: the identical artifact, no bad bytes. Without it a 400 says
+	// nothing — this endpoint answers 400 for malformed frontmatter too.
+	if rr := doArtifactRequest(srv, "POST", "/api/v1/workspaces/"+ws+"/import-artifact", []byte(good)); rr.Code != http.StatusOK && rr.Code != http.StatusCreated {
+		t.Fatalf("control artifact must import, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	for _, tc := range []struct {
+		name string
+		body []byte
+	}{
+		{"NUL byte in the body", []byte(strings.Replace(good, "body", "bo\x00dy", 1))},
+		{"invalid UTF-8 in the body", append([]byte(strings.Replace(good, "body", "bo", 1)), 0xff, '\n')},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := doArtifactRequest(srv, "POST", "/api/v1/workspaces/"+ws+"/import-artifact", tc.body)
+			if rr.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d: %s", rr.Code, rr.Body.String())
+			}
+			if !strings.Contains(rr.Body.String(), "invalid_body") {
+				t.Errorf("expected the invalid_body code, got %s", rr.Body.String())
+			}
+		})
+	}
+}

--- a/internal/server/handlers_attachments.go
+++ b/internal/server/handlers_attachments.go
@@ -331,7 +331,20 @@ func (s *Server) handleUploadAttachment(w http.ResponseWriter, r *http.Request) 
 	// query rules; falling back to a generic name rather than refusing the
 	// upload, because the bytes are fine and only the label is unusable
 	// (codex round 4, BUG-2803).
+	// Reduce to a leaf under BOTH separator conventions before anything else.
+	// filepath.Base is platform-specific, so on Unix it leaves a backslash
+	// alone — and the stored name is consumed cross-platform (a Windows client
+	// joining it onto a directory reads "..\\evil" as a traversal). Splitting
+	// on the backslash too makes the stored value a safe path component
+	// everywhere rather than only on the server's own OS (codex round 28).
+	//
+	// This NORMALISES rather than refuses: a legitimate Unix name containing a
+	// backslash keeps its last segment instead of being replaced wholesale,
+	// which is less lossy than the alternative and still portable.
 	filename := filepath.Base(header.Filename)
+	if i := strings.LastIndexByte(filename, '\\'); i >= 0 {
+		filename = filename[i+1:]
+	}
 	if !bindableText(filename) {
 		// Keep the EXTENSION when it is itself storable. The unusable part
 		// of a name like "sh<NUL>ot.png" is the stem; ".png" is ordinary

--- a/internal/server/handlers_attachments.go
+++ b/internal/server/handlers_attachments.go
@@ -367,8 +367,17 @@ func (s *Server) handleUploadAttachment(w http.ResponseWriter, r *http.Request) 
 	//
 	// Checking the trimmed form rather than listing spellings, so "...",
 	// "./", and friends cannot each need their own case.
-	if filename == "" || filename == "/" || strings.Trim(filename, ".") == "" ||
-		strings.ContainsAny(filename, `/\`) {
+	// Only "." and ".." are path components; "..." and longer runs are
+	// ordinary POSIX filenames and are kept (codex round 27 — the trimmed-form
+	// check I used first refused those too, which is over-refusal for no
+	// gain). A backslash is likewise a legal character in a Unix filename, and
+	// filepath.Base above has already reduced any "a/b" to "b", so a separator
+	// test here is dead on this platform and was removed rather than left to
+	// look load-bearing.
+	//
+	// What remains is the real hazard: a name a consumer joins onto a
+	// directory and lands somewhere else.
+	if filename == "" || filename == "." || filename == ".." || filename == "/" {
 		filename = "upload.bin"
 	}
 

--- a/internal/server/handlers_attachments.go
+++ b/internal/server/handlers_attachments.go
@@ -651,8 +651,11 @@ func writeAttachmentNotFound(w http.ResponseWriter) {
 //   - Resolves the storage backend via the Registry and opens the blob.
 //   - Sets Content-Type from the DB row (which is already the canonical
 //     post-allowlist MIME, not the client-supplied one).
-//   - Sets Content-Disposition from the MIME's RenderMode entry:
-//     RenderForceDownload → "attachment", everything else → "inline".
+//   - Sets Content-Disposition fail-closed via the explicit ServeInline
+//     allowlist (BUG-2413): only audited types are "inline", everything
+//     else — RenderChip types included — is "attachment". (An earlier
+//     version of this line derived the answer from RenderMode, the
+//     pre-BUG-2413 policy; codex closing round 8.)
 //   - Hands off to http.ServeContent when the backend supports Seek
 //     (FSStore returns *os.File, so this is the common path) — that
 //     gives us If-Modified-Since, If-None-Match, Range/206, Accept-Ranges

--- a/internal/server/handlers_attachments.go
+++ b/internal/server/handlers_attachments.go
@@ -359,7 +359,16 @@ func (s *Server) handleUploadAttachment(w http.ResponseWriter, r *http.Request) 
 			filename = "upload"
 		}
 	}
-	if filename == "" || filename == "." || filename == "/" {
+	// A name that is only dots or separators is not a filename, it is a PATH
+	// COMPONENT, and consumers join it onto a directory. ".." was missing
+	// here: it survives bindableText, and filepath.Ext("..") is "." — non-empty
+	// — so even an extension check passes it through, while filepath.Join on
+	// the client side resolves it to the PARENT directory (codex round 26).
+	//
+	// Checking the trimmed form rather than listing spellings, so "...",
+	// "./", and friends cannot each need their own case.
+	if filename == "" || filename == "/" || strings.Trim(filename, ".") == "" ||
+		strings.ContainsAny(filename, `/\`) {
 		filename = "upload.bin"
 	}
 

--- a/internal/server/handlers_attachments.go
+++ b/internal/server/handlers_attachments.go
@@ -46,11 +46,35 @@ const multipartParseMemory = 1 << 20 // 1 MiB
 // ONLY. Unlike (*http.Request).FormValue it does not fall back to the
 // URL query string, which keeps the two item_id input channels distinct
 // so they can be resolved and cross-checked independently.
+// multipartValues returns a multipart form field's TEXT values, dropping any
+// that are not bindable text.
+//
+// The multipart body is exempt from BUG-2803's JSON rule for a good reason —
+// its payload is binary blob content and must not be scanned for text
+// validity — but its TEXT fields are a different thing: item_id goes to
+// ResolveItem and into a database comparison exactly as the query-string
+// channel does, and that channel has been validated at the transport since
+// BUG-2784. A raw NUL arriving through the form instead of the query reached
+// the store unchecked (codex round 4, BUG-2803).
+//
+// Dropping rather than erroring keeps this helper's signature and matches
+// what callers already do with absent values: resolveUploadItemID treats
+// absent and explicitly-empty alike, so an unusable value becomes "no value"
+// and the request is answered by the same path that handles a missing one. A
+// value that cannot name anything and one that was never sent are the same
+// thing to the caller.
 func multipartValues(r *http.Request, key string) []string {
 	if r.MultipartForm == nil {
 		return nil
 	}
-	return r.MultipartForm.Value[key]
+	raw := r.MultipartForm.Value[key]
+	out := make([]string, 0, len(raw))
+	for _, v := range raw {
+		if bindableText(v) {
+			out = append(out, v)
+		}
+	}
+	return out
 }
 
 // maxUploadItemIDValues bounds how many item_id values one input channel
@@ -301,7 +325,16 @@ func (s *Server) handleUploadAttachment(w http.ResponseWriter, r *http.Request) 
 	// Sanitize the filename: strip path components so a client can't
 	// sneak directory traversal through the display name. We don't
 	// store this in the storage backend — only in the DB row for UI.
+	// The uploaded filename is caller-supplied text bound for a text column,
+	// and a multipart header can carry a NUL through the RFC 5987 encoded
+	// form (filename*=UTF-8\'\'a%00.png). Same predicate as the path and
+	// query rules; falling back to a generic name rather than refusing the
+	// upload, because the bytes are fine and only the label is unusable
+	// (codex round 4, BUG-2803).
 	filename := filepath.Base(header.Filename)
+	if !bindableText(filename) {
+		filename = "upload"
+	}
 	if filename == "" || filename == "." || filename == "/" {
 		filename = "upload.bin"
 	}

--- a/internal/server/handlers_attachments.go
+++ b/internal/server/handlers_attachments.go
@@ -378,8 +378,6 @@ func (s *Server) handleUploadAttachment(w http.ResponseWriter, r *http.Request) 
 	// — so even an extension check passes it through, while filepath.Join on
 	// the client side resolves it to the PARENT directory (codex round 26).
 	//
-	// Checking the trimmed form rather than listing spellings, so "...",
-	// "./", and friends cannot each need their own case.
 	// Only "." and ".." are path components; "..." and longer runs are
 	// ordinary POSIX filenames and are kept (codex round 27 — the trimmed-form
 	// check I used first refused those too, which is over-refusal for no

--- a/internal/server/handlers_attachments.go
+++ b/internal/server/handlers_attachments.go
@@ -333,7 +333,23 @@ func (s *Server) handleUploadAttachment(w http.ResponseWriter, r *http.Request) 
 	// (codex round 4, BUG-2803).
 	filename := filepath.Base(header.Filename)
 	if !bindableText(filename) {
-		filename = "upload"
+		// Keep the EXTENSION when it is itself storable. The unusable part
+		// of a name like "sh<NUL>ot.png" is the stem; ".png" is ordinary
+		// text, and it is what every downstream consumer dispatches on —
+		// Content-Disposition, the web download anchor, bundle export naming,
+		// and `pad attachment view`, whose whole contract is handing a path to
+		// something that opens files by extension.
+		//
+		// Dropping it made this fallback lossier than the empty-name one two
+		// lines below, which has always produced "upload.bin" (codex round
+		// 24). Bounded to a short extension so a hostile name cannot smuggle
+		// a long tail through the fallback.
+		ext := filepath.Ext(filename)
+		if len(ext) > 1 && len(ext) <= 16 && bindableText(ext) {
+			filename = "upload" + ext
+		} else {
+			filename = "upload"
+		}
 	}
 	if filename == "" || filename == "." || filename == "/" {
 		filename = "upload.bin"

--- a/internal/server/handlers_attachments.go
+++ b/internal/server/handlers_attachments.go
@@ -344,9 +344,17 @@ func (s *Server) handleUploadAttachment(w http.ResponseWriter, r *http.Request) 
 		// lines below, which has always produced "upload.bin" (codex round
 		// 24). Bounded to a short extension so a hostile name cannot smuggle
 		// a long tail through the fallback.
-		ext := filepath.Ext(filename)
-		if len(ext) > 1 && len(ext) <= 16 && bindableText(ext) {
-			filename = "upload" + ext
+		// bindableText is NOT the bar here (codex round 25). It permits
+		// control characters — they are valid UTF-8 and not NUL — and a
+		// control character survives storage but is STRIPPED when the name
+		// is written into Content-Disposition. So ".s<VT>vg" passes the
+		// extension blocklist, which sees no known extension, and reappears
+		// as ".svg" at the client. attachments.SafeFallbackExtension requires
+		// a KNOWN, ALLOWED, plain-alphanumeric extension instead, so a
+		// synthesised name can only carry a suffix the product already
+		// accepts on the ordinary path.
+		if ext := filepath.Ext(filename); attachments.SafeFallbackExtension(ext) {
+			filename = "upload" + strings.ToLower(ext)
 		} else {
 			filename = "upload"
 		}

--- a/internal/server/handlers_attachments_test.go
+++ b/internal/server/handlers_attachments_test.go
@@ -973,8 +973,41 @@ func TestUpload_MultipartTextFieldsAreBindableText(t *testing.T) {
 		if strings.ContainsRune(got.Filename, 0) {
 			t.Errorf("the stored filename still carries a NUL: %q", got.Filename)
 		}
+		// The EXTENSION survives the fallback. The unusable part of
+		// "sh<NUL>ot.png" is the stem; ".png" is ordinary text and is what
+		// every consumer dispatches on — Content-Disposition, the web
+		// download anchor, bundle export naming, and `pad attachment view`,
+		// whose contract is handing a path to something that opens files by
+		// extension. Dropping it made this fallback lossier than the
+		// empty-name one, which has always produced "upload.bin" (codex
+		// round 24).
+		if got.Filename != "upload.png" {
+			t.Errorf("expected the generic fallback to keep the storable extension, got %q", got.Filename)
+		}
+	})
+
+	t.Run("an unusable extension does not survive the fallback", func(t *testing.T) {
+		// The counterpart leg. Keeping a storable extension must not become
+		// "keep whatever trails the last dot" — an extension that is itself
+		// unstorable has to be dropped, or the fallback reintroduces exactly
+		// the value it exists to remove.
+		rr := uploadWithRawDisposition(t,
+			`form-data; name="file"; filename*=UTF-8''shot.p%00ng`)
+		if rr.Code != http.StatusCreated && rr.Code != http.StatusOK {
+			t.Fatalf("upload should still succeed, got %d: %s", rr.Code, rr.Body.String())
+		}
+		var got struct {
+			Filename string `json:"filename"`
+		}
+		if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+			t.Fatalf("decode upload response: %v (body %s)", err, rr.Body.String())
+		}
+		if strings.ContainsRune(got.Filename, 0) {
+			t.Errorf("the stored filename still carries a NUL: %q", got.Filename)
+		}
 		if got.Filename != "upload" {
-			t.Errorf("expected the generic fallback name, got %q", got.Filename)
+			t.Errorf("an unstorable extension must be dropped, not carried into the fallback; got %q",
+				got.Filename)
 		}
 	})
 

--- a/internal/server/handlers_attachments_test.go
+++ b/internal/server/handlers_attachments_test.go
@@ -992,6 +992,17 @@ func TestUpload_MultipartTextFieldsAreBindableText(t *testing.T) {
 		if control.Code != http.StatusCreated && control.Code != http.StatusOK {
 			t.Fatalf("control (no item_id) must succeed, got %d: %s", control.Code, control.Body.String())
 		}
+		// Both byte classes, not just the NUL: a filter that rejected NULs
+		// while letting malformed UTF-8 through would have passed the
+		// earlier version of this leg (codex round 13). Invalid UTF-8 is the
+		// class that reaches Postgres as 22021 on a UTF8 database.
+		for _, bad := range []string{"TASK-1\x00", "TASK-1\xff"} {
+			rr := upload(t, "clean.png", &bad)
+			if rr.Code != control.Code {
+				t.Errorf("an unusable item_id %q must be treated as no value (like the control, %d), got %d: %s",
+					bad, control.Code, rr.Code, rr.Body.String())
+			}
+		}
 		bad := "TASK-1\x00"
 		rr := upload(t, "clean.png", &bad)
 		if rr.Code != control.Code {

--- a/internal/server/handlers_attachments_test.go
+++ b/internal/server/handlers_attachments_test.go
@@ -11,6 +11,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"net/textproto"
 	"net/url"
 	"os"
 	"strings"
@@ -876,3 +877,126 @@ func TestUpload_QuotaCheckResolves(t *testing.T) {
 var _ = io.Discard
 var _ = models.Attachment{}
 var _ = strings.Contains
+
+// TestUpload_MultipartTextFieldsAreBindableText covers codex round 4's P2 on
+// BUG-2803. The multipart body is deliberately exempt from the JSON NUL rule
+// — its payload is binary blob content and must not be scanned for text
+// validity — but its TEXT fields are a different thing. `item_id` goes to
+// ResolveItem and into a database comparison exactly as the query-string
+// channel does, and that channel has been validated at the transport since
+// BUG-2784; the form channel was not. The FILENAME is the same shape: a
+// multipart header can carry a NUL through the RFC 5987 encoded form.
+//
+// Both legs have a control that differs only in the bad byte, so a pass
+// cannot come from the upload failing for an unrelated reason.
+func TestUpload_MultipartTextFieldsAreBindableText(t *testing.T) {
+	srv, slug := testServerWithAttachments(t)
+
+	upload := func(t *testing.T, filename string, itemID *string) *httptest.ResponseRecorder {
+		t.Helper()
+		var buf bytes.Buffer
+		mw := multipart.NewWriter(&buf)
+		if itemID != nil {
+			// WriteField would reject nothing, which is the point: the raw
+			// bytes reach r.MultipartForm.Value verbatim.
+			_ = mw.WriteField("item_id", *itemID)
+		}
+		part, _ := mw.CreateFormFile("file", filename)
+		part.Write(realPNG())
+		mw.Close()
+
+		req := httptest.NewRequest("POST", "/api/v1/workspaces/"+slug+"/attachments", &buf)
+		req.Header.Set("Content-Type", mw.FormDataContentType())
+		req.RemoteAddr = "127.0.0.1:1234"
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+		return rr
+	}
+
+	// uploadWithRawDisposition writes the part header by hand so the test can
+	// use the RFC 5987 encoded filename form. A RAW NUL in the header is not
+	// the vector: Go's multipart reader refuses it as a malformed MIME header
+	// line before any handler sees it (measured — the request answers 400
+	// with "malformed MIME header line"). The percent-encoded form is
+	// accepted by the header parser and decodes to the byte afterwards, which
+	// is what makes it the reachable spelling.
+	uploadWithRawDisposition := func(t *testing.T, disposition string) *httptest.ResponseRecorder {
+		t.Helper()
+		var buf bytes.Buffer
+		mw := multipart.NewWriter(&buf)
+		h := make(textproto.MIMEHeader)
+		h.Set("Content-Disposition", disposition)
+		h.Set("Content-Type", "image/png")
+		part, err := mw.CreatePart(h)
+		if err != nil {
+			t.Fatalf("create part: %v", err)
+		}
+		part.Write(realPNG())
+		mw.Close()
+
+		req := httptest.NewRequest("POST", "/api/v1/workspaces/"+slug+"/attachments", &buf)
+		req.Header.Set("Content-Type", mw.FormDataContentType())
+		req.RemoteAddr = "127.0.0.1:1234"
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+		return rr
+	}
+
+	t.Run("filename carrying a NUL does not reach the attachment row", func(t *testing.T) {
+		control := uploadWithRawDisposition(t,
+			`form-data; name="file"; filename*=UTF-8''clean.png`)
+		if control.Code != http.StatusCreated && control.Code != http.StatusOK {
+			t.Fatalf("control upload must succeed, got %d: %s", control.Code, control.Body.String())
+		}
+		if !strings.Contains(control.Body.String(), "clean.png") {
+			t.Fatalf("control should keep its encoded filename, got %s", control.Body.String())
+		}
+
+		rr := uploadWithRawDisposition(t,
+			`form-data; name="file"; filename*=UTF-8''sh%00ot.png`)
+		if rr.Code != http.StatusCreated && rr.Code != http.StatusOK {
+			t.Fatalf("upload with an unusable filename should still succeed (the BYTES are fine), got %d: %s",
+				rr.Code, rr.Body.String())
+		}
+		// Assert the REPLACEMENT, not the absence of a raw NUL byte. The
+		// response is JSON, so a NUL in the filename comes back as the
+		// six-character escape rather than as a 0x00 — a ContainsRune(body,
+		// 0) check passes whether or not the fix is present, and it did:
+		// disabling the fallback left this leg green until the assertion was
+		// changed. CONVE-12, caught by the mutation rather than by review.
+		var got struct {
+			Filename string `json:"filename"`
+		}
+		if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+			t.Fatalf("decode upload response: %v (body %s)", err, rr.Body.String())
+		}
+		if strings.ContainsRune(got.Filename, 0) {
+			t.Errorf("the stored filename still carries a NUL: %q", got.Filename)
+		}
+		if got.Filename != "upload" {
+			t.Errorf("expected the generic fallback name, got %q", got.Filename)
+		}
+	})
+
+	t.Run("item_id carrying a NUL is not resolved", func(t *testing.T) {
+		// A NUL-bearing item_id cannot name anything, so it must be treated
+		// as no value rather than handed to the store. The control is a
+		// syntactically fine but non-existent ref, which the handler answers
+		// with a 4xx — if the NUL leg produced a 500 instead, the value
+		// reached the database.
+		// Assert it behaves like NO value, not merely "not a 500". A 500 is
+		// the Postgres-only symptom; on SQLite an unfiltered value would
+		// instead resolve to nothing and answer 4xx, so a >=500 check would
+		// pass on this backend whether or not the filter exists.
+		control := upload(t, "clean.png", nil)
+		if control.Code != http.StatusCreated && control.Code != http.StatusOK {
+			t.Fatalf("control (no item_id) must succeed, got %d: %s", control.Code, control.Body.String())
+		}
+		bad := "TASK-1\x00"
+		rr := upload(t, "clean.png", &bad)
+		if rr.Code != control.Code {
+			t.Errorf("an unusable item_id must be treated as no value (like the control, %d), got %d: %s",
+				control.Code, rr.Code, rr.Body.String())
+		}
+	})
+}

--- a/internal/server/handlers_attachments_test.go
+++ b/internal/server/handlers_attachments_test.go
@@ -1068,7 +1068,7 @@ func TestUpload_MultipartTextFieldsAreBindableText(t *testing.T) {
 		// filepath.Join(dir, "..") is dir's PARENT. It survives bindableText,
 		// and filepath.Ext("..") is "." (non-empty), so an extension check
 		// waves it through too (codex round 26).
-		for _, raw := range []string{"..", "...", "./", "a/b"} {
+		for _, raw := range []string{"..", "./", "a/b"} {
 			rr := uploadWithRawDisposition(t,
 				`form-data; name="file"; filename=`+strconv.Quote(raw))
 			if rr.Code != http.StatusCreated && rr.Code != http.StatusOK {
@@ -1083,6 +1083,29 @@ func TestUpload_MultipartTextFieldsAreBindableText(t *testing.T) {
 			if strings.Trim(got.Filename, ".") == "" || strings.ContainsAny(got.Filename, `/\`) {
 				t.Errorf("upload %q stored the path component %q; a consumer joining that onto a "+
 					"directory escapes it", raw, got.Filename)
+			}
+		}
+
+		// PRESERVATION controls. Refusing path components must not become
+		// refusing anything unusual: "..." and a backslash are ordinary POSIX
+		// filenames and a user who uploads one should get it back (codex
+		// round 27 flagged the earlier version as over-refusing both).
+		// A backslash name is legitimate on Unix too, but expressing one
+		// through a quoted Content-Disposition tests the header grammar more
+		// than it tests this guard, so it is left out deliberately rather
+		// than fudged.
+		for _, keep := range []string{"...", "....", "a.b.c.png"} {
+			rr := uploadWithRawDisposition(t,
+				`form-data; name="file"; filename=`+strconv.Quote(keep))
+			var got struct {
+				Filename string `json:"filename"`
+			}
+			if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+				t.Fatalf("decode response for %q: %v", keep, err)
+			}
+			if got.Filename != keep {
+				t.Errorf("legitimate filename %q was altered to %q; the guard is for path "+
+					"components, not for unusual-looking names", keep, got.Filename)
 			}
 		}
 

--- a/internal/server/handlers_attachments_test.go
+++ b/internal/server/handlers_attachments_test.go
@@ -1094,6 +1094,22 @@ func TestUpload_MultipartTextFieldsAreBindableText(t *testing.T) {
 		// through a quoted Content-Disposition tests the header grammar more
 		// than it tests this guard, so it is left out deliberately rather
 		// than fudged.
+		// A Windows-style path must be reduced to its leaf, not stored whole:
+		// the stored name is consumed cross-platform, and a client joining
+		// "..\\evil" onto a directory traverses upward (codex round 28).
+		winPath := uploadWithRawDisposition(t,
+			`form-data; name="file"; filename=`+strconv.Quote(`..\evil.png`))
+		var win struct {
+			Filename string `json:"filename"`
+		}
+		if err := json.Unmarshal(winPath.Body.Bytes(), &win); err != nil {
+			t.Fatalf("decode windows-path response: %v", err)
+		}
+		if win.Filename != "evil.png" {
+			t.Errorf("a backslash path must be reduced to its leaf; got %q, which a Windows consumer "+
+				"joining onto a directory would read as a traversal", win.Filename)
+		}
+
 		for _, keep := range []string{"...", "....", "a.b.c.png"} {
 			rr := uploadWithRawDisposition(t,
 				`form-data; name="file"; filename=`+strconv.Quote(keep))

--- a/internal/server/handlers_attachments_test.go
+++ b/internal/server/handlers_attachments_test.go
@@ -14,6 +14,7 @@ import (
 	"net/textproto"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -1058,6 +1059,44 @@ func TestUpload_MultipartTextFieldsAreBindableText(t *testing.T) {
 		if got.Filename != "upload" {
 			t.Errorf("an unstorable extension must be dropped, not carried into the fallback; got %q",
 				got.Filename)
+		}
+	})
+
+	t.Run("a path-component filename never reaches the row", func(t *testing.T) {
+		// ".." is not a filename, it is a path component, and consumers join
+		// it onto a directory — the CLI builds its temp path this way, where
+		// filepath.Join(dir, "..") is dir's PARENT. It survives bindableText,
+		// and filepath.Ext("..") is "." (non-empty), so an extension check
+		// waves it through too (codex round 26).
+		for _, raw := range []string{"..", "...", "./", "a/b"} {
+			rr := uploadWithRawDisposition(t,
+				`form-data; name="file"; filename=`+strconv.Quote(raw))
+			if rr.Code != http.StatusCreated && rr.Code != http.StatusOK {
+				t.Fatalf("upload %q should still succeed, got %d: %s", raw, rr.Code, rr.Body.String())
+			}
+			var got struct {
+				Filename string `json:"filename"`
+			}
+			if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+				t.Fatalf("decode upload response for %q: %v (body %s)", raw, err, rr.Body.String())
+			}
+			if strings.Trim(got.Filename, ".") == "" || strings.ContainsAny(got.Filename, `/\`) {
+				t.Errorf("upload %q stored the path component %q; a consumer joining that onto a "+
+					"directory escapes it", raw, got.Filename)
+			}
+		}
+
+		// Premise: an ordinary name is still kept verbatim, so the loop above
+		// pins path components rather than a handler that renames everything.
+		rr := uploadWithRawDisposition(t, `form-data; name="file"; filename="ordinary.png"`)
+		var ok struct {
+			Filename string `json:"filename"`
+		}
+		if err := json.Unmarshal(rr.Body.Bytes(), &ok); err != nil {
+			t.Fatalf("decode control response: %v", err)
+		}
+		if ok.Filename != "ordinary.png" {
+			t.Fatalf("premise failed: an ordinary filename must be kept, got %q", ok.Filename)
 		}
 	})
 

--- a/internal/server/handlers_attachments_test.go
+++ b/internal/server/handlers_attachments_test.go
@@ -986,6 +986,56 @@ func TestUpload_MultipartTextFieldsAreBindableText(t *testing.T) {
 		}
 	})
 
+	t.Run("a control-obfuscated extension does not survive the fallback", func(t *testing.T) {
+		// The one with teeth (codex round 25). A vertical tab is valid UTF-8
+		// and not a NUL, so bindableText calls ".s<VT>vg" storable. The
+		// extension blocklist then sees no KNOWN extension and passes it,
+		// and Content-Disposition sanitising strips the control byte — so the
+		// client is handed ".svg" for a name the blocklist never evaluated as
+		// SVG. Carrying it into a synthesised fallback name would be adding a
+		// door to that; the fallback now requires a known, allowed,
+		// alphanumeric extension.
+		rr := uploadWithRawDisposition(t,
+			`form-data; name="file"; filename*=UTF-8''bad%00.s%0Bvg`)
+		if rr.Code != http.StatusCreated && rr.Code != http.StatusOK {
+			t.Fatalf("upload should still succeed, got %d: %s", rr.Code, rr.Body.String())
+		}
+		var got struct {
+			Filename string `json:"filename"`
+		}
+		if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+			t.Fatalf("decode upload response: %v (body %s)", err, rr.Body.String())
+		}
+		if strings.Contains(strings.ToLower(got.Filename), "svg") {
+			t.Errorf("a control-obfuscated .svg reached the stored name as %q; sanitising the header "+
+				"later turns that into .svg for the client, past a blocklist that never saw it", got.Filename)
+		}
+		if got.Filename != "upload" {
+			t.Errorf("expected the extension to be dropped entirely, got %q", got.Filename)
+		}
+	})
+
+	t.Run("an unknown extension does not survive the fallback", func(t *testing.T) {
+		// ".foo" is plain text and plain alphanumeric, but it is not a known
+		// extension, so it cannot be carried into a name the SERVER
+		// synthesised — otherwise an arbitrary suffix rides along on content
+		// that does not support it.
+		rr := uploadWithRawDisposition(t,
+			`form-data; name="file"; filename*=UTF-8''bad%00.foo`)
+		if rr.Code != http.StatusCreated && rr.Code != http.StatusOK {
+			t.Fatalf("upload should still succeed, got %d: %s", rr.Code, rr.Body.String())
+		}
+		var got struct {
+			Filename string `json:"filename"`
+		}
+		if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+			t.Fatalf("decode upload response: %v (body %s)", err, rr.Body.String())
+		}
+		if got.Filename != "upload" {
+			t.Errorf("an unknown extension must be dropped from a synthesised name, got %q", got.Filename)
+		}
+	})
+
 	t.Run("an unusable extension does not survive the fallback", func(t *testing.T) {
 		// The counterpart leg. Keeping a storable extension must not become
 		// "keep whatever trails the last dot" — an extension that is itself

--- a/internal/server/handlers_attachments_transform.go
+++ b/internal/server/handlers_attachments_transform.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"bytes"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"image"
@@ -226,8 +225,8 @@ func (s *Server) handleTransformAttachment(w http.ResponseWriter, r *http.Reques
 	}
 
 	var req transformRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "bad_request", "Invalid JSON body")
+	if err := decodeJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
 		return
 	}
 

--- a/internal/server/handlers_auth.go
+++ b/internal/server/handlers_auth.go
@@ -308,7 +308,7 @@ func (s *Server) rotateSessionsAfterCredentialChange(w http.ResponseWriter, r *h
 			"user_id", user.ID, "error", err)
 	}
 
-	token, err := s.store.CreateSession(user.ID, "web", clientIP(r), requestUserAgent(r), webSessionTTL)
+	token, err := s.store.CreateSession(user.ID, "web", clientIP(r), r.UserAgent(), webSessionTTL)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error",
 			"Credentials updated but failed to refresh session. Please sign in again.")
@@ -329,7 +329,7 @@ func (s *Server) rotateSessionsAfterCredentialChange(w http.ResponseWriter, r *h
 }
 
 func (s *Server) createAuthSession(w http.ResponseWriter, r *http.Request, user *models.User, ttl time.Duration) (string, error) {
-	token, err := s.store.CreateSession(user.ID, "web", clientIP(r), requestUserAgent(r), ttl)
+	token, err := s.store.CreateSession(user.ID, "web", clientIP(r), r.UserAgent(), ttl)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to create session")
 		return "", err
@@ -1313,7 +1313,7 @@ func (s *Server) handleResetPassword(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Create a fresh session so the user is logged in
-	sessionToken, err := s.store.CreateSession(user.ID, "web", clientIP(r), requestUserAgent(r), webSessionTTL)
+	sessionToken, err := s.store.CreateSession(user.ID, "web", clientIP(r), r.UserAgent(), webSessionTTL)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", "Password updated but failed to create session")
 		return

--- a/internal/server/handlers_auth.go
+++ b/internal/server/handlers_auth.go
@@ -308,7 +308,7 @@ func (s *Server) rotateSessionsAfterCredentialChange(w http.ResponseWriter, r *h
 			"user_id", user.ID, "error", err)
 	}
 
-	token, err := s.store.CreateSession(user.ID, "web", clientIP(r), r.UserAgent(), webSessionTTL)
+	token, err := s.store.CreateSession(user.ID, "web", clientIP(r), requestUserAgent(r), webSessionTTL)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error",
 			"Credentials updated but failed to refresh session. Please sign in again.")
@@ -329,7 +329,7 @@ func (s *Server) rotateSessionsAfterCredentialChange(w http.ResponseWriter, r *h
 }
 
 func (s *Server) createAuthSession(w http.ResponseWriter, r *http.Request, user *models.User, ttl time.Duration) (string, error) {
-	token, err := s.store.CreateSession(user.ID, "web", clientIP(r), r.UserAgent(), ttl)
+	token, err := s.store.CreateSession(user.ID, "web", clientIP(r), requestUserAgent(r), ttl)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to create session")
 		return "", err
@@ -1313,7 +1313,7 @@ func (s *Server) handleResetPassword(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Create a fresh session so the user is logged in
-	sessionToken, err := s.store.CreateSession(user.ID, "web", clientIP(r), r.UserAgent(), webSessionTTL)
+	sessionToken, err := s.store.CreateSession(user.ID, "web", clientIP(r), requestUserAgent(r), webSessionTTL)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", "Password updated but failed to create session")
 		return

--- a/internal/server/handlers_cloud.go
+++ b/internal/server/handlers_cloud.go
@@ -205,7 +205,7 @@ func (s *Server) handleOAuthLogin(w http.ResponseWriter, r *http.Request) {
 	// 4. Sanitize inputs
 	input.Name = strings.TrimSpace(input.Name)
 	if len(input.Name) > 200 {
-		input.Name = input.Name[:200]
+		input.Name = truncateBindableText(input.Name, 200)
 	}
 	if input.AvatarURL != "" {
 		if u, err := url.Parse(input.AvatarURL); err != nil || (u.Scheme != "http" && u.Scheme != "https") {

--- a/internal/server/handlers_comments.go
+++ b/internal/server/handlers_comments.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"database/sql"
-	"encoding/json"
 	"net/http"
 	"strings"
 
@@ -320,8 +319,8 @@ func (s *Server) handleCreateReply(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var input models.CommentCreate
-	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid_json", "Invalid JSON body")
+	if err := decodeJSON(r, &input); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_json", err.Error())
 		return
 	}
 	if strings.TrimSpace(input.Body) == "" {
@@ -428,8 +427,8 @@ func (s *Server) handleAddReaction(w http.ResponseWriter, r *http.Request) {
 	var input struct {
 		Emoji string `json:"emoji"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid_json", "Invalid JSON body")
+	if err := decodeJSON(r, &input); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_json", err.Error())
 		return
 	}
 	if strings.TrimSpace(input.Emoji) == "" {

--- a/internal/server/handlers_connected_apps.go
+++ b/internal/server/handlers_connected_apps.go
@@ -217,7 +217,7 @@ func (s *Server) handleRevokeConnectedApp(w http.ResponseWriter, r *http.Request
 		UserID:    user.ID,
 		Metadata:  string(metaJSON),
 		IPAddress: clientIP(r),
-		UserAgent: r.UserAgent(),
+		UserAgent: requestUserAgent(r),
 	}); err != nil {
 		slog.Warn("connected-apps: audit log write failed", "error", err, "user_id", user.ID, "connection_id", id)
 	}
@@ -359,7 +359,7 @@ func (s *Server) handleRenameConnectedApp(w http.ResponseWriter, r *http.Request
 	}
 	name := strings.TrimSpace(body.Name)
 	if len(name) > 120 {
-		name = name[:120]
+		name = truncateBindableText(name, 120)
 	}
 	if err := s.store.RenameConnection(id, name); err != nil {
 		writeInternalError(w, err)

--- a/internal/server/handlers_connected_apps.go
+++ b/internal/server/handlers_connected_apps.go
@@ -342,9 +342,9 @@ func (s *Server) respondWithConnection(w http.ResponseWriter, userID, requestID 
 }
 
 // handleRenameConnectedApp: PATCH /api/v1/connected-apps/{id}/name
-// Body: {"name": "..."} — trimmed + capped at 120 chars (matches the
-// consent-screen suggested-name cap). Empty string is valid (clears
-// the name, the connections-page UI prompts again).
+// Body: {"name": "..."} — trimmed + capped at 120 BYTES, rune-safe
+// (matches the consent-screen suggested-name cap). Empty string is
+// valid (clears the name, the connections-page UI prompts again).
 func (s *Server) handleRenameConnectedApp(w http.ResponseWriter, r *http.Request) {
 	user, id, ok := s.requireConnectionOwner(w, r)
 	if !ok {

--- a/internal/server/handlers_documents.go
+++ b/internal/server/handlers_documents.go
@@ -423,7 +423,7 @@ func (s *Server) logActivityWithMetaReturningID(workspaceID, documentID, action 
 		Metadata:    metadata,
 		UserID:      uid,
 		IPAddress:   clientIP(r),
-		UserAgent:   r.Header.Get("User-Agent"),
+		UserAgent:   requestUserAgent(r),
 	})
 	// Bump last_write_at on the actor. Every action that flows through this
 	// helper (created/updated/archived/restored/moved/commented) is a write.
@@ -454,7 +454,7 @@ func (s *Server) logAuditEventForUser(action string, r *http.Request, userID str
 		Metadata:  metadata,
 		UserID:    userID,
 		IPAddress: clientIP(r),
-		UserAgent: r.Header.Get("User-Agent"),
+		UserAgent: requestUserAgent(r),
 	})
 }
 
@@ -483,7 +483,7 @@ func (s *Server) logWorkspaceAuditEvent(workspaceID, action string, r *http.Requ
 		Metadata:    metadata,
 		UserID:      currentUserID(r),
 		IPAddress:   clientIP(r),
-		UserAgent:   r.Header.Get("User-Agent"),
+		UserAgent:   requestUserAgent(r),
 	})
 }
 

--- a/internal/server/handlers_import_bundle.go
+++ b/internal/server/handlers_import_bundle.go
@@ -336,6 +336,18 @@ func (s *Server) importBundle(ctx context.Context, r io.Reader, newName, ownerID
 			if err != nil {
 				return ws, fmt.Errorf("read manifest.json: %w", err)
 			}
+			// The manifest is a second JSON document inside the bundle,
+			// parsed here rather than through decodeJSON, so it needs the
+			// same check pad-export.json gets a few lines up. Without it a
+			// NUL in a manifest string reached rehydrateAttachment, whose
+			// failure is logged and SKIPPED below — so the import reported
+			// success while silently dropping the attachment (codex round 4,
+			// BUG-2803). The skip-on-failure behaviour is pre-existing and
+			// deliberate (a partial restore beats none); refusing the bad
+			// INPUT is what stops it from being reached this way.
+			if bodyDecodesNUL(buf) {
+				return ws, fmt.Errorf("manifest decode: %w (workspace created but attachments not restored)", errJSONBodyNUL)
+			}
 			var manifest models.AttachmentManifest
 			if err := json.Unmarshal(buf, &manifest); err != nil {
 				return ws, fmt.Errorf("manifest decode: %w (workspace created but attachments not restored)", err)

--- a/internal/server/handlers_import_bundle.go
+++ b/internal/server/handlers_import_bundle.go
@@ -344,7 +344,20 @@ func (s *Server) importBundle(ctx context.Context, r io.Reader, newName, ownerID
 			// success while silently dropping the attachment (codex round 4,
 			// BUG-2803). The skip-on-failure behaviour is pre-existing and
 			// deliberate (a partial restore beats none); refusing the bad
-			// INPUT is what stops it from being reached this way.
+			// INPUT is what stops it from being reached that way.
+			//
+			// IT DOES NOT ROLL BACK, and the earlier wording implied more
+			// than it delivers (codex round 18). A plain error with a
+			// non-nil workspace keeps the partial workspace, exactly as
+			// every other manifest failure below does — the rollback branch
+			// fires only for *importStatusError, and the comment there
+			// records that mid-stream manifest failures intentionally keep
+			// what was imported, tracked under TASK-896. Returning a
+			// rollback-shaped error HERE would give NUL-bearing manifests
+			// different semantics from malformed ones, which is a change to
+			// the bundle-import contract rather than a fix to this bug. The
+			// resulting state is pinned by a test and stated in the release
+			// note instead of being left incidental.
 			if bodyDecodesNUL(buf) {
 				return ws, fmt.Errorf("manifest decode: %w (workspace created but attachments not restored)", errJSONBodyNUL)
 			}

--- a/internal/server/handlers_import_bundle.go
+++ b/internal/server/handlers_import_bundle.go
@@ -274,6 +274,18 @@ func (s *Server) importBundle(ctx context.Context, r io.Reader, newName, ownerID
 			if err != nil {
 				return nil, fmt.Errorf("read pad-export.json: %w", err)
 			}
+			// The bundle path parses pad-export.json HERE rather than
+			// through decodeJSON, so it inherits none of that helper's
+			// checks — including BUG-2803's NUL refusal. A gzip import is
+			// the same door as the JSON one, reached by a different
+			// Content-Type, so it gets the same answer rather than a 500
+			// from Postgres further down (codex round 3).
+			if bodyDecodesNUL(buf) {
+				return nil, &importStatusError{
+					status: http.StatusBadRequest, code: "bad_bundle",
+					message: "Bundle pad-export.json could not be decoded: " + errJSONBodyNUL.Error(),
+				}
+			}
 			var export models.WorkspaceExport
 			if err := json.Unmarshal(buf, &export); err != nil {
 				return nil, &importStatusError{

--- a/internal/server/handlers_import_bundle_test.go
+++ b/internal/server/handlers_import_bundle_test.go
@@ -632,3 +632,68 @@ func TestIsSafeBundleEntryName(t *testing.T) {
 		})
 	}
 }
+
+// TestImportBundle_RefusesNULInExport is codex round 3's P1 on BUG-2803. The
+// tar.gz bundle path parses pad-export.json itself rather than through
+// decodeJSON, so it inherited none of that helper's checks: the SAME workspace
+// import, reached with Content-Type application/gzip instead of
+// application/json, walked straight past the NUL refusal and into Postgres.
+//
+// The control leg is the identical bundle with an ordinary value. Without it a
+// 400 proves nothing here — this path answers 400 for a dozen unrelated
+// reasons (bad gzip, out-of-order tar, duplicate entries).
+func TestImportBundle_RefusesNULInExport(t *testing.T) {
+	src, srcSlug := testServerWithAttachments(t)
+	rr := doRequest(src, "GET", "/api/v1/workspaces/"+srcSlug+"/export", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("export src: %d %s", rr.Code, rr.Body.String())
+	}
+	clean := rr.Body.String()
+
+	// Put the escape inside the exported workspace NAME. Editing the JSON
+	// text directly is the point: the bundle is bytes on the wire, and this
+	// is the shape a hand-built bundle would carry.
+	esc := string([]byte{'\\', 'u', '0', '0', '0', '0'})
+	withNUL := strings.Replace(clean, `"name":"`, `"name":"a`+esc+`b `, 1)
+	if withNUL == clean {
+		t.Fatal("fixture did not modify the export; the probe would be vacuous")
+	}
+
+	bundle := func(t *testing.T, exportJSON string) []byte {
+		t.Helper()
+		var buf bytes.Buffer
+		gzw := gzip.NewWriter(&buf)
+		tw := tar.NewWriter(gzw)
+		if err := tw.WriteHeader(&tar.Header{Name: "pad-export.json", Mode: 0o644, Size: int64(len(exportJSON))}); err != nil {
+			t.Fatalf("write header: %v", err)
+		}
+		if _, err := tw.Write([]byte(exportJSON)); err != nil {
+			t.Fatalf("write export: %v", err)
+		}
+		tw.Close()
+		gzw.Close()
+		return buf.Bytes()
+	}
+
+	post := func(t *testing.T, name string, body []byte) *httptest.ResponseRecorder {
+		t.Helper()
+		dest, _ := testServerWithAttachments(t)
+		req := httptest.NewRequest("POST", "/api/v1/workspaces/import?name="+name, bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/gzip")
+		req.RemoteAddr = "127.0.0.1:1234"
+		rec := httptest.NewRecorder()
+		dest.ServeHTTP(rec, req)
+		return rec
+	}
+
+	if got := post(t, "CleanBundle", bundle(t, clean)); got.Code != http.StatusOK && got.Code != http.StatusCreated {
+		t.Fatalf("control bundle must import, got %d: %s", got.Code, got.Body.String())
+	}
+	got := post(t, "NULBundle", bundle(t, withNUL))
+	if got.Code != http.StatusBadRequest {
+		t.Errorf("bundle carrying a NUL escape: status=%d, want 400; body=%s", got.Code, got.Body.String())
+	}
+	if !strings.Contains(got.Body.String(), "NUL") {
+		t.Errorf("the 400 should name the cause, got body=%s", got.Body.String())
+	}
+}

--- a/internal/server/handlers_import_bundle_test.go
+++ b/internal/server/handlers_import_bundle_test.go
@@ -765,8 +765,11 @@ func TestImportBundle_RefusesNULInManifest(t *testing.T) {
 	got := httptest.NewRecorder()
 	dest.ServeHTTP(got, req)
 
-	if got.Code < 400 {
-		t.Errorf("a manifest carrying a NUL escape must be refused, got %d: %s", got.Code, got.Body.String())
+	// Exactly 400, not "any error": the refusal is a caller-input verdict
+	// the release note promises, and a >=400 assertion would let it decay
+	// into a 500 unnoticed (codex closing round 8).
+	if got.Code != http.StatusBadRequest {
+		t.Errorf("a manifest carrying a NUL escape must be refused with 400, got %d: %s", got.Code, got.Body.String())
 	}
 	if !strings.Contains(got.Body.String(), "NUL") {
 		t.Errorf("the refusal should name the cause, got body=%s", got.Body.String())

--- a/internal/server/handlers_import_bundle_test.go
+++ b/internal/server/handlers_import_bundle_test.go
@@ -757,11 +757,37 @@ func TestImportBundle_RefusesNULInManifest(t *testing.T) {
 	if got := post(t, "CleanManifest", bundle(t, cleanManifest)); got.Code != http.StatusOK && got.Code != http.StatusCreated {
 		t.Fatalf("control bundle must import, got %d: %s", got.Code, got.Body.String())
 	}
-	got := post(t, "NULManifest", bundle(t, nulManifest))
+	dest, _ := testServerWithAttachments(t)
+	req := httptest.NewRequest("POST", "/api/v1/workspaces/import?name=NULManifest",
+		bytes.NewReader(bundle(t, nulManifest)))
+	req.Header.Set("Content-Type", "application/gzip")
+	req.RemoteAddr = "127.0.0.1:1234"
+	got := httptest.NewRecorder()
+	dest.ServeHTTP(got, req)
+
 	if got.Code < 400 {
 		t.Errorf("a manifest carrying a NUL escape must be refused, got %d: %s", got.Code, got.Body.String())
 	}
 	if !strings.Contains(got.Body.String(), "NUL") {
 		t.Errorf("the refusal should name the cause, got body=%s", got.Body.String())
+	}
+
+	// And the PERSISTED state, which the HTTP answer alone does not tell you
+	// (codex round 18). A manifest refusal is NOT a rollback: it keeps the
+	// partial workspace, exactly as every other manifest failure does — the
+	// rollback branch fires only for *importStatusError, and mid-stream
+	// manifest failures intentionally keep what was imported (TASK-896).
+	//
+	// Asserting it here makes that contract deliberate rather than
+	// incidental: if someone later routes this rejection through the
+	// rollback branch, this test says so instead of staying green while the
+	// release note goes stale.
+	list := doRequest(dest, "GET", "/api/v1/workspaces", nil)
+	if list.Code != http.StatusOK {
+		t.Fatalf("list workspaces: %d %s", list.Code, list.Body.String())
+	}
+	if !strings.Contains(list.Body.String(), "NULManifest") {
+		t.Errorf("a manifest refusal keeps the partial workspace (TASK-896); it is absent, so the "+
+			"behaviour changed and the release note now says something false: %s", list.Body.String())
 	}
 }

--- a/internal/server/handlers_import_bundle_test.go
+++ b/internal/server/handlers_import_bundle_test.go
@@ -697,3 +697,71 @@ func TestImportBundle_RefusesNULInExport(t *testing.T) {
 		t.Errorf("the 400 should name the cause, got body=%s", got.Body.String())
 	}
 }
+
+// TestImportBundle_RefusesNULInManifest is the leg codex round 13 found
+// missing: TestImportBundle_RefusesNULInExport builds bundles containing only
+// pad-export.json, so removing the INDEPENDENT manifest check left the suite
+// green. The manifest is a second JSON document parsed the same way and needs
+// its own coverage.
+//
+// Both bundles carry a valid export; they differ only in the manifest, so a
+// refusal cannot come from the export half.
+func TestImportBundle_RefusesNULInManifest(t *testing.T) {
+	src, srcSlug := testServerWithAttachments(t)
+	rr := doRequest(src, "GET", "/api/v1/workspaces/"+srcSlug+"/export", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("export src: %d %s", rr.Code, rr.Body.String())
+	}
+	exportJSON := rr.Body.Bytes()
+
+	esc := string([]byte{'\\', 'u', '0', '0', '0', '0'})
+	cleanManifest := `{"version":1,"entries":[]}`
+	nulManifest := `{"version":1,"entries":[{"id":"00000000-0000-0000-0000-000000000001",` +
+		`"filename":"a` + esc + `b.png","mime":"image/png","size_bytes":1,"content_hash":"deadbeef"}]}`
+
+	bundle := func(t *testing.T, manifest string) []byte {
+		t.Helper()
+		var buf bytes.Buffer
+		gzw := gzip.NewWriter(&buf)
+		tw := tar.NewWriter(gzw)
+		for _, e := range []struct {
+			name string
+			body []byte
+		}{
+			{"pad-export.json", exportJSON},
+			{"attachments/manifest.json", []byte(manifest)},
+		} {
+			if err := tw.WriteHeader(&tar.Header{Name: e.name, Mode: 0o644, Size: int64(len(e.body))}); err != nil {
+				t.Fatalf("write header %s: %v", e.name, err)
+			}
+			if _, err := tw.Write(e.body); err != nil {
+				t.Fatalf("write %s: %v", e.name, err)
+			}
+		}
+		tw.Close()
+		gzw.Close()
+		return buf.Bytes()
+	}
+
+	post := func(t *testing.T, name string, body []byte) *httptest.ResponseRecorder {
+		t.Helper()
+		dest, _ := testServerWithAttachments(t)
+		req := httptest.NewRequest("POST", "/api/v1/workspaces/import?name="+name, bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/gzip")
+		req.RemoteAddr = "127.0.0.1:1234"
+		rec := httptest.NewRecorder()
+		dest.ServeHTTP(rec, req)
+		return rec
+	}
+
+	if got := post(t, "CleanManifest", bundle(t, cleanManifest)); got.Code != http.StatusOK && got.Code != http.StatusCreated {
+		t.Fatalf("control bundle must import, got %d: %s", got.Code, got.Body.String())
+	}
+	got := post(t, "NULManifest", bundle(t, nulManifest))
+	if got.Code < 400 {
+		t.Errorf("a manifest carrying a NUL escape must be refused, got %d: %s", got.Code, got.Body.String())
+	}
+	if !strings.Contains(got.Body.String(), "NUL") {
+		t.Errorf("the refusal should name the cause, got body=%s", got.Body.String())
+	}
+}

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -1969,8 +1969,8 @@ func (s *Server) handleMoveItem(w http.ResponseWriter, r *http.Request) {
 		TargetCollection string         `json:"target_collection"`
 		FieldOverrides   map[string]any `json:"field_overrides"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid_body", "Invalid JSON body")
+	if err := decodeJSON(r, &input); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_body", err.Error())
 		return
 	}
 	if input.TargetCollection == "" {

--- a/internal/server/handlers_oauth.go
+++ b/internal/server/handlers_oauth.go
@@ -1787,9 +1787,11 @@ func (s *Server) renderConsent(w http.ResponseWriter, r *http.Request, ar fosite
 	// edit before submit; nothing client-side is binding.
 	//
 	// Trim + cap defensively. Long suggested names would just truncate
-	// in the connections-page UI; capping at 120 chars matches the
-	// schema column's effective-text limit (TEXT in SQLite, no hard
-	// cap in PG, but 120 keeps the connections-page card width sane).
+	// in the connections-page UI; capping at 120 BYTES (rune-safe cut —
+	// the form's maxlength=120 counts characters, so a multibyte name
+	// can pass the client and still be truncated here) keeps the
+	// connections-page card width sane (TEXT in SQLite, no hard cap
+	// in PG).
 	suggested := strings.TrimSpace(r.URL.Query().Get("suggested_name"))
 	if len(suggested) > 120 {
 		suggested = truncateBindableText(suggested, 120)

--- a/internal/server/handlers_oauth.go
+++ b/internal/server/handlers_oauth.go
@@ -987,7 +987,7 @@ func (s *Server) parseConsentPayload(r *http.Request, ar fosite.AuthorizeRequest
 	// prompts the user to name it on first visit.
 	name := strings.TrimSpace(r.FormValue("connection_name"))
 	if len(name) > 120 {
-		name = name[:120]
+		name = truncateBindableText(name, 120)
 	}
 
 	// may_create_workspaces is a checkbox — present (value="1") if
@@ -1784,7 +1784,7 @@ func (s *Server) renderConsent(w http.ResponseWriter, r *http.Request, ar fosite
 	// cap in PG, but 120 keeps the connections-page card width sane).
 	suggested := strings.TrimSpace(r.URL.Query().Get("suggested_name"))
 	if len(suggested) > 120 {
-		suggested = suggested[:120]
+		suggested = truncateBindableText(suggested, 120)
 	}
 
 	data := consentData{

--- a/internal/server/handlers_oauth.go
+++ b/internal/server/handlers_oauth.go
@@ -227,7 +227,7 @@ func (s *Server) handleOAuthRegister(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var input dcrRequest
-	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+	if err := decodeJSON(r, &input); err != nil {
 		writeDCRError(w, http.StatusBadRequest, "invalid_client_metadata",
 			"Request body must be JSON: "+err.Error())
 		return

--- a/internal/server/handlers_oauth.go
+++ b/internal/server/handlers_oauth.go
@@ -228,8 +228,16 @@ func (s *Server) handleOAuthRegister(w http.ResponseWriter, r *http.Request) {
 
 	var input dcrRequest
 	if err := decodeJSON(r, &input); err != nil {
-		writeDCRError(w, http.StatusBadRequest, "invalid_client_metadata",
-			"Request body must be JSON: "+err.Error())
+		// Two different failures reach here and the message must not
+		// conflate them: a body that is not JSON, and a body that IS valid
+		// JSON but carries text the database cannot store (BUG-2803). The
+		// second one was being reported as "must be JSON", which sends a
+		// client looking for a syntax error it does not have (codex round 7).
+		msg := "Request body must be JSON: " + err.Error()
+		if errors.Is(err, errJSONBodyNUL) {
+			msg = err.Error()
+		}
+		writeDCRError(w, http.StatusBadRequest, "invalid_client_metadata", msg)
 		return
 	}
 

--- a/internal/server/handlers_reports.go
+++ b/internal/server/handlers_reports.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"encoding/json"
 	"net/http"
 	"strconv"
 	"strings"
@@ -144,8 +143,8 @@ func (s *Server) handleSaveReportLayout(w http.ResponseWriter, r *http.Request) 
 	}
 
 	var layout models.ReportLayout
-	if err := json.NewDecoder(r.Body).Decode(&layout); err != nil {
-		writeError(w, http.StatusBadRequest, "bad_request", "Invalid layout JSON")
+	if err := decodeJSON(r, &layout); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
 		return
 	}
 

--- a/internal/server/handlers_timeline.go
+++ b/internal/server/handlers_timeline.go
@@ -336,9 +336,16 @@ func structuredTimelineEntries(item *models.Item, before time.Time, beforeID str
 		// A raw id must be usable as a CURSOR, not merely unique: the client
 		// sends it back as `before_id` and the handler now refuses a value the
 		// database would refuse (BUG-2774's validCursorID). These ids come
-		// from the item's fields blob and nothing validates them on write, so
-		// a JSON `\u0000` reaches here intact on SQLite — Postgres's jsonb
-		// rejects it at the door, which is why this is a one-backend hazard.
+		// from the item's fields blob, and a JSON NUL escape there reaches
+		// here intact on SQLite — Postgres's jsonb rejects it at the door,
+		// which is why this is a one-backend hazard. This comment used to
+		// say "nothing validates them on write"; since BUG-2803 the HTTP
+		// API does refuse a request body whose strings decode to a NUL,
+		// including one nested inside a JSON-encoded `fields` string. The
+		// store does not, so rows predating that rule, and anything writing
+		// a blob by another path (a migration, an import, a future
+		// non-HTTP writer), can still carry one — which is why this
+		// fallback stays.
 		// Emitting such an id would make the server hand out a cursor it then
 		// answers 400 to, wedging paging on that item (codex round 1). It gets
 		// the positional fallback the empty and duplicate cases already take.

--- a/internal/server/handlers_timeline_cursor_validation_test.go
+++ b/internal/server/handlers_timeline_cursor_validation_test.go
@@ -178,12 +178,26 @@ func TestListBeforeTime_InvalidUTF8CursorIsADialectDivergence(t *testing.T) {
 }
 
 // The other direction of the same rule: the server must never EMIT a cursor it
-// would then refuse. A structured id comes from the item's fields blob, which
-// nothing validates on write, so a JSON \u0000 escape reaches the timeline as
-// a real NUL on SQLite (Postgres's jsonb refuses it at the door — a
-// one-backend hazard). Handing that out as next_before_id would wedge paging
-// on the item: the client sends it back and gets a 400 from the validation
-// above.
+// would then refuse. A structured id comes from the item's fields blob, and a
+// JSON NUL escape there reaches the timeline as a real NUL on SQLite
+// (Postgres's jsonb refuses it at the door — a one-backend hazard). Handing
+// that out as next_before_id would wedge paging on the item: the client sends
+// it back and gets a 400 from the validation above.
+//
+// THE FIXTURE WRITES THE BLOB DIRECTLY, and it did not have to when this test
+// was written. The original built the item through the API, on the premise —
+// stated in this comment until BUG-2803 — that "nothing validates the fields
+// blob on write". That premise is now false: decodeJSON refuses a request
+// body whose strings decode to a NUL, including one nested inside a
+// JSON-encoded `fields` string, so the API can no longer produce this row.
+//
+// The DEFENCE this test covers is still live, which is why the test is
+// repaired rather than deleted. Rows in this shape can predate the rule, and
+// the store has no such check of its own, so anything writing a blob directly
+// — a migration, an import, a future non-HTTP writer — can still produce one.
+// The timeline must keep refusing to hand out an unusable cursor for data it
+// did not create. Writing the row through the store is what makes the test
+// about the timeline's defence rather than about the request validator.
 func TestTimeline_NeverEmitsACursorItWouldRefuse(t *testing.T) {
 	t.Parallel()
 	srv := testServer(t)
@@ -193,10 +207,24 @@ func TestTimeline_NeverEmitsACursorItWouldRefuse(t *testing.T) {
 	// truncating limit — that is what makes it the emitted next_before_id
 	// rather than merely an entry id. The clean one is the control: it
 	// distinguishes "replaced the unusable id" from "stopped using raw ids".
-	notes := `[{"id":"note-\u0000-bad","summary":"middle","created_at":"2026-04-02T10:00:01Z"},` +
+	notes := `[{"id":"note-PLACEHOLDER-bad","summary":"middle","created_at":"2026-04-02T10:00:01Z"},` +
 		`{"id":"note-clean","summary":"newest note","created_at":"2026-04-02T10:00:02Z"},` +
 		`{"id":"note-oldest","summary":"oldest","created_at":"2026-04-02T10:00:00Z"}]`
 	item := timelineItemWithStructured(t, srv, ws, notes, "")
+
+	// Swap the placeholder for the JSON NUL ESCAPE directly in the stored
+	// blob — the six characters, not a raw NUL byte. The blob is stored as
+	// JSON text and both backends hold a CHECK/type constraint that a raw NUL
+	// violates; the NUL only comes into existence when Go decodes the blob,
+	// which is precisely how the timeline ends up with one inside an entry id.
+	// The API refuses this body (BUG-2803); the store does not, which is the
+	// gap this test exists to cover.
+	if _, err := srv.store.DB().Exec(
+		`UPDATE items SET fields = REPLACE(fields, 'PLACEHOLDER', ?) WHERE id = ?`,
+		string([]byte{'\\', 'u', '0', '0', '0', '0'}), item.ID,
+	); err != nil {
+		t.Fatalf("inject NUL into the stored fields blob: %v", err)
+	}
 
 	// The item's own `created` activity plus three notes; limit=3 truncates,
 	// so the cursor is the third entry — the NUL-bearing note.

--- a/internal/server/handlers_timeline_cursor_validation_test.go
+++ b/internal/server/handlers_timeline_cursor_validation_test.go
@@ -213,10 +213,18 @@ func TestTimeline_NeverEmitsACursorItWouldRefuse(t *testing.T) {
 	item := timelineItemWithStructured(t, srv, ws, notes, "")
 
 	// Swap the placeholder for the JSON NUL ESCAPE directly in the stored
-	// blob — the six characters, not a raw NUL byte. The blob is stored as
-	// JSON text and both backends hold a CHECK/type constraint that a raw NUL
-	// violates; the NUL only comes into existence when Go decodes the blob,
-	// which is precisely how the timeline ends up with one inside an entry id.
+	// blob — the six characters, not a raw NUL byte. The NUL only comes into
+	// existence when Go DECODES the blob, which is precisely how the timeline
+	// ends up with one inside an entry id.
+	//
+	// A raw NUL does not work here, and the reason is not the one this
+	// comment first gave: items.fields is a plain `TEXT NOT NULL DEFAULT
+	// '{}'` column with no CHECK constraint on SQLite. What was OBSERVED is
+	// that the update fails with "SQL logic error: malformed JSON"; the
+	// likely source is one of the expression indexes over json_extract(fields
+	// ...) rather than a column constraint, and that attribution is NOT
+	// verified. The claim corrected to what the run actually showed (codex
+	// round 8).
 	// The API refuses this body (BUG-2803); the store does not, which is the
 	// gap this test exists to cover.
 	if _, err := srv.store.DB().Exec(

--- a/internal/server/handlers_watches.go
+++ b/internal/server/handlers_watches.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"database/sql"
+	"errors"
+	"io"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
@@ -52,8 +54,15 @@ func (s *Server) handleCreateWatch(w http.ResponseWriter, r *http.Request) {
 	// A watch with no body is valid (unconditional watch) — only reject
 	// a body that's present but malformed JSON, mirroring the tolerant-
 	// empty-body pattern other optional-body endpoints use.
-	if r.ContentLength > 0 {
-		if err := decodeJSON(r, &input); err != nil {
+	//
+	// != 0, not > 0: a CHUNKED body arrives with ContentLength == -1, and
+	// the old guard silently DROPPED it — the caller's predicate was
+	// ignored and an unconditional watch created with a 200 (codex closing
+	// round 4; handlers_tokens.go already used the != 0 form). decodeJSON
+	// answers a genuinely empty body with io.EOF, which keeps the
+	// no-body-is-valid contract for an empty chunked body too.
+	if r.Body != nil && r.ContentLength != 0 {
+		if err := decodeJSON(r, &input); err != nil && !errors.Is(err, io.EOF) {
 			writeError(w, http.StatusBadRequest, "bad_request", err.Error())
 			return
 		}

--- a/internal/server/handlers_watches_test.go
+++ b/internal/server/handlers_watches_test.go
@@ -177,3 +177,72 @@ func TestListWatches_RequiresAuth(t *testing.T) {
 		t.Fatalf("unexpected 500: %s", rec.Body.String())
 	}
 }
+
+// chunkedBearerCall is bearerCall with ContentLength forced to -1, the way a
+// chunked request arrives. The old guard (`ContentLength > 0`) silently
+// DROPPED such bodies — predicate ignored, unconditional watch, 200 (codex
+// closing round 4).
+func chunkedBearerCall(t *testing.T, srv *Server, method, path, token string, body []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(method, path, bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.RemoteAddr = "127.0.0.1:0"
+	req.ContentLength = -1
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestCreateWatch_ChunkedBodyIsDecoded(t *testing.T) {
+	t.Parallel()
+	srv := testServer(t)
+	slug, item, tok, _ := setupWatchTestUser(t, srv)
+	path := "/api/v1/workspaces/" + slug + "/items/" + item.Slug + "/watch"
+
+	// The discriminating assertion is the PREDICATE, not the status code:
+	// the unfixed handler also answered 200, with the predicate silently
+	// dropped to "".
+	rr := chunkedBearerCall(t, srv, "POST", path, tok.Token, []byte(`{"predicate":"status=done"}`))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("chunked create watch: expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	var w models.Watch
+	parseJSON(t, rr, &w)
+	if w.Predicate != "status=done" {
+		t.Fatalf("chunked body was dropped: predicate = %q, want %q", w.Predicate, "status=done")
+	}
+}
+
+func TestCreateWatch_ChunkedMalformedBodyRejected(t *testing.T) {
+	t.Parallel()
+	srv := testServer(t)
+	slug, item, tok, _ := setupWatchTestUser(t, srv)
+	path := "/api/v1/workspaces/" + slug + "/items/" + item.Slug + "/watch"
+
+	// A chunked body must reach the SAME gate a measured one does — here the
+	// NUL rule. Unfixed, this answered 200 and created an unconditional watch.
+	rr := chunkedBearerCall(t, srv, "POST", path, tok.Token, []byte("{\"predicate\":\"status=do\\u0000ne\"}"))
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("chunked NUL body: expected 400, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+}
+
+func TestCreateWatch_ChunkedEmptyBodyStaysValid(t *testing.T) {
+	t.Parallel()
+	srv := testServer(t)
+	slug, item, tok, _ := setupWatchTestUser(t, srv)
+	path := "/api/v1/workspaces/" + slug + "/items/" + item.Slug + "/watch"
+
+	// The tolerant no-body contract must survive the fix: decodeJSON answers
+	// an empty body with io.EOF, which the handler treats as absent.
+	rr := chunkedBearerCall(t, srv, "POST", path, tok.Token, []byte(""))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("chunked empty body: expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	var w models.Watch
+	parseJSON(t, rr, &w)
+	if w.Predicate != "" {
+		t.Fatalf("expected unconditional watch, got predicate %q", w.Predicate)
+	}
+}

--- a/internal/server/middleware_mcp_audit.go
+++ b/internal/server/middleware_mcp_audit.go
@@ -408,12 +408,22 @@ func parseMCPRequestBody(body []byte) (toolName, argsHash string) {
 	// the round-20 sanitise created and did not test). Cleaning before the
 	// test makes the invariant structural instead of something every return
 	// has to remember.
-	method := sanitiseStoredText(env.Method)
-	if method == "" {
+	// CLASSIFY ON THE RAW METHOD, store the sanitised one. Sanitising first
+	// and then comparing let "tools/<NUL>call" clean up INTO "tools/call",
+	// so the parser extracted params.name and hashed the arguments for a
+	// method that was never tools/call — producing an audit row identical to
+	// a genuine call (measured: tool_name="pad_item" with a full args_hash).
+	// That was a regression introduced by the round-21 fix, which reordered
+	// these two steps to keep the fallback alive; codex round 22 caught it.
+	// Cleaning is for the value that gets STORED. Dispatch decisions read
+	// what the client actually sent.
+	if env.Method != "tools/call" {
+		if method := sanitiseStoredText(env.Method); method != "" {
+			return method, ""
+		}
+		// Empty only after cleaning — keep the visible signal rather than
+		// storing "". This is the round-21 boundary, preserved.
 		return "(unknown)", ""
-	}
-	if method != "tools/call" {
-		return method, ""
 	}
 	var p struct {
 		Name      string          `json:"name"`

--- a/internal/server/middleware_mcp_audit.go
+++ b/internal/server/middleware_mcp_audit.go
@@ -369,6 +369,26 @@ func (s *Server) recordMCPCallMetrics(tool, status, userID string, dur time.Dura
 // Returns ("(unknown)", "") on parse failure or empty body — gives
 // the audit reader a visible signal rather than silently dropping
 // the row.
+//
+// Both values that come from the CALLER's body are run through
+// sanitiseStoredText before they leave this function, because they
+// are bound to mcp_audit_log.tool_name (TEXT NOT NULL). This
+// middleware runs its own json.Unmarshal, so a `\u0000` escape in
+// `method` or `params.name` arrives here as a real NUL: PostgreSQL
+// then refuses the audit INSERT with 22021 and SQLite stores an
+// unprintable tool name. Nothing upstream catches it — the /mcp
+// transport decodes the JSON-RPC envelope itself rather than through
+// decodeJSON, so the body rule never sees this request (BUG-2803,
+// codex round 20; that unit's completeness map had wrongly certified
+// this reader as safe on the grounds that the dispatcher decodes the
+// body again, which is true and does not bear on what is persisted
+// here).
+//
+// Sanitising rather than refusing is deliberate: see sanitiseStoredText.
+// The request carrying a malformed name is the one most worth having
+// an audit row for. Both callers of this function — the ok path and
+// the denied path — are covered because the cleaning happens here
+// rather than at either call site.
 func parseMCPRequestBody(body []byte) (toolName, argsHash string) {
 	if len(body) == 0 {
 		return "(unknown)", ""
@@ -381,7 +401,7 @@ func parseMCPRequestBody(body []byte) (toolName, argsHash string) {
 		return "(unknown)", ""
 	}
 	if env.Method != "tools/call" {
-		return env.Method, ""
+		return sanitiseStoredText(env.Method), ""
 	}
 	var p struct {
 		Name      string          `json:"name"`
@@ -390,7 +410,7 @@ func parseMCPRequestBody(body []byte) (toolName, argsHash string) {
 	if err := json.Unmarshal(env.Params, &p); err != nil || p.Name == "" {
 		return "tools/call", ""
 	}
-	return p.Name, hashCanonicalJSON(p.Arguments)
+	return sanitiseStoredText(p.Name), hashCanonicalJSON(p.Arguments)
 }
 
 // hashCanonicalJSON returns a SHA-256 hex of a canonicalized form of

--- a/internal/server/middleware_mcp_audit.go
+++ b/internal/server/middleware_mcp_audit.go
@@ -397,20 +397,35 @@ func parseMCPRequestBody(body []byte) (toolName, argsHash string) {
 		Method string          `json:"method"`
 		Params json.RawMessage `json:"params"`
 	}
-	if err := json.Unmarshal(body, &env); err != nil || env.Method == "" {
+	if err := json.Unmarshal(body, &env); err != nil {
 		return "(unknown)", ""
 	}
-	if env.Method != "tools/call" {
-		return sanitiseStoredText(env.Method), ""
+	// SANITISE FIRST, THEN test for emptiness — not the other way round. A
+	// value made entirely of NUL escapes is non-empty as decoded and empty
+	// once cleaned, so checking first passed it over the fallback and then
+	// blanked it, storing an empty tool_name. That is precisely the silent
+	// drop these fallbacks exist to prevent (codex round 21 — the boundary
+	// the round-20 sanitise created and did not test). Cleaning before the
+	// test makes the invariant structural instead of something every return
+	// has to remember.
+	method := sanitiseStoredText(env.Method)
+	if method == "" {
+		return "(unknown)", ""
+	}
+	if method != "tools/call" {
+		return method, ""
 	}
 	var p struct {
 		Name      string          `json:"name"`
 		Arguments json.RawMessage `json:"arguments"`
 	}
-	if err := json.Unmarshal(env.Params, &p); err != nil || p.Name == "" {
+	if err := json.Unmarshal(env.Params, &p); err != nil {
 		return "tools/call", ""
 	}
-	return sanitiseStoredText(p.Name), hashCanonicalJSON(p.Arguments)
+	if name := sanitiseStoredText(p.Name); name != "" {
+		return name, hashCanonicalJSON(p.Arguments)
+	}
+	return "tools/call", ""
 }
 
 // hashCanonicalJSON returns a SHA-256 hex of a canonicalized form of

--- a/internal/server/middleware_mcp_audit.go
+++ b/internal/server/middleware_mcp_audit.go
@@ -412,24 +412,23 @@ func metricsToolLabel(tool string) string {
 	return tool
 }
 
-// auditLabel marks a value that only became well-formed by being cleaned.
-//
-// Cleaning is lossy, so without a marker "pad_<NUL>item" is stored as
-// "pad_item" — an audit row and a Prometheus label indistinguishable from a
-// genuine pad_item call, and mintable by anyone who can send a request
+// sanitisedLabelPrefix marks an identity that only became well-formed after
+// cleaning. Cleaning is lossy, so without a marker "pad_<NUL>item" is stored
+// as "pad_item" — an audit row and a Prometheus label indistinguishable from
+// a genuine pad_item call, and mintable by anyone who can send a request
 // (codex round 23). Marking keeps the diagnostic value of the cleaned text
 // while making the row honest about what arrived.
 //
-// The parenthesised form is the one this file already uses for a synthesised
-// value ("(unknown)"), and a real JSON-RPC method or MCP tool name does not
-// begin with "(" — so the marker cannot itself be forged by a caller choosing
-// a clever name.
-// sanitisedLabelPrefix marks an identity that only became well-formed after
-// cleaning. Parenthesised like this file's other synthesised value,
-// "(unknown)", and a real JSON-RPC method or MCP tool name does not begin with
-// "(" — so a caller cannot forge the marker by choosing a clever name.
+// The parenthesised spelling alone does NOT make the marker unforgeable — a
+// caller can name a tool "(sanitised) x" — which is why auditLabel below
+// reserves the whole leading-"(" namespace and re-marks anything
+// caller-supplied that enters it. Two earlier copies of this comment rested
+// the non-forgeability claim on "real names do not begin with (", the exact
+// reasoning round 25 retired (codex closing round 3).
 const sanitisedLabelPrefix = "(sanitised) "
 
+// auditLabel applies the marker; see the body for the namespace-reservation
+// rule that makes it non-forgeable.
 func auditLabel(clean string, changed bool) string {
 	// A caller can legitimately name a tool "(unknown)", or "(sanitised)
 	// pad_item", and then a genuine request is indistinguishable from a

--- a/internal/server/middleware_mcp_audit.go
+++ b/internal/server/middleware_mcp_audit.go
@@ -389,6 +389,25 @@ func (s *Server) recordMCPCallMetrics(tool, status, userID string, dur time.Dura
 // an audit row for. Both callers of this function — the ok path and
 // the denied path — are covered because the cleaning happens here
 // rather than at either call site.
+// auditLabel marks a value that only became well-formed by being cleaned.
+//
+// Cleaning is lossy, so without a marker "pad_<NUL>item" is stored as
+// "pad_item" — an audit row and a Prometheus label indistinguishable from a
+// genuine pad_item call, and mintable by anyone who can send a request
+// (codex round 23). Marking keeps the diagnostic value of the cleaned text
+// while making the row honest about what arrived.
+//
+// The parenthesised form is the one this file already uses for a synthesised
+// value ("(unknown)"), and a real JSON-RPC method or MCP tool name does not
+// begin with "(" — so the marker cannot itself be forged by a caller choosing
+// a clever name.
+func auditLabel(clean string, changed bool) string {
+	if !changed {
+		return clean
+	}
+	return "(sanitised) " + clean
+}
+
 func parseMCPRequestBody(body []byte) (toolName, argsHash string) {
 	if len(body) == 0 {
 		return "(unknown)", ""
@@ -418,8 +437,8 @@ func parseMCPRequestBody(body []byte) (toolName, argsHash string) {
 	// Cleaning is for the value that gets STORED. Dispatch decisions read
 	// what the client actually sent.
 	if env.Method != "tools/call" {
-		if method := sanitiseStoredText(env.Method); method != "" {
-			return method, ""
+		if method, changed := sanitiseStoredTextChanged(env.Method); method != "" {
+			return auditLabel(method, changed), ""
 		}
 		// Empty only after cleaning — keep the visible signal rather than
 		// storing "". This is the round-21 boundary, preserved.
@@ -432,8 +451,10 @@ func parseMCPRequestBody(body []byte) (toolName, argsHash string) {
 	if err := json.Unmarshal(env.Params, &p); err != nil {
 		return "tools/call", ""
 	}
-	if name := sanitiseStoredText(p.Name); name != "" {
-		return name, hashCanonicalJSON(p.Arguments)
+	if name, changed := sanitiseStoredTextChanged(p.Name); name != "" {
+		// The hash still describes the real arguments, so it is kept; it is
+		// the NAME that has to stay distinguishable.
+		return auditLabel(name, changed), hashCanonicalJSON(p.Arguments)
 	}
 	return "tools/call", ""
 }

--- a/internal/server/middleware_mcp_audit.go
+++ b/internal/server/middleware_mcp_audit.go
@@ -431,7 +431,28 @@ func metricsToolLabel(tool string) string {
 const sanitisedLabelPrefix = "(sanitised) "
 
 func auditLabel(clean string, changed bool) string {
-	if !changed {
+	// A caller can legitimately name a tool "(unknown)", or "(sanitised)
+	// pad_item", and then a genuine request is indistinguishable from a
+	// substituted one — the marker was forgeable and the older "(unknown)" /
+	// "tools/call" sentinels always were (codex round 25).
+	//
+	// So the leading "(" is RESERVED for values this server synthesises. Any
+	// caller-supplied name that enters that namespace is marked too, whether
+	// or not cleaning touched it. A marked "pad_item" is "(sanitised)
+	// pad_item"; a caller who sends that literal string gets "(sanitised)
+	// (sanitised) pad_item", which is a different value, so the two never
+	// collide. Same for a tool called "(unknown)".
+	//
+	// This is cheaper and more complete than marking only what cleaning
+	// changed, and it needs no schema change. The principled fix for the
+	// whole class is a separate provenance FIELD rather than sentinel strings
+	// in a caller-controlled namespace — BUG-2819, filed rather than folded
+	// in because it is a migration on two tables and this is not.
+	//
+	// Cost, stated: an MCP tool genuinely named with a leading "(" is
+	// recorded marked. Tool names are identifiers in every catalog this
+	// server knows, so nothing legitimate lands here today.
+	if !changed && !strings.HasPrefix(clean, "(") {
 		return clean
 	}
 	return sanitisedLabelPrefix + clean

--- a/internal/server/middleware_mcp_audit.go
+++ b/internal/server/middleware_mcp_audit.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -350,6 +351,7 @@ func (s *Server) recordMCPCallMetrics(tool, status, userID string, dur time.Dura
 	if s.metrics == nil {
 		return
 	}
+	tool = metricsToolLabel(tool)
 	s.metrics.MCPToolCallsTotal.WithLabelValues(userID, tool, status).Inc()
 	// Histogram is per-tool only — duration distributions per user
 	// would explode the series count without a clear analytical
@@ -389,6 +391,27 @@ func (s *Server) recordMCPCallMetrics(tool, status, userID string, dur time.Dura
 // an audit row for. Both callers of this function — the ok path and
 // the denied path — are covered because the cleaning happens here
 // rather than at either call site.
+// metricsToolLabel collapses a marked audit label to the marker alone before it
+// becomes a Prometheus label value.
+//
+// The audit ROW wants the cleaned name — an operator reading one row needs to
+// know which tool it resembles. A metric SERIES does not: keeping the name
+// there would split "(sanitised) pad_item" from "pad_item" into two series per
+// user and status, for a distinction no aggregate query asks. Collapsing keeps
+// exactly one extra label value in total, and it is a constant rather than
+// anything a caller supplies.
+//
+// This bounds only the marker's contribution. The tool label as a whole is
+// still caller-driven and unbounded — see BUG-2817 — because it comes from
+// params.name. That is pre-existing and not this unit's to fix, but it is the
+// reason this function collapses rather than passing the marked name through.
+func metricsToolLabel(tool string) string {
+	if strings.HasPrefix(tool, sanitisedLabelPrefix) {
+		return strings.TrimSuffix(sanitisedLabelPrefix, " ")
+	}
+	return tool
+}
+
 // auditLabel marks a value that only became well-formed by being cleaned.
 //
 // Cleaning is lossy, so without a marker "pad_<NUL>item" is stored as
@@ -401,11 +424,17 @@ func (s *Server) recordMCPCallMetrics(tool, status, userID string, dur time.Dura
 // value ("(unknown)"), and a real JSON-RPC method or MCP tool name does not
 // begin with "(" — so the marker cannot itself be forged by a caller choosing
 // a clever name.
+// sanitisedLabelPrefix marks an identity that only became well-formed after
+// cleaning. Parenthesised like this file's other synthesised value,
+// "(unknown)", and a real JSON-RPC method or MCP tool name does not begin with
+// "(" — so a caller cannot forge the marker by choosing a clever name.
+const sanitisedLabelPrefix = "(sanitised) "
+
 func auditLabel(clean string, changed bool) string {
 	if !changed {
 		return clean
 	}
-	return "(sanitised) " + clean
+	return sanitisedLabelPrefix + clean
 }
 
 func parseMCPRequestBody(body []byte) (toolName, argsHash string) {

--- a/internal/server/middleware_mcp_audit_test.go
+++ b/internal/server/middleware_mcp_audit_test.go
@@ -482,7 +482,11 @@ func TestMCPAudit_ToolNameCannotCarryANUL(t *testing.T) {
 // This is the round-20 fix's own boundary: I closed the NUL door and did not
 // ask what the close does when it consumes the entire value.
 func TestMCPAudit_SanitiseNeverEmptiesToolName(t *testing.T) {
-	nul := "\\u0000" // the escape, not the character
+	// escNULLiteral, not a local literal. Rolling my own here is exactly how
+	// two of these tests became vacuous: written inline, the escape is one
+	// backslash away from being the NUL itself, which is what that helper
+	// exists to prevent and what its comment already warned about.
+	nul := escNULLiteral
 
 	for _, tc := range []struct {
 		name string
@@ -521,7 +525,11 @@ func TestMCPAudit_SanitiseNeverEmptiesToolName(t *testing.T) {
 // full 64-character args_hash — an audit row indistinguishable from a genuine
 // pad_item call, forgeable by anyone who can send a request.
 func TestMCPAudit_RawMethodDecidesClassification(t *testing.T) {
-	nul := "\\u0000" // the escape, not the character
+	// escNULLiteral, not a local literal. Rolling my own here is exactly how
+	// two of these tests became vacuous: written inline, the escape is one
+	// backslash away from being the NUL itself, which is what that helper
+	// exists to prevent and what its comment already warned about.
+	nul := escNULLiteral
 
 	name, hash := parseMCPRequestBody([]byte(
 		`{"method":"tools/` + nul + `call","params":{"name":"pad_item","arguments":{}}}`))
@@ -558,7 +566,11 @@ func TestMCPAudit_RawMethodDecidesClassification(t *testing.T) {
 // property; the specific marker text is incidental and deliberately not
 // asserted beyond being distinguishable.
 func TestMCPAudit_CleanedIdentityIsNotForgeable(t *testing.T) {
-	nul := "\\u0000" // the escape, not the character
+	// escNULLiteral, not a local literal. Rolling my own here is exactly how
+	// two of these tests became vacuous: written inline, the escape is one
+	// backslash away from being the NUL itself, which is what that helper
+	// exists to prevent and what its comment already warned about.
+	nul := escNULLiteral
 
 	for _, tc := range []struct {
 		name          string

--- a/internal/server/middleware_mcp_audit_test.go
+++ b/internal/server/middleware_mcp_audit_test.go
@@ -377,3 +377,83 @@ func TestMCPAudit_ClassifyResult(t *testing.T) {
 		}
 	}
 }
+
+// TestMCPAudit_ToolNameCannotCarryANUL closes a door BUG-2803's own
+// completeness map wrongly certified as safe (codex round 20).
+//
+// That map listed middleware_mcp_audit.go as "audit capture — records the body
+// and restores it; decoding still happens in the MCP dispatcher". The first
+// half is true and the second is irrelevant: parseMCPRequestBody runs its OWN
+// json.Unmarshal and hands the DECODED params.name straight to
+// mcp_audit_log.tool_name, a TEXT NOT NULL column. Whether the dispatcher
+// decodes the body again has no bearing on what this middleware persists.
+//
+// The /mcp transport decodes the JSON-RPC envelope itself rather than through
+// decodeJSON, so nothing upstream refuses the escape either. On PostgreSQL the
+// insert fails with 22021 — the exact symptom this whole unit exists to
+// remove; on SQLite it is stored and the audit log carries an unprintable
+// tool name.
+//
+// The disposition is SANITISE, not refuse, following the User-Agent precedent
+// established earlier in this unit: the audit row is metadata the SERVER chose
+// to record about a request, and the request that carries a malformed value is
+// precisely the one you most want a row for. Failing the audit write would
+// lose that row, which is worse than recording a cleaned name.
+func TestMCPAudit_ToolNameCannotCarryANUL(t *testing.T) {
+	srv, user, bearer := auditedMCPServer(t)
+
+	post := func(t *testing.T, body string) {
+		t.Helper()
+		req := httptest.NewRequest("POST", "/mcp", strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+bearer)
+		req.Header.Set("Content-Type", "application/json")
+		req.RemoteAddr = "192.0.2.1:1234"
+		srv.ServeHTTP(httptest.NewRecorder(), req)
+	}
+
+	// Control FIRST, so the test asserts its own premise: an ordinary name is
+	// stored verbatim. Without this leg the assertion below would pass against
+	// a middleware that mangled or dropped every tool name.
+	post(t, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"pad_item","arguments":{}}}`)
+	rows := waitForAuditRows(t, srv, user.ID, 1)
+	if rows[0].ToolName != "pad_item" {
+		t.Fatalf("premise failed: an ordinary tool name must round-trip verbatim, got %q", rows[0].ToolName)
+	}
+
+	post(t, `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"pad_item`+escNULLiteral+`evil","arguments":{}}}`)
+	rows = waitForAuditRows(t, srv, user.ID, 2)
+
+	for _, row := range rows {
+		if strings.ContainsRune(row.ToolName, 0) {
+			t.Errorf("a decoded NUL reached mcp_audit_log.tool_name (%q). On PostgreSQL this insert "+
+				"fails with 22021; the value must be sanitised before it is persisted", row.ToolName)
+		}
+	}
+
+	// And the sanitised name must still IDENTIFY the tool — dropping the row
+	// or storing "(unknown)" would make the audit log useless for exactly the
+	// requests worth auditing.
+	var sanitised string
+	for _, row := range rows {
+		if row.ToolName != "pad_item" {
+			sanitised = row.ToolName
+		}
+	}
+	if want := "pad_itemevil"; sanitised != want {
+		t.Errorf("the NUL-bearing call should be recorded under a cleaned name %q, got %q", want, sanitised)
+	}
+
+	// The OTHER path into tool_name. parseMCPRequestBody has two returns that
+	// carry caller text - params.name for tools/call, and the METHOD itself
+	// for everything else - and both are bound to the same column. Testing
+	// only the first would leave the second's sanitise call unkilled by any
+	// mutation, which is how a fixed surface count turns back into a defect.
+	post(t, `{"jsonrpc":"2.0","id":3,"method":"tools/li`+escNULLiteral+`st"}`)
+	rows = waitForAuditRows(t, srv, user.ID, 3)
+	for _, row := range rows {
+		if strings.ContainsRune(row.ToolName, 0) {
+			t.Errorf("a decoded NUL reached tool_name via the METHOD path (%q); params.name is not "+
+				"the only return that carries caller text", row.ToolName)
+		}
+	}
+}

--- a/internal/server/middleware_mcp_audit_test.go
+++ b/internal/server/middleware_mcp_audit_test.go
@@ -439,8 +439,17 @@ func TestMCPAudit_ToolNameCannotCarryANUL(t *testing.T) {
 			sanitised = row.ToolName
 		}
 	}
-	if want := "pad_itemevil"; sanitised != want {
-		t.Errorf("the NUL-bearing call should be recorded under a cleaned name %q, got %q", want, sanitised)
+	// The cleaned text is kept for diagnosis, but MARKED — round 23 showed
+	// that storing the bare cleaned name makes the row indistinguishable from
+	// a genuine call with that name. Asserted as "contains the cleaned text
+	// and is not equal to it", so this pins the two properties that matter
+	// (diagnosable, and distinguishable) without pinning the marker's wording.
+	if !strings.Contains(sanitised, "pad_itemevil") {
+		t.Errorf("the NUL-bearing call should still be diagnosable from its cleaned name, got %q", sanitised)
+	}
+	if sanitised == "pad_itemevil" {
+		t.Errorf("the cleaned name is stored bare, so it is indistinguishable from a genuine call " +
+			"named pad_itemevil; it must be marked as cleaned")
 	}
 
 	// The OTHER path into tool_name. parseMCPRequestBody has two returns that
@@ -512,7 +521,7 @@ func TestMCPAudit_SanitiseNeverEmptiesToolName(t *testing.T) {
 // full 64-character args_hash — an audit row indistinguishable from a genuine
 // pad_item call, forgeable by anyone who can send a request.
 func TestMCPAudit_RawMethodDecidesClassification(t *testing.T) {
-	nul := "\u0000" // the escape, not the character
+	nul := "\\u0000" // the escape, not the character
 
 	name, hash := parseMCPRequestBody([]byte(
 		`{"method":"tools/` + nul + `call","params":{"name":"pad_item","arguments":{}}}`))
@@ -532,5 +541,63 @@ func TestMCPAudit_RawMethodDecidesClassification(t *testing.T) {
 	if name != "pad_item" || hash == "" {
 		t.Fatalf("premise failed: a genuine tools/call must still yield its name and a hash, got %q / %d chars",
 			name, len(hash))
+	}
+}
+
+// TestMCPAudit_CleanedIdentityIsNotForgeable pins that a value which only
+// became well-formed by cleaning cannot imitate a genuine one (codex round 23).
+//
+// Round 22 closed the coarse version: sanitising before classifying let
+// "tools/<NUL>call" become a real tools/call and lift params.name. Classifying
+// on the raw method fixed that, but cleaning is LOSSY, so the stored pair
+// still collapsed onto a genuine identity — "pad_<NUL>item" stored exactly
+// what "pad_item" stores, hash included. An audit row anyone can mint to look
+// like someone else's call is not an audit row.
+//
+// Each case asserts the forged value DIFFERS from the genuine one. That is the
+// property; the specific marker text is incidental and deliberately not
+// asserted beyond being distinguishable.
+func TestMCPAudit_CleanedIdentityIsNotForgeable(t *testing.T) {
+	nul := "\\u0000" // the escape, not the character
+
+	for _, tc := range []struct {
+		name          string
+		forged, real_ string
+	}{
+		{
+			"tool name",
+			`{"method":"tools/call","params":{"name":"pad_` + nul + `item","arguments":{"a":1}}}`,
+			`{"method":"tools/call","params":{"name":"pad_item","arguments":{"a":1}}}`,
+		},
+		{
+			"method name",
+			`{"method":"initialize` + nul + `"}`,
+			`{"method":"initialize"}`,
+		},
+		{
+			"method that cleans into tools/call",
+			`{"method":"tools/` + nul + `call","params":{"name":"pad_item","arguments":{}}}`,
+			`{"method":"tools/call","params":{"name":"pad_item","arguments":{}}}`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fName, fHash := parseMCPRequestBody([]byte(tc.forged))
+			rName, rHash := parseMCPRequestBody([]byte(tc.real_))
+
+			if fName == rName && fHash == rHash {
+				t.Errorf("a NUL-bearing request stores the SAME audit identity as a genuine one "+
+					"(tool_name=%q args_hash=%q) — anyone who can send a request can mint a row "+
+					"attributed to a real call", fName, fHash)
+			}
+			if fName == "" {
+				t.Errorf("the forged case must still record something diagnosable, got an empty tool_name")
+			}
+			// Premise: the genuine leg is the ordinary value, so the
+			// assertion above is about the forged one differing rather than
+			// about the parser having stopped working.
+			if rName == "" {
+				t.Fatalf("premise failed: the genuine request must record a name, got empty")
+			}
+		})
 	}
 }

--- a/internal/server/middleware_mcp_audit_test.go
+++ b/internal/server/middleware_mcp_audit_test.go
@@ -613,3 +613,40 @@ func TestMCPAudit_CleanedIdentityIsNotForgeable(t *testing.T) {
 		})
 	}
 }
+
+// TestMetricsToolLabelIsBounded pins that the cleaned-identity marker costs
+// exactly ONE extra Prometheus label value, not one per tool (codex round 24).
+//
+// The audit ROW keeps the cleaned name; an operator reading a single row needs
+// to know which tool it resembles. A metric SERIES does not, and keeping the
+// name there would split "(sanitised) pad_item" from "pad_item" per user and
+// per status for a distinction no aggregate query asks.
+//
+// This bounds the MARKER only. The tool label as a whole is still caller-driven
+// and unbounded (BUG-2817, pre-existing); that is why this collapses rather
+// than passing the marked name through.
+func TestMetricsToolLabelIsBounded(t *testing.T) {
+	genuine := metricsToolLabel("pad_item")
+	if genuine != "pad_item" {
+		t.Fatalf("premise failed: an unmarked name must reach metrics unchanged, got %q", genuine)
+	}
+
+	// Every marked name collapses to the SAME label value, so the marker adds
+	// one series family rather than doubling every tool's.
+	seen := map[string]bool{}
+	for _, name := range []string{"pad_item", "pad_workspace", "pad_search", "initialize"} {
+		seen[metricsToolLabel(auditLabel(name, true))] = true
+	}
+	if len(seen) != 1 {
+		t.Errorf("marked names must collapse to one metrics label; got %d distinct values: %v",
+			len(seen), seen)
+	}
+	for label := range seen {
+		if strings.ContainsAny(label, "abcdefghijklmnopqrstuvwxyz_") && label != "(sanitised)" {
+			t.Errorf("the collapsed label still carries caller-derived text: %q", label)
+		}
+		if label == genuine {
+			t.Errorf("the marked label collides with the genuine one (%q)", label)
+		}
+	}
+}

--- a/internal/server/middleware_mcp_audit_test.go
+++ b/internal/server/middleware_mcp_audit_test.go
@@ -502,3 +502,35 @@ func TestMCPAudit_SanitiseNeverEmptiesToolName(t *testing.T) {
 		t.Fatalf("premise failed: an ordinary method must round-trip, got %q", got)
 	}
 }
+
+// TestMCPAudit_RawMethodDecidesClassification pins that dispatch reads what the
+// client SENT while only the stored value is cleaned (codex round 22).
+//
+// The round-21 fix sanitised before comparing, so "tools/<NUL>call" cleaned up
+// INTO the literal "tools/call" and the parser then extracted params.name and
+// hashed the arguments. Measured before the fix: tool_name="pad_item" with a
+// full 64-character args_hash — an audit row indistinguishable from a genuine
+// pad_item call, forgeable by anyone who can send a request.
+func TestMCPAudit_RawMethodDecidesClassification(t *testing.T) {
+	nul := "\u0000" // the escape, not the character
+
+	name, hash := parseMCPRequestBody([]byte(
+		`{"method":"tools/` + nul + `call","params":{"name":"pad_item","arguments":{}}}`))
+	if name == "pad_item" {
+		t.Errorf("a method that is not tools/call must NOT have params.name lifted out of it; " +
+			"tool_name came back as the inner tool name, which forges a genuine call")
+	}
+	if hash != "" {
+		t.Errorf("args_hash must be empty for a non-tools/call method, got %d chars", len(hash))
+	}
+
+	// Control: a genuine tools/call still classifies and still hashes, so the
+	// assertions above pin the classification rather than a parser that
+	// stopped working.
+	name, hash = parseMCPRequestBody([]byte(
+		`{"method":"tools/call","params":{"name":"pad_item","arguments":{}}}`))
+	if name != "pad_item" || hash == "" {
+		t.Fatalf("premise failed: a genuine tools/call must still yield its name and a hash, got %q / %d chars",
+			name, len(hash))
+	}
+}

--- a/internal/server/middleware_mcp_audit_test.go
+++ b/internal/server/middleware_mcp_audit_test.go
@@ -457,3 +457,48 @@ func TestMCPAudit_ToolNameCannotCarryANUL(t *testing.T) {
 		}
 	}
 }
+
+// TestMCPAudit_SanitiseNeverEmptiesToolName covers the boundary the round-20
+// fix created and did not test (codex round 21, top-ranked un-probed lens).
+//
+// parseMCPRequestBody checks env.Method == "" and p.Name == "" BEFORE
+// sanitising, so a value made ENTIRELY of NULs is non-empty at the fallback
+// and empty by the time it is returned. tool_name is TEXT NOT NULL, so the
+// row still inserts — with an empty identifier, which defeats the whole point
+// of the "(unknown)" / "tools/call" fallbacks. That function's own doc comment
+// says they exist to give the audit reader a visible signal rather than
+// silently dropping the row; an empty string is the silent drop wearing a
+// different shape.
+//
+// This is the round-20 fix's own boundary: I closed the NUL door and did not
+// ask what the close does when it consumes the entire value.
+func TestMCPAudit_SanitiseNeverEmptiesToolName(t *testing.T) {
+	nul := "\\u0000" // the escape, not the character
+
+	for _, tc := range []struct {
+		name string
+		body string
+		want string
+	}{
+		{"method is all NULs", `{"jsonrpc":"2.0","id":1,"method":"` + nul + `"}`, "(unknown)"},
+		{"tools/call name is all NULs",
+			`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"` + nul + `"}}`, "tools/call"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, _ := parseMCPRequestBody([]byte(tc.body))
+			if got == "" {
+				t.Fatalf("tool_name came back EMPTY; the fallback must survive sanitisation, want %q", tc.want)
+			}
+			if got != tc.want {
+				t.Errorf("tool_name = %q, want the fallback %q", got, tc.want)
+			}
+		})
+	}
+
+	// Premise: the same shapes with ordinary values still return the value
+	// itself, so the assertions above are about emptiness rather than about
+	// the fallback swallowing everything.
+	if got, _ := parseMCPRequestBody([]byte(`{"method":"tools/list"}`)); got != "tools/list" {
+		t.Fatalf("premise failed: an ordinary method must round-trip, got %q", got)
+	}
+}

--- a/internal/server/middleware_mcp_audit_test.go
+++ b/internal/server/middleware_mcp_audit_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -649,4 +650,63 @@ func TestMetricsToolLabelIsBounded(t *testing.T) {
 			t.Errorf("the marked label collides with the genuine one (%q)", label)
 		}
 	}
+}
+
+// TestMCPAudit_SynthesisedNamespaceIsReserved pins that a caller cannot name a
+// tool so that its UNMODIFIED value collides with a value this server
+// synthesises (codex round 25).
+//
+// Marking only what cleaning changed was not enough: "(unknown)" is what the
+// parser returns for a malformed body, and "(sanitised) pad_item" is what it
+// returns for a NUL-bearing pad_item — both are strings a caller may simply
+// choose. The leading "(" is now reserved, so any caller value entering that
+// namespace is marked and therefore differs from the synthesised one.
+func TestMCPAudit_SynthesisedNamespaceIsReserved(t *testing.T) {
+	nul := escNULLiteral
+
+	// What the server synthesises, obtained from the server rather than
+	// hardcoded, so this test cannot drift away from the real values.
+	synthUnknown, _ := parseMCPRequestBody([]byte(`not json at all`))
+	synthMarked, _ := parseMCPRequestBody([]byte(
+		`{"method":"tools/call","params":{"name":"pad_` + nul + `item","arguments":{}}}`))
+	if synthUnknown == "" || synthMarked == "" {
+		t.Fatalf("premise failed: expected synthesised values, got %q and %q", synthUnknown, synthMarked)
+	}
+
+	for _, tc := range []struct {
+		name, chosen, collidesWith string
+	}{
+		{"a tool named like the unknown fallback", synthUnknown, synthUnknown},
+		{"a tool named like a marked identity", synthMarked, synthMarked},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, _ := parseMCPRequestBody([]byte(
+				`{"method":"tools/call","params":{"name":` + mustJSONString(t, tc.chosen) + `,"arguments":{}}}`))
+			if got == tc.collidesWith {
+				t.Errorf("a caller choosing the name %q produces the same audit identity as the value "+
+					"the server synthesises; a genuine request is then indistinguishable from a "+
+					"substituted one", tc.chosen)
+			}
+			if got == "" {
+				t.Errorf("the call must still record something diagnosable, got an empty tool_name")
+			}
+		})
+	}
+
+	// Premise: an ordinary name outside the reserved namespace is untouched,
+	// so the assertions above pin the namespace rather than a parser that
+	// marks everything.
+	if got, _ := parseMCPRequestBody([]byte(
+		`{"method":"tools/call","params":{"name":"pad_item","arguments":{}}}`)); got != "pad_item" {
+		t.Fatalf("premise failed: an ordinary name must be recorded verbatim, got %q", got)
+	}
+}
+
+func mustJSONString(t *testing.T, s string) string {
+	t.Helper()
+	b, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal %q: %v", s, err)
+	}
+	return string(b)
 }

--- a/internal/server/middleware_mcp_metrics_test.go
+++ b/internal/server/middleware_mcp_metrics_test.go
@@ -225,3 +225,46 @@ func gaugeValueOrZero(t *testing.T, g interface {
 	}
 	return m.GetGauge().GetValue()
 }
+
+// TestRecordMCPCallMetrics_CollapsesSanitisedLabel is the WIRING leg for the
+// cleaned-identity marker (codex round 24; CONVE-19 — a direct-call test
+// vouches for the component, not its binding).
+//
+// TestMetricsToolLabelIsBounded proves metricsToolLabel collapses a marked
+// name. It does NOT prove recordMCPCallMetrics calls it, and removing that
+// call from the emit path leaves that test green — measured, which is why this
+// one exists.
+//
+// The audit ROW keeps the cleaned name; the metric SERIES must not, or every
+// tool gains a second series per user and status for a distinction no
+// aggregate query asks.
+func TestRecordMCPCallMetrics_CollapsesSanitisedLabel(t *testing.T) {
+	s := &Server{metrics: metrics.New()}
+	r := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+
+	marked := auditLabel("pad_item", true)
+	s.recordMCPCallMetrics(marked, "ok", "user-1", 10*time.Millisecond, r, http.StatusOK)
+
+	// The marked name must NOT appear as a label value.
+	if got := counterValue(t, s.metrics.MCPToolCallsTotal.WithLabelValues("user-1", marked, "ok")); got != 0 {
+		t.Errorf("the marked name %q reached Prometheus as a label value (count %v); it must be "+
+			"collapsed, or each tool gains a second series per user and status", marked, got)
+	}
+	// It must land under the collapsed marker instead.
+	collapsed := metricsToolLabel(marked)
+	if got := counterValue(t, s.metrics.MCPToolCallsTotal.WithLabelValues("user-1", collapsed, "ok")); got != 1 {
+		t.Errorf("expected the call to be counted under the collapsed label %q, got %v", collapsed, got)
+	}
+	// And it must not be silently folded into the genuine tool's series.
+	if got := counterValue(t, s.metrics.MCPToolCallsTotal.WithLabelValues("user-1", "pad_item", "ok")); got != 0 {
+		t.Errorf("a cleaned identity was counted as the genuine tool pad_item (count %v); the "+
+			"marker exists precisely so the two stay apart", got)
+	}
+
+	// Premise: an ordinary name still counts under itself, so the assertions
+	// above are about the marked case rather than about counting being broken.
+	s.recordMCPCallMetrics("pad_item", "ok", "user-2", 10*time.Millisecond, r, http.StatusOK)
+	if got := counterValue(t, s.metrics.MCPToolCallsTotal.WithLabelValues("user-2", "pad_item", "ok")); got != 1 {
+		t.Fatalf("premise failed: an unmarked name must count under itself, got %v", got)
+	}
+}

--- a/internal/server/middleware_request_text.go
+++ b/internal/server/middleware_request_text.go
@@ -347,22 +347,6 @@ func validQueryText(rawQuery string) bool {
 	return true
 }
 
-// jsonNULEscape is the six-byte JSON escape that decodes to a NUL. It is
-// built from bytes rather than written as a literal so that no layer between
-// this source and the compiler can transform it into the character it
-// describes — the same reason the tests construct it this way.
-//
-// It is the only spelling OF THE ESCAPE ITSELF. JSON forbids an unescaped
-// control character inside a string, so a raw 0x00 byte never survives
-// decoding (encoding/json answers `invalid character '\x00' in string
-// literal`), and the uppercase \U form is not a JSON escape at all
-// (`invalid character 'U' in string escape code`). Both measured against
-// encoding/json, BUG-2803.
-//
-// THAT SENTENCE DOES NOT MAKE THE SUBSTRING A SOUND FILTER, which is the
-// mistake this comment used to encode — see bodyDecodesNUL's gate.
-var jsonNULEscape = []byte{'\\', 'u', '0', '0', '0', '0'}
-
 // bodyDecodesNUL reports whether any string a handler could read out of this
 // JSON body — an object key or a value, at any nesting depth, including
 // inside a JSON document carried as a string — decodes to a string containing
@@ -373,7 +357,10 @@ var jsonNULEscape = []byte{'\\', 'u', '0', '0', '0', '0'}
 // query value is a substring of the raw request with ASCII substitutions: the
 // bad byte in the raw text IS the bad byte in the value, so a middleware can
 // find it without parsing. That property does not hold for a JSON body. The
-// reachable NUL arrives as jsonNULEscape — six ordinary ASCII characters — so
+// reachable NUL arrives as a six-character JSON escape (backslash, u, and
+// four zeros — spelled out rather than written, since a literal is one
+// transformation away from being the character it describes), all ordinary
+// ASCII, so
 // a transport-level scan for a NUL byte sees nothing, and no request
 // middleware can find it without decoding the body, which is the handler's
 // job. BUG-2784 recorded this as the reason its rule stops at the query
@@ -382,7 +369,7 @@ var jsonNULEscape = []byte{'\\', 'u', '0', '0', '0', '0'}
 // THE GATE IS A BACKSLASH, NOT THE ESCAPE SUBSTRING, and the difference is a
 // real bypass rather than a stylistic one.
 //
-// The obvious fast path — "does the raw body contain jsonNULEscape?" — is
+// The obvious fast path — "does the raw body contain that escape?" — is
 // UNSOUND, and codex round 4 on BUG-2803 demonstrated it. The escape may be
 // spelled obliquely: `\u005c` decodes to a BACKSLASH, so a body carrying
 // `\u005cu0000` contains no literal six-character escape anywhere in its raw
@@ -405,7 +392,7 @@ var jsonNULEscape = []byte{'\\', 'u', '0', '0', '0', '0'}
 // which is the cost of being correct here.
 //
 // WHY THE EXACT STEP IS NOT A SUBSTRING SEARCH EITHER. Containing
-// jsonNULEscape is not sufficient: `\\u0000` (an escaped backslash followed
+// the escape is not sufficient either: `\\u0000` (an escaped backslash followed
 // by literal text) contains the same six characters and decodes to no NUL at
 // all. Refusing on the substring alone would reject a legitimate value, and in
 // THIS product that is not hypothetical — items and documents store markdown,

--- a/internal/server/middleware_request_text.go
+++ b/internal/server/middleware_request_text.go
@@ -478,6 +478,28 @@ var jsonEncodedFieldKeys = map[string]bool{
 	"traits":         true,
 }
 
+// isJSONEncodedFieldKey matches a wire key the way the DECODER that consumes
+// it does: case-insensitively.
+//
+// encoding/json matches an incoming key to a struct field by an exact match
+// first and a CASE-INSENSITIVE one otherwise, so `{"Fields":...}` and
+// `{"FIELDS":...}` both land in ItemCreate.Fields. A case-SENSITIVE lookup
+// here therefore skipped the nested walk for a body the handler went on to
+// accept, and the database answered the original 500 (codex round 16,
+// measured: `fields` refused, `Fields` and `FIELDS` accepted).
+//
+// This is the same defect shape as the rest of BUG-2803 — a check that agrees
+// with one layer's rules while the layer that actually consumes the value
+// uses different ones — and it is the reason this predicate is a function
+// rather than a bare map index: the map is the vocabulary, the MATCHING RULE
+// belongs to the consumer.
+func isJSONEncodedFieldKey(k string) bool {
+	if jsonEncodedFieldKeys[k] {
+		return true
+	}
+	return jsonEncodedFieldKeys[strings.ToLower(k)]
+}
+
 // valueDecodesNUL walks a decoded request body for a string that contains a
 // NUL, descending into a JSON document carried as a string exactly once.
 //
@@ -520,7 +542,7 @@ func valueDecodesNUL(v any, inUserData bool) bool {
 			if strings.ContainsRune(k, 0) {
 				return true
 			}
-			if !inUserData && jsonEncodedFieldKeys[k] {
+			if !inUserData && isJSONEncodedFieldKey(k) {
 				if str, isString := sub.(string); isString {
 					// BOTH checks. The nested walk answers "is there an
 					// escape inside the document this string carries"; it

--- a/internal/server/middleware_request_text.go
+++ b/internal/server/middleware_request_text.go
@@ -522,7 +522,15 @@ func valueDecodesNUL(v any, inUserData bool) bool {
 			}
 			if !inUserData && jsonEncodedFieldKeys[k] {
 				if str, isString := sub.(string); isString {
-					if nestedDocumentDecodesNUL(str) {
+					// BOTH checks. The nested walk answers "is there an
+					// escape inside the document this string carries"; it
+					// does NOT answer "does this string itself contain a
+					// NUL", and taking the JSON-encoded branch used to skip
+					// the plain check entirely — so a direct NUL in a
+					// `fields` value was accepted, reopening the door this
+					// whole change exists to close (codex round 9, a
+					// regression introduced by the round-8 restructure).
+					if strings.ContainsRune(str, 0) || nestedDocumentDecodesNUL(str) {
 						return true
 					}
 					continue

--- a/internal/server/middleware_request_text.go
+++ b/internal/server/middleware_request_text.go
@@ -593,3 +593,54 @@ func readBodyForDecode(r *http.Request, maxBytes int64) ([]byte, error) {
 	r.Body = http.MaxBytesReader(nil, r.Body, maxBytes)
 	return io.ReadAll(r.Body)
 }
+
+// truncateBindableText cuts s to at most maxBytes bytes WITHOUT splitting a
+// rune, so the result is still valid UTF-8.
+//
+// A plain s[:n] slices bytes. If byte n lands inside a multi-byte rune the
+// result ends in a partial sequence, which is not valid UTF-8 — so a value
+// that PASSED the body check a few frames earlier becomes unbindable on its
+// way to the store, and Postgres answers 22021 for a request the server
+// already accepted. Found by the codex round 5 enumeration on BUG-2803, which
+// asked what could still reach a text parameter unvalidated and named
+// truncation rather than any input path.
+//
+// The failure is invisible in testing with ASCII, which is why it survived
+// four review rounds aimed at the input side: every fixture in this area uses
+// ASCII names, and ASCII cannot reproduce it.
+func truncateBindableText(s string, maxBytes int) string {
+	if len(s) <= maxBytes {
+		return s
+	}
+	cut := maxBytes
+	// Walk back off any continuation bytes (10xxxxxx) to the start of the
+	// rune that straddles the boundary, then drop that rune entirely.
+	for cut > 0 && s[cut]&0xC0 == 0x80 {
+		cut--
+	}
+	return s[:cut]
+}
+
+// requestUserAgent returns the User-Agent header as text the database can
+// store, replacing any invalid UTF-8 and dropping any NUL.
+//
+// A header is not a path, a query or a body, so none of the rules above see
+// it — and unlike those, it is not the caller ASKING for anything: it is
+// metadata this server chose to record. Refusing the whole request because a
+// header is malformed would answer 400 to a request whose actual subject is
+// fine, so this sanitizes rather than rejects, which is the opposite
+// disposition from the rest of this file and deliberately so.
+//
+// The sinks are text columns: activities.user_agent (documents and the
+// connected-apps revoke path) and sessions.user_agent (three login paths).
+// The two sites that HASH the header instead are left alone — sha256 over
+// arbitrary bytes is well defined, and changing what is hashed would
+// invalidate every stored UAHash.
+//
+// Found by the codex round 5 enumeration on BUG-2803. The filing's own
+// earlier probe had recorded User-Agent as NOT reproducing on the item-create
+// path, which was true and did not generalise: these are different sinks.
+func requestUserAgent(r *http.Request) string {
+	ua := strings.ToValidUTF8(r.Header.Get("User-Agent"), "")
+	return strings.ReplaceAll(ua, "\x00", "")
+}

--- a/internal/server/middleware_request_text.go
+++ b/internal/server/middleware_request_text.go
@@ -795,5 +795,25 @@ func requestUserAgent(r *http.Request) string {
 // is the body rule's job, and silently cleaning such a value would store
 // something the caller did not send.
 func sanitiseStoredText(s string) string {
-	return strings.ReplaceAll(strings.ToValidUTF8(s, ""), "\x00", "")
+	clean, _ := sanitiseStoredTextChanged(s)
+	return clean
+}
+
+// sanitiseStoredTextChanged is sanitiseStoredText plus the fact a caller needs
+// when the value is an IDENTITY rather than free text: whether anything was
+// removed.
+//
+// Cleaning is LOSSY, so distinct inputs collapse onto the same output —
+// "pad_<NUL>item" and "pad_item" both become "pad_item". For a User-Agent
+// that is fine; nothing decides anything on it. For a value that NAMES what a
+// request did, it is a forgery: an audit row or a metric label that cannot be
+// told apart from the genuine one it imitates (codex round 23, after round 22
+// closed the coarser version of the same hole).
+//
+// Callers that store an identity must use this and mark a changed value, so
+// "was cleaned" stays visible instead of being silently absorbed. Callers that
+// store descriptive text can keep using sanitiseStoredText.
+func sanitiseStoredTextChanged(s string) (string, bool) {
+	clean := strings.ReplaceAll(strings.ToValidUTF8(s, ""), "\x00", "")
+	return clean, clean != s
 }

--- a/internal/server/middleware_request_text.go
+++ b/internal/server/middleware_request_text.go
@@ -424,6 +424,64 @@ var unicodeEscapePrefix = []byte{'\\', 'u', '0', '0'}
 // A malformed body returns false rather than an error: the caller's decode
 // runs next and reports the JSON error itself, so there is exactly one place
 // that phrases "invalid JSON" and this function never has to agree with it.
+// That choice has a consequence, and it is finding (2) below rather than a
+// clean separation of concerns.
+//
+// WHAT THIS CHECK DOES NOT COVER — four measured disagreements between what
+// this scan sees and what the typed decode does, left OPEN deliberately
+// (BUG-2803 rounds 16-17, lead ruling day-68: land-and-follow). They are
+// recorded here because this is the function a reader consults before
+// trusting the check, and an unqualified doc comment above an incomplete
+// guard is how the next person inherits a false belief.
+//
+// The root cause of all four is one thing: this scan decodes into
+// map[string]any, and encoding/json's typed decode does NOT agree with that
+// model about keys. TWO UNDER-REFUSE (a NUL gets through) and TWO
+// OVER-REFUSE (a legitimate body is rejected).
+//
+// UNDER-REFUSALS — these are the BUG-2812 unit's spec, not a TODO here. Both
+// dissolve under a token-stream walk that never builds values, which is that
+// unit's design; patching them into the map model would be re-plumbing an
+// 18-commit branch late under review pressure, and this branch's one
+// regression came from exactly that.
+//
+//  1. DUPLICATE KEYS MERGE DIFFERENTLY (P1). For
+//     {"fields_patch":{"orphan":"<NUL>"},"fields_patch":{"status":"open"}},
+//     decoding into map[string]any REPLACES the first value, so this scan
+//     sees only `status`; encoding/json MERGES into an already-populated map
+//     field, so the handler keeps both and persists the NUL. The `any` scan
+//     structurally cannot see the shadowed occurrence — no amount of care
+//     inside this model reaches it.
+//  2. A SCAN FAILURE LETS A KNOWN-BAD VALUE THROUGH (P1). For
+//     {"title":"a<NUL>b","ignored":1e999}, the overflowing number makes the
+//     `any` unmarshal fail, this function returns false (see the paragraph
+//     above), and the typed decode then SKIPS the unknown field and accepts
+//     the body with its NUL title. Returning an error instead would reject
+//     bodies the handlers accept today, so the fix is not "refuse on scan
+//     failure" — it is not building values in the first place.
+//
+// OVER-REFUSALS — dispositions, ACCEPTED as-is, and the reason each is
+// tolerable is that it refuses rather than admits:
+//
+//  3. UNKNOWN FIELDS ARE SCANNED THOUGH HANDLERS IGNORE THEM (P2).
+//     {"title":"valid","future_field":"<NUL>"} is refused although the value
+//     reaches nothing. Scoping the scan to known fields would need the
+//     destination type, which this function deliberately does not have (see
+//     WHY NOT REFLECT above) — so the alternative is not a smaller change,
+//     it is a different design. ACCEPTED, and it is an OBSERVABLE
+//     COMPATIBILITY CHANGE: a client sending a forward-compatible field with
+//     a NUL escape in it now gets a 400 where it got a 200. Stated in the
+//     release note for that reason, not only here.
+//  4. CASE-VARIANT DUPLICATES OVER-REJECT (P2). For
+//     {"title":"<NUL>","TITLE":"safe"} the typed decode keeps `safe` and
+//     discards the NUL, while this scan sees both keys and refuses. Same
+//     root as (1), opposite direction: there the map model hides an
+//     occurrence, here it retains one the decode drops. ACCEPTED — refusing
+//     a body that deliberately spells one field twice in two cases costs a
+//     caller nothing real.
+//
+// The asymmetry is the honest summary: within the map model, (1) and (4) are
+// the same defect seen from two sides, and only one of them fails safe.
 func bodyDecodesNUL(raw []byte) bool {
 	if !bytes.Contains(raw, unicodeEscapePrefix) {
 		return false

--- a/internal/server/middleware_request_text.go
+++ b/internal/server/middleware_request_text.go
@@ -497,7 +497,18 @@ func isJSONEncodedFieldKey(k string) bool {
 	if jsonEncodedFieldKeys[k] {
 		return true
 	}
-	return jsonEncodedFieldKeys[strings.ToLower(k)]
+	// EqualFold, not ToLower. encoding/json matches with Unicode SIMPLE
+	// FOLDING, which is wider than lower-casing: U+017F LATIN SMALL LETTER
+	// LONG S folds to 's', so "ſchema" reaches the `schema` field while
+	// strings.ToLower("ſchema") is still "ſchema" and missed the allowlist
+	// (codex round 17). Fixing the ASCII half and leaving the Unicode half
+	// would have been this bug's own pattern one more time.
+	for canonical := range jsonEncodedFieldKeys {
+		if strings.EqualFold(k, canonical) {
+			return true
+		}
+	}
+	return false
 }
 
 // valueDecodesNUL walks a decoded request body for a string that contains a

--- a/internal/server/middleware_request_text.go
+++ b/internal/server/middleware_request_text.go
@@ -441,9 +441,10 @@ var unicodeEscapePrefix = []byte{'\\', 'u', '0', '0'}
 //
 // UNDER-REFUSALS — these are the BUG-2812 unit's spec, not a TODO here. Both
 // dissolve under a token-stream walk that never builds values, which is that
-// unit's design; patching them into the map model would be re-plumbing an
-// 18-commit branch late under review pressure, and this branch's one
-// regression came from exactly that.
+// unit's design. The ruling's reasoning for not folding that rewrite in: a
+// review loop finding something in nearly every round says the pre-scan
+// machinery has a DESIGN problem, and the answer to that is a unit of its
+// own rather than a late restructure of a branch already deep in review.
 //
 //  1. DUPLICATE KEYS MERGE DIFFERENTLY (P1). For
 //     {"fields_patch":{"orphan":"<NUL>"},"fields_patch":{"status":"open"}},

--- a/internal/server/middleware_request_text.go
+++ b/internal/server/middleware_request_text.go
@@ -408,8 +408,28 @@ var jsonNULEscape = []byte{'\\', 'u', '0', '0', '0', '0'}
 // runs next and reports the JSON error itself, so there is exactly one place
 // that phrases "invalid JSON" and this function never has to agree with it.
 func bodyDecodesNUL(raw []byte) bool {
+	return bodyDecodesNULAtDepth(raw, 0)
+}
+
+// maxJSONDocumentNesting bounds how many times bodyDecodesNULAtDepth will
+// descend into a string that is itself a JSON document. Each level must be a
+// strict substring of the one above, so recursion terminates on its own; the
+// bound exists to keep a hostile body from buying many full re-parses of a
+// large payload. Eight is far past any shape this API produces — the deepest
+// real case is one level (a `fields` blob inside a request body) — and a body
+// nested deeper than this is refused, since bodyDecodesNULAtDepth answers
+// "assume the worst" rather than "give up" at the limit.
+const maxJSONDocumentNesting = 8
+
+func bodyDecodesNULAtDepth(raw []byte, depth int) bool {
 	if !bytes.Contains(raw, jsonNULEscape) {
 		return false
+	}
+	if depth >= maxJSONDocumentNesting {
+		// The escape IS present and we have stopped looking. Refusing is the
+		// safe direction: the alternative is to pass a body we declined to
+		// inspect.
+		return true
 	}
 	dec := json.NewDecoder(bytes.NewReader(raw))
 	for {
@@ -418,10 +438,59 @@ func bodyDecodesNUL(raw []byte) bool {
 			// io.EOF, or malformed input the caller's decode will report.
 			return false
 		}
-		if s, ok := tok.(string); ok && strings.ContainsRune(s, 0) {
+		s, ok := tok.(string)
+		if !ok {
+			continue
+		}
+		if strings.ContainsRune(s, 0) {
+			return true
+		}
+		if stringIsJSONDocument(s) && bodyDecodesNULAtDepth([]byte(s), depth+1) {
 			return true
 		}
 	}
+}
+
+// stringIsJSONDocument reports whether a decoded string is itself a complete
+// JSON object or array — the class of value this API re-parses downstream.
+//
+// WHY THE RECURSION EXISTS AT ALL. Several fields cross the wire as
+// JSON-ENCODED STRINGS rather than as nested objects: an item's `fields`, a
+// collection's `schema`, a workspace's `settings`. In
+// `{"fields":"{\"k\":\"a<escape>b\"}"}` the OUTER decode yields the
+// literal text of the inner document, in which the escape is still six
+// ordinary characters and no NUL exists. The single-layer walk therefore
+// passed it, and Postgres refused it later with a DIFFERENT error from the
+// rest of this family:
+//
+//	insert collection: ERROR: unsupported Unicode escape sequence (SQLSTATE 22P05)
+//
+// 22P05, not the 22021 the path and query halves produce. The outer string is
+// pure ASCII so it never trips the text-encoding check; this is Postgres's own
+// JSON parser refusing the escape inside a document bound for jsonb, which
+// cannot represent a NUL. Measured on Postgres 17: item `fields`, collection
+// `schema` and workspace `settings` each answered 500 with a 201 control leg,
+// after the single-layer check was in place. Found by codex round 1 on
+// BUG-2803, by asking what the destination TYPE does with the value — the
+// angle the endpoint-and-field sweep never rotated to.
+//
+// WHAT THIS DELIBERATELY OVER-REFUSES, stated rather than left to be
+// discovered. The test is structural, not destination-typed: a plain TEXT
+// field whose ENTIRE value happens to be a valid JSON document carrying the
+// escape is refused too, even though its column would have stored it. Prose
+// ABOUT a JSON escape does not parse as a bare document, so the case is
+// narrow, and a value of that exact shape breaks any consumer that parses it.
+//
+// The destination-typed alternative — an allow-list of the fields that arrive
+// JSON-encoded — is exactly correct and goes stale in silence, which is the
+// failure mode ValidateQuery's comment rejects when it explains why per-site
+// query validators could not be written.
+func stringIsJSONDocument(s string) bool {
+	t := strings.TrimSpace(s)
+	if len(t) == 0 || (t[0] != '{' && t[0] != '[') {
+		return false
+	}
+	return json.Valid([]byte(t))
 }
 
 // readBodyForDecode reads the whole request body so it can be scanned before

--- a/internal/server/middleware_request_text.go
+++ b/internal/server/middleware_request_text.go
@@ -352,16 +352,21 @@ func validQueryText(rawQuery string) bool {
 // this source and the compiler can transform it into the character it
 // describes — the same reason the tests construct it this way.
 //
-// It is the ONLY spelling. JSON forbids an unescaped control character inside
-// a string, so a raw 0x00 byte never survives decoding (encoding/json answers
-// `invalid character '\x00' in string literal`), and the uppercase \U form is
-// not a JSON escape at all (`invalid character 'U' in string escape code`).
-// Both measured against encoding/json, BUG-2803.
+// It is the only spelling OF THE ESCAPE ITSELF. JSON forbids an unescaped
+// control character inside a string, so a raw 0x00 byte never survives
+// decoding (encoding/json answers `invalid character '\x00' in string
+// literal`), and the uppercase \U form is not a JSON escape at all
+// (`invalid character 'U' in string escape code`). Both measured against
+// encoding/json, BUG-2803.
+//
+// THAT SENTENCE DOES NOT MAKE THE SUBSTRING A SOUND FILTER, which is the
+// mistake this comment used to encode — see bodyDecodesNUL's gate.
 var jsonNULEscape = []byte{'\\', 'u', '0', '0', '0', '0'}
 
 // bodyDecodesNUL reports whether any string a handler could read out of this
-// JSON body — an object key or a value, at any nesting depth — decodes to a
-// string containing a NUL.
+// JSON body — an object key or a value, at any nesting depth, including
+// inside a JSON document carried as a string — decodes to a string containing
+// a NUL.
 //
 // WHY THE BODY NEEDS ITS OWN RULE, when ValidatePath and ValidateQuery already
 // apply bindableText at the transport. Those work because a decoded path or
@@ -374,23 +379,43 @@ var jsonNULEscape = []byte{'\\', 'u', '0', '0', '0', '0'}
 // job. BUG-2784 recorded this as the reason its rule stops at the query
 // string; this is the missing half.
 //
-// WHY IT IS NOT A SUBSTRING SEARCH. Containing jsonNULEscape is necessary but
-// NOT sufficient: `\\u0000` (an escaped backslash followed by literal text)
-// contains the same six characters and decodes to no NUL at all. Refusing on
-// the substring alone would reject a legitimate value, and in THIS product
-// that is not hypothetical — items and documents store markdown, and writing
-// about a JSON escape sequence is an ordinary thing for a document to do.
+// THE GATE IS A BACKSLASH, NOT THE ESCAPE SUBSTRING, and the difference is a
+// real bypass rather than a stylistic one.
 //
-// So the substring is used as a FAST PATH only, and it is sound in that
-// direction: a body that does not contain it cannot decode to a NUL anywhere,
-// because the escape is the only spelling (see jsonNULEscape). Bodies
-// containing it — rare, and already unusual — pay for an exact answer.
+// The obvious fast path — "does the raw body contain jsonNULEscape?" — is
+// UNSOUND, and codex round 4 on BUG-2803 demonstrated it. The escape may be
+// spelled obliquely: `\u005c` decodes to a BACKSLASH, so a body carrying
+// `\u005cu0000` contains no literal six-character escape anywhere in its raw
+// bytes, yet the OUTER decode manufactures one inside the string, and if that
+// string is re-parsed as a JSON document (see jsonEncodedFieldKeys) the
+// second parse turns it into a real NUL. Measured before the fix: that body
+// answered 201 through the real router while the direct spelling answered
+// 400.
 //
-// THE EXACT STEP IS json.Decoder.Token(), which hands back the DECODED string
-// for every key and value in the document. It distinguishes the two cases
-// above by construction rather than by pattern, it needs no knowledge of the
-// destination type, and it reaches nested maps such as an item's `fields`
-// blob, which a struct-shaped check would miss.
+// The mistake was applying a fact about how a NUL is spelled INSIDE a decoded
+// string to the RAW BYTES, where the backslash itself can be written as an
+// escape. It is the same layer-confusion this whole bug is made of, three
+// rounds in a row.
+//
+// A backslash is the sound gate: every JSON escape mechanism requires one, so
+// a body with no backslash anywhere has decoded strings byte-identical to its
+// raw bytes, and a raw NUL cannot survive the decoder. No backslash therefore
+// means no NUL, at any depth, however spelled. Bodies WITH a backslash pay for
+// an exact answer — a larger set than before (any nested JSON carries `\"`),
+// which is the cost of being correct here.
+//
+// WHY THE EXACT STEP IS NOT A SUBSTRING SEARCH EITHER. Containing
+// jsonNULEscape is not sufficient: `\\u0000` (an escaped backslash followed
+// by literal text) contains the same six characters and decodes to no NUL at
+// all. Refusing on the substring alone would reject a legitimate value, and in
+// THIS product that is not hypothetical — items and documents store markdown,
+// and writing about a JSON escape sequence is an ordinary thing for a document
+// to do.
+//
+// So the exact step is a walk over the DECODED body (valueDecodesNUL), which
+// distinguishes those cases by construction rather than by pattern, needs no
+// knowledge of the destination type, and reaches nested maps such as an item's
+// `fields` blob that a struct-shaped check would miss.
 //
 // WHY NOT REFLECT OVER THE DECODED VALUE, which is the other obvious design.
 // A reflective walk sees a []byte field AFTER base64 decoding, so a body
@@ -408,7 +433,7 @@ var jsonNULEscape = []byte{'\\', 'u', '0', '0', '0', '0'}
 // runs next and reports the JSON error itself, so there is exactly one place
 // that phrases "invalid JSON" and this function never has to agree with it.
 func bodyDecodesNUL(raw []byte) bool {
-	if !bytes.Contains(raw, jsonNULEscape) {
+	if !bytes.ContainsRune(raw, '\\') {
 		return false
 	}
 	var v any
@@ -495,11 +520,11 @@ func valueDecodesNUL(v any, inJSONEncodedField bool, depth int) bool {
 		if strings.ContainsRune(t, 0) {
 			return true
 		}
-		if !inJSONEncodedField || !strings.Contains(t, string(jsonNULEscape)) {
+		if !inJSONEncodedField || !strings.ContainsRune(t, '\\') {
 			return false
 		}
 		if depth >= maxJSONDocumentNesting {
-			// The escape IS present and we have stopped looking. Refusing is
+			// Escapes ARE present and we have stopped looking. Refusing is
 			// the safe direction: the alternative is to pass a document we
 			// declined to inspect.
 			return true

--- a/internal/server/middleware_request_text.go
+++ b/internal/server/middleware_request_text.go
@@ -1,6 +1,9 @@
 package server
 
 import (
+	"bytes"
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -342,4 +345,103 @@ func validQueryText(rawQuery string) bool {
 		}
 	}
 	return true
+}
+
+// jsonNULEscape is the six-byte JSON escape that decodes to a NUL. It is
+// built from bytes rather than written as a literal so that no layer between
+// this source and the compiler can transform it into the character it
+// describes — the same reason the tests construct it this way.
+//
+// It is the ONLY spelling. JSON forbids an unescaped control character inside
+// a string, so a raw 0x00 byte never survives decoding (encoding/json answers
+// `invalid character '\x00' in string literal`), and the uppercase \U form is
+// not a JSON escape at all (`invalid character 'U' in string escape code`).
+// Both measured against encoding/json, BUG-2803.
+var jsonNULEscape = []byte{'\\', 'u', '0', '0', '0', '0'}
+
+// bodyDecodesNUL reports whether any string a handler could read out of this
+// JSON body — an object key or a value, at any nesting depth — decodes to a
+// string containing a NUL.
+//
+// WHY THE BODY NEEDS ITS OWN RULE, when ValidatePath and ValidateQuery already
+// apply bindableText at the transport. Those work because a decoded path or
+// query value is a substring of the raw request with ASCII substitutions: the
+// bad byte in the raw text IS the bad byte in the value, so a middleware can
+// find it without parsing. That property does not hold for a JSON body. The
+// reachable NUL arrives as jsonNULEscape — six ordinary ASCII characters — so
+// a transport-level scan for a NUL byte sees nothing, and no request
+// middleware can find it without decoding the body, which is the handler's
+// job. BUG-2784 recorded this as the reason its rule stops at the query
+// string; this is the missing half.
+//
+// WHY IT IS NOT A SUBSTRING SEARCH. Containing jsonNULEscape is necessary but
+// NOT sufficient: `\\u0000` (an escaped backslash followed by literal text)
+// contains the same six characters and decodes to no NUL at all. Refusing on
+// the substring alone would reject a legitimate value, and in THIS product
+// that is not hypothetical — items and documents store markdown, and writing
+// about a JSON escape sequence is an ordinary thing for a document to do.
+//
+// So the substring is used as a FAST PATH only, and it is sound in that
+// direction: a body that does not contain it cannot decode to a NUL anywhere,
+// because the escape is the only spelling (see jsonNULEscape). Bodies
+// containing it — rare, and already unusual — pay for an exact answer.
+//
+// THE EXACT STEP IS json.Decoder.Token(), which hands back the DECODED string
+// for every key and value in the document. It distinguishes the two cases
+// above by construction rather than by pattern, it needs no knowledge of the
+// destination type, and it reaches nested maps such as an item's `fields`
+// blob, which a struct-shaped check would miss.
+//
+// WHY NOT REFLECT OVER THE DECODED VALUE, which is the other obvious design.
+// A reflective walk sees a []byte field AFTER base64 decoding, so a body
+// carrying legitimate binary — `{"b":"AQAC"}` decodes to the bytes 01 00 02 —
+// would be refused for a NUL that is not text and never reaches a text
+// column. A token walk sees the base64 characters instead. No request struct
+// has such a field today (searched: []byte fields with a json tag in
+// internal/server and internal/models, non-test — the only hit is
+// models.YjsUpdate.UpdateData, which no handler decodes from a body, since
+// collab moves Yjs data over the WebSocket as binary). The token walk is
+// chosen so that adding one later cannot silently start rejecting valid
+// requests.
+//
+// A malformed body returns false rather than an error: the caller's decode
+// runs next and reports the JSON error itself, so there is exactly one place
+// that phrases "invalid JSON" and this function never has to agree with it.
+func bodyDecodesNUL(raw []byte) bool {
+	if !bytes.Contains(raw, jsonNULEscape) {
+		return false
+	}
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			// io.EOF, or malformed input the caller's decode will report.
+			return false
+		}
+		if s, ok := tok.(string); ok && strings.ContainsRune(s, 0) {
+			return true
+		}
+	}
+}
+
+// readBodyForDecode reads the whole request body so it can be scanned before
+// it is decoded, with the caller's size cap applied.
+//
+// Buffering is not a cost paid for the scan. json.Decoder.Decode already
+// holds the entire top-level value in memory before it finishes — refill
+// accumulates into dec.buf and grows it by DOUBLING (encoding/json/stream.go,
+// `newBuf := make([]byte, len(dec.buf), 2*cap(dec.buf)+minRead)` plus a copy)
+// — so streaming never avoided the copy, it just reallocated its way there.
+// Measured on the 64 MiB workspace-import shape, total allocation: stream and
+// decode 354.7 MiB, read-all and Unmarshal 256.5 MiB, read-all and Decode
+// 512.5 MiB. Peak heap is indistinguishable between the first two and is
+// order-dependent, so it does not discriminate. BUG-2803.
+func readBodyForDecode(r *http.Request, maxBytes int64) ([]byte, error) {
+	if r.Body == nil {
+		return nil, io.EOF
+	}
+	// MaxBytesReader.Close() is a no-op; setting this also lets the server
+	// return 413 automatically via the error the caller wraps.
+	r.Body = http.MaxBytesReader(nil, r.Body, maxBytes)
+	return io.ReadAll(r.Body)
 }

--- a/internal/server/middleware_request_text.go
+++ b/internal/server/middleware_request_text.go
@@ -434,47 +434,37 @@ func bodyDecodesNUL(raw []byte) bool {
 		// function never has to phrase one.
 		return false
 	}
-	return valueDecodesNUL(v, false, 0)
+	return valueDecodesNUL(v, false)
 }
 
-// maxJSONDocumentNesting bounds how many times valueDecodesNUL will descend
-// into a string that is itself a JSON document. Each level must be a strict
-// substring of the one above, so recursion terminates on its own; the bound
-// keeps a hostile body from buying many full re-parses of a large payload.
-// Eight is far past any shape this API produces — the deepest real case is
-// one level, a `fields` blob inside a request body.
-const maxJSONDocumentNesting = 8
-
-// jsonEncodedFieldKeys are the wire keys whose STRING value is itself a JSON
-// document that something downstream re-parses. They are the only keys under
-// which valueDecodesNUL descends.
+// jsonEncodedFieldKeys are the REQUEST-BODY keys whose STRING value is itself
+// a JSON document that something downstream re-parses. They are the only keys
+// under which the walk descends into a second document.
 //
 // WHY THE SCOPING EXISTS. The first version of this check recursed into ANY
-// string that parsed as a JSON document, on the argument that the test should
-// be structural rather than destination-typed. Codex round 2 on BUG-2803
-// showed what that costs: a plain-text `content` value holding a JSON snippet
-// that mentions the escape was ACCEPTED before this fix, is stored in a text
+// string that parsed as a JSON document, on the argument that a structural
+// test beats a destination-typed one. Codex round 2 on BUG-2803 showed what
+// that costs: a plain-text `content` value holding a JSON snippet that merely
+// MENTIONS the escape was ACCEPTED before this branch, is stored in a text
 // column that has no problem with it, and was newly refused — including on
-// re-import of an export carrying it. Refusing a value the server itself
-// emitted, and that nothing downstream would choke on, is a worse failure
-// than the narrow door the recursion was closing.
+// re-import of an export carrying it. Refusing input the server itself
+// produced is a worse failure than the narrow door the recursion closed.
 //
 // WHY A LIST IS SAFE HERE, when ValidateQuery's comment rejects exactly this
-// shape for query parameters. There the set of names is UNBOUNDED BY DESIGN —
-// parseItemListParams turns any unrecognised parameter into a field filter, so
-// no list could be complete. Here the set is a closed property of the wire
-// model: a field is JSON-encoded because a Go struct declares it as a string
-// holding JSON. That is enumerable, and
-// TestJSONEncodedFieldKeysCoversTheModels derives the set from
-// internal/models and fails when a new one appears, so the list cannot go
-// stale in silence.
+// shape for query parameters: there the set of names is UNBOUNDED BY DESIGN
+// (parseItemListParams turns any unrecognised parameter into a field filter),
+// so no list could be complete. Here the set is a closed property of the wire
+// model — a field is JSON-encoded because a Go struct declares it as a string
+// holding JSON — and TestJSONEncodedFieldKeysCoversTheModels derives it from
+// internal/models and fails when a new one appears.
 //
-// OVER-INCLUSION IS THE SAFE DIRECTION and this list deliberately takes it: a
-// key listed here that is NOT actually JSON-encoded costs one parse attempt
-// and can only refuse a value that IS a complete JSON document carrying the
-// escape. A key MISSING from it reopens a door. `traits` is here for that
-// reason — it carries JSON but its field declaration has no comment saying
-// so, which is exactly how the derivation test would have missed it.
+// OVER-INCLUSION IS THE SAFE DIRECTION and this list takes it: a listed key
+// that is not really JSON-encoded costs one parse attempt and can only refuse
+// a complete JSON document carrying the escape, while a missing key reopens a
+// door. `traits` is listed by hand for that reason — it carries JSON but its
+// field declaration has no comment saying so, which is exactly how the
+// derivation test would have missed it, so that test asserts coverage in one
+// direction only and the list is allowed to be a superset.
 var jsonEncodedFieldKeys = map[string]bool{
 	"config":         true,
 	"events":         true,
@@ -488,83 +478,90 @@ var jsonEncodedFieldKeys = map[string]bool{
 	"traits":         true,
 }
 
-// valueDecodesNUL walks a decoded request body for a string that either
-// CONTAINS a NUL or, under a JSON-encoded key, is a document whose own
-// strings do.
+// valueDecodesNUL walks a decoded request body for a string that contains a
+// NUL, descending into a JSON document carried as a string exactly once.
 //
-// WHY A DECODED WALK RATHER THAN reflection over the destination struct. A
+// inUserData says the walk has left the REQUEST's own structure and is inside
+// caller data — the natural object under `fields`, an element of a `tags`
+// array, or a re-parsed document. The key list is not consulted there, and
+// both halves of that matter:
+//
+//   - A collection may declare a user field literally named `schema` or
+//     `tags`. Treating `{"fields":{"schema":"..."}}`'s inner key as a wire key
+//     refused valid text that happened to hold a JSON example (codex round 8).
+//   - Below the document Postgres parses, an escape is harmless. Measured on
+//     Postgres 17 with the check disabled: a NUL escape two levels deep
+//     imports 201, because `fields` is parsed ONCE and the inner text is
+//     re-escaped when the blob is written, so Postgres never sees an escape
+//     (codex round 7).
+//
+// Together those make the descent exactly one level deep by construction,
+// which is why there is no depth counter here. An earlier version had one,
+// bounding a recursion that inherited the flag through the whole subtree;
+// with the flag no longer inherited, a counter would be a bound that can
+// never fire, and dead protection reads as protection.
+//
+// WHY A DECODED WALK RATHER THAN reflection over the destination struct: a
 // reflective walk sees []byte fields AFTER base64 decoding, so a body
-// carrying legitimate binary — `{"b":"AQAC"}` decodes to the bytes 01 00 02 —
+// carrying legitimate binary — {"b":"AQAC"} decodes to the bytes 01 00 02 —
 // would be refused for a NUL that is not text and never reaches a text
 // column. Decoding into `any` never produces a []byte, so the value seen here
-// is the base64 TEXT, which is ASCII. No request struct has such a field
-// today (searched: []byte with a json tag in internal/server and
-// internal/models, non-test — only models.YjsUpdate.UpdateData, which no
-// handler decodes from a body); this shape is chosen so that adding one later
-// cannot silently start rejecting valid requests.
-//
-// inJSONEncodedField is inherited by the whole subtree below a listed key: a
-// document nested inside a JSON-encoded document is re-parsed just as its
-// parent is.
-func valueDecodesNUL(v any, inJSONEncodedField bool, depth int) bool {
+// is the base64 TEXT. No request struct has such a field today (searched:
+// []byte with a json tag in internal/server and internal/models, non-test —
+// only models.YjsUpdate.UpdateData, which no handler decodes from a body);
+// this shape is chosen so that adding one later cannot silently start
+// rejecting valid requests.
+func valueDecodesNUL(v any, inUserData bool) bool {
 	switch t := v.(type) {
 	case string:
-		if strings.ContainsRune(t, 0) {
-			return true
-		}
-		if !inJSONEncodedField || !strings.Contains(t, string(unicodeEscapePrefix)) {
-			return false
-		}
-		if depth >= maxJSONDocumentNesting {
-			// Escapes ARE present and we have stopped looking. Refusing is
-			// the safe direction: the alternative is to pass a document we
-			// declined to inspect.
-			return true
-		}
-		if !stringIsJSONDocument(t) {
-			return false
-		}
-		var inner any
-		if err := json.Unmarshal([]byte(strings.TrimSpace(t)), &inner); err != nil {
-			return false
-		}
-		// false, not true: inside a re-parsed document the SAME key rule
-		// applies again. Inheriting it blanket-wise refused a value that is
-		// demonstrably safe — measured on Postgres, a NUL escape two levels
-		// deep imports 201, because the handler parses `fields` ONCE and the
-		// inner text is re-escaped when the blob is written, so Postgres
-		// never sees it as an escape. Only the document Postgres itself
-		// parses can carry a fatal one (codex round 7).
-		return valueDecodesNUL(inner, false, depth+1)
+		return strings.ContainsRune(t, 0)
 	case map[string]any:
 		for k, sub := range t {
 			if strings.ContainsRune(k, 0) {
 				return true
 			}
-			// A listed key marks its value as a JSON document only when that
-			// value is a STRING. The same fields also accept their NATURAL
-			// shape — `"tags":["a","b"]`, `"fields":{"k":"v"}` — and in that
-			// shape the elements are ordinary strings the server marshals
-			// itself, so nothing re-parses them and an element that merely
-			// LOOKS like a document must not be treated as one. Propagating
-			// the flag into containers refused a free-form tag whose whole
-			// value happened to be a JSON document (codex round 6).
-			childEncoded := inJSONEncodedField
-			if _, isString := sub.(string); isString && jsonEncodedFieldKeys[k] {
-				childEncoded = true
+			if !inUserData && jsonEncodedFieldKeys[k] {
+				if str, isString := sub.(string); isString {
+					if nestedDocumentDecodesNUL(str) {
+						return true
+					}
+					continue
+				}
+				// The field's NATURAL shape: an array or object whose
+				// elements the server marshals itself. Nothing re-parses
+				// them, so everything below is caller data.
+				if valueDecodesNUL(sub, true) {
+					return true
+				}
+				continue
 			}
-			if valueDecodesNUL(sub, childEncoded, depth) {
+			if valueDecodesNUL(sub, inUserData) {
 				return true
 			}
 		}
 	case []any:
 		for _, sub := range t {
-			if valueDecodesNUL(sub, inJSONEncodedField, depth) {
+			if valueDecodesNUL(sub, inUserData) {
 				return true
 			}
 		}
 	}
 	return false
+}
+
+// nestedDocumentDecodesNUL walks a JSON document carried as a string — an
+// item's `fields` blob, a collection's `schema` — for a string containing a
+// NUL. This is the layer Postgres itself parses, so an escape here is fatal
+// where one a level deeper is not.
+func nestedDocumentDecodesNUL(s string) bool {
+	if !strings.Contains(s, string(unicodeEscapePrefix)) || !stringIsJSONDocument(s) {
+		return false
+	}
+	var inner any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(s)), &inner); err != nil {
+		return false
+	}
+	return valueDecodesNUL(inner, true)
 }
 
 // stringIsJSONDocument reports whether a string is a complete JSON object or
@@ -612,8 +609,13 @@ func readBodyForDecode(r *http.Request, maxBytes int64) ([]byte, error) {
 	if r.Body == nil {
 		return nil, io.EOF
 	}
-	// MaxBytesReader.Close() is a no-op; setting this also lets the server
-	// return 413 automatically via the error the caller wraps.
+	// The nil ResponseWriter is deliberate and its consequence is worth
+	// stating, because the comment this replaces got it wrong twice over:
+	// MaxBytesReader.Close forwards to the underlying body rather than being
+	// a no-op, and with a nil writer there is no automatic 413 — hitting the
+	// cap surfaces as a read error, which decodeJSONWithLimit wraps and every
+	// caller turns into a 400. That is the existing behaviour, unchanged
+	// here; only the claim about it is corrected (codex round 8).
 	r.Body = http.MaxBytesReader(nil, r.Body, maxBytes)
 	return io.ReadAll(r.Body)
 }

--- a/internal/server/middleware_request_text.go
+++ b/internal/server/middleware_request_text.go
@@ -429,7 +429,7 @@ var unicodeEscapePrefix = []byte{'\\', 'u', '0', '0'}
 //
 // WHAT THIS CHECK DOES NOT COVER — four measured disagreements between what
 // this scan sees and what the typed decode does, left OPEN deliberately
-// (BUG-2803 rounds 16-17, lead ruling day-68: land-and-follow). They are
+// (BUG-2803 rounds 16-17; lead ruling: land-and-follow). They are
 // recorded here because this is the function a reader consults before
 // trusting the check, and an unqualified doc comment above an incomplete
 // guard is how the next person inherits a false belief.

--- a/internal/server/middleware_request_text.go
+++ b/internal/server/middleware_request_text.go
@@ -347,6 +347,11 @@ func validQueryText(rawQuery string) bool {
 	return true
 }
 
+// unicodeEscapePrefix is the four bytes that begin any JSON \u escape for a
+// character below U+0100. Built from bytes rather than written as a literal,
+// for the reason the tests do the same.
+var unicodeEscapePrefix = []byte{'\\', 'u', '0', '0'}
+
 // bodyDecodesNUL reports whether any string a handler could read out of this
 // JSON body — an object key or a value, at any nesting depth, including
 // inside a JSON document carried as a string — decodes to a string containing
@@ -420,7 +425,7 @@ func validQueryText(rawQuery string) bool {
 // runs next and reports the JSON error itself, so there is exactly one place
 // that phrases "invalid JSON" and this function never has to agree with it.
 func bodyDecodesNUL(raw []byte) bool {
-	if !bytes.ContainsRune(raw, '\\') {
+	if !bytes.Contains(raw, unicodeEscapePrefix) {
 		return false
 	}
 	var v any
@@ -507,7 +512,7 @@ func valueDecodesNUL(v any, inJSONEncodedField bool, depth int) bool {
 		if strings.ContainsRune(t, 0) {
 			return true
 		}
-		if !inJSONEncodedField || !strings.ContainsRune(t, '\\') {
+		if !inJSONEncodedField || !strings.Contains(t, string(unicodeEscapePrefix)) {
 			return false
 		}
 		if depth >= maxJSONDocumentNesting {
@@ -529,7 +534,19 @@ func valueDecodesNUL(v any, inJSONEncodedField bool, depth int) bool {
 			if strings.ContainsRune(k, 0) {
 				return true
 			}
-			if valueDecodesNUL(sub, inJSONEncodedField || jsonEncodedFieldKeys[k], depth) {
+			// A listed key marks its value as a JSON document only when that
+			// value is a STRING. The same fields also accept their NATURAL
+			// shape — `"tags":["a","b"]`, `"fields":{"k":"v"}` — and in that
+			// shape the elements are ordinary strings the server marshals
+			// itself, so nothing re-parses them and an element that merely
+			// LOOKS like a document must not be treated as one. Propagating
+			// the flag into containers refused a free-form tag whose whole
+			// value happened to be a JSON document (codex round 6).
+			childEncoded := inJSONEncodedField
+			if _, isString := sub.(string); isString && jsonEncodedFieldKeys[k] {
+				childEncoded = true
+			}
+			if valueDecodesNUL(sub, childEncoded, depth) {
 				return true
 			}
 		}
@@ -631,11 +648,18 @@ func truncateBindableText(s string, maxBytes int) string {
 // fine, so this sanitizes rather than rejects, which is the opposite
 // disposition from the rest of this file and deliberately so.
 //
-// The sinks are text columns: activities.user_agent (documents and the
-// connected-apps revoke path) and sessions.user_agent (three login paths).
-// The two sites that HASH the header instead are left alone — sha256 over
-// arbitrary bytes is well defined, and changing what is hashed would
-// invalidate every stored UAHash.
+// The sink is one text column: activities.user_agent, reached from three
+// document paths and the connected-apps revoke.
+//
+// THE LOGIN PATHS ARE NOT SINKS, and I wired them before reading
+// store.CreateSession, which is the mistake this note exists to stop
+// recurring. It HASHES the header (sessions.ua_hash) and never stores the
+// text — the round-5 enumeration listed "sessions.user_agent" and I took the
+// name for a column. Sanitising there would have been actively harmful:
+// login would store sha256(sanitised) while middleware_auth still compares
+// sha256(RAW), so every session belonging to a client with a non-UTF-8
+// User-Agent would fail validation. Hashing arbitrary bytes is well defined
+// and needs no help; the hash sites are deliberately untouched.
 //
 // Found by the codex round 5 enumeration on BUG-2803. The filing's own
 // earlier probe had recorded User-Agent as NOT reproducing on the item-create

--- a/internal/server/middleware_request_text.go
+++ b/internal/server/middleware_request_text.go
@@ -774,6 +774,26 @@ func truncateBindableText(s string, maxBytes int) string {
 // earlier probe had recorded User-Agent as NOT reproducing on the item-create
 // path, which was true and did not generalise: these are different sinks.
 func requestUserAgent(r *http.Request) string {
-	ua := strings.ToValidUTF8(r.Header.Get("User-Agent"), "")
-	return strings.ReplaceAll(ua, "\x00", "")
+	return sanitiseStoredText(r.Header.Get("User-Agent"))
+}
+
+// sanitiseStoredText makes a caller-influenced string safe to bind to a text
+// column, by removing what a text column cannot hold rather than by refusing
+// the request.
+//
+// SANITISE VERSUS REFUSE is the whole decision here, and it turns on WHO ASKED
+// FOR THE VALUE TO EXIST. The body rule refuses, because there the bad value
+// is the thing the caller asked to store. This helper serves metadata the
+// SERVER chose to record about a request — a User-Agent header, an MCP audit
+// row — where the caller never asked for a write at all. Turning an otherwise
+// fine request into a 400, or losing the audit row entirely, because of a
+// field the server elected to keep would be the wrong trade: the request
+// carrying a malformed value is precisely the one most worth recording.
+//
+// Extracted so the two callers share one rule rather than two copies that
+// drift. Do NOT reach for this on a value the caller asked to persist — that
+// is the body rule's job, and silently cleaning such a value would store
+// something the caller did not send.
+func sanitiseStoredText(s string) string {
+	return strings.ReplaceAll(strings.ToValidUTF8(s, ""), "\x00", "")
 }

--- a/internal/server/middleware_request_text.go
+++ b/internal/server/middleware_request_text.go
@@ -408,60 +408,139 @@ var jsonNULEscape = []byte{'\\', 'u', '0', '0', '0', '0'}
 // runs next and reports the JSON error itself, so there is exactly one place
 // that phrases "invalid JSON" and this function never has to agree with it.
 func bodyDecodesNUL(raw []byte) bool {
-	return bodyDecodesNULAtDepth(raw, 0)
-}
-
-// maxJSONDocumentNesting bounds how many times bodyDecodesNULAtDepth will
-// descend into a string that is itself a JSON document. Each level must be a
-// strict substring of the one above, so recursion terminates on its own; the
-// bound exists to keep a hostile body from buying many full re-parses of a
-// large payload. Eight is far past any shape this API produces — the deepest
-// real case is one level (a `fields` blob inside a request body) — and a body
-// nested deeper than this is refused, since bodyDecodesNULAtDepth answers
-// "assume the worst" rather than "give up" at the limit.
-const maxJSONDocumentNesting = 8
-
-func bodyDecodesNULAtDepth(raw []byte, depth int) bool {
 	if !bytes.Contains(raw, jsonNULEscape) {
 		return false
 	}
-	if depth >= maxJSONDocumentNesting {
-		// The escape IS present and we have stopped looking. Refusing is the
-		// safe direction: the alternative is to pass a body we declined to
-		// inspect.
-		return true
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		// Malformed: the caller's own decode reports the JSON error, so this
+		// function never has to phrase one.
+		return false
 	}
-	dec := json.NewDecoder(bytes.NewReader(raw))
-	for {
-		tok, err := dec.Token()
-		if err != nil {
-			// io.EOF, or malformed input the caller's decode will report.
-			return false
-		}
-		s, ok := tok.(string)
-		if !ok {
-			continue
-		}
-		if strings.ContainsRune(s, 0) {
-			return true
-		}
-		if stringIsJSONDocument(s) && bodyDecodesNULAtDepth([]byte(s), depth+1) {
-			return true
-		}
-	}
+	return valueDecodesNUL(v, false, 0)
 }
 
-// stringIsJSONDocument reports whether a decoded string is itself a complete
-// JSON object or array — the class of value this API re-parses downstream.
+// maxJSONDocumentNesting bounds how many times valueDecodesNUL will descend
+// into a string that is itself a JSON document. Each level must be a strict
+// substring of the one above, so recursion terminates on its own; the bound
+// keeps a hostile body from buying many full re-parses of a large payload.
+// Eight is far past any shape this API produces — the deepest real case is
+// one level, a `fields` blob inside a request body.
+const maxJSONDocumentNesting = 8
+
+// jsonEncodedFieldKeys are the wire keys whose STRING value is itself a JSON
+// document that something downstream re-parses. They are the only keys under
+// which valueDecodesNUL descends.
 //
-// WHY THE RECURSION EXISTS AT ALL. Several fields cross the wire as
-// JSON-ENCODED STRINGS rather than as nested objects: an item's `fields`, a
-// collection's `schema`, a workspace's `settings`. In
-// `{"fields":"{\"k\":\"a<escape>b\"}"}` the OUTER decode yields the
-// literal text of the inner document, in which the escape is still six
-// ordinary characters and no NUL exists. The single-layer walk therefore
-// passed it, and Postgres refused it later with a DIFFERENT error from the
-// rest of this family:
+// WHY THE SCOPING EXISTS. The first version of this check recursed into ANY
+// string that parsed as a JSON document, on the argument that the test should
+// be structural rather than destination-typed. Codex round 2 on BUG-2803
+// showed what that costs: a plain-text `content` value holding a JSON snippet
+// that mentions the escape was ACCEPTED before this fix, is stored in a text
+// column that has no problem with it, and was newly refused — including on
+// re-import of an export carrying it. Refusing a value the server itself
+// emitted, and that nothing downstream would choke on, is a worse failure
+// than the narrow door the recursion was closing.
+//
+// WHY A LIST IS SAFE HERE, when ValidateQuery's comment rejects exactly this
+// shape for query parameters. There the set of names is UNBOUNDED BY DESIGN —
+// parseItemListParams turns any unrecognised parameter into a field filter, so
+// no list could be complete. Here the set is a closed property of the wire
+// model: a field is JSON-encoded because a Go struct declares it as a string
+// holding JSON. That is enumerable, and
+// TestJSONEncodedFieldKeysCoversTheModels derives the set from
+// internal/models and fails when a new one appears, so the list cannot go
+// stale in silence.
+//
+// OVER-INCLUSION IS THE SAFE DIRECTION and this list deliberately takes it: a
+// key listed here that is NOT actually JSON-encoded costs one parse attempt
+// and can only refuse a value that IS a complete JSON document carrying the
+// escape. A key MISSING from it reopens a door. `traits` is here for that
+// reason — it carries JSON but its field declaration has no comment saying
+// so, which is exactly how the derivation test would have missed it.
+var jsonEncodedFieldKeys = map[string]bool{
+	"config":         true,
+	"events":         true,
+	"fields":         true,
+	"metadata":       true,
+	"phase_data":     true,
+	"plan_overrides": true,
+	"schema":         true,
+	"settings":       true,
+	"tags":           true,
+	"traits":         true,
+}
+
+// valueDecodesNUL walks a decoded request body for a string that either
+// CONTAINS a NUL or, under a JSON-encoded key, is a document whose own
+// strings do.
+//
+// WHY A DECODED WALK RATHER THAN reflection over the destination struct. A
+// reflective walk sees []byte fields AFTER base64 decoding, so a body
+// carrying legitimate binary — `{"b":"AQAC"}` decodes to the bytes 01 00 02 —
+// would be refused for a NUL that is not text and never reaches a text
+// column. Decoding into `any` never produces a []byte, so the value seen here
+// is the base64 TEXT, which is ASCII. No request struct has such a field
+// today (searched: []byte with a json tag in internal/server and
+// internal/models, non-test — only models.YjsUpdate.UpdateData, which no
+// handler decodes from a body); this shape is chosen so that adding one later
+// cannot silently start rejecting valid requests.
+//
+// inJSONEncodedField is inherited by the whole subtree below a listed key: a
+// document nested inside a JSON-encoded document is re-parsed just as its
+// parent is.
+func valueDecodesNUL(v any, inJSONEncodedField bool, depth int) bool {
+	switch t := v.(type) {
+	case string:
+		if strings.ContainsRune(t, 0) {
+			return true
+		}
+		if !inJSONEncodedField || !strings.Contains(t, string(jsonNULEscape)) {
+			return false
+		}
+		if depth >= maxJSONDocumentNesting {
+			// The escape IS present and we have stopped looking. Refusing is
+			// the safe direction: the alternative is to pass a document we
+			// declined to inspect.
+			return true
+		}
+		if !stringIsJSONDocument(t) {
+			return false
+		}
+		var inner any
+		if err := json.Unmarshal([]byte(strings.TrimSpace(t)), &inner); err != nil {
+			return false
+		}
+		return valueDecodesNUL(inner, true, depth+1)
+	case map[string]any:
+		for k, sub := range t {
+			if strings.ContainsRune(k, 0) {
+				return true
+			}
+			if valueDecodesNUL(sub, inJSONEncodedField || jsonEncodedFieldKeys[k], depth) {
+				return true
+			}
+		}
+	case []any:
+		for _, sub := range t {
+			if valueDecodesNUL(sub, inJSONEncodedField, depth) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// stringIsJSONDocument reports whether a string is a complete JSON object or
+// array — the shape a downstream consumer will re-parse.
+//
+// WHY THE RECURSION IT GATES EXISTS. Several fields cross the wire as
+// JSON-ENCODED STRINGS rather than nested objects: an item's `fields`, a
+// collection's `schema`, a workspace's `settings`. In such a body the OUTER
+// decode yields the inner document as literal text, in which the escape is
+// still six ordinary characters and no NUL exists. A single-layer walk
+// therefore passed it, and Postgres refused it later with a DIFFERENT error
+// from the rest of this family:
 //
 //	insert collection: ERROR: unsupported Unicode escape sequence (SQLSTATE 22P05)
 //
@@ -473,18 +552,6 @@ func bodyDecodesNULAtDepth(raw []byte, depth int) bool {
 // after the single-layer check was in place. Found by codex round 1 on
 // BUG-2803, by asking what the destination TYPE does with the value — the
 // angle the endpoint-and-field sweep never rotated to.
-//
-// WHAT THIS DELIBERATELY OVER-REFUSES, stated rather than left to be
-// discovered. The test is structural, not destination-typed: a plain TEXT
-// field whose ENTIRE value happens to be a valid JSON document carrying the
-// escape is refused too, even though its column would have stored it. Prose
-// ABOUT a JSON escape does not parse as a bare document, so the case is
-// narrow, and a value of that exact shape breaks any consumer that parses it.
-//
-// The destination-typed alternative — an allow-list of the fields that arrive
-// JSON-encoded — is exactly correct and goes stale in silence, which is the
-// failure mode ValidateQuery's comment rejects when it explains why per-site
-// query validators could not be written.
 func stringIsJSONDocument(s string) bool {
 	t := strings.TrimSpace(s)
 	if len(t) == 0 || (t[0] != '{' && t[0] != '[') {

--- a/internal/server/middleware_request_text.go
+++ b/internal/server/middleware_request_text.go
@@ -528,7 +528,14 @@ func valueDecodesNUL(v any, inJSONEncodedField bool, depth int) bool {
 		if err := json.Unmarshal([]byte(strings.TrimSpace(t)), &inner); err != nil {
 			return false
 		}
-		return valueDecodesNUL(inner, true, depth+1)
+		// false, not true: inside a re-parsed document the SAME key rule
+		// applies again. Inheriting it blanket-wise refused a value that is
+		// demonstrably safe — measured on Postgres, a NUL escape two levels
+		// deep imports 201, because the handler parses `fields` ONCE and the
+		// inner text is re-escaped when the blob is written, so Postgres
+		// never sees it as an escape. Only the document Postgres itself
+		// parses can carry a fatal one (codex round 7).
+		return valueDecodesNUL(inner, false, depth+1)
 	case map[string]any:
 		for k, sub := range t {
 			if strings.ContainsRune(k, 0) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2203,7 +2203,15 @@ func decodeJSONWithLimit(r *http.Request, v interface{}, maxBytes int64) error {
 	// while json.Unmarshal answers a SyntaxError instead, which that check
 	// cannot see. Found by TestPlaybookRunAcceptsEmptyBody, which is exactly
 	// the wiring a helper-level change is blind to.
-	if len(bytes.TrimSpace(raw)) == 0 {
+	// Trim only the four bytes JSON itself calls whitespace. bytes.TrimSpace
+	// uses unicode.IsSpace, which also strips \v, \f, U+00A0 and friends —
+	// none of which encoding/json accepts. With TrimSpace a body of just
+	// "\v" looked EMPTY here and returned io.EOF, so an EOF-tolerant caller
+	// (playbook run, share links) treated a syntactically invalid body as an
+	// ABSENT one and proceeded. Same Go-versus-spec whitespace divergence
+	// that bites when a Go trim stands in for another grammar's definition
+	// (codex round 22).
+	if len(bytes.Trim(raw, " \t\r\n")) == 0 {
 		return fmt.Errorf("invalid JSON: %w", io.EOF)
 	}
 	// Refuse a decoded NUL BEFORE unmarshalling, so the value never exists

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2229,9 +2229,15 @@ func decodeJSONWithLimit(r *http.Request, v interface{}, maxBytes int64) error {
 
 // errJSONBodyNUL is returned by decodeJSON when a string in the request body
 // decodes to a value containing a NUL. Every decodeJSON caller already turns
-// a decode error into a 400 carrying err.Error(), so this reaches the client
-// as a client error with a message naming the cause, at all 65 call sites,
-// without touching any of them.
+// a decode error into a 400, so the refusal reaches the client as a client
+// error at all 65 call sites without touching any of them.
+//
+// NOT every caller shows this message, and the earlier version of this
+// comment claimed otherwise: many substitute a generic string of their own
+// ("Invalid JSON body"). The status is uniform; the wording is not. Where a
+// caller's own message would actively mislead — the OAuth registration
+// endpoint's "Request body must be JSON", for a body that IS valid JSON —
+// that caller distinguishes the two cases explicitly (codex round 8).
 //
 // The wording avoids writing the escape sequence literally: the message is
 // rendered in terminals, logs and a browser, and a literal escape in an error

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2230,7 +2230,7 @@ func decodeJSONWithLimit(r *http.Request, v interface{}, maxBytes int64) error {
 // errJSONBodyNUL is returned by decodeJSON when a string in the request body
 // decodes to a value containing a NUL. Every decodeJSON caller already turns
 // a decode error into a 400, so the refusal reaches the client as a client
-// error at all 65 call sites without touching any of them.
+// error at every call site without touching any of them.
 //
 // NOT every caller shows this message, and the earlier version of this
 // comment claimed otherwise: many substitute a generic string of their own

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -6,7 +6,9 @@ import (
 	"crypto/subtle"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"log/slog"
 	"net"
@@ -2190,17 +2192,52 @@ func decodeJSON(r *http.Request, v interface{}) error {
 // default cap is too small — but always pass an explicit cap, never
 // remove the wrapper.
 func decodeJSONWithLimit(r *http.Request, v interface{}, maxBytes int64) error {
-	// http.MaxBytesReader.Close() is a no-op; the decoder leaves r.Body at
-	// EOF anyway. Setting this here also lets the server return a 413
-	// automatically via the error we wrap below.
-	if r.Body != nil {
-		r.Body = http.MaxBytesReader(nil, r.Body, maxBytes)
+	raw, err := readBodyForDecode(r, maxBytes)
+	if err != nil {
+		return fmt.Errorf("invalid JSON: %w", err)
 	}
-	if err := json.NewDecoder(r.Body).Decode(v); err != nil {
+	// An EMPTY (or whitespace-only) body must keep returning a wrapped
+	// io.EOF. json.Decoder.Decode answered io.EOF there and at least one
+	// caller depends on it — handlers_playbooks.go treats
+	// errors.Is(err, io.EOF) as "no arguments supplied" and runs anyway —
+	// while json.Unmarshal answers a SyntaxError instead, which that check
+	// cannot see. Found by TestPlaybookRunAcceptsEmptyBody, which is exactly
+	// the wiring a helper-level change is blind to.
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return fmt.Errorf("invalid JSON: %w", io.EOF)
+	}
+	// Refuse a decoded NUL BEFORE unmarshalling, so the value never exists
+	// in a Go string that a handler could hand to the store. See
+	// bodyDecodesNUL for why the body needs its own rule and why the check
+	// cannot be a substring search. BUG-2803.
+	if bodyDecodesNUL(raw) {
+		return errJSONBodyNUL
+	}
+	// json.Unmarshal rather than a Decoder over the buffer: it is the
+	// cheaper of the two by ~2x in total allocation (see readBodyForDecode's
+	// measurement), and it REFUSES trailing non-whitespace after the JSON
+	// value where Decode silently ignores it. That second difference is a
+	// deliberate behaviour change in the same direction as this fix —
+	// malformed input is refused at the door rather than partly consumed —
+	// and it is the only compatibility change in BUG-2803. Trailing
+	// whitespace, which real clients do send, is still accepted.
+	if err := json.Unmarshal(raw, v); err != nil {
 		return fmt.Errorf("invalid JSON: %w", err)
 	}
 	return nil
 }
+
+// errJSONBodyNUL is returned by decodeJSON when a string in the request body
+// decodes to a value containing a NUL. Every decodeJSON caller already turns
+// a decode error into a 400 carrying err.Error(), so this reaches the client
+// as a client error with a message naming the cause, at all 65 call sites,
+// without touching any of them.
+//
+// The wording avoids writing the escape sequence literally: the message is
+// rendered in terminals, logs and a browser, and a literal escape in an error
+// string is the kind of thing an intermediate layer transforms.
+var errJSONBodyNUL = errors.New(
+	"request body contains a NUL character in a JSON string (a u0000 escape); text values cannot contain NUL")
 
 // getWorkspaceID resolves workspace slug/ID from the request.
 // If RequireWorkspaceAccess already resolved the workspace, reads from context.

--- a/web/src/routes/console/connected-apps/+page.svelte
+++ b/web/src/routes/console/connected-apps/+page.svelte
@@ -80,6 +80,17 @@
 		try {
 			const updated = await api.connectedApps.rename(app.id, draft);
 			replaceApp(updated);
+			// Sync the draft to what the server actually STORED, not to what
+			// was typed. The server normalises — it trims, and it caps the
+			// name at 120 BYTES via a rune-safe truncation while this input
+			// allows 120 CHARACTERS, so any multibyte name near the limit
+			// comes back shorter than the draft. Without this the equality
+			// check below never matches, Save stays enabled forever, and each
+			// press re-sends the same request (codex round 24, BUG-2803).
+			//
+			// Assigning the canonical value rather than comparing lengths
+			// keeps this correct for any future normalisation too.
+			nameDrafts[app.id] = updated.name ?? '';
 		} catch (e) {
 			setError(app.id, e instanceof Error ? e.message : 'Failed to rename');
 		} finally {


### PR DESCRIPTION
> **Twenty-nine adversarial review rounds; twenty-eight found something real** — including two bypasses of this PR's own fixes, one regression it briefly introduced, and one attempted optimisation that was unsound and got reverted. The commits tell that story in order; this describes the CURRENT state.

**Three defects, not one.** The body half of BUG-2782 (path) and BUG-2784 (query): a caller-supplied string reached a Postgres text parameter, Postgres refused it, and the handler answered **500** — the honest answer is 400. Found on the way: **six handlers read request bodies with no size cap at all**, and **four sites truncated strings mid-rune**, undoing validation that had already passed.

## Why the transport rule could not simply be extended

`ValidateQuery` works because a decoded query value is a substring of the raw query with ASCII substitutions: the bad byte in the raw text **is** the bad byte in the value. That fails for a JSON body — the reachable NUL arrives as a six-character escape, all ordinary ASCII — so no request middleware can find it without decoding the body, which is the handler's job.

## The check

At `decodeJSONWithLimit`, before unmarshalling into the target: read the body, walk it, refuse a decoded NUL with a 400. No call site changed for the refusal — all 65 `decodeJSON` callers already turn a decode error into a 400.

**The gate.** The walk runs only when the raw bytes contain `\u00`, the prefix of any `\u` escape for a character below U+0100. Each character of the NUL escape arrives either literally (so the raw contains the escape, which starts with that prefix) or from a `\u` escape of its own — and backslash, `u` and `0` all sit below U+0100.

That argument is **instrumented, not trusted**. An earlier version ("the escape has only one spelling") was true of a decoded string, false of raw bytes, and round 4 turned it into a live bypass: `\^@` contains no literal escape yet decodes into one. A **differential test** runs the gated function against an ungated walk over a corpus built to attack it, and asserts the corpus is not one-sided. It has since caught a second unsound gate — see *What did not ship*.

**The walk** decodes into `any` and recurses. It refuses a NUL in any string or object key. Under a REQUEST key whose string value is a JSON document something re-parses (`config, events, fields, metadata, phase_data, plan_overrides, schema, settings, tags, traits`) it walks that document too — the escape survives the outer decode as literal text and becomes a NUL on the second parse, which Postgres reports differently: **22P05**, not the 22021 the rest of the family produces.

**Four things it deliberately does NOT do**, each after a round found it refusing something legitimate:

- **Not reflection over the destination struct** — that sees `[]byte` after base64 decoding, so legitimate binary containing `0x00` would be refused.
- **Not the natural shape of those fields** — `tags` and `fields` also arrive as arrays/objects the server marshals itself. Only a direct *string* child of a listed key is a document.
- **Not inside caller data** — a collection may declare a user field named `schema`; the key list is consulted only outside caller data, so a user field is never mistaken for a wire key.
- **Not below the document Postgres parses** — measured: with that check disabled, a NUL escape two levels down imports **201**, because `fields` is parsed once and the inner text is re-escaped when the blob is written. Those last two make the descent exactly one level deep by construction, which is why there is no depth counter.

`TestJSONEncodedFieldKeysCoversTheModels` derives the key set from `internal/models` and fails when a new one appears.

## Population — measured, with a control leg on every endpoint

92 mutating routes enumerated via `chi.Walk`; 13 probed on Postgres 17 through the real router.

```
before:  12 of 13 DOOR   (control 201 / NUL 500, SQLSTATE 22021)
after:    0 of 13        every NUL leg 400, every control leg unchanged
```

**`workspace-token.name` is UNMEASURED, not clean** — its control also 500s, on an unrelated FK. The other 79 routes are **unprobed, not claimed clean**; completeness is carried structurally instead, by `TestEveryRequestBodyReaderIsAccountedFor`, which requires every file touching a request body to be listed with a reason and fails in both directions.

An earlier run said 9 of 13 — the control PATCH renamed the shared fixture item, so later probes 404'd and read as non-doors. A fixture artifact producing a negative result is exactly the shape this filing was re-scoped for.

## Doors closed beyond the JSON body

- **The tar.gz bundle import** parsed `pad-export.json` and the attachment manifest itself. A NUL in the manifest reached `rehydrateAttachment`, whose failure is logged and *skipped*, so the import reported success while dropping the attachment.
- **The raw artifact import** takes TEXT, not JSON — no check at all. And **YAML has its own escapes**: `title: "a\0b"` carries no NUL in the request bytes and manufactures one on decode, importing **201 with a NUL in the item title**. Both the raw bytes and the decoded artifact are now checked.
- **Multipart TEXT fields** — `item_id` reaches ResolveItem exactly as the query channel does. (A raw NUL in the header is *not* the vector — Go refuses it as a malformed MIME header; the RFC 5987 encoded form is.)
- **Byte truncation** — four sites cut with a plain slice, so a value that *passed* validation arrived unbindable. Downstream of validation, and invisible with ASCII fixtures, which is what every test in that area used.
- **`User-Agent`** into `activities.user_agent`. Sanitised, not refused — a header is metadata the server chose to record.
- **One caller swallowed the refusal** — the admin test-email endpoint fell back to the admin's own address, so a NUL body answered 200.

## Second defect: six unbounded body reads

Those six handlers had **no `http.MaxBytesReader`** — the 2 MiB cap `decodeJSON` has always applied. Each was an unbounded body read: a multi-GB POST to comment-create, item-move, report-layout, attachment-transform, comment-reactions or OAuth DCR streamed into a single allocation. A memory-exhaustion door independent of the NUL bug, closed here because it lives on the same six lines.

## Release note — measured doors closed, with filed residuals

Scope statement first, because "closed" unqualified would be wrong: this closes every door the
population sweep MEASURED, and leaves ten named residuals filed rather than fixed (see *Known,
filed, NOT fixed here*). Several of those — BUG-2811, BUG-2812's two under-refusals, BUG-2813,
BUG-2814 — are known ways a NUL can still reach a text column.

Behaviour changes an operator or client author would notice:

1. A **NUL in a JSON request body** returns **400 instead of 500** on PostgreSQL, and **400 instead of silently storing it** on SQLite.
2. **Raw artifact imports** refuse invalid UTF-8 or a NUL — including one written as a YAML escape — with 400 `invalid_body`.
3. **Bundle imports** refuse NUL-bearing `pad-export.json` or attachment manifests. A manifest refusal happens after the workspace row exists, so it leaves a partially created workspace, as other manifest failures already did.
4. **Six endpoints gain the 2 MiB body cap** they never had: comment create, comment reactions, item move, report layout, attachment transform, OAuth dynamic client registration. A body over the cap now answers 400.
5. **Trailing non-whitespace after a JSON body is refused** where it was previously ignored. Trailing whitespace still passes.
6. The **admin test-email** endpoint answers 400 for an unusable body instead of silently sending to the admin's own address. An absent body still means "send it to me".
7. **Multipart `item_id` and filename** values that cannot be stored are dropped rather than passed through — an unusable `item_id` behaves as if absent, an unusable filename becomes a generic one.
8. **Stored `User-Agent`** values are sanitised (invalid UTF-8 and NULs removed) before reaching the activity log. Session UA hashing is unchanged.
9. **A SQLite workspace containing a NUL can be exported but not re-imported.** See `docs/backup.md`;
   `pad db migrate-to-pg` has the same limitation and reports it later. Tracked as BUG-2810. Note the
   rule lives in the BINARY, not the database, so this is not only about historical data — a rollback
   or a mixed-version window on SQLite can still create such rows (BUG-2813). PostgreSQL is unaffected
   at every version; it refuses a NUL itself.
10. **An unknown field carrying a NUL escape is now refused**, even though no handler reads it —
    `{"title":"valid","future_field":"<NUL escape>"}` answers 400 where it answered 200. The
    check has no destination type by design (see *Four things it deliberately does NOT do*), so it
    cannot tell a forward-compatible field from a real one. Accepted: refusing is the safe
    direction. A client sending forward-compatible fields is the one affected.

11. **Uploaded filenames are reduced further than before**: leading/trailing whitespace is trimmed,
    a name containing a backslash is treated as a path and reduced to its final segment (a
    cross-platform safety choice — a Unix file legitimately named `a\b.png` uploads as `b.png`),
    and dot-only names become the generic fallback. Names that reduce to nothing get the generic
    fallback with a vetted extension.
12. **`pad attachment view` names its temp file more usefully**: when the stored name has no
    extension (or only a trailing dot), the canonical extension for the attachment's MIME type is
    appended, and every ALLOWED type now has one — including alias spellings like `text/xml`.
    Blocked types (`image/svg+xml`, executables) never gain an extension this way. The id-based
    fallback name is reduced the same way as a stored filename, and the id is path-escaped on the
    wire — a traversal-shaped "id" harvested from item content could previously re-route the
    request and steer the local write outside the temp directory.
13. **Chunked watch-creation bodies are now decoded.** A `POST .../watch` sent with chunked
    transfer encoding previously had its body silently ignored — the predicate was dropped and an
    unconditional watch created with a 200. The body now flows through the shared decoder (NUL
    rule and size cap included); an empty chunked body still means an unconditional watch. The
    CLI also refuses the two exact dot-segment attachment "ids" (`.` and `..`) that PathEscape
    leaves unchanged, before any request is sent.

## Rounds 20-24: what a fresh angle found that twenty confirm-shaped rounds could not

Rounds 1-18 probed the guard. Rounds 19-24 probed things *around* it, and every one found something.

- **R20 (bypass population).** `middleware_mcp_audit.go` runs its OWN `json.Unmarshal` and binds the
  decoded `method` / `params.name` to `mcp_audit_log.tool_name` (`TEXT NOT NULL`). Postgres refuses
  that INSERT with 22021; SQLite stores it. Nothing upstream catches it — the `/mcp` transport decodes
  the JSON-RPC envelope itself, not through `decodeJSON`. **This PR's own completeness map had
  certified that reader safe**, on the true-but-irrelevant grounds that the dispatcher decodes the body
  again. Fixed by sanitising at the choke point.
- **R21 (angle enumeration).** The R20 fix's own boundary: a value made entirely of NUL escapes was
  non-empty at the fallback check and empty after cleaning, storing an empty required field. Fixed by
  ordering — clean, then test.
- **R22.** That reorder made classification read the *sanitised* method, so `tools/<NUL>call` became a
  genuine `tools/call` and lifted `params.name`. Measured: `tool_name="pad_item"` with a full
  args_hash — **an audit row indistinguishable from a real call**. Also: `bytes.TrimSpace` is
  `unicode.IsSpace`, which strips `\v`, `\f`, U+00A0 — none of which JSON accepts — so a `\v`-only body
  read as ABSENT and playbook-run proceeded on it. Both fixed.
- **R23.** Cleaning is lossy, so `pad_<NUL>item` still stored exactly what `pad_item` stores. Cleaned
  identities are now marked: diagnosable, non-forgeable.
- **R24 (consumer enumeration).** Most consumers came back FINE — the useful half. Three did not: the
  marker was splitting Prometheus series (now collapsed to one constant label value); the filename
  fallback dropped a storable extension, making it lossier than its own `upload.bin` sibling and
  breaking `pad attachment view`'s documented contract; and a connected-app rename could never come
  clean, because the draft was never synced to the normalised stored value.

- **R25 (attack the substitutes).** The diff no longer only refuses — it SYNTHESISES values. Preserving
  a storable extension turned out to carry a blocklist bypass: control bytes are storable (valid UTF-8,
  not NUL) and are *stripped* into `Content-Disposition`, so `.s<VT>vg` passes an extension blocklist
  that sees no known extension and reaches the client as `.svg` — and that blocklist is the whole
  defence for SVG, since `DetectContentType` calls it allowed `text/xml`. Fallbacks now require a
  KNOWN, ALLOWED extension. Separately, the sentinels were forgeable: a caller may simply name a tool
  `(unknown)`. A leading `(` is now reserved for synthesised values.

- **R26-R29 (the newest fixes, and the instruments).** Each of these rounds targeted the previous
  round's fix, on the evidence that this is where defects were landing. R26 found the fix-boundary
  defects plus a P1 on memory (measured at **1.56x**, folded into BUG-2812 rather than overstated).
  R27 found that the reverse MIME map I had just added emitted **BLOCKED** extensions — I closed an SVG
  door and reopened one through a different helper. R28 found the fifth consecutive false negative in
  the body-reader scan. R29 attacked the *reasoning* behind the fix for R28 and was right.

**Where the findings actually are.** The NUL guard itself has not produced a finding since round 17.
Rounds 24-29 found defects almost entirely in the FIXES and the TEST INSTRUMENTS — a shared oracle, a
lexical inventory, two vacuous tests, a guard that could not fire, over-refusals. That is worth stating
plainly, because a raw round count implies the feature is unstable and the record does not support that.

**Nine consecutive rounds each found a defect introduced by the previous round's fix.** Every fix was
correct for the case it addressed and wrong about something adjacent. That is the argument for the
residuals below being filed rather than folded in — this area demonstrably generates a new defect per
fix, which is what the land-and-follow ruling anticipated.

## Known, filed, NOT fixed here

- **BUG-2810** — rows already carrying the escape: exportable, not importable, and `migrate-to-pg` fails mid-copy. Needs a preflight and a repair path; the disposition is a product ruling.
- **BUG-2818** — control bytes in a filename bypass the extension blocklist and are then stripped into
  `Content-Disposition`, so a `.svg` can be served named `.svg` without ever being blocklisted as one.
  PRE-EXISTING on the ordinary upload path, where no fallback is involved; this PR only declined to add
  a second door via the synthesised name.
- **BUG-2819** — substituted metadata is indistinguishable from caller-supplied metadata. The MCP half
  is closed here by reserving a namespace; attachment filenames cannot be rescued that way (they are
  legitimately parenthesised), so the principled fix — a provenance field — is a migration and is filed.
- **BUG-2814** — guarded writes re-emit at-rest NULs (`fields_patch`, bulk update, move, cross-workspace
  copy, version restore, schema defaults, activity merges, outbox snapshots). Distinct from BUG-2813 and
  the distinction is operational: 2813 is a NUL being WRITTEN while an old binary serves, 2814 is the
  fixed binary SPREADING one already at rest into rows with no history of it.
- **BUG-2817** — the MCP tool metrics label is caller-driven, not catalog-bounded, so an authenticated
  caller can mint unbounded Prometheus series. Pre-existing; `internal/metrics` documented the opposite
  and that comment is corrected here. This PR bounds only its OWN marker's contribution.
- **BUG-2813** — the invariant is enforced by the BINARY, not the database, so on SQLite a rollback or a
  mixed-version window can still write a NUL; the guard returns and the rows are already stored. Found by
  round 19's deploy/rollback pass, which also caught `docs/backup.md` claiming such rows "can only affect
  data written before that rule existed" — false for exactly that reason. The DOC half is fixed in this PR;
  store-layer enforcement is the filed follow-up, since it is a dialect-level change and the day-68 ruling
  is land-and-follow.
- **BUG-2811** — OAuth **form-encoded** bodies parse outside the shared validator. This was BUG-2803's original subject; it needs a fosite-backed fixture, and the previous probe 404'd on every leg *including its control*.
- **The four `map[string]any` model disagreements** (rounds 16-17), all documented on
  `bodyDecodesNUL` and pinned by `TestBodyDecodesNULKnownMapModelDisagreements`. One root cause:
  this scan decodes into `map[string]any` and `encoding/json`'s typed decode does not agree with
  that model about keys. **Two under-refuse and are BUG-2812's spec** — duplicate keys merge
  differently (the map REPLACES, the decode MERGES, so the scan cannot see the shadowed
  occurrence), and a scan failure lets a known-bad value through (`1e999` breaks the `any`
  unmarshal, the typed decode then skips the unknown field and accepts the NUL title). **Two
  over-refuse and are ACCEPTED** — unknown fields (release note 10) and case-variant duplicates.
  Per the day-68 ruling these are NOT patched here: 17 finding-rounds in 19 says the pre-scan
  machinery has a design problem, and restructuring it late under review pressure is what produced
  this branch's one regression. The two known-gap test legs assert the WRONG answer on purpose, so
  BUG-2812's fix makes them FAIL rather than letting this note go stale.
- **BUG-2812** — owns the two under-refusals above, and separately: a body carrying *harmless* escape text forces the generic walk: measured **1.8x allocation, 2.3x time** on a ~14 MiB body (~1.5x/2.0x discounting the trigger text's own size). Bounded — authenticated, capped, and the two representations are sequential rather than simultaneous.

- **BUG-2820** — the body-reader accounting test resolves names with a PARSER: a request reached
  through a struct field, a context value, or a type alias is invisible to it, as its KNOWN LIMITS
  block states. Closing that means go/types with a real package load, not more parser patches —
  five rounds of scope-patching is what proved the point. Filed from the closing round.
- **BUG-2822** — stored filenames can still be WINDOWS-unstorable: trailing dots/spaces and
  reserved device names (`CON`, `COM1`, …) survive the server guard. The in-repo CLI consumer is
  defended (it strips trailing dots locally and falls back to the attachment id); the stored value
  itself is the residual. Filed from the closing round.

## What did not ship, and why it is worth knowing

An escape-parity pre-filter would have killed BUG-2812's trigger without a walk: a backslash introduces an escape only when an even number precede it, so a doubled backslash could be skipped. **It is unsound, and the existing tests failed the moment it landed** — parity is layer-relative, and in a JSON-encoded field the escape carries one more backslash than it will have after the outer decode, so "even, therefore literal" at the raw layer becomes a live escape one decode later. The substring gate is the minimal sound filter.

## The instruments, and why they were rebuilt twice

The tests guarding this change were themselves the subject of five rounds, and the write-up would be
dishonest without saying so.

- **The differential test shared its oracle with the code under test** — the "ungated" reference called
  the same production walker, so a walker defect cancelled on both sides. Now checked against an
  independently written walker; removing the nested-document descent leaves the differential GREEN and
  fails the new oracle. The oracle was itself wrong twice more (a natural object under a listed key; a
  JSON scalar) before it matched production exactly.
- **Two tests were VACUOUS** — they used the NUL character where the six-character escape text belonged,
  so their bodies were malformed JSON that never reached the paths they named. Found only because a
  mutation SURVIVED and that was treated as a question rather than an answer.
- **The body-reader inventory** went from a regex (blind to any name but `r`/`req`, and matching inside
  comments) to an AST scan, then through five rounds of scope patches, and finally to a deliberately
  CONSERVATIVE scan. The last change was the important one: over-approximating makes every
  scope-shaped false negative structurally impossible, and per-file reader COUNTS mean an accounting
  entry can no longer absorb a reader added later — demonstrated by inserting one into an
  already-accounted file and watching it fail.

## Verification

- **A guard that could not fire, found by its own mutation.** `SafeFallbackExtension` originally carried
  an explicit alphanumeric loop as well as the known-extension lookup. Removing the loop changed
  nothing — no `extMIMEMap` key contains a non-alphanumeric character, so the lookup already excluded
  every obfuscated suffix. Keeping an unreachable guard whose comment claims it stops control
  characters would misdescribe which line does the work, so it is gone and `TestExtMIMEMapKeysArePlain`
  enforces the property it relied on.
- **Instrument repairs, because two of these tests were vacuous.** The differential test compared the
  gated function against an "ungated" reference calling the SAME production walker, so a walker defect
  cancelled on both sides; it now also runs against an independently-written oracle. Demonstrated:
  removing the nested-document descent leaves the differential **green** and fails the new oracle. The
  body-reader inventory was lexical — it recognised only `r`/`req`, matched inside comments, and my
  first fix (any identifier) was worse, flagging five files that read no request body at all; it is now
  `go/ast`, keyed on `*http.Request`. And two of my own new tests used `"\^@"`, which in Go is the
  NUL *character*, not the escape text — so their bodies were malformed JSON that never reached the
  path they named. Found only because a mutation SURVIVED and was treated as a question rather than an
  answer. All three now use the canonical `escNULLiteral` helper, which exists for exactly that reason.
- **Mutation matrices**: 7/7 on the original check (6 killed, 1 survived by design), 6/6 on the scoped walk, plus one mutation per later fix — each killing only its own leg. One mutant was a **false kill** (an unused import meant it never compiled); the harness now flags a kill carrying no FAIL lines. One assertion was **vacuous** and the mutation caught it: a NUL in a JSON response comes back escaped, so `ContainsRune(body, 0)` passed with the fix disabled.
- **Gates** on the tip: `go test ./...` 28 ok / 0 FAIL · Postgres 17 full suite 28 ok / 0 FAIL (own container, not the shared port) · `-race` on `internal/server` ok · `golangci-lint` 0 issues · `gofmt` 0 files · `govulncheck` 0 called.

Closes BUG-2803.




