### PR TITLE
fix(store,links): remove both quadratics in the item rename cascade and bound it (BUG-2804)

### DIFF
--- a/internal/links/links.go
+++ b/internal/links/links.go
@@ -177,7 +177,7 @@ func RewriteBracketsAt(content string, rewrites []BracketRewrite, newTitle, coll
 			// Overlaps a rewrite already applied (or a duplicate offset).
 			continue
 		}
-		newSegment, displaySuffix, bracketEnd, ok := bracketRewriteAt(content, rw.Position, rw.TargetTitle, newTitle, collSlug)
+		qualified, displaySuffix, bracketEnd, ok := bracketRewriteAt(content, rw.Position, rw.TargetTitle, newTitle, collSlug)
 		if !ok {
 			continue
 		}
@@ -189,7 +189,7 @@ func RewriteBracketsAt(content string, rewrites []BracketRewrite, newTitle, coll
 		// rename rewrite content, bump seq, and emit events for every linker
 		// (codex R1 P2). The old code compared whole bodies to decide this;
 		// comparing the bracket is the same question asked locally.
-		if bracketUnchanged(content, rw.Position, bracketEnd, newSegment, displaySuffix) {
+		if bracketUnchanged(content, rw.Position, bracketEnd, qualified, newTitle, collSlug, displaySuffix) {
 			continue
 		}
 		if applied == 0 {
@@ -200,7 +200,11 @@ func RewriteBracketsAt(content string, rewrites []BracketRewrite, newTitle, coll
 		}
 		b.WriteString(content[cursor:rw.Position])
 		b.WriteString("[[")
-		b.WriteString(newSegment)
+		if qualified {
+			b.WriteString(collSlug)
+			b.WriteString("/")
+		}
+		b.WriteString(newTitle)
 		b.WriteString(displaySuffix)
 		b.WriteString("]]")
 		cursor = bracketEnd
@@ -239,11 +243,11 @@ func ProjectRewrittenLen(content string, rewrites []BracketRewrite, newTitle, co
 		if rw.Position < cursor {
 			continue
 		}
-		newSegment, displaySuffix, bracketEnd, ok := bracketRewriteAt(content, rw.Position, rw.TargetTitle, newTitle, collSlug)
+		qualified, displaySuffix, bracketEnd, ok := bracketRewriteAt(content, rw.Position, rw.TargetTitle, newTitle, collSlug)
 		if !ok {
 			continue
 		}
-		if bracketUnchanged(content, rw.Position, bracketEnd, newSegment, displaySuffix) {
+		if bracketUnchanged(content, rw.Position, bracketEnd, qualified, newTitle, collSlug, displaySuffix) {
 			// Deliberately does NOT advance the cursor, mirroring the real pass
 			// exactly. An earlier version advanced it here, which made the two
 			// loops disagree about which overlapping rewrites the guard skips:
@@ -263,7 +267,7 @@ func ProjectRewrittenLen(content string, rewrites []BracketRewrite, newTitle, co
 		// replacement per bracket to measure it would reintroduce, one layer
 		// down, exactly the allocate-then-refuse shape the cap exists to
 		// prevent (codex R1 P1).
-		length += (2 + len(newSegment) + len(displaySuffix) + 2) - (bracketEnd - rw.Position)
+		length += (2 + bracketSegmentLen(qualified, newTitle, collSlug) + len(displaySuffix) + 2) - (bracketEnd - rw.Position)
 		cursor = bracketEnd
 		applied++
 	}
@@ -273,16 +277,43 @@ func ProjectRewrittenLen(content string, rewrites []BracketRewrite, newTitle, co
 	return length, applied
 }
 
+// bracketSegmentLen is the byte length of the title segment a matched bracket
+// will carry: the optional `<collSlug>/` prefix plus newTitle. Computed, never
+// built.
+func bracketSegmentLen(qualified bool, newTitle, collSlug string) int {
+	if qualified {
+		return len(collSlug) + 1 + len(newTitle)
+	}
+	return len(newTitle)
+}
+
 // bracketUnchanged reports whether rewriting the bracket at [position,
-// bracketEnd) would reproduce it byte-for-byte. Allocation-free: it compares
-// the two halves of the existing body against the segments in place rather
-// than concatenating them.
-func bracketUnchanged(content string, position, bracketEnd int, newSegment, displaySuffix string) bool {
+// bracketEnd) would reproduce it byte-for-byte.
+//
+// Allocation-free, and now segment-wise: it walks the existing body against the
+// optional slug prefix, then newTitle, then the display suffix, rather than
+// concatenating them into a candidate string. Building the candidate just to
+// compare it would reintroduce the newTitle-proportional allocation that
+// bracketRewriteAt exists to avoid — on every bracket, in the projection path,
+// before the cap fires (codex R5).
+func bracketUnchanged(content string, position, bracketEnd int, qualified bool, newTitle, collSlug, displaySuffix string) bool {
 	body := content[position+2 : bracketEnd-2]
-	if len(body) != len(newSegment)+len(displaySuffix) {
+	if len(body) != bracketSegmentLen(qualified, newTitle, collSlug)+len(displaySuffix) {
 		return false
 	}
-	return body[:len(newSegment)] == newSegment && body[len(newSegment):] == displaySuffix
+	if qualified {
+		if len(body) < len(collSlug)+1 {
+			return false
+		}
+		if body[:len(collSlug)] != collSlug || body[len(collSlug)] != '/' {
+			return false
+		}
+		body = body[len(collSlug)+1:]
+	}
+	if len(body) < len(newTitle) || body[:len(newTitle)] != newTitle {
+		return false
+	}
+	return body[len(newTitle):] == displaySuffix
 }
 
 // bracketRewriteAt is the per-bracket decision, and the ONLY copy of it. It
@@ -292,17 +323,17 @@ func bracketUnchanged(content string, position, bracketEnd int, newSegment, disp
 //
 // It reads only content[position:bracketEnd] — that locality is what makes a
 // single pass possible, since the rest of the body is pure carry.
-func bracketRewriteAt(content string, position int, targetTitle, newTitle, collSlug string) (newSegment, displaySuffix string, bracketEnd int, ok bool) {
+func bracketRewriteAt(content string, position int, targetTitle, newTitle, collSlug string) (qualified bool, displaySuffix string, bracketEnd int, ok bool) {
 	if position < 0 || position+2 > len(content) {
-		return "", "", 0, false
+		return false, "", 0, false
 	}
 	if content[position:position+2] != "[[" {
-		return "", "", 0, false
+		return false, "", 0, false
 	}
 	rest := content[position+2:]
 	closeIdx := strings.Index(rest, "]]")
 	if closeIdx < 0 {
-		return "", "", 0, false
+		return false, "", 0, false
 	}
 	body := rest[:closeIdx]
 	bracketEnd = position + 2 + closeIdx + 2 // past `]]`
@@ -310,37 +341,50 @@ func bracketRewriteAt(content string, position int, targetTitle, newTitle, collS
 	tLower := strings.ToLower(body)
 	ttLower := strings.ToLower(targetTitle)
 
-	// Compose the new title segment. If target_title starts with
-	// `<collSlug>/`, preserve that prefix on output so a qualified
-	// body like `[[tasks/Old Title]]` becomes `[[tasks/New Title]]`
-	// — the cascade SELECT already proved this row points at the
-	// renamed item via stage-2 qualified-fallback resolution, so
-	// the slug is guaranteed to match collSlug.
-	newSegment = newTitle
+	// MATCH FIRST, then describe the replacement. Nothing proportional to
+	// newTitle is built here at all — this returns a DESCRIPTION (does the
+	// qualified prefix apply, what display suffix carries over) and lets each
+	// caller either measure it or write it.
+	//
+	// Both properties matter and both were violated before (codex R1, then R5
+	// one layer down). An earlier version composed `collSlug + "/" + newTitle`
+	// BEFORE the match check, so every bracket paid for it including the
+	// leave-alone exit — and ProjectRewrittenLen calls this once per rewrite
+	// BEFORE the cap fires. BUG-2831 then measured that newTitle has no
+	// validation bound, so a bracket-dense body with a multi-megabyte new title
+	// projected gigabytes of immediately-discarded allocation ahead of the
+	// refusal that exists to prevent exactly that.
+	//
+	// Case 1: body equals target_title (case-insensitive) — no display segment.
+	// Case 2: body starts with target_title + "|" — the display segment from
+	// the pipe onward carries over verbatim (a SLICE of body, not a copy).
+	switch {
+	case tLower == ttLower:
+	case len(tLower) > len(ttLower) && tLower[len(ttLower)] == '|' && tLower[:len(ttLower)] == ttLower:
+		// Spelled out rather than HasPrefix(tLower, ttLower+"|") so the
+		// concatenation disappears; it is the same predicate, byte for byte,
+		// on the same two already-lowered strings.
+		displaySuffix = body[len(targetTitle):] // includes the pipe
+	default:
+		// Bracket doesn't match the expected shape — leave it alone.
+		// (Index drift or a stored full-body title with embedded pipe;
+		// the trailing replaceWikiLinks call will reconcile.)
+		return false, "", 0, false
+	}
+
+	// Only now, on a confirmed match: does the `<collSlug>/` prefix carry over?
+	// A qualified body like `[[tasks/Old Title]]` becomes `[[tasks/New Title]]`
+	// — the cascade SELECT already proved this row points at the renamed item
+	// via stage-2 qualified-fallback resolution, so the slug is guaranteed to
+	// match collSlug. Reported as a flag; the caller writes collSlug and "/"
+	// directly rather than receiving them spliced onto newTitle.
 	if collSlug != "" {
 		pfx := collSlug + "/"
 		if strings.HasPrefix(strings.ToLower(targetTitle), strings.ToLower(pfx)) {
-			newSegment = pfx + newTitle
+			qualified = true
 		}
 	}
-
-	// Case 1: body equals target_title (case-insensitive) — no
-	// display segment, replace whole.
-	if tLower == ttLower {
-		return newSegment, "", bracketEnd, true
-	}
-
-	// Case 2: body starts with target_title + "|" — display segment
-	// follows. Preserve everything from the pipe onward verbatim.
-	if strings.HasPrefix(tLower, ttLower+"|") {
-		displaySuffix = body[len(targetTitle):] // includes the pipe
-		return newSegment, displaySuffix, bracketEnd, true
-	}
-
-	// Bracket doesn't match the expected shape — leave it alone.
-	// (Index drift or a stored full-body title with embedded pipe;
-	// the trailing replaceWikiLinks call will reconcile.)
-	return "", "", 0, false
+	return qualified, displaySuffix, bracketEnd, true
 }
 
 // replaceAll substitutes every occurrence of old with new, scanning the INPUT

--- a/internal/links/links.go
+++ b/internal/links/links.go
@@ -111,11 +111,14 @@ func RewriteWikiTitle(content, oldTitle, newTitle, collSlug string) string {
 // code regions from prose. A bracket inside fenced code at the
 // recorded position WILL be rewritten — matches the document
 // rename path's behavior.
+//
 // Implemented as the one-element case of RewriteBracketsAt so the two cannot
-// drift: the per-bracket decision lives in exactly one place (bracketRewriteAt),
-// and TestRewriteBracketAt_EquivalentToRewriteBracketsAtOfOne pins the
-// equivalence over this function's existing behaviour corpus rather than
-// arguing it. BUG-2804.
+// drift: the per-bracket decision lives in exactly one place (bracketRewriteAt).
+// Behaviour across that refactor is pinned by
+// TestRewriteBracketAt_MatchesPreRefactorImplementation and its randomised
+// sibling, which compare against the pre-refactor code frozen as an oracle —
+// comparing this function to RewriteBracketsAt-of-one would be vacuous, since
+// that is now its definition. BUG-2804.
 func RewriteBracketAt(content string, position int, targetTitle, newTitle, collSlug string) string {
 	out, _ := RewriteBracketsAt(content, []BracketRewrite{{Position: position, TargetTitle: targetTitle}}, newTitle, collSlug)
 	return out
@@ -174,8 +177,19 @@ func RewriteBracketsAt(content string, rewrites []BracketRewrite, newTitle, coll
 			// Overlaps a rewrite already applied (or a duplicate offset).
 			continue
 		}
-		replacement, bracketEnd, ok := bracketRewriteAt(content, rw.Position, rw.TargetTitle, newTitle, collSlug)
+		newSegment, displaySuffix, bracketEnd, ok := bracketRewriteAt(content, rw.Position, rw.TargetTitle, newTitle, collSlug)
 		if !ok {
+			continue
+		}
+		// A rewrite that reproduces the bracket byte-for-byte is NOT a change.
+		// Skipping it leaves the identical bytes to the verbatim carry, so the
+		// output is the same either way — but `applied` then counts CHANGES
+		// rather than matches, and the cascade uses that count to decide
+		// whether to write the row at all. Counting matches made a no-op
+		// rename rewrite content, bump seq, and emit events for every linker
+		// (codex R1 P2). The old code compared whole bodies to decide this;
+		// comparing the bracket is the same question asked locally.
+		if bracketUnchanged(content, rw.Position, bracketEnd, newSegment, displaySuffix) {
 			continue
 		}
 		if applied == 0 {
@@ -185,7 +199,10 @@ func RewriteBracketsAt(content string, rewrites []BracketRewrite, newTitle, coll
 			b.Grow(len(content))
 		}
 		b.WriteString(content[cursor:rw.Position])
-		b.WriteString(replacement)
+		b.WriteString("[[")
+		b.WriteString(newSegment)
+		b.WriteString(displaySuffix)
+		b.WriteString("]]")
 		cursor = bracketEnd
 		applied++
 	}
@@ -222,11 +239,19 @@ func ProjectRewrittenLen(content string, rewrites []BracketRewrite, newTitle, co
 		if rw.Position < cursor {
 			continue
 		}
-		replacement, bracketEnd, ok := bracketRewriteAt(content, rw.Position, rw.TargetTitle, newTitle, collSlug)
+		newSegment, displaySuffix, bracketEnd, ok := bracketRewriteAt(content, rw.Position, rw.TargetTitle, newTitle, collSlug)
 		if !ok {
 			continue
 		}
-		length += len(replacement) - (bracketEnd - rw.Position)
+		if bracketUnchanged(content, rw.Position, bracketEnd, newSegment, displaySuffix) {
+			cursor = bracketEnd
+			continue
+		}
+		// Length arithmetic only — NOTHING is built here. Concatenating a
+		// replacement per bracket to measure it would reintroduce, one layer
+		// down, exactly the allocate-then-refuse shape the cap exists to
+		// prevent (codex R1 P1).
+		length += (2 + len(newSegment) + len(displaySuffix) + 2) - (bracketEnd - rw.Position)
 		cursor = bracketEnd
 		applied++
 	}
@@ -236,6 +261,18 @@ func ProjectRewrittenLen(content string, rewrites []BracketRewrite, newTitle, co
 	return length, applied
 }
 
+// bracketUnchanged reports whether rewriting the bracket at [position,
+// bracketEnd) would reproduce it byte-for-byte. Allocation-free: it compares
+// the two halves of the existing body against the segments in place rather
+// than concatenating them.
+func bracketUnchanged(content string, position, bracketEnd int, newSegment, displaySuffix string) bool {
+	body := content[position+2 : bracketEnd-2]
+	if len(body) != len(newSegment)+len(displaySuffix) {
+		return false
+	}
+	return body[:len(newSegment)] == newSegment && body[len(newSegment):] == displaySuffix
+}
+
 // bracketRewriteAt is the per-bracket decision, and the ONLY copy of it. It
 // returns the replacement text for the bracket at `position` (including its
 // enclosing `[[`/`]]`), the offset just past the bracket it replaces, and
@@ -243,17 +280,17 @@ func ProjectRewrittenLen(content string, rewrites []BracketRewrite, newTitle, co
 //
 // It reads only content[position:bracketEnd] — that locality is what makes a
 // single pass possible, since the rest of the body is pure carry.
-func bracketRewriteAt(content string, position int, targetTitle, newTitle, collSlug string) (replacement string, bracketEnd int, ok bool) {
+func bracketRewriteAt(content string, position int, targetTitle, newTitle, collSlug string) (newSegment, displaySuffix string, bracketEnd int, ok bool) {
 	if position < 0 || position+2 > len(content) {
-		return "", 0, false
+		return "", "", 0, false
 	}
 	if content[position:position+2] != "[[" {
-		return "", 0, false
+		return "", "", 0, false
 	}
 	rest := content[position+2:]
 	closeIdx := strings.Index(rest, "]]")
 	if closeIdx < 0 {
-		return "", 0, false
+		return "", "", 0, false
 	}
 	body := rest[:closeIdx]
 	bracketEnd = position + 2 + closeIdx + 2 // past `]]`
@@ -267,7 +304,7 @@ func bracketRewriteAt(content string, position int, targetTitle, newTitle, collS
 	// — the cascade SELECT already proved this row points at the
 	// renamed item via stage-2 qualified-fallback resolution, so
 	// the slug is guaranteed to match collSlug.
-	newSegment := newTitle
+	newSegment = newTitle
 	if collSlug != "" {
 		pfx := collSlug + "/"
 		if strings.HasPrefix(strings.ToLower(targetTitle), strings.ToLower(pfx)) {
@@ -278,20 +315,20 @@ func bracketRewriteAt(content string, position int, targetTitle, newTitle, collS
 	// Case 1: body equals target_title (case-insensitive) — no
 	// display segment, replace whole.
 	if tLower == ttLower {
-		return "[[" + newSegment + "]]", bracketEnd, true
+		return newSegment, "", bracketEnd, true
 	}
 
 	// Case 2: body starts with target_title + "|" — display segment
 	// follows. Preserve everything from the pipe onward verbatim.
 	if strings.HasPrefix(tLower, ttLower+"|") {
-		displaySuffix := body[len(targetTitle):] // includes the pipe
-		return "[[" + newSegment + displaySuffix + "]]", bracketEnd, true
+		displaySuffix = body[len(targetTitle):] // includes the pipe
+		return newSegment, displaySuffix, bracketEnd, true
 	}
 
 	// Bracket doesn't match the expected shape — leave it alone.
 	// (Index drift or a stored full-body title with embedded pipe;
 	// the trailing replaceWikiLinks call will reconcile.)
-	return "", 0, false
+	return "", "", 0, false
 }
 
 // replaceAll substitutes every occurrence of old with new, scanning the INPUT

--- a/internal/links/links.go
+++ b/internal/links/links.go
@@ -2,6 +2,7 @@ package links
 
 import (
 	"regexp"
+	"sort"
 	"strings"
 )
 
@@ -110,20 +111,112 @@ func RewriteWikiTitle(content, oldTitle, newTitle, collSlug string) string {
 // code regions from prose. A bracket inside fenced code at the
 // recorded position WILL be rewritten — matches the document
 // rename path's behavior.
+// Implemented as the one-element case of RewriteBracketsAt so the two cannot
+// drift: the per-bracket decision lives in exactly one place (bracketRewriteAt),
+// and TestRewriteBracketAt_EquivalentToRewriteBracketsAtOfOne pins the
+// equivalence over this function's existing behaviour corpus rather than
+// arguing it. BUG-2804.
 func RewriteBracketAt(content string, position int, targetTitle, newTitle, collSlug string) string {
+	out, _ := RewriteBracketsAt(content, []BracketRewrite{{Position: position, TargetTitle: targetTitle}}, newTitle, collSlug)
+	return out
+}
+
+// BracketRewrite names one bracket to rewrite: the byte offset its `[[` starts
+// at, and the target_title the index recorded for it. NewTitle and collSlug are
+// shared across a whole call because a rename cascade renames ONE item to ONE
+// new title.
+type BracketRewrite struct {
+	Position    int
+	TargetTitle string
+}
+
+// RewriteBracketsAt rewrites every bracket named in `rewrites` in a SINGLE pass
+// over `content`, returning the new content and how many rewrites it applied.
+//
+// This exists because calling RewriteBracketAt once per bracket is quadratic in
+// the body size, and that is reachable in one request: the cheapest wiki-link is
+// five bytes (`[[A]]`) and nothing caps links per item, so a C-byte body carries
+// C/5 brackets and each call rebuilt the whole body. Measured before the fix at
+// 1.00x the body allocated per call — see internal/store's BUG-2804 probes,
+// which measured the cascade at 2.01x body per bracket and showed allocation
+// growing 3.83/3.92/3.95 per doubling of C, i.e. O(C^2).
+//
+// Semantics, which are deliberately stricter than "apply them in some order":
+//
+//   - `rewrites` may arrive in ANY order. The cascade's SELECT returns positions
+//     DESCENDING (so that repeated whole-body rewrites did not invalidate each
+//     other's offsets); a single pass needs them ascending, so this function
+//     sorts a COPY and never mutates the caller's slice.
+//   - A rewrite whose bracket does not match the expected shape is SKIPPED and
+//     its bytes are carried verbatim — the same conservative posture
+//     RewriteBracketAt has always had, where a drifted offset leaves content
+//     alone and the caller's re-parse reconciles the index.
+//   - A rewrite that OVERLAPS one already applied is skipped. Distinct brackets
+//     cannot overlap, so this only fires on a corrupt or duplicated offset; in
+//     that case carrying the bytes verbatim is the only non-corrupting choice.
+//   - Applying nothing returns the input string unchanged, allocating nothing.
+//     Callers use the count to decide whether a write is owed, which also spares
+//     them a full-body string comparison to detect it.
+func RewriteBracketsAt(content string, rewrites []BracketRewrite, newTitle, collSlug string) (string, int) {
+	if len(rewrites) == 0 {
+		return content, 0
+	}
+
+	ordered := make([]BracketRewrite, len(rewrites))
+	copy(ordered, rewrites)
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i].Position < ordered[j].Position })
+
+	var b strings.Builder
+	cursor := 0
+	applied := 0
+	for _, rw := range ordered {
+		if rw.Position < cursor {
+			// Overlaps a rewrite already applied (or a duplicate offset).
+			continue
+		}
+		replacement, bracketEnd, ok := bracketRewriteAt(content, rw.Position, rw.TargetTitle, newTitle, collSlug)
+		if !ok {
+			continue
+		}
+		if applied == 0 {
+			// First real rewrite — size the buffer once. len(content) is the
+			// right order of magnitude in both directions (a rename that grows
+			// the body reallocates once; one that shrinks it wastes a little).
+			b.Grow(len(content))
+		}
+		b.WriteString(content[cursor:rw.Position])
+		b.WriteString(replacement)
+		cursor = bracketEnd
+		applied++
+	}
+	if applied == 0 {
+		return content, 0
+	}
+	b.WriteString(content[cursor:])
+	return b.String(), applied
+}
+
+// bracketRewriteAt is the per-bracket decision, and the ONLY copy of it. It
+// returns the replacement text for the bracket at `position` (including its
+// enclosing `[[`/`]]`), the offset just past the bracket it replaces, and
+// whether the bracket matched at all.
+//
+// It reads only content[position:bracketEnd] — that locality is what makes a
+// single pass possible, since the rest of the body is pure carry.
+func bracketRewriteAt(content string, position int, targetTitle, newTitle, collSlug string) (replacement string, bracketEnd int, ok bool) {
 	if position < 0 || position+2 > len(content) {
-		return content
+		return "", 0, false
 	}
 	if content[position:position+2] != "[[" {
-		return content
+		return "", 0, false
 	}
 	rest := content[position+2:]
 	closeIdx := strings.Index(rest, "]]")
 	if closeIdx < 0 {
-		return content
+		return "", 0, false
 	}
 	body := rest[:closeIdx]
-	bracketEnd := position + 2 + closeIdx + 2 // past `]]`
+	bracketEnd = position + 2 + closeIdx + 2 // past `]]`
 
 	tLower := strings.ToLower(body)
 	ttLower := strings.ToLower(targetTitle)
@@ -145,20 +238,20 @@ func RewriteBracketAt(content string, position int, targetTitle, newTitle, collS
 	// Case 1: body equals target_title (case-insensitive) — no
 	// display segment, replace whole.
 	if tLower == ttLower {
-		return content[:position] + "[[" + newSegment + "]]" + content[bracketEnd:]
+		return "[[" + newSegment + "]]", bracketEnd, true
 	}
 
 	// Case 2: body starts with target_title + "|" — display segment
 	// follows. Preserve everything from the pipe onward verbatim.
 	if strings.HasPrefix(tLower, ttLower+"|") {
 		displaySuffix := body[len(targetTitle):] // includes the pipe
-		return content[:position] + "[[" + newSegment + displaySuffix + "]]" + content[bracketEnd:]
+		return "[[" + newSegment + displaySuffix + "]]", bracketEnd, true
 	}
 
 	// Bracket doesn't match the expected shape — leave it alone.
 	// (Index drift or a stored full-body title with embedded pipe;
 	// the trailing replaceWikiLinks call will reconcile.)
-	return content
+	return "", 0, false
 }
 
 // replaceAll substitutes every occurrence of old with new, scanning the INPUT

--- a/internal/links/links.go
+++ b/internal/links/links.go
@@ -244,7 +244,19 @@ func ProjectRewrittenLen(content string, rewrites []BracketRewrite, newTitle, co
 			continue
 		}
 		if bracketUnchanged(content, rw.Position, bracketEnd, newSegment, displaySuffix) {
-			cursor = bracketEnd
+			// Deliberately does NOT advance the cursor, mirroring the real pass
+			// exactly. An earlier version advanced it here, which made the two
+			// loops disagree about which overlapping rewrites the guard skips:
+			// on `[[A[[B]]]]` with a no-op at 0 and a change at 3, projection
+			// reported (10 bytes, 0 applied) while the pass produced 13 bytes
+			// and applied 1 — so the cascade charged a read it never charged
+			// the rewrite for, and the bound leaked on exactly the corrupt or
+			// duplicated offsets the defensive paths exist to handle
+			// (codex R2).
+			//
+			// The pass is the side that must not move: its behaviour is pinned
+			// to the descending fold the cascade used to perform. So the
+			// projection follows it, never the reverse.
 			continue
 		}
 		// Length arithmetic only — NOTHING is built here. Concatenating a

--- a/internal/links/links.go
+++ b/internal/links/links.go
@@ -196,6 +196,46 @@ func RewriteBracketsAt(content string, rewrites []BracketRewrite, newTitle, coll
 	return b.String(), applied
 }
 
+// ProjectRewrittenLen returns the byte length RewriteBracketsAt WOULD produce
+// for the same arguments, and how many rewrites it would apply, without
+// building the result.
+//
+// It exists so a caller can bound what a cascade will hold BEFORE allocating
+// it — refusing after the amplified string is built bounds nothing. Exact
+// rather than an estimate: it runs the same per-bracket decision
+// (bracketRewriteAt) and the same ordering and skip rules as the real pass, so
+// the two cannot disagree about which brackets apply.
+//
+// Cost is O(total bracket text), not O(len(content) * len(rewrites)) — each
+// bracket is inspected once and the untouched spans are only measured.
+func ProjectRewrittenLen(content string, rewrites []BracketRewrite, newTitle, collSlug string) (length, applied int) {
+	if len(rewrites) == 0 {
+		return len(content), 0
+	}
+	ordered := make([]BracketRewrite, len(rewrites))
+	copy(ordered, rewrites)
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i].Position < ordered[j].Position })
+
+	length = len(content)
+	cursor := 0
+	for _, rw := range ordered {
+		if rw.Position < cursor {
+			continue
+		}
+		replacement, bracketEnd, ok := bracketRewriteAt(content, rw.Position, rw.TargetTitle, newTitle, collSlug)
+		if !ok {
+			continue
+		}
+		length += len(replacement) - (bracketEnd - rw.Position)
+		cursor = bracketEnd
+		applied++
+	}
+	if applied == 0 {
+		return len(content), 0
+	}
+	return length, applied
+}
+
 // bracketRewriteAt is the per-bracket decision, and the ONLY copy of it. It
 // returns the replacement text for the bracket at `position` (including its
 // enclosing `[[`/`]]`), the offset just past the bracket it replaces, and

--- a/internal/links/probe_alloc_test.go
+++ b/internal/links/probe_alloc_test.go
@@ -29,3 +29,50 @@ func TestProbeRewriteBracketAtAllocation(t *testing.T) {
 			tc.name, per, float64(per)/float64(len(body)), len(body))
 	}
 }
+
+// TestProjectRewrittenLenDoesNotAllocatePerBracket pins codex R5's finding.
+//
+// ProjectRewrittenLen runs once per rewrite BEFORE the cascade's cap can fire.
+// An earlier bracketRewriteAt composed `collSlug + "/" + newTitle` on every
+// call — before the match check, so even the leave-alone exit paid — which made
+// the projection allocate newTitle bytes PER BRACKET while measuring something
+// it was about to refuse.
+//
+// It is not a micro-optimisation: BUG-2831 established that item titles carry
+// no validation bound, so a multi-megabyte newTitle is admissible, and a
+// bracket-dense body then projects gigabytes of immediately-discarded
+// allocation ahead of the refusal that exists to prevent it.
+//
+// The ceiling is expressed per bracket and in units of newTitle, so it stays
+// meaningful if the sizes move. Measured after the fix: ~0.00x.
+func TestProjectRewrittenLenDoesNotAllocatePerBracket(t *testing.T) {
+	const brackets = 4096
+	newTitle := strings.Repeat("N", 1<<20) // 1 MiB, no validation bound exists
+	content := strings.Repeat("[[A]]", brackets)
+
+	rewrites := make([]BracketRewrite, 0, brackets)
+	for i := 0; i < brackets; i++ {
+		rewrites = append(rewrites, BracketRewrite{Position: i * len("[[A]]"), TargetTitle: "A"})
+	}
+
+	var before, after runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+	length, applied := ProjectRewrittenLen(content, rewrites, newTitle, "tasks")
+	runtime.ReadMemStats(&after)
+
+	if applied != brackets {
+		t.Fatalf("applied = %d, want %d — the projection did not exercise every bracket", applied, brackets)
+	}
+	allocated := after.TotalAlloc - before.TotalAlloc
+	perBracket := float64(allocated) / float64(brackets) / float64(len(newTitle))
+
+	// One newTitle per bracket is the defect; a tenth of one is already far
+	// below anything the old shape could achieve.
+	t.Logf("projected len=%d applied=%d; allocated %d bytes = %.4f x newTitle per bracket",
+		length, applied, allocated, perBracket)
+	if perBracket > 0.1 {
+		t.Errorf("projection allocated %.4f x newTitle per bracket (%d bytes total) — it is "+
+			"materialising the replacement it was only asked to measure", perBracket, allocated)
+	}
+}

--- a/internal/links/probe_alloc_test.go
+++ b/internal/links/probe_alloc_test.go
@@ -1,0 +1,31 @@
+package links
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// Isolates RewriteBracketAt's own allocation per call, away from the cascade
+// loop, to establish where the measured ~2x-body-per-bracket constant lives.
+func TestProbeRewriteBracketAtAllocation(t *testing.T) {
+	const c = 256 << 10
+	body := strings.Repeat("[[A]]", c/5)
+
+	for _, tc := range []struct{ name, newTitle string }{
+		{"same-length", "B"},
+		{"longer", "BBBBBBBBBBBBBBBB"},
+	} {
+		var before, after runtime.MemStats
+		runtime.GC()
+		runtime.ReadMemStats(&before)
+		const n = 200
+		for i := 0; i < n; i++ {
+			_ = RewriteBracketAt(body, 0, "A", tc.newTitle, "")
+		}
+		runtime.ReadMemStats(&after)
+		per := (after.TotalAlloc - before.TotalAlloc) / n
+		t.Logf("%-12s per call=%-9d (=%.2fx the %d-byte body)",
+			tc.name, per, float64(per)/float64(len(body)), len(body))
+	}
+}

--- a/internal/links/rewrite_brackets_diff_test.go
+++ b/internal/links/rewrite_brackets_diff_test.go
@@ -383,3 +383,105 @@ func TestRewriteBracketsAt_MixedChangedAndUnchangedCountsOnlyTheChanged(t *testi
 		t.Errorf("applied = %d, want 2 — the middle bracket was already [[New]]", applied)
 	}
 }
+
+// TestProjectRewrittenLen_IsLockstepWithTheRealPass pins the invariant the cap
+// depends on: what the projection PREDICTS must be exactly what the rewrite
+// DOES, for every input including the defensive ones.
+//
+// This is the property codex R2 found broken. The projection advanced its
+// cursor past a no-op bracket while the real pass did not, so on corrupt,
+// duplicated or overlapping offsets the two disagreed about which rewrites the
+// overlap guard skips — projection reporting (unchanged, 0 applied) where the
+// pass actually applied one and grew the body. The cascade charges from the
+// projection, so the bound's guarantee leaked on precisely the inputs the
+// defensive paths exist for.
+//
+// The corpus deliberately includes NESTED-LOOKING brackets like `[[A[[B]]]]`,
+// where two valid `[[` offsets share a closing `]]` and therefore genuinely
+// overlap. Random offsets alone rarely produce that shape, which is why it is
+// constructed rather than left to chance.
+func TestProjectRewrittenLen_IsLockstepWithTheRealPass(t *testing.T) {
+	rng := rand.New(rand.NewSource(20260902))
+	titles := []string{"Old", "old", "A|B", "Other", "A[[B", "B"}
+	news := []string{"New", "N", "A[[B", strings.Repeat("N", 20), ""}
+
+	overlapping := []string{
+		"[[A[[B]]]]",
+		"[[Old[[Old]]]]",
+		"x [[A[[B]]]] y",
+		"[[A[[B]]]] [[Old]]",
+	}
+
+	check := func(t *testing.T, content string, rewrites []BracketRewrite, newTitle, collSlug string) {
+		t.Helper()
+		wantLen, wantApplied := ProjectRewrittenLen(content, rewrites, newTitle, collSlug)
+		got, gotApplied := RewriteBracketsAt(content, rewrites, newTitle, collSlug)
+		if len(got) != wantLen || gotApplied != wantApplied {
+			t.Fatalf("projection and the real pass disagree\n content=%q rewrites=%+v new=%q slug=%q\n"+
+				" projected len=%d applied=%d\n actual    len=%d applied=%d (result %q)",
+				content, rewrites, newTitle, collSlug, wantLen, wantApplied, len(got), gotApplied, got)
+		}
+	}
+
+	// MIXED target titles per position, not one title for the whole call.
+	// Cascade rows carry their own target_title (one row may have stored
+	// "Old" and another "tasks/Old"), and a single shared title is exactly
+	// what hid this divergence from the first version of this test: the
+	// reproducing case needs one bracket to be a NO-OP while an overlapping
+	// one CHANGES, which a single title cannot express.
+	for _, content := range overlapping {
+		offs := bracketOffsets(content)
+		for _, newTitle := range news {
+			for ti := range titles {
+				rewrites := make([]BracketRewrite, 0, len(offs))
+				for j, p := range offs {
+					rewrites = append(rewrites, BracketRewrite{
+						Position:    p,
+						TargetTitle: titles[(ti+j)%len(titles)],
+					})
+				}
+				check(t, content, rewrites, newTitle, "")
+			}
+		}
+	}
+
+	// The exact shape codex R2 named, asserted directly so the regression has
+	// a named home rather than depending on the random search rediscovering it:
+	// bracket [0,8) is a no-op, bracket [3,8) overlaps it and changes.
+	check(t, "[[A[[B]]]]", []BracketRewrite{
+		{Position: 0, TargetTitle: "A[[B"},
+		{Position: 3, TargetTitle: "B"},
+	}, "A[[B", "")
+
+	const iterations = 20000
+	for i := 0; i < iterations; i++ {
+		content := randomBracketContent(rng)
+		if rng.Intn(4) == 0 {
+			content += overlapping[rng.Intn(len(overlapping))]
+		}
+		target := titles[rng.Intn(len(titles))]
+		newTitle := news[rng.Intn(len(news))]
+
+		positions := bracketOffsets(content)
+		if rng.Intn(3) == 0 && len(content) > 0 {
+			positions = append(positions, rng.Intn(len(content)))
+		}
+		if rng.Intn(4) == 0 && len(positions) > 0 {
+			positions = append(positions, positions[rng.Intn(len(positions))])
+		}
+		if len(positions) == 0 {
+			continue
+		}
+		rng.Shuffle(len(positions), func(a, b int) { positions[a], positions[b] = positions[b], positions[a] })
+
+		rewrites := make([]BracketRewrite, 0, len(positions))
+		for j, p := range positions {
+			tt := target
+			if rng.Intn(2) == 0 {
+				tt = titles[(i+j)%len(titles)]
+			}
+			rewrites = append(rewrites, BracketRewrite{Position: p, TargetTitle: tt})
+		}
+		check(t, content, rewrites, newTitle, "")
+	}
+}

--- a/internal/links/rewrite_brackets_diff_test.go
+++ b/internal/links/rewrite_brackets_diff_test.go
@@ -202,8 +202,17 @@ func TestRewriteBracketsAt_MatchesSequentialDescendingFold(t *testing.T) {
 			want = RewriteBracketAt(want, p, target, newTitle, "")
 		}
 
-		rewrites := make([]BracketRewrite, 0, len(positions))
-		for _, p := range positions {
+		// SHUFFLED on purpose. bracketOffsets returns ascending order, but the
+		// real caller passes the cascade's `ORDER BY wl.position DESC` rows —
+		// so an ascending-only fixture cannot detect a missing internal sort.
+		// Found by mutation: dropping the sort left this test green until the
+		// order fed in stopped being the order the implementation wanted.
+		shuffled := make([]int, len(positions))
+		copy(shuffled, positions)
+		rng.Shuffle(len(shuffled), func(a, b int) { shuffled[a], shuffled[b] = shuffled[b], shuffled[a] })
+
+		rewrites := make([]BracketRewrite, 0, len(shuffled))
+		for _, p := range shuffled {
 			rewrites = append(rewrites, BracketRewrite{Position: p, TargetTitle: target})
 		}
 		got, applied := RewriteBracketsAt(content, rewrites, newTitle, "")

--- a/internal/links/rewrite_brackets_diff_test.go
+++ b/internal/links/rewrite_brackets_diff_test.go
@@ -316,3 +316,70 @@ func bracketOffsets(content string) []int {
 	}
 	return out
 }
+
+// TestRewriteBracketsAt_ByteIdenticalRewriteIsNotAChange pins that `applied`
+// counts CHANGES, not matches (codex R1 P2).
+//
+// The cascade uses the count to decide whether to write the row at all. The
+// pre-BUG-2804 code compared whole bodies for this, so a rewrite that
+// reproduced the content byte-for-byte wrote nothing; counting matches instead
+// would rewrite content, bump seq, and emit an item.bulk_updated event for
+// every linker on a rename that changed nothing.
+//
+// REACHABILITY, stated rather than implied: I have NOT established that
+// cascadeTitleRename can reach this today — it returns early when
+// oldTitle == newTitle, which blocks the obvious route. This pins the
+// FUNCTION's contract, which the cascade depends on, without claiming a live
+// user-visible bug.
+func TestRewriteBracketsAt_ByteIdenticalRewriteIsNotAChange(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		content     string
+		targetTitle string
+		newTitle    string
+		collSlug    string
+	}{
+		{"plain body already equals the new title", "x [[Old]] y", "Old", "Old", ""},
+		{"qualified body already equals", "x [[tasks/Old]] y", "tasks/Old", "Old", "tasks"},
+		{"display suffix preserved, title unchanged", "x [[Old|alias]] y", "Old", "Old", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			offs := bracketOffsets(tc.content)
+			if len(offs) != 1 {
+				t.Fatalf("fixture: %d brackets, want 1", len(offs))
+			}
+			got, applied := RewriteBracketsAt(tc.content,
+				[]BracketRewrite{{Position: offs[0], TargetTitle: tc.targetTitle}}, tc.newTitle, tc.collSlug)
+			if got != tc.content {
+				t.Errorf("content changed: got %q, want %q", got, tc.content)
+			}
+			if applied != 0 {
+				t.Errorf("applied = %d, want 0 — a byte-identical rewrite is not a change, and the "+
+					"cascade uses this count to decide whether to write the row", applied)
+			}
+		})
+	}
+}
+
+// TestRewriteBracketsAt_MixedChangedAndUnchangedCountsOnlyTheChanged pins the
+// count when a single body carries both kinds, which is the case a whole-body
+// comparison could never have distinguished.
+func TestRewriteBracketsAt_MixedChangedAndUnchangedCountsOnlyTheChanged(t *testing.T) {
+	content := "[[Old]] and [[New]] and [[Old]]"
+	offs := bracketOffsets(content)
+	if len(offs) != 3 {
+		t.Fatalf("fixture: %d brackets, want 3", len(offs))
+	}
+	rewrites := []BracketRewrite{
+		{Position: offs[0], TargetTitle: "Old"},
+		{Position: offs[1], TargetTitle: "New"}, // already reads [[New]] — no change
+		{Position: offs[2], TargetTitle: "Old"},
+	}
+	got, applied := RewriteBracketsAt(content, rewrites, "New", "")
+	if want := "[[New]] and [[New]] and [[New]]"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+	if applied != 2 {
+		t.Errorf("applied = %d, want 2 — the middle bracket was already [[New]]", applied)
+	}
+}

--- a/internal/links/rewrite_brackets_diff_test.go
+++ b/internal/links/rewrite_brackets_diff_test.go
@@ -1,0 +1,309 @@
+package links
+
+import (
+	"math/rand"
+	"strings"
+	"testing"
+)
+
+// BUG-2804 differential tests for the single-pass rewrite.
+//
+// WHY THE OBVIOUS TEST WOULD BE VACUOUS, stated because the GO condition was
+// worded as "RewriteBracketAt is equivalent to RewriteBracketsAt-of-one":
+// RewriteBracketAt is now IMPLEMENTED as RewriteBracketsAt-of-one, so asserting
+// those two agree compares a function with its own definition. It cannot fail,
+// and a test that cannot fail is not evidence.
+//
+// The property actually worth pinning is that behaviour did not change ACROSS
+// THE REFACTOR, so the oracle here is the pre-refactor implementation, copied
+// verbatim from commit 37d84d87 and frozen. That test can fail, and it fails if
+// anyone changes the per-bracket decision.
+//
+// The second test pins what actually licenses the fix: the cascade used to fold
+// RewriteBracketAt over its rows in DESCENDING position order, and now makes one
+// RewriteBracketsAt call. Those two must agree for every input, or the fix is a
+// behaviour change wearing a performance change's clothes.
+
+// rewriteBracketAtV0 is the implementation as it stood before BUG-2804, copied
+// verbatim. Frozen on purpose: it is an ORACLE, not live code, and it must not
+// be "kept in sync" with the real one — if the two disagree, that is the test
+// working.
+func rewriteBracketAtV0(content string, position int, targetTitle, newTitle, collSlug string) string {
+	if position < 0 || position+2 > len(content) {
+		return content
+	}
+	if content[position:position+2] != "[[" {
+		return content
+	}
+	rest := content[position+2:]
+	closeIdx := strings.Index(rest, "]]")
+	if closeIdx < 0 {
+		return content
+	}
+	body := rest[:closeIdx]
+	bracketEnd := position + 2 + closeIdx + 2
+
+	tLower := strings.ToLower(body)
+	ttLower := strings.ToLower(targetTitle)
+
+	newSegment := newTitle
+	if collSlug != "" {
+		pfx := collSlug + "/"
+		if strings.HasPrefix(strings.ToLower(targetTitle), strings.ToLower(pfx)) {
+			newSegment = pfx + newTitle
+		}
+	}
+
+	if tLower == ttLower {
+		return content[:position] + "[[" + newSegment + "]]" + content[bracketEnd:]
+	}
+
+	if strings.HasPrefix(tLower, ttLower+"|") {
+		displaySuffix := body[len(targetTitle):]
+		return content[:position] + "[[" + newSegment + displaySuffix + "]]" + content[bracketEnd:]
+	}
+
+	return content
+}
+
+// diffCase is one (content, position, targetTitle, newTitle, collSlug) probe.
+type diffCase struct {
+	name        string
+	content     string
+	position    int
+	targetTitle string
+	newTitle    string
+	collSlug    string
+}
+
+// behaviourCorpus enumerates the documented behaviour of RewriteBracketAt —
+// every branch named in its doc comment plus the rejection paths. Enumerated
+// against the FUNCTION'S CONTRACT rather than against the diff, so it covers
+// cases the refactor did not happen to touch.
+func behaviourCorpus() []diffCase {
+	return []diffCase{
+		{"whole body match", "x [[Old]] y", 2, "Old", "New", ""},
+		{"case-insensitive match", "x [[oLd]] y", 2, "Old", "New", ""},
+		{"pipe display preserved", "x [[Old|alias]] y", 2, "Old", "New", ""},
+		{"pipe display case-insensitive", "x [[oLd|alias]] y", 2, "Old", "New", ""},
+		{"empty display segment", "x [[Old|]] y", 2, "Old", "New", ""},
+		{"slug-qualified", "x [[tasks/Old]] y", 2, "tasks/Old", "New", "tasks"},
+		{"slug-qualified with display", "x [[tasks/Old|alias]] y", 2, "tasks/Old", "New", "tasks"},
+		{"slug set but title unqualified", "x [[Old]] y", 2, "Old", "New", "tasks"},
+		{"slug case-insensitive prefix", "x [[TASKS/Old]] y", 2, "TASKS/Old", "New", "tasks"},
+		{"non-matching body", "x [[Other]] y", 2, "Old", "New", ""},
+		{"position not at a bracket", "x [[Old]] y", 3, "Old", "New", ""},
+		{"position negative", "x [[Old]] y", -1, "Old", "New", ""},
+		{"position past end", "x [[Old]] y", 999, "Old", "New", ""},
+		{"position at very end", "ab", 1, "Old", "New", ""},
+		{"unclosed bracket", "x [[Old y", 2, "Old", "New", ""},
+		{"empty content", "", 0, "Old", "New", ""},
+		{"empty target title", "x [[]] y", 2, "", "New", ""},
+		{"empty new title", "x [[Old]] y", 2, "Old", "", ""},
+		{"bracket at offset zero", "[[Old]] tail", 0, "Old", "New", ""},
+		{"bracket at end of content", "head [[Old]]", 5, "Old", "New", ""},
+		{"new title longer", "x [[Old]] y", 2, "Old", strings.Repeat("N", 64), ""},
+		{"new title shorter", "x [[LongOldTitle]] y", 2, "LongOldTitle", "N", ""},
+		{"title with pipe in it", "x [[A|B]] y", 2, "A|B", "New", ""},
+		{"nested-looking brackets", "x [[Old]] [[Old]] y", 2, "Old", "New", ""},
+		{"multibyte content around", "é [[Old]] é", 3, "Old", "New", ""},
+		{"multibyte title", "x [[Ünïcødé]] y", 2, "Ünïcødé", "New", ""},
+	}
+}
+
+func TestRewriteBracketAt_MatchesPreRefactorImplementation(t *testing.T) {
+	for _, tc := range behaviourCorpus() {
+		t.Run(tc.name, func(t *testing.T) {
+			want := rewriteBracketAtV0(tc.content, tc.position, tc.targetTitle, tc.newTitle, tc.collSlug)
+			got := RewriteBracketAt(tc.content, tc.position, tc.targetTitle, tc.newTitle, tc.collSlug)
+			if got != want {
+				t.Errorf("behaviour changed across the refactor\n content=%q pos=%d target=%q new=%q slug=%q\n  v0=%q\n new=%q",
+					tc.content, tc.position, tc.targetTitle, tc.newTitle, tc.collSlug, want, got)
+			}
+		})
+	}
+}
+
+// TestRewriteBracketAt_MatchesPreRefactorOnRandomInput widens the corpus beyond
+// the cases a human thought of. The generator deliberately produces positions
+// that are often WRONG (mid-bracket, past the end, pointing at prose), because
+// the rejection paths are where a refactor is most likely to diverge and the
+// hand-written corpus can only cover the ones I anticipated.
+func TestRewriteBracketAt_MatchesPreRefactorOnRandomInput(t *testing.T) {
+	rng := rand.New(rand.NewSource(20260831))
+	titles := []string{"Old", "old", "tasks/Old", "A|B", "", "Ünïcødé", "LongOldTitle"}
+	news := []string{"New", "", "N", strings.Repeat("N", 40)}
+	slugs := []string{"", "tasks", "docs"}
+
+	const iterations = 20000
+	for i := 0; i < iterations; i++ {
+		content := randomBracketContent(rng)
+		pos := rng.Intn(len(content)+4) - 2 // includes negatives and past-end
+		target := titles[rng.Intn(len(titles))]
+		newTitle := news[rng.Intn(len(news))]
+		slug := slugs[rng.Intn(len(slugs))]
+
+		want := rewriteBracketAtV0(content, pos, target, newTitle, slug)
+		got := RewriteBracketAt(content, pos, target, newTitle, slug)
+		if got != want {
+			t.Fatalf("divergence at iteration %d\n content=%q pos=%d target=%q new=%q slug=%q\n  v0=%q\n new=%q",
+				i, content, pos, target, newTitle, slug, want, got)
+		}
+	}
+}
+
+// TestRewriteBracketsAt_MatchesSequentialDescendingFold is the test that
+// licenses the fix.
+//
+// The cascade's old inner loop was exactly this fold: rows arrive ORDER BY
+// position DESC, and each RewriteBracketAt call operated on the output of the
+// last. Descending order is what kept the earlier offsets valid. The new code
+// makes ONE RewriteBracketsAt call, and the two must agree on every input or
+// this is a silent behaviour change.
+//
+// Positions fed in are the REAL bracket offsets plus deliberate corruptions, so
+// the skip paths (non-matching shape, overlap, duplicates) are exercised rather
+// than assumed unreachable.
+func TestRewriteBracketsAt_MatchesSequentialDescendingFold(t *testing.T) {
+	rng := rand.New(rand.NewSource(20260901))
+	titles := []string{"Old", "old", "A|B", "Other"}
+	news := []string{"New", "N", strings.Repeat("N", 24), ""}
+
+	const iterations = 5000
+	for i := 0; i < iterations; i++ {
+		content := randomBracketContent(rng)
+		target := titles[rng.Intn(len(titles))]
+		newTitle := news[rng.Intn(len(news))]
+
+		positions := bracketOffsets(content)
+		// Corrupt some of the time so skip paths get exercised.
+		if rng.Intn(3) == 0 && len(content) > 0 {
+			positions = append(positions, rng.Intn(len(content)))
+		}
+		if rng.Intn(4) == 0 && len(positions) > 0 {
+			positions = append(positions, positions[rng.Intn(len(positions))]) // duplicate
+		}
+		if len(positions) == 0 {
+			continue
+		}
+
+		// Old behaviour: fold RewriteBracketAt over positions DESCENDING.
+		desc := make([]int, len(positions))
+		copy(desc, positions)
+		for a := 0; a < len(desc); a++ {
+			for b := a + 1; b < len(desc); b++ {
+				if desc[b] > desc[a] {
+					desc[a], desc[b] = desc[b], desc[a]
+				}
+			}
+		}
+		want := content
+		for _, p := range desc {
+			want = RewriteBracketAt(want, p, target, newTitle, "")
+		}
+
+		rewrites := make([]BracketRewrite, 0, len(positions))
+		for _, p := range positions {
+			rewrites = append(rewrites, BracketRewrite{Position: p, TargetTitle: target})
+		}
+		got, applied := RewriteBracketsAt(content, rewrites, newTitle, "")
+
+		if got != want {
+			t.Fatalf("single pass diverges from the descending fold at iteration %d\n content=%q positions=%v target=%q new=%q\n fold=%q\n pass=%q (applied=%d)",
+				i, content, positions, target, newTitle, want, got, applied)
+		}
+		if want == content && applied != 0 {
+			t.Fatalf("iteration %d: content unchanged but applied=%d — callers use the count to decide whether a write is owed",
+				i, applied)
+		}
+	}
+}
+
+// TestRewriteBracketsAt_NoRewritesReturnsInputUnchanged pins the allocation-free
+// no-op path the cascade relies on to skip a write.
+func TestRewriteBracketsAt_NoRewritesReturnsInputUnchanged(t *testing.T) {
+	const content = "nothing [[Other]] to do here"
+	got, applied := RewriteBracketsAt(content, nil, "New", "")
+	if got != content || applied != 0 {
+		t.Fatalf("empty rewrites: got %q applied=%d, want %q applied=0", got, applied, content)
+	}
+	got, applied = RewriteBracketsAt(content, []BracketRewrite{{Position: 8, TargetTitle: "Old"}}, "New", "")
+	if got != content || applied != 0 {
+		t.Fatalf("non-matching rewrite: got %q applied=%d, want %q applied=0", got, applied, content)
+	}
+}
+
+// TestRewriteBracketsAt_DoesNotMutateCallerSlice pins that the internal sort
+// works on a copy. The cascade reuses its row slice, and a silent reordering
+// would be the kind of defect that only shows up under a second caller.
+func TestRewriteBracketsAt_DoesNotMutateCallerSlice(t *testing.T) {
+	content := "[[Old]] a [[Old]] b [[Old]]"
+	offs := bracketOffsets(content)
+	rewrites := []BracketRewrite{
+		{Position: offs[2], TargetTitle: "Old"},
+		{Position: offs[0], TargetTitle: "Old"},
+		{Position: offs[1], TargetTitle: "Old"},
+	}
+	before := make([]BracketRewrite, len(rewrites))
+	copy(before, rewrites)
+
+	if _, applied := RewriteBracketsAt(content, rewrites, "New", ""); applied != 3 {
+		t.Fatalf("applied = %d, want 3", applied)
+	}
+	for i := range before {
+		if rewrites[i] != before[i] {
+			t.Fatalf("caller slice was reordered: index %d was %+v, now %+v", i, before[i], rewrites[i])
+		}
+	}
+}
+
+// TestRewriteBracketsAt_AppliesEveryBracketInOnePass is the plain positive case:
+// N brackets, one call, all rewritten.
+func TestRewriteBracketsAt_AppliesEveryBracketInOnePass(t *testing.T) {
+	const n = 500
+	content := strings.Repeat("[[Old]] filler ", n)
+	offs := bracketOffsets(content)
+	if len(offs) != n {
+		t.Fatalf("fixture: %d offsets, want %d", len(offs), n)
+	}
+	rewrites := make([]BracketRewrite, 0, n)
+	for _, p := range offs {
+		rewrites = append(rewrites, BracketRewrite{Position: p, TargetTitle: "Old"})
+	}
+	got, applied := RewriteBracketsAt(content, rewrites, "New", "")
+	if applied != n {
+		t.Fatalf("applied = %d, want %d", applied, n)
+	}
+	if want := strings.Repeat("[[New]] filler ", n); got != want {
+		t.Fatalf("got %q, want %q", got[:80], want[:80])
+	}
+}
+
+// randomBracketContent builds a short body mixing prose, matching brackets,
+// non-matching brackets, unclosed brackets and multibyte runes.
+func randomBracketContent(rng *rand.Rand) string {
+	pieces := []string{
+		"[[Old]]", "[[old]]", "[[Old|alias]]", "[[Other]]", "[[tasks/Old]]",
+		"[[A|B]]", "[[", "]]", "[[Old", "prose ", " ", "é", "[[]]", "[[Old|]]",
+	}
+	var b strings.Builder
+	n := rng.Intn(8)
+	for i := 0; i < n; i++ {
+		b.WriteString(pieces[rng.Intn(len(pieces))])
+	}
+	return b.String()
+}
+
+// bracketOffsets returns the byte offset of every `[[` that has a matching `]]`
+// after it, scanning the way the parser does.
+func bracketOffsets(content string) []int {
+	var out []int
+	for i := 0; i+1 < len(content); i++ {
+		if content[i] == '[' && content[i+1] == '[' {
+			if strings.Index(content[i+2:], "]]") >= 0 {
+				out = append(out, i)
+			}
+		}
+	}
+	return out
+}

--- a/internal/links/rewrite_brackets_diff_test.go
+++ b/internal/links/rewrite_brackets_diff_test.go
@@ -199,7 +199,14 @@ func TestRewriteBracketsAt_MatchesSequentialDescendingFold(t *testing.T) {
 		}
 		want := content
 		for _, p := range desc {
-			want = RewriteBracketAt(want, p, target, newTitle, "")
+			// rewriteBracketAtV0, NOT RewriteBracketAt. The latter now delegates
+			// to RewriteBracketsAt, so folding it would build the oracle out of
+			// the code under test and the comparison would be circular — the
+			// same vacuity that made the one-element assertion worthless, in
+			// the multi-bracket case, which I missed when I caught it there
+			// (codex R3). The frozen pre-refactor primitive is the only
+			// genuinely independent oracle available.
+			want = rewriteBracketAtV0(want, p, target, newTitle, "")
 		}
 
 		// SHUFFLED on purpose. bracketOffsets returns ascending order, but the

--- a/internal/server/handlers_collab.go
+++ b/internal/server/handlers_collab.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/PerpetualSoftware/pad/internal/collab"
 	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/store"
 	"github.com/go-chi/chi/v5"
 	"github.com/gorilla/websocket"
 )
@@ -456,6 +457,28 @@ func (s *Server) applyContentViaCollab(r *http.Request, itemID, markdown string,
 	return collab.ErrRoomActiveDuringPrune
 }
 
+// isDeterministicWriteFailure reports whether an error from a direct-write
+// callback is a settled answer rather than a transient condition.
+//
+// These three are the errors handleUpdateItem already treats as FINAL at every
+// call site: a rejection, a conflict, and a refusal. None can come out
+// differently on a retry, so a fallback path that swallows one and retries is
+// doing the work twice to reach the same answer — and, worse, may reach it by
+// a route that reports it differently.
+func isDeterministicWriteFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+	if _, ok := asOpenChildrenGuardError(err); ok {
+		return true
+	}
+	if _, ok := asUpdateConflictError(err); ok {
+		return true
+	}
+	var tooLarge *store.ItemRenameCascadeTooLargeError
+	return errors.As(err, &tooLarge)
+}
+
 func (s *Server) applyContentViaCollabOnce(r *http.Request, itemID, markdown string, directWrite directWriteFn) error {
 	err := s.collab.ApplyExternalContent(itemID, markdown)
 	switch {
@@ -518,6 +541,22 @@ func (s *Server) applyContentViaCollabOnce(r *http.Request, itemID, markdown str
 			// review round 6.
 			return paErr
 		default:
+			// A DETERMINISTIC failure from directWrite is the caller's answer,
+			// not a collab routing problem, so it must survive this branch
+			// (BUG-2804 / codex R2). Returning `err` here discards it and hands
+			// the caller the original collab error instead, which reads as
+			// "couldn't route through an applier" — recoverable — so the caller
+			// falls through to its own direct write and re-derives the identical
+			// refusal from scratch. Measured: a refused rename ran the whole
+			// cascade TWICE, 64 rewritten bodies built for one request.
+			//
+			// Scoped to errors that cannot come out differently on a second
+			// attempt. Everything else keeps returning `err`, preserving the
+			// graceful-degradation contract this branch exists for: a prune
+			// failure or a transient write fault should still fall through.
+			if isDeterministicWriteFailure(paErr) {
+				return paErr
+			}
 			slog.Warn("collab: failed to prune op-log on direct-write fallback",
 				"item_id", itemID,
 				"error", paErr,

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -892,6 +892,37 @@ func (s *Server) handleGetItem(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleUpdateItem updates an existing item (fields, content, or both).
+
+// writeItemRenameCascadeTooLarge answers a BUG-2804 cascade refusal as 413 and
+// reports whether it handled the error.
+//
+// SHARED because handleUpdateItem reaches store.UpdateItemWithParentLink from
+// THREE places — the plain path, the collab-snapshot callback, and the
+// collab-edit callback — each with its own error block. The plain path was
+// mapped first and the other two were missed, which is a population error, not
+// a typo: the sweep that established "bulk and restore never set Title"
+// checked other HANDLERS and never asked whether this handler had more than
+// one error block (codex R2).
+//
+// The refusal is DETERMINISTIC and permanent, which is why the collab-edit
+// path must treat it as final rather than letting it fall through to the
+// direct write: falling through re-runs the whole cascade, re-reads every
+// linking body and re-charges the projection, only to refuse identically. The
+// caller waits twice for one answer.
+func writeItemRenameCascadeTooLarge(w http.ResponseWriter, err error) bool {
+	var tooLarge *store.ItemRenameCascadeTooLargeError
+	if !errors.As(err, &tooLarge) {
+		return false
+	}
+	// Composed from TYPED fields, never by splicing err.Error() — every wrapper
+	// the call path added would otherwise be published to the client.
+	writeError(w, http.StatusRequestEntityTooLarge, "rename_cascade_too_large",
+		fmt.Sprintf("This rename would rewrite more linked content than the server will process in one "+
+			"operation: at least %d bytes, and the limit is %d. Reduce the number of items linking "+
+			"this title, or split the rename, and try again.", tooLarge.Processed, tooLarge.Max))
+	return true
+}
+
 func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 	workspaceID, ok := s.getWorkspaceID(w, r)
 	if !ok {
@@ -1542,6 +1573,12 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 				writeUpdateConflictError(w, itemRefOrSlug(*item), conflict)
 				return
 			}
+			// BUG-2804 / codex R2: without this the cascade refusal reaches the
+			// client as a 500 from this path only, while the plain path answers
+			// 413 for the identical store error.
+			if writeItemRenameCascadeTooLarge(w, err) {
+				return
+			}
 			// Mirror the main UpdateItem path: map UNIQUE constraint /
 			// duplicate key races (e.g. concurrent edits both racing the
 			// invocation_slug partial unique index) to 409 conflict so
@@ -1619,6 +1656,12 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 			// the same race again.
 			writeUpdateConflictError(w, itemRefOrSlug(*item), conflict)
 			return
+		} else if writeItemRenameCascadeTooLarge(w, err) {
+			// FINAL, like the guard and conflict arms above. The refusal is
+			// deterministic, so the fall-through to the direct write below would
+			// re-run the entire cascade — every linking body read and projected a
+			// second time — and refuse identically (codex R2).
+			return
 		} else if errors.Is(err, collab.ErrApplierAmbiguous) {
 			// BUG-2276 residual 2 (P1, mixed-deploy window): a legacy (non-bracket-
 			// capable) applier was caught by a concurrent version restore and its
@@ -1668,12 +1711,7 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 		// fields and never by splicing err.Error(), because every wrapper the
 		// call path added on the way up would otherwise be published to the
 		// client.
-		var cascadeTooLarge *store.ItemRenameCascadeTooLargeError
-		if errors.As(err, &cascadeTooLarge) {
-			writeError(w, http.StatusRequestEntityTooLarge, "rename_cascade_too_large",
-				fmt.Sprintf("This rename would rewrite more linked content than the server will process in one "+
-					"operation: at least %d bytes, and the limit is %d. Reduce the number of items linking "+
-					"this title, or split the rename, and try again.", cascadeTooLarge.Processed, cascadeTooLarge.Max))
+		if writeItemRenameCascadeTooLarge(w, err) {
 			return
 		}
 		// Map UNIQUE constraint races (e.g. concurrent updates that both

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -1656,6 +1656,26 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 			writeUpdateConflictError(w, itemRefOrSlug(*item), conflict)
 			return
 		}
+		// BUG-2804: the item rename cascade refuses renames that would process
+		// more linking content than MaxItemRenameCascadeBytes. Without this arm
+		// the refusal falls through to writeInternalError and lands as a 500 —
+		// which tells the caller the server broke and that retrying might work,
+		// when in fact the request was understood, deliberately declined, and
+		// will be declined identically until the workspace's content changes.
+		//
+		// Mirrors the document twin at handlers_documents.go:202, including its
+		// rule about composition: the sentence is built from the error's TYPED
+		// fields and never by splicing err.Error(), because every wrapper the
+		// call path added on the way up would otherwise be published to the
+		// client.
+		var cascadeTooLarge *store.ItemRenameCascadeTooLargeError
+		if errors.As(err, &cascadeTooLarge) {
+			writeError(w, http.StatusRequestEntityTooLarge, "rename_cascade_too_large",
+				fmt.Sprintf("This rename would rewrite more linked content than the server will process in one "+
+					"operation: at least %d bytes, and the limit is %d. Reduce the number of items linking "+
+					"this title, or split the rename, and try again.", cascadeTooLarge.Processed, cascadeTooLarge.Max))
+			return
+		}
 		// Map UNIQUE constraint races (e.g. concurrent updates that both
 		// pass checkUniqueFields and then both hit the partial unique
 		// index on invocation_slug) to 409 conflict, matching the create

--- a/internal/server/handlers_items_rename_cascade_test.go
+++ b/internal/server/handlers_items_rename_cascade_test.go
@@ -1,0 +1,146 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/store"
+)
+
+// TestItemRenameCascadeTooLarge_IsPermanentShapedNotRetryable pins the STATUS
+// and shape of the item rename cascade refusal (BUG-2804, codex R1 P2).
+//
+// The store's refusal is a deliberate, permanent decline: the request was
+// understood, and retrying it unchanged will be declined identically until the
+// workspace's content changes. Without an errors.As arm in handleUpdateItem it
+// fell through to writeInternalError and reached the client as a 500 — which
+// says the server broke and implies a retry might help. Both halves of that are
+// false.
+//
+// The exact status is pinned rather than "not 500", per the BUG-2803 round-4
+// lesson: a test asserting only the absence of the wrong answer passes on any
+// of several other wrong answers.
+//
+// Mirrors TestRenameCascadeTooLarge_IsPermanentShapedNotRetryable on the
+// document side, deliberately — the two paths are separate implementations
+// with separate sentinels, so parity is a property that has to be tested, not
+// inherited.
+func TestItemRenameCascadeTooLarge_IsPermanentShapedNotRetryable(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	rr := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items", map[string]interface{}{
+		"title": "Old",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create target: %d: %s", rr.Code, rr.Body.String())
+	}
+	var target models.Item
+	parseJSON(t, rr, &target)
+
+	// Bodies each well inside the 2 MiB request cap, together over the
+	// cascade bound — the same total-not-per-item shape the store test pins,
+	// driven through real HTTP requests. That the hostile input is CHEAP to
+	// deliver is the point.
+	const body = 1 << 20
+	perLinker := int64(body) * 2
+	linkers := int(store.MaxItemRenameCascadeBytes/perLinker) + 2
+	linkerBody := "[[Old]]" + strings.Repeat("x", body-len("[[Old]]"))
+
+	for i := 0; i < linkers; i++ {
+		rr = doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items", map[string]interface{}{
+			"title":   fmt.Sprintf("Linker %d", i),
+			"content": linkerBody,
+		})
+		if rr.Code != http.StatusCreated {
+			t.Fatalf("create linker %d: %d: %s", i, rr.Code, rr.Body.String())
+		}
+	}
+
+	rr = doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+target.Slug, map[string]interface{}{
+		"title": "New",
+	})
+
+	if rr.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("got %d, want 413 — a deliberate refusal must not surface as a server fault: %s",
+			rr.Code, rr.Body.String())
+	}
+	if got := rr.Header().Get("Retry-After"); got != "" {
+		t.Errorf("Retry-After = %q; a permanent refusal must not invite a retry", got)
+	}
+
+	respBody := rr.Body.String()
+	if !strings.Contains(respBody, "rename_cascade_too_large") {
+		t.Errorf("response lacks the error code a client would switch on: %s", respBody)
+	}
+	// The actual CAP, not the word "maximum" — a message reading "maximum
+	// exceeded" would satisfy a word check and tell the caller nothing about
+	// how far over they are. Same reasoning as the document twin's codex
+	// round 4.
+	if !strings.Contains(respBody, fmt.Sprint(int64(store.MaxItemRenameCascadeBytes))) {
+		t.Errorf("response does not state the limit %d: %s", int64(store.MaxItemRenameCascadeBytes), respBody)
+	}
+	// The internal call path must NOT be published. The store wraps its
+	// sentinel on the way up; splicing err.Error() would leak those prefixes
+	// to the client, which is why the handler composes from typed fields.
+	if strings.Contains(respBody, "store:") || strings.Contains(respBody, "cascade rename:") {
+		t.Errorf("response leaks the internal error chain: %s", respBody)
+	}
+
+	// And the rename did not take effect.
+	rr = doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/items/"+target.Slug, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("re-read target: %d: %s", rr.Code, rr.Body.String())
+	}
+	var after models.Item
+	parseJSON(t, rr, &after)
+	if after.Title != "Old" {
+		t.Errorf("title = %q after a refused rename, want %q", after.Title, "Old")
+	}
+}
+
+// TestItemRename_OrdinaryCascadeStillSucceeds is the counterfactual for the
+// test above: without it, a handler arm that answered 413 for EVERY rename
+// would pass every assertion there.
+func TestItemRename_OrdinaryCascadeStillSucceeds(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	rr := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items", map[string]interface{}{
+		"title": "Old",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create target: %d: %s", rr.Code, rr.Body.String())
+	}
+	var target models.Item
+	parseJSON(t, rr, &target)
+
+	for i := 0; i < 3; i++ {
+		rr = doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items", map[string]interface{}{
+			"title":   fmt.Sprintf("Linker %d", i),
+			"content": "see [[Old]] for details",
+		})
+		if rr.Code != http.StatusCreated {
+			t.Fatalf("create linker %d: %d: %s", i, rr.Code, rr.Body.String())
+		}
+	}
+
+	rr = doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+target.Slug, map[string]interface{}{
+		"title": "New",
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("ordinary rename: got %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+
+	// The cascade actually ran — the linkers point at the new title.
+	rr = doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/collections/tasks/items", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("list items: %d", rr.Code)
+	}
+	if n := strings.Count(rr.Body.String(), "[[New]]"); n != 3 {
+		t.Errorf("found %d rewritten linkers, want 3: the cascade did not run", n)
+	}
+}

--- a/internal/server/handlers_items_rename_cascade_test.go
+++ b/internal/server/handlers_items_rename_cascade_test.go
@@ -230,10 +230,15 @@ func TestItemRenameCascadeTooLarge_CollabEditPathDoesNotRunTheCascadeTwice(t *te
 	var target models.Item
 	parseJSON(t, rr, &target)
 
-	const body = 1 << 20
+	// Body size chosen so perLinker does NOT divide the cap evenly, and the
+	// assertion below is a TOTAL rather than an exact count: the scan charges
+	// the same budget before the rewrite loop runs (BUG-2804 / codex R4), so
+	// the admitted count is a fixture detail that shifts when that charge
+	// changes. Pinning it exactly made this test fail for a reason unrelated to
+	// the property it exists for.
+	const body = 768 << 10 // 0.75 MiB
 	perLinker := int64(body) * 2
-	admits := int(store.MaxItemRenameCascadeBytes / perLinker)
-	linkers := admits + 2
+	linkers := int(store.MaxItemRenameCascadeBytes/perLinker) + 3
 	linkerBody := "[[Old]]" + strings.Repeat("x", body-len("[[Old]]"))
 	for i := 0; i < linkers; i++ {
 		rr = doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items", map[string]interface{}{
@@ -259,10 +264,19 @@ func TestItemRenameCascadeTooLarge_CollabEditPathDoesNotRunTheCascadeTwice(t *te
 	if rr.Code != http.StatusRequestEntityTooLarge {
 		t.Fatalf("collab-edit path: got %d, want 413: %s", rr.Code, rr.Body.String())
 	}
-	if built != admits {
-		t.Errorf("cascade built %d bodies for ONE request, want %d — a second full cascade ran, "+
-			"which means the deterministic refusal fell through to the direct write and was "+
-			"re-derived from scratch", built, admits)
+	if built == 0 {
+		t.Fatalf("cascade built nothing — the fixture refused before the rewrite loop ran, so this " +
+			"test is not exercising the fall-through at all")
 	}
-	t.Logf("built %d bodies for one refused request (cap admits %d sources)", built, admits)
+	// ONE cascade's worth of work fits inside the budget by construction. TWO
+	// cascades — the fall-through re-deriving the same refusal — is about twice
+	// the cap, so the total is what discriminates without pinning a count.
+	if total := int64(built) * perLinker; total > store.MaxItemRenameCascadeBytes {
+		t.Errorf("cascade built %d bodies totalling %d charged bytes for ONE request, over the %d "+
+			"cap — a second full cascade ran, which means the deterministic refusal fell through "+
+			"to the direct write and was re-derived from scratch",
+			built, total, int64(store.MaxItemRenameCascadeBytes))
+	}
+	t.Logf("built %d bodies (%d charged bytes) for one refused request; cap %d",
+		built, int64(built)*perLinker, int64(store.MaxItemRenameCascadeBytes))
 }

--- a/internal/server/handlers_items_rename_cascade_test.go
+++ b/internal/server/handlers_items_rename_cascade_test.go
@@ -144,3 +144,125 @@ func TestItemRename_OrdinaryCascadeStillSucceeds(t *testing.T) {
 		t.Errorf("found %d rewritten linkers, want 3: the cascade did not run", n)
 	}
 }
+
+// TestItemRenameCascadeTooLarge_MappedOnTheCollabSnapshotPath closes codex R2's
+// second finding.
+//
+// handleUpdateItem reaches store.UpdateItemWithParentLink from THREE places,
+// each with its own error block: the plain path, the collab-snapshot callback,
+// and the collab-edit callback. R1 mapped the first. This pins the second, on
+// which the identical store refusal was still answering 500.
+//
+// Why the miss is worth naming: the CONVE-18 sweep I ran after R1 asked "do
+// other HANDLERS reach this?" and correctly answered no. It never asked
+// "does THIS handler reach it more than once?" — so the population was scoped
+// to the wrong axis, and a grep for the store call inside one function would
+// have found all three immediately.
+func TestItemRenameCascadeTooLarge_MappedOnTheCollabSnapshotPath(t *testing.T) {
+	srv := testServerWithCollab(t)
+	slug := createWSWithCollections(t, srv)
+
+	rr := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items", map[string]interface{}{
+		"title": "Old",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create target: %d: %s", rr.Code, rr.Body.String())
+	}
+	var target models.Item
+	parseJSON(t, rr, &target)
+
+	const body = 1 << 20
+	perLinker := int64(body) * 2
+	linkers := int(store.MaxItemRenameCascadeBytes/perLinker) + 2
+	linkerBody := "[[Old]]" + strings.Repeat("x", body-len("[[Old]]"))
+	for i := 0; i < linkers; i++ {
+		rr = doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items", map[string]interface{}{
+			"title":   fmt.Sprintf("Linker %d", i),
+			"content": linkerBody,
+		})
+		if rr.Code != http.StatusCreated {
+			t.Fatalf("create linker %d: %d: %s", i, rr.Code, rr.Body.String())
+		}
+	}
+
+	// ?source=collab-snapshot with content routes through the collab-snapshot
+	// callback rather than the plain path.
+	rr = doRequest(srv, "PATCH",
+		"/api/v1/workspaces/"+slug+"/items/"+target.Slug+"?source=collab-snapshot",
+		map[string]interface{}{
+			"title":         "New",
+			"content":       "rewritten by the editor",
+			"op_log_cursor": 0,
+		})
+
+	if rr.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("collab-snapshot path: got %d, want 413 — the same store refusal the plain path "+
+			"answers 413 for: %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "rename_cascade_too_large") {
+		t.Errorf("response lacks the error code: %s", rr.Body.String())
+	}
+}
+
+// TestItemRenameCascadeTooLarge_CollabEditPathDoesNotRunTheCascadeTwice closes
+// the other half of codex R2's second finding.
+//
+// The collab-edit path treats most callback errors as recoverable and falls
+// through to a direct write — graceful degradation for applier timeouts. A
+// cascade refusal is NOT recoverable: it is deterministic, so the fall-through
+// re-reads every linking body, re-charges the projection, and refuses
+// identically. The caller waits twice for one answer.
+//
+// STATUS CANNOT PIN THIS. Both behaviours end in 413 — the fall-through reaches
+// the plain path's arm — so a status assertion passes either way. The
+// observable that discriminates is how much WORK the cascade did, counted via
+// the store's build observer.
+func TestItemRenameCascadeTooLarge_CollabEditPathDoesNotRunTheCascadeTwice(t *testing.T) {
+	srv := testServerWithCollab(t)
+	slug := createWSWithCollections(t, srv)
+
+	rr := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items", map[string]interface{}{
+		"title": "Old",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create target: %d: %s", rr.Code, rr.Body.String())
+	}
+	var target models.Item
+	parseJSON(t, rr, &target)
+
+	const body = 1 << 20
+	perLinker := int64(body) * 2
+	admits := int(store.MaxItemRenameCascadeBytes / perLinker)
+	linkers := admits + 2
+	linkerBody := "[[Old]]" + strings.Repeat("x", body-len("[[Old]]"))
+	for i := 0; i < linkers; i++ {
+		rr = doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items", map[string]interface{}{
+			"title":   fmt.Sprintf("Linker %d", i),
+			"content": linkerBody,
+		})
+		if rr.Code != http.StatusCreated {
+			t.Fatalf("create linker %d: %d: %s", i, rr.Code, rr.Body.String())
+		}
+	}
+
+	var built int
+	srv.store.SetCascadeBuildObserver(func(int) { built++ })
+	defer srv.store.SetCascadeBuildObserver(nil)
+
+	// Title + content with collab enabled and no collab-snapshot marker routes
+	// through the collab-edit callback.
+	rr = doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+target.Slug, map[string]interface{}{
+		"title":   "New",
+		"content": "rewritten by the editor",
+	})
+
+	if rr.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("collab-edit path: got %d, want 413: %s", rr.Code, rr.Body.String())
+	}
+	if built != admits {
+		t.Errorf("cascade built %d bodies for ONE request, want %d — a second full cascade ran, "+
+			"which means the deterministic refusal fell through to the direct write and was "+
+			"re-derived from scratch", built, admits)
+	}
+	t.Logf("built %d bodies for one refused request (cap admits %d sources)", built, admits)
+}

--- a/internal/store/items_rename_bounds_test.go
+++ b/internal/store/items_rename_bounds_test.go
@@ -141,11 +141,14 @@ func TestItemRenameCascade_AllowsARealisticCascade(t *testing.T) {
 // by one whole unit: refusing before the build yields N, refusing after yields
 // N+1. Found by make test-pg, which is the whole reason that gate exists.
 func TestItemRenameCascade_RefusesBeforeBuildingTheRewrittenBody(t *testing.T) {
-	const body = 2 << 20
+	// Body size chosen so perLinker does NOT divide the cap evenly. With an
+	// exact division the assertion below cannot discriminate: refusing after
+	// the build would total exactly the cap rather than exceeding it. It also
+	// must not assume a precise admitted count, because the scan charges the
+	// same budget first (codex R4) and that shifts the boundary by a source.
+	const body = 1536 << 10 // 1.5 MiB
 	perLinker := int64(body) * 2
-	// The cascade admits floor(cap/perLinker) sources; the NEXT one crosses.
-	admits := int(MaxItemRenameCascadeBytes / perLinker)
-	linkers := admits + 2
+	linkers := int(MaxItemRenameCascadeBytes/perLinker) + 3
 
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "ItemRenameNoBuild")
@@ -166,15 +169,24 @@ func TestItemRenameCascade_RefusesBeforeBuildingTheRewrittenBody(t *testing.T) {
 		t.Fatalf("rename: got %v, want ErrItemRenameCascadeTooLarge", err)
 	}
 
-	// The source that CROSSES the cap must not have had its body built. Every
-	// source admitted before it legitimately did.
-	if built != admits {
-		t.Errorf("cascade built %d rewritten bodies before refusing, want %d — the projection is "+
-			"running AFTER the body it was supposed to prevent (one extra build is exactly the defect)",
-			built, admits)
+	// Everything the cascade BUILT must fit inside the budget. Building the
+	// source that crosses the cap is exactly the defect, and it shows up here
+	// as a total that exceeds the cap by one body.
+	//
+	// Stated as a total rather than an exact count on purpose: the admitted
+	// count depends on what the scan charged first, which is a detail of the
+	// fixture rather than the property under test.
+	if built == 0 {
+		t.Fatalf("cascade built nothing — the fixture refused before the rewrite loop ran, so this " +
+			"test is not exercising the loop's ordering at all")
 	}
-	t.Logf("built %d rewritten bodies before refusing; cap admits %d sources of %d bytes each",
-		built, admits, body)
+	if total := int64(built) * perLinker; total > MaxItemRenameCascadeBytes {
+		t.Errorf("cascade built %d bodies totalling %d charged bytes, over the %d cap — the "+
+			"projection is running AFTER the body it was supposed to prevent",
+			built, total, int64(MaxItemRenameCascadeBytes))
+	}
+	t.Logf("built %d bodies (%d charged bytes) before refusing; cap %d",
+		built, int64(built)*perLinker, int64(MaxItemRenameCascadeBytes))
 }
 
 // TestItemRenameCascade_DoesNotChargeForRewritesItWillNotPerform pins the
@@ -233,5 +245,183 @@ func TestItemRenameCascade_DoesNotChargeForRewritesItWillNotPerform(t *testing.T
 	if _, err := s.UpdateItem(target.ID, models.ItemUpdate{Title: &newTitle}); err != nil {
 		t.Fatalf("cascade refused, but the drifted sources should only have been charged "+
 			"for their reads: %v", err)
+	}
+}
+
+// TestItemRenameCascade_BoundsTheScanNotJustTheRewrite closes codex R4's P1.
+//
+// The rewrite loop's cap charges CONTENT bytes. The scan that feeds it retains
+// one entry per matching link ROW, each carrying that row's target_title — and
+// item titles have no length bound (MaxDocumentTitleRunes covers documents
+// only; there is no item equivalent, verified by grep across internal/).
+//
+// So the attack needs no large content at all: give the renamed item a title
+// measured in megabytes, link it from enough rows, and the cascade retains
+// rows x title bytes before reading a single body. A content-bytes cap cannot
+// see it, because the content is a few dozen bytes per linker.
+//
+// This is the case my own doc comment on MaxItemRenameCascadeBytes previously
+// claimed was impossible — it asserted the cascade's retention was O(1) in the
+// linker count and attributed the remaining k-linear growth to the outbox
+// (BUG-2827), which is a different vector entirely.
+func TestItemRenameCascade_BoundsTheScanNotJustTheRewrite(t *testing.T) {
+	// The largest title one JSON request can deliver (server.defaultJSONBodyLimit
+	// is 2 MiB). Nothing validates item title length, so this is reachable
+	// through the ordinary create path — and using the maximum keeps the ROW
+	// COUNT down, which is what this test's runtime is dominated by.
+	const titleBytes = 2 << 20
+	hugeTitle := strings.Repeat("T", titleBytes)
+
+	// THREE TIMES the rows needed to cross the cap, not just a few over.
+	//
+	// The margin is the instrument. A scan that refuses the moment it crosses
+	// stops after ~cap bytes; one that accumulates the whole result set and only
+	// discovers the problem later reports ~3x that. A fixture only a few rows
+	// over cannot tell those apart, which is how the first version of this test
+	// let the defect survive.
+	rowsToCross := int(MaxItemRenameCascadeBytes / int64(titleBytes))
+	rowsNeeded := rowsToCross * 2
+	linkBody := "[[" + hugeTitle + "]]"
+
+	s := testStore(t)
+	// SQLITE ONLY, and the reason is measured rather than assumed.
+	//
+	// On Postgres this fixture cannot be built at all: `items` carries
+	// UNIQUE(workspace_id, slug), the slug is derived from the title with no
+	// truncation (store.go::slugify), and a btree index tuple is capped at
+	// 8191 bytes. Creating the target fails with
+	//
+	//	insert item: ERROR: index row requires 24064 bytes, maximum size is 8191 (SQLSTATE 54000)
+	//
+	// — 24,064 rather than 2 MiB because the repetitive title compresses hard
+	// before indexing. So the huge-title shape is UNREACHABLE on Postgres,
+	// which bounds item titles in practice at a few KB while SQLite accepts
+	// them at any length.
+	//
+	// That divergence is a defect in its own right (same input accepted on one
+	// backend, refused with a 500-shaped error on the other — the BUG-2782 /
+	// BUG-2784 family) and is reported separately rather than bundled here.
+	//
+	// What it does NOT mean is that the scan bound is SQLite-only. Row count is
+	// unbounded on both backends: at Postgres's practical title ceiling the
+	// same attack needs roughly 24,000 link rows instead of 64, which a popular
+	// item accumulates over time. This test picks the cheap end of that
+	// trade — 64 rows instead of 24,000 — and pays for it by being
+	// dialect-scoped.
+	if s.dialect.Driver() == DriverPostgres {
+		t.Skip("huge-title fixture is unreachable on Postgres: UNIQUE(workspace_id, slug) btree caps the index tuple at 8191 bytes")
+	}
+	ws := createTestWorkspace(t, s, "ItemRenameScanBound")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	target := createTestItem(t, s, ws.ID, col.ID, hugeTitle, "the item being renamed")
+
+	contentBytes := 0
+	for i := 0; i < rowsNeeded; i++ {
+		createTestItem(t, s, ws.ID, col.ID, "Linker "+itoa(i), linkBody)
+		contentBytes += len(linkBody)
+	}
+
+	// FIXTURE PRECONDITION, and the first version of this was the wrong one.
+	// I originally required the content to stay small, on the theory that a
+	// large-content fixture would trip the rewrite loop's half of the budget
+	// instead. That is not achievable and the guard correctly failed the test:
+	// a link to a T-byte title costs T bytes of body text, so content and
+	// retained-title bytes are COUPLED and content is always the larger.
+	//
+	// The property that actually distinguishes the two halves is WHEN the
+	// refusal fires. Scan bytes alone must cross the cap, so the scan is the
+	// binding constraint and the refusal lands before the rewrite loop runs at
+	// all — which `built == 0` below then measures. Without the scan charge the
+	// same fixture still refuses, but only after the loop has read and built
+	// roughly a dozen bodies.
+	if scanBytes := int64(rowsNeeded) * int64(titleBytes); scanBytes <= MaxItemRenameCascadeBytes {
+		t.Fatalf("fixture: retained title bytes total %d, under the %d cap — the scan would not "+
+			"be the binding constraint and this test could not show it is bounded",
+			scanBytes, int64(MaxItemRenameCascadeBytes))
+	}
+	_ = contentBytes
+
+	// And the cascade must not have built anything before refusing.
+	var built int
+	s.onItemCascadeBodyBuilt = func(int) { built++ }
+	defer func() { s.onItemCascadeBodyBuilt = nil }()
+
+	newTitle := "New"
+	_, err := s.UpdateItem(target.ID, models.ItemUpdate{Title: &newTitle})
+	if !errors.Is(err, ErrItemRenameCascadeTooLarge) {
+		t.Fatalf("rename with %d link rows carrying %d-byte titles: got %v, want "+
+			"ErrItemRenameCascadeTooLarge — the scan is unbounded", rowsNeeded, titleBytes, err)
+	}
+	if built != 0 {
+		t.Errorf("cascade built %d bodies, want 0 — the refusal must fire during the SCAN, "+
+			"before the rewrite loop reads anything", built)
+	}
+
+	// WHERE the refusal fired, which is the part `built == 0` cannot see.
+	//
+	// Charging during the scan but only CHECKING afterwards would still report
+	// zero builds — the accumulated total trips on the loop's very first source
+	// — while the scan had already materialised every row. The figure
+	// distinguishes them: refusing on crossing stops within ONE ROW of the cap;
+	// finishing the scan first reports roughly the whole result set.
+	var typed *ItemRenameCascadeTooLargeError
+	if !errors.As(err, &typed) {
+		t.Fatalf("error does not carry the typed figures: %T", err)
+	}
+	ceiling := int64(MaxItemRenameCascadeBytes) + int64(titleBytes) + cascadeRowOverheadBytes + cascadeSourceOverheadBytes + 128
+	if typed.Processed > ceiling {
+		t.Errorf("refused at %d bytes, but crossing the %d cap should stop within one row of it "+
+			"(<= %d) — the scan ran to completion and only then noticed, so every row was "+
+			"materialised before anything refused", typed.Processed, int64(MaxItemRenameCascadeBytes), ceiling)
+	}
+	t.Logf("refused at %d bytes (cap %d, one-row ceiling %d) with %d bodies built; fixture carried "+
+		"%d rows of %d-byte titles", typed.Processed, int64(MaxItemRenameCascadeBytes), ceiling, built,
+		rowsNeeded, titleBytes)
+
+	// Rolled back.
+	got, gerr := s.GetItem(target.ID)
+	if gerr != nil {
+		t.Fatalf("re-read target: %v", gerr)
+	}
+	if got.Title != hugeTitle {
+		t.Errorf("title changed despite the refusal")
+	}
+}
+
+// TestItemRenameCascade_ScanBoundAllowsRealisticTitles is the counterfactual.
+// Without it, charging an absurd per-row overhead — or refusing outright —
+// would satisfy the test above while breaking every ordinary rename.
+//
+// Sized from the live-workspace measurement on MaxItemRenameCascadeBytes: the
+// worst real cascade was 23 sources, and item titles there are ordinary
+// sentence-length strings.
+func TestItemRenameCascade_ScanBoundAllowsRealisticTitles(t *testing.T) {
+	const sources = 50
+	title := "A Perfectly Ordinary Item Title Of The Kind Real Workspaces Contain"
+
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "ItemRenameScanOrdinary")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	target := createTestItem(t, s, ws.ID, col.ID, title, "the item being renamed")
+
+	// Several links per source, so the row count is well above the source count.
+	body := strings.Repeat("see [["+title+"]] and also [["+title+"]]. ", 5)
+	for i := 0; i < sources; i++ {
+		createTestItem(t, s, ws.ID, col.ID, "Linker "+itoa(i), body)
+	}
+
+	newTitle := "A Perfectly Ordinary Renamed Title"
+	if _, err := s.UpdateItem(target.ID, models.ItemUpdate{Title: &newTitle}); err != nil {
+		t.Fatalf("a realistic cascade was refused by the scan bound: %v", err)
+	}
+
+	var rewritten int
+	if err := s.db.QueryRow(s.q(
+		`SELECT COUNT(*) FROM items WHERE workspace_id = ? AND content LIKE '%' || ? || '%'`),
+		ws.ID, "[["+newTitle+"]]").Scan(&rewritten); err != nil {
+		t.Fatalf("count rewritten: %v", err)
+	}
+	if rewritten != sources {
+		t.Errorf("%d of %d linkers rewritten — the cascade did not complete", rewritten, sources)
 	}
 }

--- a/internal/store/items_rename_bounds_test.go
+++ b/internal/store/items_rename_bounds_test.go
@@ -1,0 +1,244 @@
+package store
+
+import (
+	"errors"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// BUG-2804 M3 guards: the bound on how much linking-item content ONE item
+// rename may process.
+//
+// These are regression tests, not probes — each was run against the code
+// WITHOUT the cap and fails there. The mutation matrix is on the trail.
+
+// bigLinker builds a body of approximately bodyBytes carrying exactly one
+// [[title]] link, so the cascade sees one row per source and the cost is
+// dominated by the body rather than by link count.
+func bigLinker(t *testing.T, title string, bodyBytes int) string {
+	t.Helper()
+	return probeBody(t, title, 1, bodyBytes)
+}
+
+// TestItemRenameCascade_RefusesWhenTheCascadeExceedsTheBound is the core guard.
+//
+// Each linker is charged its body as read PLUS the body the rewrite will
+// build, so a 2 MiB linker costs ~4 MiB against a 64 MiB cap and ~17 of them
+// cross it. Sizes are derived from MaxItemRenameCascadeBytes rather than
+// hardcoded, so the test follows the constant if it is ever retuned.
+func TestItemRenameCascade_RefusesWhenTheCascadeExceedsTheBound(t *testing.T) {
+	const body = 2 << 20 // the largest body one JSON request can carry
+	perLinker := int64(body) * 2
+	linkers := int(MaxItemRenameCascadeBytes/perLinker) + 2
+
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "ItemRenameBound")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	target := createTestItem(t, s, ws.ID, col.ID, "Old", "the item being renamed")
+	linkerBody := bigLinker(t, "Old", body)
+	for i := 0; i < linkers; i++ {
+		createTestItem(t, s, ws.ID, col.ID, "Linker "+strings.Repeat("x", i%3)+itoa(i), linkerBody)
+	}
+
+	newTitle := "New"
+	_, err := s.UpdateItem(target.ID, models.ItemUpdate{Title: &newTitle})
+	if !errors.Is(err, ErrItemRenameCascadeTooLarge) {
+		t.Fatalf("rename over the bound: got %v, want ErrItemRenameCascadeTooLarge", err)
+	}
+
+	var typed *ItemRenameCascadeTooLargeError
+	if !errors.As(err, &typed) {
+		t.Fatalf("error does not carry the typed figures: %T", err)
+	}
+	if typed.NewTitle != newTitle {
+		t.Errorf("NewTitle = %q, want %q — the caller needs to see which rename was refused", typed.NewTitle, newTitle)
+	}
+	if typed.Max != MaxItemRenameCascadeBytes {
+		t.Errorf("Max = %d, want %d", typed.Max, MaxItemRenameCascadeBytes)
+	}
+	if typed.Processed <= MaxItemRenameCascadeBytes {
+		t.Errorf("Processed = %d, must exceed the cap %d at the moment of refusal", typed.Processed, MaxItemRenameCascadeBytes)
+	}
+
+	// The refusal must roll the whole rename back — the title is unchanged and
+	// no linker was rewritten. Without this leg the test would pass on an
+	// implementation that refused AFTER mutating half the workspace.
+	got, err := s.GetItem(target.ID)
+	if err != nil {
+		t.Fatalf("re-read target: %v", err)
+	}
+	if got.Title != "Old" {
+		t.Errorf("title = %q after a refused rename, want %q — the refusal did not roll back", got.Title, "Old")
+	}
+	var rewritten int
+	if err := s.db.QueryRow(s.q(
+		`SELECT COUNT(*) FROM items WHERE workspace_id = ? AND content LIKE '%[[New]]%'`),
+		ws.ID).Scan(&rewritten); err != nil {
+		t.Fatalf("count rewritten: %v", err)
+	}
+	if rewritten != 0 {
+		t.Errorf("%d linkers were rewritten despite the refusal", rewritten)
+	}
+}
+
+// TestItemRenameCascade_AllowsARealisticCascade is the counterfactual: a
+// cascade the size real workspaces actually produce must NOT be refused.
+//
+// Sized from the live-workspace measurement recorded on
+// MaxItemRenameCascadeBytes: the worst ACTUAL cascade there was 173,378 bytes
+// across 23 sources. This uses 30 sources at the measured p99.9 body size
+// (51,000 bytes), which is ~9x that worst case and still ~21x under the cap.
+func TestItemRenameCascade_AllowsARealisticCascade(t *testing.T) {
+	const p999Body = 51000
+	const sources = 30
+
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "ItemRenameOrdinary")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	target := createTestItem(t, s, ws.ID, col.ID, "Old", "the item being renamed")
+	linkerBody := bigLinker(t, "Old", p999Body)
+	for i := 0; i < sources; i++ {
+		createTestItem(t, s, ws.ID, col.ID, "Linker "+itoa(i), linkerBody)
+	}
+
+	newTitle := "New"
+	if _, err := s.UpdateItem(target.ID, models.ItemUpdate{Title: &newTitle}); err != nil {
+		t.Fatalf("a realistic cascade was refused: %v", err)
+	}
+
+	var rewritten int
+	if err := s.db.QueryRow(s.q(
+		`SELECT COUNT(*) FROM items WHERE workspace_id = ? AND content LIKE '%[[New]]%'`),
+		ws.ID).Scan(&rewritten); err != nil {
+		t.Fatalf("count rewritten: %v", err)
+	}
+	if rewritten != sources {
+		t.Errorf("%d of %d linkers rewritten — the cascade did not complete", rewritten, sources)
+	}
+}
+
+// TestItemRenameCascade_RefusesBeforeBuildingTheRewrittenBody closes the hole
+// every other oversize test leaves open: moving the projection below the
+// rewrite would keep them all green while destroying the point of the guard,
+// which is that the amplified string is never built.
+//
+// Instrument is cumulative allocation, the same counter BUG-2798's equivalent
+// test uses. Both sides of the threshold are measured, not estimated — see the
+// trail for the figure this produced against a mutation with the cap check
+// moved below RewriteBracketsAt.
+func TestItemRenameCascade_RefusesBeforeBuildingTheRewrittenBody(t *testing.T) {
+	const body = 2 << 20
+	perLinker := int64(body) * 2
+	linkers := int(MaxItemRenameCascadeBytes/perLinker) + 2
+
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "ItemRenameNoBuild")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	target := createTestItem(t, s, ws.ID, col.ID, "Old", "the item being renamed")
+	linkerBody := bigLinker(t, "Old", body)
+	for i := 0; i < linkers; i++ {
+		createTestItem(t, s, ws.ID, col.ID, "Linker "+itoa(i), linkerBody)
+	}
+
+	// THE CEILING IS TIGHT ON PURPOSE, and the margin is one body.
+	//
+	// BUG-2798's equivalent test could be generous because on that path the
+	// rewrite was amplified 51.8x, so building it before refusing was a
+	// twenty-fold difference. M2 removed the amplification here: the
+	// single-pass rewrite costs 1x the body, so checking the cap AFTER the
+	// build instead of before costs exactly ONE extra 2 MiB body. A generous
+	// ceiling cannot see that — measured: a 16 MiB slack let the
+	// check-after-build mutant SURVIVE, which is how this margin was chosen
+	// rather than guessed.
+	//
+	// Measured on this machine, three consecutive runs: refusing allocates
+	// 69,406,336 / 69,415,928 / 69,417,888 bytes — ~11.5 KB of spread. The
+	// check-after-build mutant allocates 71,505,640, i.e. 2,089,304 bytes more
+	// (one 2 MiB body, as predicted). The ceiling below is 70,254,592, which
+	// leaves ~837 KB of headroom over the clean figure while sitting ~1.25 MB
+	// under the mutant. Signal-to-noise is roughly 180x.
+	//
+	// If this test ever fails by a small margin on a different runtime, the fix
+	// is to re-measure and re-state both figures here — NOT to widen the
+	// ceiling until it passes, which would restore the surviving mutant.
+	const allocCeiling = MaxItemRenameCascadeBytes + (3 << 20)
+
+	newTitle := "New"
+	var before, after runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+	_, err := s.UpdateItem(target.ID, models.ItemUpdate{Title: &newTitle})
+	runtime.ReadMemStats(&after)
+
+	if !errors.Is(err, ErrItemRenameCascadeTooLarge) {
+		t.Fatalf("rename: got %v, want ErrItemRenameCascadeTooLarge", err)
+	}
+	allocated := after.TotalAlloc - before.TotalAlloc
+	t.Logf("refused rename allocated %d bytes; ceiling %d", allocated, uint64(allocCeiling))
+	if allocated > uint64(allocCeiling) {
+		t.Errorf("the refused rename allocated %d bytes, ceiling %d — the projection is running "+
+			"AFTER the rewritten bodies it was supposed to prevent", allocated, uint64(allocCeiling))
+	}
+}
+
+// TestItemRenameCascade_DoesNotChargeForRewritesItWillNotPerform pins the
+// asymmetry that keeps the bound honest in the direction that matters.
+//
+// A source whose recorded offsets no longer point at a matching bracket is
+// charged for the body it had to READ — unavoidable, it is already in memory —
+// but NOT for a rewritten copy that will never be built. Charging for both
+// would let content the rewriter can never touch push a legitimate rename over
+// the cap, which is the class BUG-2798's codex round 7 caught on the document
+// path in a different costume.
+//
+// Drift is simulated the only way it occurs in production: the content changes
+// without the index being re-parsed. The test writes items.content directly so
+// replaceWikiLinks does not run.
+func TestItemRenameCascade_DoesNotChargeForRewritesItWillNotPerform(t *testing.T) {
+	const body = 2 << 20
+	live := 12
+	drifted := 6
+
+	// The fixture is sized so the two charging rules give OPPOSITE answers, and
+	// it asserts that rather than assuming it. Without this the test could
+	// silently stop discriminating if the cap or the body size is ever retuned
+	// — it would still pass, while proving nothing.
+	honest := int64(live)*int64(body)*2 + int64(drifted)*int64(body)
+	overcharged := int64(live+drifted) * int64(body) * 2
+	if honest > MaxItemRenameCascadeBytes {
+		t.Fatalf("fixture: honest charging is %d, over the %d cap — this test would pass for the wrong reason",
+			honest, int64(MaxItemRenameCascadeBytes))
+	}
+	if overcharged <= MaxItemRenameCascadeBytes {
+		t.Fatalf("fixture: charging the drifted sources for rewrites too is %d, still under the %d cap — "+
+			"this test cannot detect the defect it exists for", overcharged, int64(MaxItemRenameCascadeBytes))
+	}
+
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "ItemRenameDrift")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	target := createTestItem(t, s, ws.ID, col.ID, "Old", "the item being renamed")
+	linkerBody := bigLinker(t, "Old", body)
+
+	for i := 0; i < live; i++ {
+		createTestItem(t, s, ws.ID, col.ID, "Live "+itoa(i), linkerBody)
+	}
+	// The drifted ones: created with a real link so index rows exist, then
+	// their content is overwritten behind the index's back.
+	for i := 0; i < drifted; i++ {
+		it := createTestItem(t, s, ws.ID, col.ID, "Drifted "+itoa(i), linkerBody)
+		if _, err := s.db.Exec(s.q(`UPDATE items SET content = ? WHERE id = ?`),
+			strings.Repeat("z", body), it.ID); err != nil {
+			t.Fatalf("simulate drift: %v", err)
+		}
+	}
+
+	newTitle := "New"
+	if _, err := s.UpdateItem(target.ID, models.ItemUpdate{Title: &newTitle}); err != nil {
+		t.Fatalf("cascade refused, but the drifted sources should only have been charged "+
+			"for their reads: %v", err)
+	}
+}

--- a/internal/store/items_rename_bounds_test.go
+++ b/internal/store/items_rename_bounds_test.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"errors"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -125,14 +124,28 @@ func TestItemRenameCascade_AllowsARealisticCascade(t *testing.T) {
 // rewrite would keep them all green while destroying the point of the guard,
 // which is that the amplified string is never built.
 //
-// Instrument is cumulative allocation, the same counter BUG-2798's equivalent
-// test uses. Both sides of the threshold are measured, not estimated — see the
-// trail for the figure this produced against a mutation with the cap check
-// moved below RewriteBracketsAt.
+// THE INSTRUMENT IS A COUNT, NOT AN ALLOCATION CEILING, and that is a
+// correction rather than a preference. The first version of this test used a
+// TotalAlloc ceiling, copied in spirit from BUG-2798's equivalent. Two things
+// went wrong with it, in this order:
+//
+//  1. With 16 MiB of slack the check-after-build mutant SURVIVED. BUG-2798
+//     could afford a generous ceiling because its rewrite was amplified 51.8x;
+//     M2 removed the amplification, so the defect is worth exactly one body.
+//  2. Tightened to cap+3 MiB it killed the mutant on SQLite — and then FAILED
+//     on Postgres, where the same refusal allocates ~242 MB against SQLite's
+//     ~69 MB because the driver copies row bytes differently. The ceiling was
+//     measuring the database driver, not the guard.
+//
+// Counting bodies BUILT is exact, identical on both dialects, and discriminates
+// by one whole unit: refusing before the build yields N, refusing after yields
+// N+1. Found by make test-pg, which is the whole reason that gate exists.
 func TestItemRenameCascade_RefusesBeforeBuildingTheRewrittenBody(t *testing.T) {
 	const body = 2 << 20
 	perLinker := int64(body) * 2
-	linkers := int(MaxItemRenameCascadeBytes/perLinker) + 2
+	// The cascade admits floor(cap/perLinker) sources; the NEXT one crosses.
+	admits := int(MaxItemRenameCascadeBytes / perLinker)
+	linkers := admits + 2
 
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "ItemRenameNoBuild")
@@ -143,45 +156,25 @@ func TestItemRenameCascade_RefusesBeforeBuildingTheRewrittenBody(t *testing.T) {
 		createTestItem(t, s, ws.ID, col.ID, "Linker "+itoa(i), linkerBody)
 	}
 
-	// THE CEILING IS TIGHT ON PURPOSE, and the margin is one body.
-	//
-	// BUG-2798's equivalent test could be generous because on that path the
-	// rewrite was amplified 51.8x, so building it before refusing was a
-	// twenty-fold difference. M2 removed the amplification here: the
-	// single-pass rewrite costs 1x the body, so checking the cap AFTER the
-	// build instead of before costs exactly ONE extra 2 MiB body. A generous
-	// ceiling cannot see that — measured: a 16 MiB slack let the
-	// check-after-build mutant SURVIVE, which is how this margin was chosen
-	// rather than guessed.
-	//
-	// Measured on this machine, three consecutive runs: refusing allocates
-	// 69,406,336 / 69,415,928 / 69,417,888 bytes — ~11.5 KB of spread. The
-	// check-after-build mutant allocates 71,505,640, i.e. 2,089,304 bytes more
-	// (one 2 MiB body, as predicted). The ceiling below is 70,254,592, which
-	// leaves ~837 KB of headroom over the clean figure while sitting ~1.25 MB
-	// under the mutant. Signal-to-noise is roughly 180x.
-	//
-	// If this test ever fails by a small margin on a different runtime, the fix
-	// is to re-measure and re-state both figures here — NOT to widen the
-	// ceiling until it passes, which would restore the surviving mutant.
-	const allocCeiling = MaxItemRenameCascadeBytes + (3 << 20)
+	var built int
+	s.onItemCascadeBodyBuilt = func(int) { built++ }
+	defer func() { s.onItemCascadeBodyBuilt = nil }()
 
 	newTitle := "New"
-	var before, after runtime.MemStats
-	runtime.GC()
-	runtime.ReadMemStats(&before)
 	_, err := s.UpdateItem(target.ID, models.ItemUpdate{Title: &newTitle})
-	runtime.ReadMemStats(&after)
-
 	if !errors.Is(err, ErrItemRenameCascadeTooLarge) {
 		t.Fatalf("rename: got %v, want ErrItemRenameCascadeTooLarge", err)
 	}
-	allocated := after.TotalAlloc - before.TotalAlloc
-	t.Logf("refused rename allocated %d bytes; ceiling %d", allocated, uint64(allocCeiling))
-	if allocated > uint64(allocCeiling) {
-		t.Errorf("the refused rename allocated %d bytes, ceiling %d — the projection is running "+
-			"AFTER the rewritten bodies it was supposed to prevent", allocated, uint64(allocCeiling))
+
+	// The source that CROSSES the cap must not have had its body built. Every
+	// source admitted before it legitimately did.
+	if built != admits {
+		t.Errorf("cascade built %d rewritten bodies before refusing, want %d — the projection is "+
+			"running AFTER the body it was supposed to prevent (one extra build is exactly the defect)",
+			built, admits)
 	}
+	t.Logf("built %d rewritten bodies before refusing; cap admits %d sources of %d bytes each",
+		built, admits, body)
 }
 
 // TestItemRenameCascade_DoesNotChargeForRewritesItWillNotPerform pins the

--- a/internal/store/items_rename_probe_test.go
+++ b/internal/store/items_rename_probe_test.go
@@ -448,7 +448,13 @@ func TestProbeBUG2804_SelectMaterialisesContentPerLinkRow(t *testing.T) {
 		runtime.GC()
 		runtime.ReadMemStats(&before)
 
-		rows, err := s.db.Query(s.q(`
+		// BOTH shapes are measured, because the point of this probe is the
+		// DIFFERENCE. The "old" leg is the query cascadeTitleRename issued
+		// before BUG-2804 and no longer issues; keeping it is what makes the
+		// new leg's figure mean something rather than being a number with no
+		// scale. A probe that only measured the current code could not show
+		// that anything changed.
+		oldRows, err := s.db.Query(s.q(`
 			SELECT s.id, s.content, s.workspace_id, wl.position, wl.target_title
 			FROM item_wiki_links wl
 			JOIN items s ON s.id = wl.source_item_id
@@ -459,25 +465,72 @@ func TestProbeBUG2804_SelectMaterialisesContentPerLinkRow(t *testing.T) {
 			ORDER BY s.id, wl.position DESC
 		`), target.ID)
 		if err != nil {
-			t.Fatalf("select: %v", err)
+			t.Fatalf("select (old shape): %v", err)
 		}
-		n := 0
-		distinct := map[string]bool{}
-		for rows.Next() {
+		nOld := 0
+		for oldRows.Next() {
 			var id, content, wsID, targetTitle string
 			var position int
-			if err := rows.Scan(&id, &content, &wsID, &position, &targetTitle); err != nil {
-				rows.Close()
-				t.Fatalf("scan: %v", err)
+			if err := oldRows.Scan(&id, &content, &wsID, &position, &targetTitle); err != nil {
+				oldRows.Close()
+				t.Fatalf("scan (old shape): %v", err)
 			}
-			distinct[id] = true
-			n++
+			nOld++
 		}
-		rows.Close()
+		oldRows.Close()
 		runtime.ReadMemStats(&after)
+		oldAlloc := after.TotalAlloc - before.TotalAlloc
 
-		a := after.TotalAlloc - before.TotalAlloc
-		t.Logf("brackets=%-6d rows=%-6d distinctSources=%-3d SELECT+scan alloc=%-12d per row=%-9d (=%.2fx body)",
-			brackets, n, len(distinct), a, a/uint64(n), float64(a)/float64(n)/float64(body))
+		// New shape: the per-link query carries no content, and each DISTINCT
+		// source's body is read exactly once.
+		runtime.GC()
+		runtime.ReadMemStats(&before)
+		newRows, err := s.db.Query(s.q(`
+			SELECT s.id, s.workspace_id, wl.position, wl.target_title
+			FROM item_wiki_links wl
+			JOIN items s ON s.id = wl.source_item_id
+			WHERE wl.target_kind = 'title'
+			  AND wl.target_workspace_id IS NULL
+			  AND wl.target_item_id = ?
+			  AND s.deleted_at IS NULL
+			ORDER BY s.id, wl.position DESC
+		`), target.ID)
+		if err != nil {
+			t.Fatalf("select (new shape): %v", err)
+		}
+		nNew := 0
+		distinct := map[string]bool{}
+		var order []string
+		for newRows.Next() {
+			var id, wsID, targetTitle string
+			var position int
+			if err := newRows.Scan(&id, &wsID, &position, &targetTitle); err != nil {
+				newRows.Close()
+				t.Fatalf("scan (new shape): %v", err)
+			}
+			if !distinct[id] {
+				distinct[id] = true
+				order = append(order, id)
+			}
+			nNew++
+		}
+		newRows.Close()
+		for _, id := range order {
+			var content string
+			if err := s.db.QueryRow(s.q(`SELECT content FROM items WHERE id = ?`), id).Scan(&content); err != nil {
+				t.Fatalf("per-source read: %v", err)
+			}
+		}
+		runtime.ReadMemStats(&after)
+		newAlloc := after.TotalAlloc - before.TotalAlloc
+
+		if nOld != nNew {
+			t.Fatalf("row counts differ: old %d, new %d — the shapes are not comparable", nOld, nNew)
+		}
+		t.Logf("brackets=%-6d rows=%-6d sources=%-3d | OLD=%-12d (%.2fx body/row)  NEW=%-10d (%.2fx body total)  reduction=%.0fx",
+			brackets, nNew, len(distinct),
+			oldAlloc, float64(oldAlloc)/float64(nOld)/float64(body),
+			newAlloc, float64(newAlloc)/float64(body),
+			float64(oldAlloc)/float64(newAlloc))
 	}
 }

--- a/internal/store/items_rename_probe_test.go
+++ b/internal/store/items_rename_probe_test.go
@@ -1,0 +1,367 @@
+package store
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// BUG-2804 PROBE. Not a regression test and not a guard — a measurement
+// instrument, kept in the tree so the numbers on the trail can be reproduced
+// and re-run against any proposed cap.
+//
+// It measures the ITEM-side rename cascade (wiki_links.go::cascadeTitleRename),
+// which BUG-2798 did not touch. BUG-2798's arithmetic is explicitly
+// NON-TRANSFERABLE per that filing and the dispatch: different selection (an
+// indexed id equality, not a LIKE), a different rewriter (RewriteBracketAt at a
+// recorded offset, not ReplaceTitle over the whole body), and — as this probe
+// exists to establish — a different retention structure.
+//
+// INSTRUMENT: runtime.MemStats.TotalAlloc delta, the same counter
+// documents_rename_bounds_test.go uses, so the two paths' figures are directly
+// comparable. TotalAlloc is CUMULATIVE ALLOCATION, not peak residency: it is
+// deterministic and GC-independent, which is what makes it usable as an
+// assertion. Peak retained bytes are sampled separately below and are
+// explicitly the noisier of the two.
+//
+// Every figure this file prints is measured on the machine that ran it. Nothing
+// here is arithmetic presented as a measurement.
+
+// renameProbeResult is one measured cell.
+type renameProbeResult struct {
+	linkers      int
+	bracketsEach int
+	bodyBytes    int
+	totalAlloc   uint64
+	peakHeap     uint64
+	baseHeap     uint64
+}
+
+func (r renameProbeResult) String() string {
+	return fmt.Sprintf(
+		"k=%-4d brackets=%-5d body=%-9d | TotalAlloc=%-12d peakHeapDelta=%-12d",
+		r.linkers, r.bracketsEach, r.bodyBytes, r.totalAlloc, r.peakHeap-r.baseHeap)
+}
+
+// probeBody builds a linker body of approximately bodyBytes containing exactly
+// `brackets` occurrences of [[title]], padded with filler that contains no
+// bracket characters so the parser sees exactly the intended link count.
+func probeBody(t *testing.T, title string, brackets, bodyBytes int) string {
+	t.Helper()
+	link := "[[" + title + "]]"
+	linkBytes := len(link) * brackets
+	if linkBytes > bodyBytes {
+		t.Fatalf("probe misconfigured: %d brackets of %q need %d bytes, body is %d",
+			brackets, link, linkBytes, bodyBytes)
+	}
+	// Distribute the filler evenly between brackets.
+	filler := bodyBytes - linkBytes
+	perGap := filler / brackets
+	var b strings.Builder
+	b.Grow(bodyBytes + perGap)
+	for i := 0; i < brackets; i++ {
+		b.WriteString(link)
+		b.WriteString(strings.Repeat("x", perGap))
+	}
+	return b.String()
+}
+
+// measureRename runs one cascade and returns its allocation profile.
+//
+// The sampler goroutine that tracks peak HeapAlloc is deliberately secondary:
+// it can miss a peak between samples, so it is reported as a FLOOR on the peak
+// and never used for an assertion. TotalAlloc carries the load-bearing claims.
+func measureRename(t *testing.T, linkers, brackets, bodyBytes int) renameProbeResult {
+	t.Helper()
+
+	const oldTitle = "Old Probe Title"
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "RenameProbe")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	target := createTestItem(t, s, ws.ID, col.ID, oldTitle, "the item being renamed")
+	body := probeBody(t, oldTitle, brackets, bodyBytes)
+	for i := 0; i < linkers; i++ {
+		createTestItem(t, s, ws.ID, col.ID, fmt.Sprintf("Linker %d", i), body)
+	}
+
+	// Confirm the premise before measuring it: the cascade only does work if
+	// the index actually recorded these as title-kind links to the target. A
+	// probe that measures an empty cascade would report a flat line and read
+	// as "no amplification".
+	var indexed int
+	if err := s.db.QueryRow(s.q(`
+		SELECT COUNT(*) FROM item_wiki_links
+		WHERE target_item_id = ? AND target_kind = 'title'
+	`), target.ID).Scan(&indexed); err != nil {
+		t.Fatalf("probe: count indexed links: %v", err)
+	}
+	if want := linkers * brackets; indexed != want {
+		t.Fatalf("probe precondition: %d indexed title links, want %d — "+
+			"the cascade would not be exercised", indexed, want)
+	}
+
+	newTitle := "New Probe Title"
+
+	// The sampler MUST sleep between reads. runtime.ReadMemStats stops the
+	// world on every call, so a spin loop does not merely add overhead — it
+	// serialises the operation it is measuring against a global pause and
+	// turned a sub-second cascade into minutes of 130%-CPU wall clock on the
+	// first run of this probe. TotalAlloc's VALUE survives that (it counts
+	// bytes allocated, which STW does not change), which is exactly why the
+	// load-bearing claims are pinned to TotalAlloc and not to this sampler.
+	//
+	// At 1ms the sampler is a coarse FLOOR on peak residency and is reported
+	// as such — never as the peak itself, and never used for an assertion.
+	stop := make(chan struct{})
+	done := make(chan uint64)
+	go func() {
+		var peak uint64
+		var ms runtime.MemStats
+		for {
+			select {
+			case <-stop:
+				done <- peak
+				return
+			default:
+				runtime.ReadMemStats(&ms)
+				if ms.HeapAlloc > peak {
+					peak = ms.HeapAlloc
+				}
+				time.Sleep(time.Millisecond)
+			}
+		}
+	}()
+
+	var before, after runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+	if _, err := s.UpdateItem(target.ID, models.ItemUpdate{Title: &newTitle}); err != nil {
+		close(stop)
+		<-done
+		t.Fatalf("probe rename: %v", err)
+	}
+	runtime.ReadMemStats(&after)
+	close(stop)
+	peak := <-done
+
+	return renameProbeResult{
+		linkers:      linkers,
+		bracketsEach: brackets,
+		bodyBytes:    bodyBytes,
+		totalAlloc:   after.TotalAlloc - before.TotalAlloc,
+		peakHeap:     peak,
+		baseHeap:     before.HeapAlloc,
+	}
+}
+
+// TestProbeBUG2804_ScalesWithLinkerCount sweeps the number of linking items at
+// a fixed body size, establishing whether the cascade's cost is linear in k and
+// what the per-linker slope actually is.
+//
+// NEGATIVE CONTROL: k=0 (a rename nothing links to) is measured first. Without
+// it, a flat line across k could mean "bounded" or could mean "the cascade
+// never ran", and the probe could not tell them apart.
+func TestProbeBUG2804_ScalesWithLinkerCount(t *testing.T) {
+	const body = 256 << 10 // 256 KiB per linker
+	const brackets = 8
+
+	var results []renameProbeResult
+	for _, k := range []int{0, 1, 2, 4, 8, 16} {
+		if k == 0 {
+			// Control: same shape, no linkers. probeBody is not called.
+			s := testStore(t)
+			ws := createTestWorkspace(t, s, "RenameProbeControl")
+			col := createTestCollection(t, s, ws.ID, "Tasks")
+			target := createTestItem(t, s, ws.ID, col.ID, "Old Probe Title", "the item being renamed")
+			newTitle := "New Probe Title"
+			var before, after runtime.MemStats
+			runtime.GC()
+			runtime.ReadMemStats(&before)
+			if _, err := s.UpdateItem(target.ID, models.ItemUpdate{Title: &newTitle}); err != nil {
+				t.Fatalf("control rename: %v", err)
+			}
+			runtime.ReadMemStats(&after)
+			r := renameProbeResult{linkers: 0, bracketsEach: 0, bodyBytes: 0,
+				totalAlloc: after.TotalAlloc - before.TotalAlloc, peakHeap: 0, baseHeap: 0}
+			results = append(results, r)
+			t.Logf("CONTROL (no linkers): TotalAlloc=%d", r.totalAlloc)
+			continue
+		}
+		r := measureRename(t, k, brackets, body)
+		results = append(results, r)
+		t.Logf("%s", r)
+	}
+
+	t.Logf("--- per-linker slope, body=%d brackets=%d ---", body, brackets)
+	for i := 2; i < len(results); i++ {
+		prev, cur := results[i-1], results[i]
+		dk := cur.linkers - prev.linkers
+		if dk <= 0 {
+			continue
+		}
+		d := int64(cur.totalAlloc) - int64(prev.totalAlloc)
+		t.Logf("k %d->%d: dTotalAlloc=%d, per added linker=%d (=%.1fx body)",
+			prev.linkers, cur.linkers, d, d/int64(dk), float64(d)/float64(dk)/float64(body))
+	}
+}
+
+// TestProbeBUG2804_ScalesWithBracketCount sweeps the number of brackets inside
+// ONE linker at a fixed body size. This isolates the per-bracket rescan: the
+// rewrite loop calls links.RewriteBracketAt once per recorded row, and each
+// call takes the whole body and returns a new one.
+//
+// A flat line here means the rewriter is cheap per bracket; a linear one means
+// a single linker with many links to the renamed item amplifies on its own,
+// independently of how many linkers exist.
+func TestProbeBUG2804_ScalesWithBracketCount(t *testing.T) {
+	const body = 256 << 10
+
+	var results []renameProbeResult
+	for _, n := range []int{1, 8, 64, 512, 4096} {
+		r := measureRename(t, 1, n, body)
+		results = append(results, r)
+		t.Logf("%s", r)
+	}
+
+	t.Logf("--- per-bracket slope, k=1 body=%d ---", body)
+	for i := 1; i < len(results); i++ {
+		prev, cur := results[i-1], results[i]
+		dn := cur.bracketsEach - prev.bracketsEach
+		d := int64(cur.totalAlloc) - int64(prev.totalAlloc)
+		t.Logf("brackets %d->%d: dTotalAlloc=%d, per added bracket=%d (=%.2fx body)",
+			prev.bracketsEach, cur.bracketsEach, d, d/int64(dn),
+			float64(d)/float64(dn)/float64(body))
+	}
+}
+
+// TestProbeBUG2804_QuadraticInOneBodySize is the load-bearing measurement.
+//
+// The bracket count is not an independent knob in an attack — it is a FUNCTION
+// of the body size, because the cheapest link is 5 bytes (`[[A]]`) and nothing
+// caps how many an item may contain (verified: no per-item wiki-link limit
+// exists in internal/). So a body of C bytes carries C/5 brackets, and the
+// rewrite loop calls RewriteBracketAt once per bracket, each call rebuilding
+// the whole body (links.go:148 — `content[:position] + ... + content[end:]`).
+//
+// That makes cumulative allocation O(C^2) for a SINGLE linker in a SINGLE
+// request, with no accumulation across requests required. This test measures
+// the exponent rather than asserting it: doubling C should roughly QUADRUPLE
+// TotalAlloc. Anything near 2x instead of 4x refutes the quadratic reading.
+//
+// Sizes are kept small deliberately — the point is the exponent, and the
+// extrapolation to a full 2 MiB body is stated on the trail AS an
+// extrapolation, never as a measurement.
+func TestProbeBUG2804_QuadraticInOneBodySize(t *testing.T) {
+	type cell struct {
+		c     int
+		alloc uint64
+	}
+	var cells []cell
+	for _, c := range []int{8 << 10, 16 << 10, 32 << 10, 64 << 10} {
+		brackets := c / len("[[A]]")
+		s := testStore(t)
+		ws := createTestWorkspace(t, s, "RenameProbeQuad")
+		col := createTestCollection(t, s, ws.ID, "Tasks")
+		target := createTestItem(t, s, ws.ID, col.ID, "A", "the item being renamed")
+		createTestItem(t, s, ws.ID, col.ID, "Linker", strings.Repeat("[[A]]", brackets))
+
+		var indexed int
+		if err := s.db.QueryRow(s.q(`
+			SELECT COUNT(*) FROM item_wiki_links
+			WHERE target_item_id = ? AND target_kind = 'title'
+		`), target.ID).Scan(&indexed); err != nil {
+			t.Fatalf("count indexed: %v", err)
+		}
+		if indexed != brackets {
+			t.Fatalf("precondition: %d indexed links, want %d", indexed, brackets)
+		}
+
+		newTitle := "B"
+		var before, after runtime.MemStats
+		runtime.GC()
+		runtime.ReadMemStats(&before)
+		if _, err := s.UpdateItem(target.ID, models.ItemUpdate{Title: &newTitle}); err != nil {
+			t.Fatalf("rename at C=%d: %v", c, err)
+		}
+		runtime.ReadMemStats(&after)
+		a := after.TotalAlloc - before.TotalAlloc
+		cells = append(cells, cell{c: c, alloc: a})
+		t.Logf("C=%-8d brackets=%-6d TotalAlloc=%-14d (=%.0fx body)",
+			c, brackets, a, float64(a)/float64(c))
+	}
+
+	t.Logf("--- growth factor per doubling of C (2.0 = linear, 4.0 = quadratic) ---")
+	for i := 1; i < len(cells); i++ {
+		t.Logf("C %d->%d: alloc x%.2f",
+			cells[i-1].c, cells[i].c,
+			float64(cells[i].alloc)/float64(cells[i-1].alloc))
+	}
+}
+
+// TestProbeBUG2804_OutboxPayloadCarriesEveryBody isolates the third copy.
+//
+// The peak-residency figures are consistent with three simultaneous copies of
+// the linker set (works + member snapshots + marshalled JSON), but "consistent
+// with" is not a measurement of any one of them. This measures the outbox
+// share directly and deterministically, by reading the row the cascade wrote:
+// no sampler, no GC timing, no inference.
+//
+// It also measures a cost the memory figures miss entirely — the payload is
+// PERSISTED, so a rename cascading k linkers writes k bodies to the outbox
+// table as one row, on disk, per rename.
+//
+// emitBulkItemEventTx's own doc comment says this is deliberate and unbounded
+// in v1, and invites exactly this measurement:
+//
+//	"PAYLOAD SIZE IS DELIBERATELY UNBOUNDED IN V1 ... If a real workspace shows
+//	 this producing unreasonable rows, bounding it is a measured follow-up, not
+//	 a guess made here."
+func TestProbeBUG2804_OutboxPayloadCarriesEveryBody(t *testing.T) {
+	const body = 256 << 10
+	const brackets = 4
+
+	for _, k := range []int{1, 4, 16} {
+		s := testStore(t)
+		ws := createTestWorkspace(t, s, "RenameProbeOutbox")
+		col := createTestCollection(t, s, ws.ID, "Tasks")
+		target := createTestItem(t, s, ws.ID, col.ID, "Old Probe Title", "the item being renamed")
+		linkerBody := probeBody(t, "Old Probe Title", brackets, body)
+		for i := 0; i < k; i++ {
+			createTestItem(t, s, ws.ID, col.ID, fmt.Sprintf("Linker %d", i), linkerBody)
+		}
+
+		// Baseline: outbox bytes already present before the rename, so the
+		// delta attributes only what the cascade itself wrote.
+		var beforeBytes int64
+		if err := s.db.QueryRow(s.q(
+			`SELECT COALESCE(SUM(LENGTH(payload)), 0) FROM event_outbox`)).Scan(&beforeBytes); err != nil {
+			t.Skipf("outbox table not readable in this configuration: %v", err)
+		}
+
+		newTitle := "New Probe Title"
+		if _, err := s.UpdateItem(target.ID, models.ItemUpdate{Title: &newTitle}); err != nil {
+			t.Fatalf("rename: %v", err)
+		}
+
+		var afterBytes int64
+		if err := s.db.QueryRow(s.q(
+			`SELECT COALESCE(SUM(LENGTH(payload)), 0) FROM event_outbox`)).Scan(&afterBytes); err != nil {
+			t.Fatalf("read outbox after: %v", err)
+		}
+		var maxRow int64
+		if err := s.db.QueryRow(s.q(
+			`SELECT COALESCE(MAX(LENGTH(payload)), 0) FROM event_outbox`)).Scan(&maxRow); err != nil {
+			t.Fatalf("read max outbox row: %v", err)
+		}
+
+		bodySet := int64(body) * int64(k)
+		t.Logf("k=%-3d bodySet=%-10d outboxDelta=%-11d largestSingleRow=%-11d (=%.2fx the body set)",
+			k, bodySet, afterBytes-beforeBytes, maxRow,
+			float64(afterBytes-beforeBytes)/float64(bodySet))
+	}
+}

--- a/internal/store/items_rename_probe_test.go
+++ b/internal/store/items_rename_probe_test.go
@@ -365,3 +365,119 @@ func TestProbeBUG2804_OutboxPayloadCarriesEveryBody(t *testing.T) {
 			float64(afterBytes-beforeBytes)/float64(bodySet))
 	}
 }
+
+// TestProbeBUG2804_ConstantDependsOnTitleLengthParity checks whether the
+// measured 2.01x-body-per-bracket constant is really TWO O(C) operations per
+// bracket, as the code suggests: the concatenation in RewriteBracketAt, plus
+// the `rewritten != newContent` full-body string comparison the cascade uses
+// to set `mutated` (wiki_links.go:679).
+//
+// Go compares string LENGTHS first, so that comparison is O(1) when the
+// rewrite changed the body's length and O(C) when it did not. Both earlier
+// sweeps used same-length titles ("A"->"B", "Old Probe Title"->"New Probe
+// Title"), which is the O(C) case — so the 2.01x constant may be an artifact
+// of that choice rather than a property of the path.
+//
+// This runs the SAME shape with a different-length new title. If the constant
+// falls to ~1x, the two-operations reading is confirmed and the honest
+// statement of the constant is "1x or 2x depending on title-length parity".
+// If it stays at 2x, that reading is wrong and something else is allocating.
+//
+// Either way the QUADRATIC is unaffected: the concatenation alone is O(C) per
+// bracket. This measures the constant, not the exponent.
+func TestProbeBUG2804_ConstantDependsOnTitleLengthParity(t *testing.T) {
+	const body = 256 << 10
+	const brackets = 512
+
+	for _, tc := range []struct {
+		name     string
+		newTitle string
+	}{
+		{"same-length (comparison is O(C))", "B"},
+		{"longer     (comparison is O(1))", "BBBBBBBBBBBBBBBB"},
+	} {
+		s := testStore(t)
+		ws := createTestWorkspace(t, s, "RenameProbeParity")
+		col := createTestCollection(t, s, ws.ID, "Tasks")
+		target := createTestItem(t, s, ws.ID, col.ID, "A", "the item being renamed")
+		createTestItem(t, s, ws.ID, col.ID, "Linker", probeBody(t, "A", brackets, body))
+
+		var before, after runtime.MemStats
+		runtime.GC()
+		runtime.ReadMemStats(&before)
+		if _, err := s.UpdateItem(target.ID, models.ItemUpdate{Title: &tc.newTitle}); err != nil {
+			t.Fatalf("rename %s: %v", tc.name, err)
+		}
+		runtime.ReadMemStats(&after)
+		a := after.TotalAlloc - before.TotalAlloc
+		t.Logf("%-34s TotalAlloc=%-12d per bracket=%-9d (=%.2fx body)",
+			tc.name, a, a/brackets, float64(a)/float64(brackets)/float64(body))
+	}
+}
+
+// TestProbeBUG2804_SelectMaterialisesContentPerLinkRow isolates the SECOND
+// O(C)-per-bracket cost, which is not in the rewriter at all.
+//
+// links.RewriteBracketAt allocates 1.00x the body per call, measured in
+// isolation (internal/links/probe_alloc_test.go). The cascade's marginal cost
+// is 2.01x per bracket. This measures where the other 1.00x lives.
+//
+// cascadeTitleRename's SELECT (wiki_links.go:616) joins item_wiki_links to
+// items and projects s.content, so it returns ONE ROW PER LINK, each carrying
+// a full copy of the source body. The scan loop de-duplicates into `works` by
+// source id — but the de-duplication happens AFTER rows.Scan has already
+// allocated a fresh string for every row.
+//
+// So a single source with N brackets makes the driver materialise N full
+// bodies to build one `works` entry. That is a second quadratic, independent
+// of the rewriter: making the rewrite single-pass would leave it untouched.
+//
+// The probe runs the cascade's own SELECT verbatim at increasing bracket
+// counts against ONE source, so any growth is per-ROW cost and not per-source.
+func TestProbeBUG2804_SelectMaterialisesContentPerLinkRow(t *testing.T) {
+	const body = 256 << 10
+
+	for _, brackets := range []int{8, 64, 512, 4096} {
+		s := testStore(t)
+		ws := createTestWorkspace(t, s, "RenameProbeSelect")
+		col := createTestCollection(t, s, ws.ID, "Tasks")
+		target := createTestItem(t, s, ws.ID, col.ID, "A", "the item being renamed")
+		createTestItem(t, s, ws.ID, col.ID, "Linker", probeBody(t, "A", brackets, body))
+
+		var before, after runtime.MemStats
+		runtime.GC()
+		runtime.ReadMemStats(&before)
+
+		rows, err := s.db.Query(s.q(`
+			SELECT s.id, s.content, s.workspace_id, wl.position, wl.target_title
+			FROM item_wiki_links wl
+			JOIN items s ON s.id = wl.source_item_id
+			WHERE wl.target_kind = 'title'
+			  AND wl.target_workspace_id IS NULL
+			  AND wl.target_item_id = ?
+			  AND s.deleted_at IS NULL
+			ORDER BY s.id, wl.position DESC
+		`), target.ID)
+		if err != nil {
+			t.Fatalf("select: %v", err)
+		}
+		n := 0
+		distinct := map[string]bool{}
+		for rows.Next() {
+			var id, content, wsID, targetTitle string
+			var position int
+			if err := rows.Scan(&id, &content, &wsID, &position, &targetTitle); err != nil {
+				rows.Close()
+				t.Fatalf("scan: %v", err)
+			}
+			distinct[id] = true
+			n++
+		}
+		rows.Close()
+		runtime.ReadMemStats(&after)
+
+		a := after.TotalAlloc - before.TotalAlloc
+		t.Logf("brackets=%-6d rows=%-6d distinctSources=%-3d SELECT+scan alloc=%-12d per row=%-9d (=%.2fx body)",
+			brackets, n, len(distinct), a, a/uint64(n), float64(a)/float64(n)/float64(body))
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -112,6 +112,25 @@ type Store struct {
 	// inside it there.
 	afterLinkCascadeRead func(workspaceID string)
 
+	// onItemCascadeBodyBuilt is a TEST-ONLY seam, nil in production. When set,
+	// cascadeTitleRename calls it once per rewritten body it BUILDS, with that
+	// body's byte length.
+	//
+	// It exists because the property "the cap refuses BEFORE building the body
+	// it refuses" cannot be pinned by an allocation ceiling on this path. After
+	// BUG-2804's single-pass rewrite, building one extra body costs ~1x the body
+	// — a signal small enough that a ceiling wide enough to be portable is also
+	// wide enough to miss it. Worse, the ceiling is DIALECT-DEPENDENT: the same
+	// refusal allocated ~69 MB on SQLite and ~242 MB on Postgres, whose driver
+	// copies each row's bytes differently, so any absolute number is green on
+	// one backend and red on the other for reasons that have nothing to do with
+	// the guard.
+	//
+	// A count of bodies built is exact, dialect-independent, and discriminates
+	// by one whole unit: refusing before the build yields N, refusing after
+	// yields N+1.
+	onItemCascadeBodyBuilt func(bytes int)
+
 	// afterDebounceRefusal is a TEST-ONLY seam, nil in production. When set,
 	// CreateActivityDebounced calls it after its merge UPDATE has affected
 	// ZERO rows and before the probe that decides which of the UPDATE's two

--- a/internal/store/wiki_links.go
+++ b/internal/store/wiki_links.go
@@ -646,6 +646,27 @@ func (s *Store) cascadeTitleRename(tx *sql.Tx, renamedItemID, workspaceID, oldTi
 	}
 	var works []sourceWork
 	cursor := -1
+	// The SCAN is charged against the same budget as the rewrite loop below,
+	// and refuses DURING the scan (BUG-2804 / codex R4).
+	//
+	// `works` holds one entry per matching LINK ROW, not per source, and each
+	// entry carries that row's target_title — which is unbounded, because
+	// nothing validates item title length (there is a MaxDocumentTitleRunes,
+	// but no item equivalent). So a renamed item with a ~2 MiB title (one JSON
+	// request delivers that) linked from many rows makes this loop retain
+	// rows x title bytes BEFORE a single body is read, and the content-bytes
+	// cap in the loop below never fires because the content can be tiny.
+	//
+	// Charging it here rather than after the scan is what makes the bound real:
+	// at the moment of refusal the process holds only the rows already counted,
+	// which are under the cap by construction.
+	//
+	// ONE budget covers both phases deliberately. The two quantities differ —
+	// index rows here, content bytes below — but they are both "memory this one
+	// rename makes the server hold", and a second constant would be a second
+	// thing to tune with no separate meaning. The refusal figure is therefore
+	// the sum of both, which is what the caller actually needs to act on.
+	var processed int64
 	for rows.Next() {
 		var (
 			id, workspaceID string
@@ -655,6 +676,14 @@ func (s *Store) cascadeTitleRename(tx *sql.Tx, renamedItemID, workspaceID, oldTi
 		if err := rows.Scan(&id, &workspaceID, &position, &targetTitle); err != nil {
 			rows.Close()
 			return fmt.Errorf("cascade rename: scan source row: %w", err)
+		}
+		processed += int64(len(targetTitle)) + cascadeRowOverheadBytes
+		if cursor < 0 || works[cursor].id != id {
+			processed += int64(len(id)+len(workspaceID)) + cascadeSourceOverheadBytes
+		}
+		if processed > MaxItemRenameCascadeBytes {
+			rows.Close()
+			return newItemRenameCascadeTooLargeError(newTitle, processed)
 		}
 		if cursor < 0 || works[cursor].id != id {
 			works = append(works, sourceWork{id: id, workspaceID: workspaceID})
@@ -677,7 +706,6 @@ func (s *Store) cascadeTitleRename(tx *sql.Tx, renamedItemID, workspaceID, oldTi
 	// whose content this cascade actually rewrote, not every candidate it
 	// examined.
 	var cascaded []string
-	var processed int64
 	for _, work := range works {
 		// One read per SOURCE, not per link (BUG-2804 M1).
 		var content string
@@ -1696,8 +1724,40 @@ func newItemRenameCascadeTooLargeError(newTitle string, processed int64) error {
 // transaction that rolls back. Given a real workload three orders of magnitude
 // under the cap, the generous side is the correct side.
 //
-// This bounds WORK, not peak residency, and after M1/M2 those are different
-// quantities: the cascade now reads one body at a time and holds at most two,
-// so its own retention is O(1) in the linker count. The k-linear retention that
-// remains lives in the outbox member snapshots, filed separately as BUG-2827.
+// WHAT IT BOUNDS, corrected after codex R4 caught this comment overstating it.
+// An earlier version claimed the cascade's own retention was "O(1) in the
+// linker count", with the remaining k-linear retention attributed to the outbox
+// snapshots (BUG-2827). That was wrong, and wrong in the direction that matters:
+// the outbox is a DIFFERENT vector, and this cascade has k-linear retention of
+// its own in the `works` slice, which holds one entry per matching link row
+// with that row's unbounded target_title attached — reachable with tiny content,
+// so the content-bytes half of this budget never fires on it.
+//
+// The budget now covers BOTH phases, charged as it goes: the index rows during
+// the scan, and each body read plus the body built during the rewrite loop.
+// Peak residency is bounded by it in both, since each phase refuses before
+// allocating past it.
+//
+// Still NOT bounded here, and genuinely a separate vector: the outbox member
+// snapshots re-read every cascaded body after this function's work is done
+// (BUG-2827).
+// cascadeRowOverheadBytes and cascadeSourceOverheadBytes are the per-entry
+// costs the scan charges on top of the strings it retains.
+//
+// Derived from the struct layouts on 64-bit, not guessed: a
+// links.BracketRewrite is an int plus a string header (8 + 16 = 24), and a
+// sourceWork is two string headers plus a slice header (16 + 16 + 24 = 56).
+// Both are deliberately charged as the STRUCT size only — the string bytes are
+// charged separately and exactly at the call site, so nothing is double-counted.
+//
+// They are small relative to the strings they accompany and exist so that a
+// pathological row count with EMPTY titles still consumes budget rather than
+// being free. Approximate by nature: Go makes no layout guarantee, and slice
+// growth over-allocates. The error direction is under-charging, which the
+// content-bytes half of the same budget then catches downstream.
+const (
+	cascadeRowOverheadBytes    = 24
+	cascadeSourceOverheadBytes = 56
+)
+
 const MaxItemRenameCascadeBytes = 64 << 20

--- a/internal/store/wiki_links.go
+++ b/internal/store/wiki_links.go
@@ -1575,6 +1575,23 @@ func snippetAround(content string, position int) string {
 	return snippet
 }
 
+// SetCascadeBuildObserver installs a TEST-SUPPORT observer called once per
+// rewritten body the item rename cascade BUILDS, with that body's length. Pass
+// nil to clear.
+//
+// Exported for the same reason SetCollabRoomManager is: the property it makes
+// observable — how much work a single request causes the cascade to do — is
+// only reachable from the SERVER package, whose tests cannot touch this
+// package's unexported fields. It is the instrument behind the collab-edit
+// double-work test (codex R2), which asserts that a refused rename runs the
+// cascade ONCE rather than falling through and running it again.
+//
+// Not safe for concurrent use with in-flight renames; tests set it before
+// issuing requests and clear it after.
+func (s *Store) SetCascadeBuildObserver(fn func(bytes int)) {
+	s.onItemCascadeBodyBuilt = fn
+}
+
 // buildCascadeBody builds one rewritten body and reports the build through the
 // test seam, as ONE operation.
 //

--- a/internal/store/wiki_links.go
+++ b/internal/store/wiki_links.go
@@ -710,7 +710,7 @@ func (s *Store) cascadeTitleRename(tx *sql.Tx, renamedItemID, workspaceID, oldTi
 			return newItemRenameCascadeTooLargeError(newTitle, processed)
 		}
 
-		newContent, applied := links.RewriteBracketsAt(content, work.rewrites, newTitle, collSlug)
+		newContent, applied := s.buildCascadeBody(content, work.rewrites, newTitle, collSlug)
 		if applied == 0 {
 			// No bracket matched the expected shape at the recorded
 			// positions — possible if a previous content edit shifted
@@ -1573,6 +1573,27 @@ func snippetAround(content string, position int) string {
 		snippet = snippet + "…"
 	}
 	return snippet
+}
+
+// buildCascadeBody builds one rewritten body and reports the build through the
+// test seam, as ONE operation.
+//
+// The coupling is deliberate and load-bearing. An earlier version called
+// links.RewriteBracketsAt and fired the seam as two adjacent statements, and a
+// mutation that moved the cap check BETWEEN them — which is exactly the defect
+// the seam exists to detect — went undetected, because the build happened, the
+// mutant returned, and the seam never fired. The instrument could not observe
+// the thing it was built to observe.
+//
+// With the build and the count inside one function, a cap check can only be
+// before this call or after it, and "after" always means the count already
+// happened. There is no third position for the defect to hide in.
+func (s *Store) buildCascadeBody(content string, rewrites []links.BracketRewrite, newTitle, collSlug string) (string, int) {
+	newContent, applied := links.RewriteBracketsAt(content, rewrites, newTitle, collSlug)
+	if s.onItemCascadeBodyBuilt != nil && applied > 0 {
+		s.onItemCascadeBodyBuilt(len(newContent))
+	}
+	return newContent, applied
 }
 
 // ErrItemRenameCascadeTooLarge reports that an ITEM rename was refused because

--- a/internal/store/wiki_links.go
+++ b/internal/store/wiki_links.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"sort"
 	"strconv"
@@ -613,8 +614,16 @@ func (s *Store) cascadeTitleRename(tx *sql.Tx, renamedItemID, workspaceID, oldTi
 	// ORDER BY source_id, position DESC: descending position so
 	// rewrites at later byte offsets don't shift the offsets of
 	// earlier rows in the same source.
+	// s.content is DELIBERATELY NOT PROJECTED HERE (BUG-2804). This query
+	// returns one row per LINK, so projecting the source body made the driver
+	// materialise a full copy of it for every bracket — the Go-side
+	// de-duplication into `works` happens only after rows.Scan has already
+	// allocated each one. Measured at 1.00x the body per row against a SINGLE
+	// source: 4096 rows on one 256 KiB item allocated 1.07 GB, and since the
+	// cheapest link is five bytes with no cap on links per item, that is
+	// O(C^2) in one request. Each source's content is read ONCE below instead.
 	selectQuery := `
-		SELECT s.id, s.content, s.workspace_id, wl.position, wl.target_title
+		SELECT s.id, s.workspace_id, wl.position, wl.target_title
 		FROM item_wiki_links wl
 		JOIN items s ON s.id = wl.source_item_id
 		WHERE wl.target_kind = 'title'
@@ -631,31 +640,28 @@ func (s *Store) cascadeTitleRename(tx *sql.Tx, renamedItemID, workspaceID, oldTi
 	if err != nil {
 		return fmt.Errorf("cascade rename: scan sources: %w", err)
 	}
-	type rowInfo struct {
-		position    int
-		targetTitle string
-	}
 	type sourceWork struct {
-		id, content, workspaceID string
-		rows                     []rowInfo
+		id, workspaceID string
+		rewrites        []links.BracketRewrite
 	}
 	var works []sourceWork
 	cursor := -1
 	for rows.Next() {
 		var (
-			id, content, workspaceID string
-			position                 int
-			targetTitle              string
+			id, workspaceID string
+			position        int
+			targetTitle     string
 		)
-		if err := rows.Scan(&id, &content, &workspaceID, &position, &targetTitle); err != nil {
+		if err := rows.Scan(&id, &workspaceID, &position, &targetTitle); err != nil {
 			rows.Close()
 			return fmt.Errorf("cascade rename: scan source row: %w", err)
 		}
 		if cursor < 0 || works[cursor].id != id {
-			works = append(works, sourceWork{id: id, content: content, workspaceID: workspaceID})
+			works = append(works, sourceWork{id: id, workspaceID: workspaceID})
 			cursor = len(works) - 1
 		}
-		works[cursor].rows = append(works[cursor].rows, rowInfo{position: position, targetTitle: targetTitle})
+		works[cursor].rewrites = append(works[cursor].rewrites,
+			links.BracketRewrite{Position: position, TargetTitle: targetTitle})
 	}
 	if err := rows.Err(); err != nil {
 		rows.Close()
@@ -671,17 +677,41 @@ func (s *Store) cascadeTitleRename(tx *sql.Tx, renamedItemID, workspaceID, oldTi
 	// whose content this cascade actually rewrote, not every candidate it
 	// examined.
 	var cascaded []string
+	var processed int64
 	for _, work := range works {
-		newContent := work.content
-		mutated := false
-		for _, r := range work.rows {
-			rewritten := links.RewriteBracketAt(newContent, r.position, r.targetTitle, newTitle, collSlug)
-			if rewritten != newContent {
-				mutated = true
-				newContent = rewritten
+		// One read per SOURCE, not per link (BUG-2804 M1).
+		var content string
+		if err := tx.QueryRow(s.q(`SELECT content FROM items WHERE id = ?`), work.id).Scan(&content); err != nil {
+			if err == sql.ErrNoRows {
+				// Vanished between the index scan and here. Nothing to rewrite.
+				continue
 			}
+			return fmt.Errorf("cascade rename: read source %s: %w", work.id, err)
 		}
-		if !mutated {
+
+		// Project what this source will make the cascade DO, before building
+		// it, and charge it against the running total across the whole
+		// cascade (BUG-2804 M3). Projecting rather than measuring after the
+		// fact is what makes the bound real: at the moment of refusal nothing
+		// amplified has been allocated.
+		//
+		// Charged: the body just read plus the body about to be built, since
+		// both are alive at once. ProjectRewrittenLen applies the same
+		// per-bracket decision and skip rules as the rewrite itself, so a
+		// source whose brackets no longer match is charged only for its read
+		// and never for a rewrite that will not happen.
+		projected, willApply := links.ProjectRewrittenLen(content, work.rewrites, newTitle, collSlug)
+		cost := int64(len(content))
+		if willApply > 0 {
+			cost += int64(projected)
+		}
+		processed += cost
+		if processed > MaxItemRenameCascadeBytes {
+			return newItemRenameCascadeTooLargeError(newTitle, processed)
+		}
+
+		newContent, applied := links.RewriteBracketsAt(content, work.rewrites, newTitle, collSlug)
+		if applied == 0 {
 			// No bracket matched the expected shape at the recorded
 			// positions — possible if a previous content edit shifted
 			// the offsets in a way replaceWikiLinks didn't catch, or
@@ -691,7 +721,7 @@ func (s *Store) cascadeTitleRename(tx *sql.Tx, renamedItemID, workspaceID, oldTi
 			// so the index converges; the row will flip to broken if
 			// no clickable match remains, matching the renderer's
 			// behavior on a body that would no longer render as a link.
-			if err := s.replaceWikiLinks(tx, work.id, work.workspaceID, work.content); err != nil {
+			if err := s.replaceWikiLinks(tx, work.id, work.workspaceID, content); err != nil {
 				return fmt.Errorf("cascade rename: reparse %s: %w", work.id, err)
 			}
 			continue
@@ -1544,3 +1574,92 @@ func snippetAround(content string, position int) string {
 	}
 	return snippet
 }
+
+// ErrItemRenameCascadeTooLarge reports that an ITEM rename was refused because
+// the cascade over its title-form backlinks would process more content than
+// MaxItemRenameCascadeBytes allows.
+//
+// Deliberately its own sentinel rather than a reuse of documents.go's
+// ErrRenameCascadeTooLarge, for the same reason BUG-2804 is its own bug: the
+// two cascades have different structures, different bounds, and different
+// numbers, and a caller distinguishing them can say which surface refused.
+// Like its document-side sibling, this is a PERMANENT refusal — retrying the
+// same rename fails identically until the workspace's content changes — so it
+// must not be blurred into the contention vocabulary that asks a client to
+// retry (BUG-2798, lead ruling day-63).
+var ErrItemRenameCascadeTooLarge = errors.New("store: item rename cascade exceeds the content bound")
+
+// ItemRenameCascadeTooLargeError carries the refusal's NUMBERS as typed fields
+// so a caller-facing layer composes its own sentence instead of splicing this
+// error's text — including whatever wrappers the call path adds on the way up
+// — into a response. Same discipline as RenameCascadeTooLargeError.
+type ItemRenameCascadeTooLargeError struct {
+	// NewTitle is the caller's own requested title, echoed back so they can
+	// see which rename was refused.
+	NewTitle string
+	// Processed is a LOWER BOUND on the bytes the cascade would have handled:
+	// the loop stops at the first source that crosses the cap, so the true
+	// figure is larger. Naming it a lower bound matters — reporting it as a
+	// total would be a figure broader than the measurement supports.
+	Processed int64
+	// Max is the cap in force.
+	Max int64
+}
+
+func (e *ItemRenameCascadeTooLargeError) Error() string {
+	return fmt.Sprintf("%s: renaming to %q would process at least %d bytes of linking item content, maximum %d",
+		ErrItemRenameCascadeTooLarge.Error(), e.NewTitle, e.Processed, e.Max)
+}
+
+// Unwrap makes errors.Is(err, ErrItemRenameCascadeTooLarge) hold.
+func (e *ItemRenameCascadeTooLargeError) Unwrap() error { return ErrItemRenameCascadeTooLarge }
+
+func newItemRenameCascadeTooLargeError(newTitle string, processed int64) error {
+	return &ItemRenameCascadeTooLargeError{
+		NewTitle:  newTitle,
+		Processed: processed,
+		Max:       MaxItemRenameCascadeBytes,
+	}
+}
+
+// MaxItemRenameCascadeBytes bounds the TOTAL linking-item content one item
+// rename may process — each source's body as read, plus the rewritten body it
+// builds, summed across every source in the cascade.
+//
+// THE NUMBER HAS A RECEIPT, and it is deliberately NOT inherited from
+// documents.go's MaxRenameCascadeRetainedBytes: that constant was chosen
+// against a different cascade with a different structure, and BUG-2804's whole
+// premise is that the two paths' arithmetic does not transfer.
+//
+// Measured against the live development workspace (8,388 live items, 223 MB
+// database) on 2026-08-31:
+//
+//	items.content length   p50 1,358 B · p90 4,452 B · p99 18,634 B
+//	                       p99.9 51,000 B · max 86,385 B · none over 256 KiB
+//	worst ACTUAL cascade   173,378 bytes of source bodies across 23 sources
+//	                       (~347 KB charged here, since read + rewritten
+//	                       are both counted)
+//	max links from ONE source to ONE target   5
+//
+// So 64 MiB is ~190x the worst cascade this real workspace can produce today.
+// Stated as what it admits and refuses rather than as a feeling:
+//
+//   - ADMITS ~650 linking items at the p99.9 body size (51 KB), or ~1,300 at
+//     p99 — comfortably beyond any rename this workspace has ever performed.
+//   - REFUSES about 16 linkers carrying the largest body a 2 MiB JSON request
+//     can deliver. Every such body would be 24x larger than the biggest item
+//     that exists here, so this is the abuse shape rather than a workload.
+//
+// ERROR DIRECTION IS TOWARD REFUSING LATE, not early: the charge counts only
+// bodies the rewriter will actually touch (ProjectRewrittenLen applies the same
+// skip rules as the rewrite), so a cascade is never refused for content it was
+// not going to process. A legitimate rename being refused is user-visible
+// breakage; letting an abusive one run costs a bounded amount of work in a
+// transaction that rolls back. Given a real workload three orders of magnitude
+// under the cap, the generous side is the correct side.
+//
+// This bounds WORK, not peak residency, and after M1/M2 those are different
+// quantities: the cascade now reads one body at a time and holds at most two,
+// so its own retention is O(1) in the linker count. The k-linear retention that
+// remains lives in the outbox member snapshots, filed separately as BUG-2827.
+const MaxItemRenameCascadeBytes = 64 << 20


### PR DESCRIPTION
Two independent quadratics in the item-side rename cascade, plus the bound that keeps the whole operation finite. Fixes BUG-2804.

## What was wrong

Renaming an item cascades a rewrite through every item that links it by title. Two separate O(C²) behaviours lived on that path, both reachable from a **single request** with no accumulation:

- The cascade's SELECT joined `item_wiki_links` to `items` and projected `s.content`, returning **one row per link** — each carrying a full copy of the source body, de-duplicated only after `rows.Scan` had already allocated it.
- `links.RewriteBracketAt` was called once per bracket, each call rebuilding the entire body.

Bracket count is not independent of body size: the cheapest wiki-link is five bytes and nothing caps links per item, so a C-byte body carries C/5 brackets.

## Measured, before → after

| | before | after |
|---|---|---|
| allocation growth per doubling of C | 3.83 / 3.92 / 3.95 | **2.04 / 2.21 / 2.06** |
| per bracket | 2.01x body | **0.01x body** |
| 4096-row SELECT, one source | 1,074,850,200 B | **1,180,856 B** (910x) |
| `go test ./internal/store/` | 180.9s | 86.8s |

The growth-factor row is the property: 4.0 per doubling became 2.0.

## The fix

- **M1** — the per-link query no longer carries content; each distinct source's body is read once.
- **M2** — one `strings.Builder` pass over the recorded offsets. `RewriteBracketAt` keeps its public contract, reimplemented as the one-element case of a new `RewriteBracketsAt`.
- **M3** — `MaxItemRenameCascadeBytes` (64 MiB) bounds the total content one rename may process, charged **before** each body is built and **during** the scan, so a refusal never allocates what it refuses. The number is derived from the live workspace's measured distribution, with the receipt in the constant's doc comment.

Refusals surface as `413 rename_cascade_too_large` composed from typed fields, on all three paths `handleUpdateItem` can reach the store from.

## How the equivalence is established

The pre-refactor implementation is frozen in the test file as an oracle. Behaviour is pinned against **it**, not against the new code: a 26-case contract corpus, 20,000 randomised inputs, the descending-fold equivalence the cascade used to perform, and a projection/pass lockstep property. Comparing the new code to itself would have been vacuous, and was avoided deliberately.

Every guard is mutation-verified — including three mutants that initially **survived** and forced better instruments.

## Review

Six codex rounds, every finding real, each fix verified by the next round. Three side discoveries filed on their own trails rather than bundled: BUG-2829 (MCP 413 rendering), BUG-2830 (slash-title retarget), BUG-2831 (unbounded item titles). BUG-2827 (outbox k-linear retention) is a separate vector, tracked, not addressed here.

## Gates

`gofmt` · `go vet ./internal/...` · `go build ./...` clean. `go test ./...` PASS on **SQLite and Postgres**. `go test -race` PASS on `internal/links` and `internal/store`. Zero failures, zero data races.

Note for CI: `-race` on `internal/store` runs ~1478s, past the 600s default `go test` timeout — it needs an explicit `-timeout`.

https://claude.ai/code/session_01L7iUFWjoBY7V59Gu7mvZJq
