### PR TITLE
fix(links,store): make the rename cascade escape-aware in both directions (BUG-2805)

### DIFF
--- a/internal/links/extract.go
+++ b/internal/links/extract.go
@@ -105,13 +105,27 @@ var refPattern = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9]*-\d+$`)
 // (`(?:\\.|[^\]\\])+`), so any link the editor saves can be indexed
 // — even if its display text contains a literal `]` or `|`.
 //
+// CORRECTED 2026-08-31 (BUG-2805): this comment used to say that
 // renderMarkdown at markdown.ts:300 uses a simpler regex (`[^\]]+`)
-// that REJECTS escaped-bracket bodies, so escaped links don't
-// currently render as clickable links in the UI. That's a
-// pre-existing inconsistency in the editor pipeline; matching the
-// permissive grammar here makes the index forward-compatible with a
-// renderer fix without leaving a gap when one lands. Codex rounds
-// 4/7/10 P2.
+// and therefore REJECTS escaped bodies, making escaped links an
+// index-only citizen that never renders. That is no longer true, and
+// the citation had gone stale — markdown.ts:300 is inside a doc
+// comment now, and BOTH wiki-link regexes in that file
+// (renderMarkdown at :326 and wikiLinksToMarkdown at :625) use this
+// exact escape-aware production. The renderer comment at :323-325
+// names BUG-1744 as the change that aligned them.
+//
+// So the grammars agree across server and client, and escaped links
+// DO render as clickable. Verified by reading both regexes, not by
+// re-citing this comment — which is how the stale version survived
+// long enough to be quoted into a bug repro (TASK-2826) as a live
+// constraint. It matters for BUG-2805 in the direction that makes the
+// bug worse: the stale link that rename left behind was a WORKING,
+// clickable link, not an invisible one.
+//
+// Original rationale, still accurate: matching the permissive grammar
+// here keeps the index consistent with what the editor saves. Codex
+// rounds 4/7/10 P2.
 var wikiLinkPattern = regexp.MustCompile(`\[\[((?:\\.|[^\]\\])+)\]\]`)
 
 // fencedCodeRanges returns half-open `[start, end)` byte ranges that

--- a/internal/links/links.go
+++ b/internal/links/links.go
@@ -120,7 +120,8 @@ func RewriteWikiTitle(content, oldTitle, newTitle, collSlug string) string {
 // comparing this function to RewriteBracketsAt-of-one would be vacuous, since
 // that is now its definition. BUG-2804.
 func RewriteBracketAt(content string, position int, targetTitle, newTitle, collSlug string) string {
-	out, _ := RewriteBracketsAt(content, []BracketRewrite{{Position: position, TargetTitle: targetTitle}}, newTitle, collSlug)
+	out, _ := RewriteBracketsAt(content, []BracketRewrite{{Position: position, TargetTitle: targetTitle}},
+		NewTitleEscaper(newTitle, collSlug))
 	return out
 }
 
@@ -160,7 +161,7 @@ type BracketRewrite struct {
 //   - Applying nothing returns the input string unchanged, allocating nothing.
 //     Callers use the count to decide whether a write is owed, which also spares
 //     them a full-body string comparison to detect it.
-func RewriteBracketsAt(content string, rewrites []BracketRewrite, newTitle, collSlug string) (string, int) {
+func RewriteBracketsAt(content string, rewrites []BracketRewrite, esc TitleEscaper) (string, int) {
 	if len(rewrites) == 0 {
 		return content, 0
 	}
@@ -177,7 +178,7 @@ func RewriteBracketsAt(content string, rewrites []BracketRewrite, newTitle, coll
 			// Overlaps a rewrite already applied (or a duplicate offset).
 			continue
 		}
-		qualified, displaySuffix, bracketEnd, ok := bracketRewriteAt(content, rw.Position, rw.TargetTitle, newTitle, collSlug)
+		qualified, displaySuffix, bracketEnd, ok := bracketRewriteAt(content, rw.Position, rw.TargetTitle, esc.collSlugForMatch())
 		if !ok {
 			continue
 		}
@@ -189,7 +190,7 @@ func RewriteBracketsAt(content string, rewrites []BracketRewrite, newTitle, coll
 		// rename rewrite content, bump seq, and emit events for every linker
 		// (codex R1 P2). The old code compared whole bodies to decide this;
 		// comparing the bracket is the same question asked locally.
-		if bracketUnchanged(content, rw.Position, bracketEnd, qualified, newTitle, collSlug, displaySuffix) {
+		if bracketUnchanged(content, rw.Position, bracketEnd, qualified, esc, displaySuffix) {
 			continue
 		}
 		if applied == 0 {
@@ -201,10 +202,10 @@ func RewriteBracketsAt(content string, rewrites []BracketRewrite, newTitle, coll
 		b.WriteString(content[cursor:rw.Position])
 		b.WriteString("[[")
 		if qualified {
-			b.WriteString(collSlug)
+			b.WriteString(esc.escSlug)
 			b.WriteString("/")
 		}
-		b.WriteString(newTitle)
+		b.WriteString(esc.escTitle)
 		b.WriteString(displaySuffix)
 		b.WriteString("]]")
 		cursor = bracketEnd
@@ -229,7 +230,7 @@ func RewriteBracketsAt(content string, rewrites []BracketRewrite, newTitle, coll
 //
 // Cost is O(total bracket text), not O(len(content) * len(rewrites)) — each
 // bracket is inspected once and the untouched spans are only measured.
-func ProjectRewrittenLen(content string, rewrites []BracketRewrite, newTitle, collSlug string) (length, applied int) {
+func ProjectRewrittenLen(content string, rewrites []BracketRewrite, esc TitleEscaper) (length, applied int) {
 	if len(rewrites) == 0 {
 		return len(content), 0
 	}
@@ -243,11 +244,11 @@ func ProjectRewrittenLen(content string, rewrites []BracketRewrite, newTitle, co
 		if rw.Position < cursor {
 			continue
 		}
-		qualified, displaySuffix, bracketEnd, ok := bracketRewriteAt(content, rw.Position, rw.TargetTitle, newTitle, collSlug)
+		qualified, displaySuffix, bracketEnd, ok := bracketRewriteAt(content, rw.Position, rw.TargetTitle, esc.collSlugForMatch())
 		if !ok {
 			continue
 		}
-		if bracketUnchanged(content, rw.Position, bracketEnd, qualified, newTitle, collSlug, displaySuffix) {
+		if bracketUnchanged(content, rw.Position, bracketEnd, qualified, esc, displaySuffix) {
 			// Deliberately does NOT advance the cursor, mirroring the real pass
 			// exactly. An earlier version advanced it here, which made the two
 			// loops disagree about which overlapping rewrites the guard skips:
@@ -267,7 +268,7 @@ func ProjectRewrittenLen(content string, rewrites []BracketRewrite, newTitle, co
 		// replacement per bracket to measure it would reintroduce, one layer
 		// down, exactly the allocate-then-refuse shape the cap exists to
 		// prevent (codex R1 P1).
-		length += (2 + bracketSegmentLen(qualified, newTitle, collSlug) + len(displaySuffix) + 2) - (bracketEnd - rw.Position)
+		length += (2 + esc.segmentLen(qualified) + len(displaySuffix) + 2) - (bracketEnd - rw.Position)
 		cursor = bracketEnd
 		applied++
 	}
@@ -277,43 +278,162 @@ func ProjectRewrittenLen(content string, rewrites []BracketRewrite, newTitle, co
 	return length, applied
 }
 
-// bracketSegmentLen is the byte length of the title segment a matched bracket
-// will carry: the optional `<collSlug>/` prefix plus newTitle. Computed, never
-// built.
-func bracketSegmentLen(qualified bool, newTitle, collSlug string) int {
-	if qualified {
-		return len(collSlug) + 1 + len(newTitle)
+// escapeWikiBody escapes a title for emission INSIDE a `[[...]]` body, so the
+// parser reads back exactly the title that went in.
+//
+// Byte-for-byte the same rule as the editor's escapeWikiBody
+// (web/src/lib/utils/markdown.ts:748): backslash first, then `]` and `|`.
+// Doing backslash first is what keeps it the exact inverse of
+// unescapeWikiBody — escaping `]` first would leave the introduced backslashes
+// to be escaped again.
+//
+// BUG-2805: the rewriter previously emitted newTitle by plain concatenation.
+// A title containing `]` produced a bracket the grammar cannot parse at all
+// (`\[\[((?:\\.|[^\]\\])+)\]\]`), so the reparse found no link and DELETED the
+// index row — permanent, unrecoverable damage from an ordinary rename, since a
+// later rename has no row left to cascade. A title containing `\]` produced
+// valid syntax for a DIFFERENT title.
+func escapeWikiBody(s string) string {
+	if !strings.ContainsAny(s, `\]|`) {
+		return s
 	}
-	return len(newTitle)
+	var b strings.Builder
+	b.Grow(len(s) + 8)
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '\\', ']', '|':
+			b.WriteByte('\\')
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
 }
+
+// escapedWikiBodyLen is len(escapeWikiBody(s)) WITHOUT building it.
+//
+// The projection path runs before the cascade's cap can fire, so it must not
+// materialise anything proportional to the title (codex R5, BUG-2804). This is
+// that rule applied to the escaped form.
+func escapedWikiBodyLen(s string) int {
+	n := len(s)
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '\\', ']', '|':
+			n++
+		}
+	}
+	return n
+}
+
+// TitleEscaper carries a rename's emission-ready forms, computed ONCE per
+// cascade rather than per source or per bracket.
+//
+// It exists for the allocation reason, not for tidiness. A cascade renames one
+// item to one new title, but RewriteBracketsAt and ProjectRewrittenLen are
+// called once per SOURCE — and the scan bound admits a very large number of
+// sources when their titles are short. Escaping inside those functions would
+// therefore multiply an unbounded newTitle by an unbounded source count, which
+// is the BUG-2804 R5 defect in a new costume.
+type TitleEscaper struct {
+	escTitle string
+	escSlug  string
+	// rawSlug is the UNESCAPED slug; matching compares unescaped values.
+	rawSlug string
+	// Lengths are carried separately so the projection path can measure
+	// without touching the strings at all.
+	titleLen int
+	slugLen  int
+}
+
+// NewTitleEscaper precomputes the escaped forms for one rename.
+func NewTitleEscaper(newTitle, collSlug string) TitleEscaper {
+	return TitleEscaper{
+		escTitle: escapeWikiBody(newTitle),
+		escSlug:  escapeWikiBody(collSlug),
+		rawSlug:  collSlug,
+		titleLen: escapedWikiBodyLen(newTitle),
+		slugLen:  escapedWikiBodyLen(collSlug),
+	}
+}
+
+// scanBracketBody finds the body of the wiki-link bracket starting at
+// `position`, honouring the escape grammar.
+//
+// It implements exactly the parser's body production
+// (`(?:\\.|[^\]\\])+`, extract.go): a backslash consumes the next byte
+// whatever it is, an unescaped `]` is only legal as the first half of the
+// closing `]]`, and the body must be non-empty.
+//
+// The naive `strings.Index(rest, "]]")` this replaces finds the WRONG close on
+// an escaped body: in `[[A\]]]` it stops at the `]` belonging to the `\]`
+// escape and returns the body `A\`. That was latent while the rewriter never
+// emitted escapes; BUG-2805's fix makes escaped bodies routine, so the scan has
+// to agree with the parser or each rename corrupts what the last one wrote.
+func scanBracketBody(content string, position int) (body string, bracketEnd int, ok bool) {
+	start := position + 2
+	i := start
+	for i < len(content) {
+		switch content[i] {
+		case '\\':
+			if i+1 >= len(content) {
+				return "", 0, false // trailing backslash: `\\.` has nothing to consume
+			}
+			i += 2
+		case ']':
+			if i+1 < len(content) && content[i+1] == ']' {
+				if i == start {
+					return "", 0, false // empty body; the production is `+`
+				}
+				return content[start:i], i + 2, true
+			}
+			return "", 0, false // bare `]` is not in the body production
+		default:
+			i++
+		}
+	}
+	return "", 0, false
+}
+
+// segmentLen is the byte length of the title segment a matched bracket will
+// carry: the optional escaped `<collSlug>/` prefix plus the escaped title.
+// Computed from precomputed lengths, never built.
+func (e TitleEscaper) segmentLen(qualified bool) int {
+	if qualified {
+		return e.slugLen + 1 + e.titleLen
+	}
+	return e.titleLen
+}
+
+// collSlugForMatch returns the RAW slug the matcher compares target_title
+// against. Matching works on unescaped values, so the escaped form must not
+// leak into it.
+func (e TitleEscaper) collSlugForMatch() string { return e.rawSlug }
 
 // bracketUnchanged reports whether rewriting the bracket at [position,
 // bracketEnd) would reproduce it byte-for-byte.
 //
-// Allocation-free, and now segment-wise: it walks the existing body against the
-// optional slug prefix, then newTitle, then the display suffix, rather than
-// concatenating them into a candidate string. Building the candidate just to
-// compare it would reintroduce the newTitle-proportional allocation that
-// bracketRewriteAt exists to avoid — on every bracket, in the projection path,
-// before the cap fires (codex R5).
-func bracketUnchanged(content string, position, bracketEnd int, qualified bool, newTitle, collSlug, displaySuffix string) bool {
+// Allocation-free and segment-wise: it walks the existing body against the
+// escaped slug prefix, then the escaped title, then the display suffix, rather
+// than concatenating them into a candidate string — which would reintroduce
+// the per-bracket allocation the projection path must not have (codex R5).
+func bracketUnchanged(content string, position, bracketEnd int, qualified bool, esc TitleEscaper, displaySuffix string) bool {
 	body := content[position+2 : bracketEnd-2]
-	if len(body) != bracketSegmentLen(qualified, newTitle, collSlug)+len(displaySuffix) {
+	if len(body) != esc.segmentLen(qualified)+len(displaySuffix) {
 		return false
 	}
 	if qualified {
-		if len(body) < len(collSlug)+1 {
+		if len(body) < esc.slugLen+1 {
 			return false
 		}
-		if body[:len(collSlug)] != collSlug || body[len(collSlug)] != '/' {
+		if body[:esc.slugLen] != esc.escSlug || body[esc.slugLen] != '/' {
 			return false
 		}
-		body = body[len(collSlug)+1:]
+		body = body[esc.slugLen+1:]
 	}
-	if len(body) < len(newTitle) || body[:len(newTitle)] != newTitle {
+	if len(body) < esc.titleLen || body[:esc.titleLen] != esc.escTitle {
 		return false
 	}
-	return body[len(newTitle):] == displaySuffix
+	return body[esc.titleLen:] == displaySuffix
 }
 
 // bracketRewriteAt is the per-bracket decision, and the ONLY copy of it. It
@@ -323,66 +443,59 @@ func bracketUnchanged(content string, position, bracketEnd int, qualified bool, 
 //
 // It reads only content[position:bracketEnd] — that locality is what makes a
 // single pass possible, since the rest of the body is pure carry.
-func bracketRewriteAt(content string, position int, targetTitle, newTitle, collSlug string) (qualified bool, displaySuffix string, bracketEnd int, ok bool) {
+func bracketRewriteAt(content string, position int, targetTitle, collSlug string) (qualified bool, displaySuffix string, bracketEnd int, ok bool) {
 	if position < 0 || position+2 > len(content) {
 		return false, "", 0, false
 	}
 	if content[position:position+2] != "[[" {
 		return false, "", 0, false
 	}
-	rest := content[position+2:]
-	closeIdx := strings.Index(rest, "]]")
-	if closeIdx < 0 {
+	body, end, found := scanBracketBody(content, position)
+	if !found {
 		return false, "", 0, false
 	}
-	body := rest[:closeIdx]
-	bracketEnd = position + 2 + closeIdx + 2 // past `]]`
+	bracketEnd = end
 
-	tLower := strings.ToLower(body)
-	ttLower := strings.ToLower(targetTitle)
-
-	// MATCH FIRST, then describe the replacement. Nothing proportional to
-	// newTitle is built here at all — this returns a DESCRIPTION (does the
-	// qualified prefix apply, what display suffix carries over) and lets each
-	// caller either measure it or write it.
+	// MATCH AGAINST THE UNESCAPED BODY (BUG-2805 direction 1). The stored
+	// bracket for a title containing `]`, `|` or `\` is escape-encoded, so
+	// comparing the RAW body against the plain title never matched and the
+	// link was left stale while the index row silently flipped to broken.
 	//
-	// Both properties matter and both were violated before (codex R1, then R5
-	// one layer down). An earlier version composed `collSlug + "/" + newTitle`
-	// BEFORE the match check, so every bracket paid for it including the
-	// leave-alone exit — and ProjectRewrittenLen calls this once per rewrite
-	// BEFORE the cap fires. BUG-2831 then measured that newTitle has no
-	// validation bound, so a bracket-dense body with a multi-megabyte new title
-	// projected gigabytes of immediately-discarded allocation ahead of the
-	// refusal that exists to prevent exactly that.
+	// Order mirrors the parser and the renderer, which both prefer the FULL
+	// body as a title before splitting on a pipe (wiki_links.go's title
+	// fallback, markdown.ts resolveWikiBody). Getting this order wrong would
+	// break literal-pipe titles like "A|B", which case 1 has always handled.
 	//
-	// Case 1: body equals target_title (case-insensitive) — no display segment.
-	// Case 2: body starts with target_title + "|" — the display segment from
-	// the pipe onward carries over verbatim (a SLICE of body, not a copy).
+	// Nothing proportional to the new title is built here — this returns a
+	// DESCRIPTION and lets each caller measure it or write it (codex R5).
 	switch {
-	case tLower == ttLower:
-	case len(tLower) > len(ttLower) && tLower[len(ttLower)] == '|' && tLower[:len(ttLower)] == ttLower:
-		// Spelled out rather than HasPrefix(tLower, ttLower+"|") so the
-		// concatenation disappears; it is the same predicate, byte for byte,
-		// on the same two already-lowered strings.
-		displaySuffix = body[len(targetTitle):] // includes the pipe
+	case strings.EqualFold(unescapeWikiBody(body), targetTitle):
+		// Case 1: the whole body is the title. No display segment.
 	default:
-		// Bracket doesn't match the expected shape — leave it alone.
-		// (Index drift or a stored full-body title with embedded pipe;
-		// the trailing replaceWikiLinks call will reconcile.)
-		return false, "", 0, false
+		rawKey, _, hasPipe := splitOnUnescapedPipe(body)
+		if !hasPipe || !strings.EqualFold(unescapeWikiBody(rawKey), targetTitle) {
+			// Bracket doesn't match the expected shape — leave it alone.
+			// (Index drift, or a body whose title segment is something else;
+			// the trailing replaceWikiLinks call will reconcile the index.)
+			return false, "", 0, false
+		}
+		// Case 2: title segment matches; everything from the unescaped pipe
+		// onward carries over VERBATIM, still escape-encoded. It is a slice of
+		// body, never a copy, and it is deliberately not re-escaped — it is
+		// already in stored form.
+		displaySuffix = body[len(rawKey):]
 	}
 
 	// Only now, on a confirmed match: does the `<collSlug>/` prefix carry over?
 	// A qualified body like `[[tasks/Old Title]]` becomes `[[tasks/New Title]]`
 	// — the cascade SELECT already proved this row points at the renamed item
 	// via stage-2 qualified-fallback resolution, so the slug is guaranteed to
-	// match collSlug. Reported as a flag; the caller writes collSlug and "/"
-	// directly rather than receiving them spliced onto newTitle.
-	if collSlug != "" {
-		pfx := collSlug + "/"
-		if strings.HasPrefix(strings.ToLower(targetTitle), strings.ToLower(pfx)) {
-			qualified = true
-		}
+	// match collSlug. Reported as a flag; the caller writes the escaped slug
+	// and "/" directly rather than receiving them spliced onto the title.
+	if collSlug != "" && len(targetTitle) > len(collSlug) &&
+		targetTitle[len(collSlug)] == '/' &&
+		strings.EqualFold(targetTitle[:len(collSlug)], collSlug) {
+		qualified = true
 	}
 	return qualified, displaySuffix, bracketEnd, true
 }

--- a/internal/links/links.go
+++ b/internal/links/links.go
@@ -166,6 +166,27 @@ func RewriteBracketsAt(content string, rewrites []BracketRewrite, esc TitleEscap
 		return content, 0
 	}
 
+	// A rename that would emit an EMPTY title segment cannot be applied: the
+	// body production is `+`, so `[[]]` is not a link at all. Rewriting to it
+	// destroys the link AND its index row — the exact BUG-2805 direction-2a
+	// damage, reached through a different door.
+	//
+	// Two ways in, both real. A zero-value TitleEscaper (constructed as a
+	// struct literal rather than via NewTitleEscaper) has an empty title; and
+	// UpdateItem accepts a rename to "" outright, because the empty-title guard
+	// lives only in handleCreateItem, not handleUpdateItem — verified by
+	// renaming to "" and watching a linker become `Ref [[]] here.` with its
+	// index row deleted. The door-level validation gap is filed separately;
+	// this is the rewriter refusing to be the instrument.
+	//
+	// Refusing leaves the bracket naming the old title, which the caller's
+	// re-parse then reconciles — the ordinary `applied == 0` path. That is
+	// strictly better than destruction: the link stays clickable and a later,
+	// valid rename can still find and fix it.
+	if esc.titleLen == 0 {
+		return content, 0
+	}
+
 	ordered := make([]BracketRewrite, len(rewrites))
 	copy(ordered, rewrites)
 	sort.Slice(ordered, func(i, j int) bool { return ordered[i].Position < ordered[j].Position })
@@ -234,6 +255,13 @@ func ProjectRewrittenLen(content string, rewrites []BracketRewrite, esc TitleEsc
 	if len(rewrites) == 0 {
 		return len(content), 0
 	}
+	// Mirrors RewriteBracketsAt's refusal of an empty title segment. The two
+	// must agree exactly or the cascade charges for work the rewrite will not
+	// do — the lockstep property.
+	if esc.titleLen == 0 {
+		return len(content), 0
+	}
+
 	ordered := make([]BracketRewrite, len(rewrites))
 	copy(ordered, rewrites)
 	sort.Slice(ordered, func(i, j int) bool { return ordered[i].Position < ordered[j].Position })
@@ -377,6 +405,22 @@ func scanBracketBody(content string, position int) (body string, bracketEnd int,
 		case '\\':
 			if i+1 >= len(content) {
 				return "", 0, false // trailing backslash: `\\.` has nothing to consume
+			}
+			// `.` in Go's regexp does NOT match a newline, so `\\.` cannot
+			// consume one — a backslash before LF is not an escape pair to the
+			// parser, and the body fails to match at all. Treating it as a pair
+			// here made the scanner accept `[[A\<LF>B]]` that ExtractWikiLinks
+			// rejects (codex R2). Measured both ways before fixing.
+			//
+			// Only LF, deliberately: the Go parser's `.` excludes exactly that.
+			// The JS renderer's `.` additionally excludes CR, U+2028 and U+2029
+			// — measured with node — so Go indexes a `\<CR>` link the renderer
+			// will not render. That divergence is PRE-EXISTING in the two
+			// regexes and is filed separately rather than papered over here;
+			// this scanner's job is to agree with the parser that fills the
+			// index it reads from.
+			if content[i+1] == '\n' {
+				return "", 0, false
 			}
 			i += 2
 		case ']':

--- a/internal/links/probe_alloc_test.go
+++ b/internal/links/probe_alloc_test.go
@@ -58,7 +58,7 @@ func TestProjectRewrittenLenDoesNotAllocatePerBracket(t *testing.T) {
 	var before, after runtime.MemStats
 	runtime.GC()
 	runtime.ReadMemStats(&before)
-	length, applied := ProjectRewrittenLen(content, rewrites, newTitle, "tasks")
+	length, applied := ProjectRewrittenLen(content, rewrites, NewTitleEscaper(newTitle, "tasks"))
 	runtime.ReadMemStats(&after)
 
 	if applied != brackets {

--- a/internal/links/rewrite_brackets_diff_test.go
+++ b/internal/links/rewrite_brackets_diff_test.go
@@ -703,6 +703,61 @@ func TestScanBracketBodyAgreesWithTheParser(t *testing.T) {
 	}
 }
 
+// TestScanBracketBodyEdgeCasesMatchTheParser locks the delimiter edges down
+// against the parser as oracle, one assertion per shape.
+//
+// The parity property above generates content; this enumerates the shapes where
+// a hand-written scanner and a regex are most likely to disagree, so a failure
+// names WHICH edge broke instead of printing a random string. Every row was
+// verified against ExtractWikiLinks rather than reasoned about — including the
+// two where BOTH refuse, which is the agreement that is easiest to lose by
+// making the scanner more permissive than the grammar.
+func TestScanBracketBodyEdgeCasesMatchTheParser(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		content  string
+		wantOK   bool
+		wantBody string
+		why      string
+	}{
+		{"escape consumes the would-be close", `[[A\]]`, false, "",
+			`the \] escape eats the first ], leaving a single ] that cannot close`},
+		{"escaped close then real close", `[[A\]]]`, true, `A\]`,
+			"the naive strings.Index scan stops one byte early here — this is THE discriminating shape"},
+		{"stray ] after the close", `[[A]]]`, true, "A",
+			"close at the FIRST ]], trailing ] is ordinary text"},
+		{"]] run after the close", `[[A]]]]`, true, "A",
+			"same: first ]] wins, the rest is text"},
+		{"trailing backslash at EOF", `[[A\`, false, "",
+			`the \. production has nothing to consume`},
+		{"escaped backslash then close", `[[A\\]]`, true, `A\\`,
+			`\\ is one escaped backslash, so the ]] that follows is a real close`},
+		{"empty body", "[[]]", false, "",
+			"the body production is `+`; `[[]]` is not a link at all"},
+		{"bare ] mid-body", "[[A]B]]", false, "",
+			"an unescaped ] is not in the body production — both scanner and parser refuse"},
+		{"escaped pipe", `[[A\|B]]`, true, `A\|B`,
+			"the escaped pipe is body text, not a display separator"},
+		{"body is only an escaped ]", `[[\]]]`, true, `\]`,
+			"shortest body that needs escape-aware scanning"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			body, _, ok := scanBracketBody(tc.content, 0)
+			if ok != tc.wantOK || body != tc.wantBody {
+				t.Errorf("scanner(%q) = (body %q, ok %v), want (%q, %v)\nwhy: %s",
+					tc.content, body, ok, tc.wantBody, tc.wantOK, tc.why)
+			}
+			// The parser is the oracle: it must agree about whether a link is
+			// there at all.
+			ls := ExtractWikiLinks(tc.content)
+			if (len(ls) > 0) != tc.wantOK {
+				t.Errorf("parser found %d links in %q but the scanner says ok=%v — the scanner "+
+					"and the grammar disagree about whether this is a link", len(ls), tc.content, ok)
+			}
+		})
+	}
+}
+
 // TestBUG2805_AccidentalCompatibilitiesSurvive pins the two rescues Rook's
 // repro identified as non-reproducing directions (TASK-2826 2c and 2d).
 //

--- a/internal/links/rewrite_brackets_diff_test.go
+++ b/internal/links/rewrite_brackets_diff_test.go
@@ -123,7 +123,12 @@ func behaviourCorpus() []diffCase {
 // The domain is: the bracket at `position` has a NON-EMPTY body containing none
 // of `\`, `]`, `|`. That is exactly "no escape grammar involved", which is
 // where BUG-2805 promises byte-identical behaviour.
-func guardedDomain(content string, position int) bool {
+func guardedDomain(content string, position int, newTitle string) bool {
+	if newTitle == "" {
+		// V0 emitted `[[]]` here, which is the DESTRUCTION itself — the oracle
+		// encodes the bug in this corner. See the intentional-divergence test.
+		return false
+	}
 	if position < 0 || position+2 > len(content) || content[position:position+2] != "[[" {
 		return true // rejection paths are unchanged; still guarded
 	}
@@ -168,6 +173,16 @@ func TestRewriteBracketAt_IntentionalDivergencesFromV0(t *testing.T) {
 				"title, never matched, and left the link stale while the index flipped broken.",
 		},
 		{
+			name: "empty new title is REFUSED, not emitted", content: "x [[Old]] y", position: 2,
+			targetTitle: "Old", newTitle: "",
+			wantV0: "x [[]] y", wantNew: "x [[Old]] y",
+			why: "V0's expected output IS the damage: `[[]]` is not a link under the `+` " +
+				"production, so the reparse deletes the index row. Reachable two ways — a " +
+				"zero-value TitleEscaper, and UpdateItem accepting a rename to \"\" because the " +
+				"empty-title guard lives only in handleCreateItem. Refusing leaves the link " +
+				"clickable and repairable; emitting destroys it permanently.",
+		},
+		{
 			name: "emission now ESCAPES", content: "Ref [[Plain Target]] here.", position: 4,
 			targetTitle: "Plain Target", newTitle: "New ] Name",
 			wantV0: "Ref [[New ] Name]] here.", wantNew: `Ref [[New \] Name]] here.`,
@@ -191,7 +206,7 @@ func TestRewriteBracketAt_IntentionalDivergencesFromV0(t *testing.T) {
 func TestRewriteBracketAt_MatchesPreRefactorImplementation(t *testing.T) {
 	for _, tc := range behaviourCorpus() {
 		t.Run(tc.name, func(t *testing.T) {
-			if !guardedDomain(tc.content, tc.position) {
+			if !guardedDomain(tc.content, tc.position, tc.newTitle) {
 				t.Skip("outside the V0-guarded domain — see TestRewriteBracketAt_IntentionalDivergencesFromV0")
 			}
 			want := rewriteBracketAtV0(tc.content, tc.position, tc.targetTitle, tc.newTitle, tc.collSlug)
@@ -223,7 +238,7 @@ func TestRewriteBracketAt_MatchesPreRefactorOnRandomInput(t *testing.T) {
 		newTitle := news[rng.Intn(len(news))]
 		slug := slugs[rng.Intn(len(slugs))]
 
-		if !guardedDomain(content, pos) {
+		if !guardedDomain(content, pos, newTitle) {
 			continue
 		}
 		want := rewriteBracketAtV0(content, pos, target, newTitle, slug)
@@ -257,6 +272,11 @@ func TestRewriteBracketsAt_MatchesSequentialDescendingFold(t *testing.T) {
 		content := randomBracketContent(rng)
 		target := titles[rng.Intn(len(titles))]
 		newTitle := news[rng.Intn(len(news))]
+		if newTitle == "" {
+			// The fold oracle emits `[[]]` for an empty title — the damage the
+			// rewriter now refuses. Covered by the intentional-divergence test.
+			continue
+		}
 
 		positions := bracketOffsets(content)
 		// Corrupt some of the time so skip paths get exercised.
@@ -740,6 +760,15 @@ func TestScanBracketBodyEdgeCasesMatchTheParser(t *testing.T) {
 			"the escaped pipe is body text, not a display separator"},
 		{"body is only an escaped ]", `[[\]]]`, true, `\]`,
 			"shortest body that needs escape-aware scanning"},
+		{"backslash before LF is NOT an escape pair", "[[A\\\nB]]", false, "",
+			"Go's regexp `.` does not match a newline, so `\\.` cannot consume one and the " +
+				"parser rejects the whole body. The scanner treated backslash-ANY as a pair and " +
+				"accepted it (codex R2 P2, introduced by this diff)"},
+		{"backslash before CR IS an escape pair to Go", "[[A\\\rB]]", true, "A\\\rB",
+			"Go's `.` excludes only LF. The JS renderer's `.` also excludes CR, U+2028 and " +
+				"U+2029 (measured with node), so Go indexes a link the renderer will not " +
+				"render — a PRE-EXISTING server/client grammar divergence, filed separately. " +
+				"This scanner agrees with the GO parser, which is what fills the index it reads"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			body, _, ok := scanBracketBody(tc.content, 0)

--- a/internal/links/rewrite_brackets_diff_test.go
+++ b/internal/links/rewrite_brackets_diff_test.go
@@ -111,9 +111,89 @@ func behaviourCorpus() []diffCase {
 	}
 }
 
+// guardedDomain reports whether the frozen V0 oracle is still authoritative for
+// this input.
+//
+// BUG-2805 deliberately changes behaviour in two places, so the oracle cannot
+// be applied blanket any more — but narrowing it to the domain BUG-2805 does
+// NOT touch keeps it load-bearing for everything else, which is the large
+// majority. Outside this domain the intended new behaviour is pinned by name in
+// TestRewriteBracketAt_IntentionalDivergencesFromV0 and the BUG-2805 tests.
+//
+// The domain is: the bracket at `position` has a NON-EMPTY body containing none
+// of `\`, `]`, `|`. That is exactly "no escape grammar involved", which is
+// where BUG-2805 promises byte-identical behaviour.
+func guardedDomain(content string, position int) bool {
+	if position < 0 || position+2 > len(content) || content[position:position+2] != "[[" {
+		return true // rejection paths are unchanged; still guarded
+	}
+	rest := content[position+2:]
+	closeIdx := strings.Index(rest, "]]")
+	if closeIdx < 0 {
+		return true // unterminated: unchanged
+	}
+	body := rest[:closeIdx]
+	if body == "" {
+		return false // empty body — see the intentional-divergence test
+	}
+	return !strings.ContainsAny(body, `\]|`)
+}
+
+// TestRewriteBracketAt_IntentionalDivergencesFromV0 names every input where
+// BUG-2805 deliberately departs from the frozen pre-refactor oracle, so the
+// departures are a checked list rather than a gap in the differential tests.
+func TestRewriteBracketAt_IntentionalDivergencesFromV0(t *testing.T) {
+	cases := []struct {
+		name            string
+		content         string
+		position        int
+		targetTitle     string
+		newTitle        string
+		wantV0, wantNew string
+		why             string
+	}{
+		{
+			name: "empty body is not a link", content: "x [[]] y", position: 2,
+			targetTitle: "", newTitle: "New",
+			wantV0: "x [[New]] y", wantNew: "x [[]] y",
+			why: "the parser's body production is `+`, so `[[]]` is not a link and no " +
+				"position is ever recorded for one. V0 would MINT a link out of a non-link " +
+				"if handed a drifted offset; the escape-aware scanner refuses.",
+		},
+		{
+			name: "escaped body now MATCHES", content: `see [[Weird \] Title]] here`, position: 4,
+			targetTitle: "Weird ] Title", newTitle: "Renamed",
+			wantV0: `see [[Weird \] Title]] here`, wantNew: "see [[Renamed]] here",
+			why: "BUG-2805 direction 1: V0 compared the RAW body against the unescaped " +
+				"title, never matched, and left the link stale while the index flipped broken.",
+		},
+		{
+			name: "emission now ESCAPES", content: "Ref [[Plain Target]] here.", position: 4,
+			targetTitle: "Plain Target", newTitle: "New ] Name",
+			wantV0: "Ref [[New ] Name]] here.", wantNew: `Ref [[New \] Name]] here.`,
+			why: "BUG-2805 direction 2a: V0's plain concatenation emitted an unparseable " +
+				"bracket, so the reparse deleted the index row — permanent damage.",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := rewriteBracketAtV0(tc.content, tc.position, tc.targetTitle, tc.newTitle, ""); got != tc.wantV0 {
+				t.Fatalf("fixture drift: V0 = %q, want %q — this test documents a divergence "+
+					"FROM a specific old behaviour, so the old behaviour must be what it says", got, tc.wantV0)
+			}
+			if got := RewriteBracketAt(tc.content, tc.position, tc.targetTitle, tc.newTitle, ""); got != tc.wantNew {
+				t.Errorf("new = %q, want %q\nwhy this diverges: %s", got, tc.wantNew, tc.why)
+			}
+		})
+	}
+}
+
 func TestRewriteBracketAt_MatchesPreRefactorImplementation(t *testing.T) {
 	for _, tc := range behaviourCorpus() {
 		t.Run(tc.name, func(t *testing.T) {
+			if !guardedDomain(tc.content, tc.position) {
+				t.Skip("outside the V0-guarded domain — see TestRewriteBracketAt_IntentionalDivergencesFromV0")
+			}
 			want := rewriteBracketAtV0(tc.content, tc.position, tc.targetTitle, tc.newTitle, tc.collSlug)
 			got := RewriteBracketAt(tc.content, tc.position, tc.targetTitle, tc.newTitle, tc.collSlug)
 			if got != want {
@@ -143,6 +223,9 @@ func TestRewriteBracketAt_MatchesPreRefactorOnRandomInput(t *testing.T) {
 		newTitle := news[rng.Intn(len(news))]
 		slug := slugs[rng.Intn(len(slugs))]
 
+		if !guardedDomain(content, pos) {
+			continue
+		}
 		want := rewriteBracketAtV0(content, pos, target, newTitle, slug)
 		got := RewriteBracketAt(content, pos, target, newTitle, slug)
 		if got != want {
@@ -222,7 +305,7 @@ func TestRewriteBracketsAt_MatchesSequentialDescendingFold(t *testing.T) {
 		for _, p := range shuffled {
 			rewrites = append(rewrites, BracketRewrite{Position: p, TargetTitle: target})
 		}
-		got, applied := RewriteBracketsAt(content, rewrites, newTitle, "")
+		got, applied := RewriteBracketsAt(content, rewrites, NewTitleEscaper(newTitle, ""))
 
 		if got != want {
 			t.Fatalf("single pass diverges from the descending fold at iteration %d\n content=%q positions=%v target=%q new=%q\n fold=%q\n pass=%q (applied=%d)",
@@ -239,11 +322,11 @@ func TestRewriteBracketsAt_MatchesSequentialDescendingFold(t *testing.T) {
 // no-op path the cascade relies on to skip a write.
 func TestRewriteBracketsAt_NoRewritesReturnsInputUnchanged(t *testing.T) {
 	const content = "nothing [[Other]] to do here"
-	got, applied := RewriteBracketsAt(content, nil, "New", "")
+	got, applied := RewriteBracketsAt(content, nil, NewTitleEscaper("New", ""))
 	if got != content || applied != 0 {
 		t.Fatalf("empty rewrites: got %q applied=%d, want %q applied=0", got, applied, content)
 	}
-	got, applied = RewriteBracketsAt(content, []BracketRewrite{{Position: 8, TargetTitle: "Old"}}, "New", "")
+	got, applied = RewriteBracketsAt(content, []BracketRewrite{{Position: 8, TargetTitle: "Old"}}, NewTitleEscaper("New", ""))
 	if got != content || applied != 0 {
 		t.Fatalf("non-matching rewrite: got %q applied=%d, want %q applied=0", got, applied, content)
 	}
@@ -263,7 +346,7 @@ func TestRewriteBracketsAt_DoesNotMutateCallerSlice(t *testing.T) {
 	before := make([]BracketRewrite, len(rewrites))
 	copy(before, rewrites)
 
-	if _, applied := RewriteBracketsAt(content, rewrites, "New", ""); applied != 3 {
+	if _, applied := RewriteBracketsAt(content, rewrites, NewTitleEscaper("New", "")); applied != 3 {
 		t.Fatalf("applied = %d, want 3", applied)
 	}
 	for i := range before {
@@ -286,7 +369,7 @@ func TestRewriteBracketsAt_AppliesEveryBracketInOnePass(t *testing.T) {
 	for _, p := range offs {
 		rewrites = append(rewrites, BracketRewrite{Position: p, TargetTitle: "Old"})
 	}
-	got, applied := RewriteBracketsAt(content, rewrites, "New", "")
+	got, applied := RewriteBracketsAt(content, rewrites, NewTitleEscaper("New", ""))
 	if applied != n {
 		t.Fatalf("applied = %d, want %d", applied, n)
 	}
@@ -356,7 +439,7 @@ func TestRewriteBracketsAt_ByteIdenticalRewriteIsNotAChange(t *testing.T) {
 				t.Fatalf("fixture: %d brackets, want 1", len(offs))
 			}
 			got, applied := RewriteBracketsAt(tc.content,
-				[]BracketRewrite{{Position: offs[0], TargetTitle: tc.targetTitle}}, tc.newTitle, tc.collSlug)
+				[]BracketRewrite{{Position: offs[0], TargetTitle: tc.targetTitle}}, NewTitleEscaper(tc.newTitle, tc.collSlug))
 			if got != tc.content {
 				t.Errorf("content changed: got %q, want %q", got, tc.content)
 			}
@@ -382,7 +465,7 @@ func TestRewriteBracketsAt_MixedChangedAndUnchangedCountsOnlyTheChanged(t *testi
 		{Position: offs[1], TargetTitle: "New"}, // already reads [[New]] — no change
 		{Position: offs[2], TargetTitle: "Old"},
 	}
-	got, applied := RewriteBracketsAt(content, rewrites, "New", "")
+	got, applied := RewriteBracketsAt(content, rewrites, NewTitleEscaper("New", ""))
 	if want := "[[New]] and [[New]] and [[New]]"; got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
@@ -421,8 +504,8 @@ func TestProjectRewrittenLen_IsLockstepWithTheRealPass(t *testing.T) {
 
 	check := func(t *testing.T, content string, rewrites []BracketRewrite, newTitle, collSlug string) {
 		t.Helper()
-		wantLen, wantApplied := ProjectRewrittenLen(content, rewrites, newTitle, collSlug)
-		got, gotApplied := RewriteBracketsAt(content, rewrites, newTitle, collSlug)
+		wantLen, wantApplied := ProjectRewrittenLen(content, rewrites, NewTitleEscaper(newTitle, collSlug))
+		got, gotApplied := RewriteBracketsAt(content, rewrites, NewTitleEscaper(newTitle, collSlug))
 		if len(got) != wantLen || gotApplied != wantApplied {
 			t.Fatalf("projection and the real pass disagree\n content=%q rewrites=%+v new=%q slug=%q\n"+
 				" projected len=%d applied=%d\n actual    len=%d applied=%d (result %q)",
@@ -491,4 +574,189 @@ func TestProjectRewrittenLen_IsLockstepWithTheRealPass(t *testing.T) {
 		}
 		check(t, content, rewrites, newTitle, "")
 	}
+}
+
+// TestRewriteBracketsAt_EmissionRoundTripsThroughTheParser is the property that
+// makes BUG-2805 closed rather than patched: whatever title a rename emits, the
+// PARSER must read back exactly that title.
+//
+// This is the check no per-character test can give you. The repro on TASK-2826
+// enumerated `]`, `\]`, `|` and bare `\` and found four different outcomes —
+// destroyed, wrong-title, rescued, rescued. A property over generated titles
+// covers the combinations nobody enumerated, and it fails loudly on the two
+// that were real defects.
+func TestRewriteBracketsAt_EmissionRoundTripsThroughTheParser(t *testing.T) {
+	rng := rand.New(rand.NewSource(20260903))
+	// Alphabet weighted toward the characters that carry meaning in the body
+	// grammar; ordinary letters are along for realism.
+	alphabet := []string{"a", "B", " ", "]", "|", `\`, `\]`, `\|`, `\\`, "/", "é", "-"}
+
+	for i := 0; i < 4000; i++ {
+		n := 1 + rng.Intn(6)
+		var sb strings.Builder
+		for j := 0; j < n; j++ {
+			sb.WriteString(alphabet[rng.Intn(len(alphabet))])
+		}
+		newTitle := sb.String()
+
+		content := "before [[Plain Target]] after"
+		offs := bracketOffsets(content)
+		got, applied := RewriteBracketsAt(content,
+			[]BracketRewrite{{Position: offs[0], TargetTitle: "Plain Target"}},
+			NewTitleEscaper(newTitle, ""))
+		if applied != 1 {
+			t.Fatalf("iteration %d: applied = %d, want 1 (newTitle=%q)", i, applied, newTitle)
+		}
+
+		// The emitted content must parse, and the ONE link it contains must
+		// resolve to exactly the title we renamed to.
+		links := ExtractWikiLinks(got)
+		if len(links) != 1 {
+			t.Fatalf("iteration %d: emitted %q from newTitle=%q — parser found %d links, want 1. "+
+				"This is the BUG-2805 direction-2a shape: an unparseable bracket whose index row "+
+				"the reparse DELETES, permanently.", i, got, newTitle, len(links))
+		}
+		if links[0].Title != newTitle {
+			t.Fatalf("iteration %d: emitted %q from newTitle=%q — parser read title %q. "+
+				"This is the direction-2b shape: valid syntax for the WRONG title.",
+				i, got, newTitle, links[0].Title)
+		}
+	}
+}
+
+// TestScanBracketBodyAgreesWithTheParser pins the third half of BUG-2805, which
+// the repro did not name.
+//
+// The rewriter used strings.Index(rest, "]]") to find its closing delimiter.
+// That is not the grammar: in `[[A\]]]` it stops at the `]` belonging to the
+// `\]` escape. It was harmless only while the rewriter never EMITTED escapes —
+// and this fix makes escaped bodies routine, so a scan that disagrees with the
+// parser would corrupt on the next rename what this one wrote.
+//
+// The parser is the oracle: for every link ExtractWikiLinks reports, the
+// scanner must find the same body at the same offset.
+func TestScanBracketBodyAgreesWithTheParser(t *testing.T) {
+	// CONSTRUCTED FIRST, because the discriminating shape is rare under random
+	// generation: the naive `strings.Index(rest, "]]")` only picks the wrong
+	// close when an escaped `\]` is IMMEDIATELY followed by the real `]]`.
+	// `[[Weird \] Title]]` does NOT discriminate — its `\]` is followed by a
+	// space, so the naive scan happens to land correctly. Leaving this to the
+	// generator let the mutant survive this test and be killed only incidentally
+	// by an unrelated case.
+	for _, tc := range []struct{ name, content, wantBody string }{
+		{"escape immediately before the close", `[[A\]]]`, `A\]`},
+		{"escaped pipe before the close", `[[A\|]]`, `A\|`},
+		{"escaped backslash before the close", `[[A\\]]`, `A\\`},
+		{"escape mid-body", `[[Weird \] Title]]`, `Weird \] Title`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			body, _, ok := scanBracketBody(tc.content, 0)
+			if !ok {
+				t.Fatalf("scanner found no bracket in %q", tc.content)
+			}
+			if body != tc.wantBody {
+				t.Errorf("scanner body = %q, want %q — it disagrees with the grammar about "+
+					"where the body ends", body, tc.wantBody)
+			}
+			ls := ExtractWikiLinks(tc.content)
+			if len(ls) != 1 {
+				t.Fatalf("fixture: parser found %d links in %q, want 1", len(ls), tc.content)
+			}
+			key, _, _ := splitOnUnescapedPipe(body)
+			if got := unescapeWikiBody(key); got != ls[0].Title {
+				t.Errorf("scanner key unescapes to %q, parser read title %q", got, ls[0].Title)
+			}
+		})
+	}
+
+	rng := rand.New(rand.NewSource(20260904))
+	pieces := []string{
+		"[[A]]", `[[A\]]]`, `[[A\|B]]`, `[[A\\]]`, "[[A|B]]", "[[", "]]", "text ",
+		`[[Weird \] Title]]`, "[[tasks/X]]", "é", `\`, "]", "|",
+	}
+
+	for i := 0; i < 4000; i++ {
+		var sb strings.Builder
+		for j := 0; j < 1+rng.Intn(5); j++ {
+			sb.WriteString(pieces[rng.Intn(len(pieces))])
+		}
+		content := sb.String()
+
+		for _, l := range ExtractWikiLinks(content) {
+			body, end, ok := scanBracketBody(content, l.Position)
+			if !ok {
+				t.Fatalf("iteration %d: parser reported a link at %d in %q but the scanner "+
+					"found no bracket there", i, l.Position, content)
+			}
+			// The scanner returns the RAW body; unescaping it must give what the
+			// parser resolved the title/key to.
+			if end > len(content) || end < l.Position {
+				t.Fatalf("iteration %d: scanner returned end=%d out of range for %q", i, end, content)
+			}
+			key, _, _ := splitOnUnescapedPipe(body)
+			if unescapeWikiBody(key) != l.Title && l.Kind == WikiLinkKindTitle {
+				t.Fatalf("iteration %d: content %q at %d — scanner body %q unescapes to key %q, "+
+					"parser read title %q. The scan disagrees with the grammar.",
+					i, content, l.Position, body, unescapeWikiBody(key), l.Title)
+			}
+		}
+	}
+}
+
+// TestBUG2805_AccidentalCompatibilitiesSurvive pins the two rescues Rook's
+// repro identified as non-reproducing directions (TASK-2826 2c and 2d).
+//
+// Both are ACCIDENTS of other code — the legacy full-body-with-pipe fallback
+// and unescapeWikiBody's leniency toward a stray backslash — and both are
+// keyed on the exact bytes an escape-aware emitter changes. A fix that quietly
+// broke them would trade two silent successes for two silent failures.
+func TestBUG2805_AccidentalCompatibilitiesSurvive(t *testing.T) {
+	t.Run("legacy unescaped-pipe content still parses to the full-body title", func(t *testing.T) {
+		// Content a USER already has, written before this fix. Untouched by the
+		// change — the parser side is not modified — and it must still resolve
+		// via the full-body reading.
+		got := ExtractWikiLinks("Ref [[New | Name]] here.")
+		if len(got) != 1 {
+			t.Fatalf("parser found %d links, want 1", len(got))
+		}
+		if got[0].Title != "New " || got[0].Display != " Name" {
+			t.Errorf("split reading changed: title=%q display=%q — the store's full-body "+
+				"fallback keys on exactly these values (wiki_links.go title fallback)",
+				got[0].Title, got[0].Display)
+		}
+	})
+
+	t.Run("escaped-pipe emission resolves without needing the fallback", func(t *testing.T) {
+		// What the fix now EMITS for the same rename. Better than the rescue:
+		// it parses as a single title directly, no fallback required.
+		content := "Ref [[Plain Target]] here."
+		offs := bracketOffsets(content)
+		got, _ := RewriteBracketsAt(content,
+			[]BracketRewrite{{Position: offs[0], TargetTitle: "Plain Target"}},
+			NewTitleEscaper("New | Name", ""))
+		if want := `Ref [[New \| Name]] here.`; got != want {
+			t.Fatalf("emitted %q, want %q", got, want)
+		}
+		links := ExtractWikiLinks(got)
+		if len(links) != 1 || links[0].Title != "New | Name" || links[0].HasDisplay {
+			t.Errorf("emitted link parsed as title=%q display=%v hasDisplay=%v; want the whole "+
+				"thing as one title", links[0].Title, links[0].Display, links[0].HasDisplay)
+		}
+	})
+
+	t.Run("stray backslash leniency preserved end to end", func(t *testing.T) {
+		content := "Go [[BS Target]] now."
+		offs := bracketOffsets(content)
+		got, _ := RewriteBracketsAt(content,
+			[]BracketRewrite{{Position: offs[0], TargetTitle: "BS Target"}},
+			NewTitleEscaper(`Odd \ Name`, ""))
+		links := ExtractWikiLinks(got)
+		if len(links) != 1 {
+			t.Fatalf("emitted %q — parser found %d links, want 1", got, len(links))
+		}
+		if links[0].Title != `Odd \ Name` {
+			t.Errorf("emitted %q parsed to %q, want %q — the bare-backslash title must still "+
+				"round-trip (2d)", got, links[0].Title, `Odd \ Name`)
+		}
+	})
 }

--- a/internal/store/items_rename_escape_test.go
+++ b/internal/store/items_rename_escape_test.go
@@ -1,0 +1,150 @@
+package store
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/links"
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// BUG-2805 end-to-end, through the real rename cascade.
+//
+// The unit tests in internal/links pin the rewriter; these pin that the CASCADE
+// actually carries the fix to stored content and to the index. Both directions
+// were reproduced through the real API on TASK-2826 (Rook) before any fix, with
+// hex receipts; these are the same two shapes as store-level regressions.
+
+// TestCascade_RewritesLinksStoredInEscapedForm is BUG-2805 direction 1.
+//
+// Before: the cascade compared the RAW bracket body against the unescaped
+// title, never matched, and left the visible link naming the OLD title while
+// the `!applied` arm re-parsed and flipped the index row to broken. Content and
+// index disagreed, and the user saw a stale link.
+func TestCascade_RewritesLinksStoredInEscapedForm(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "EscapeRoundTrip")
+	col := createTestCollection(t, s, ws.ID, "Notes")
+
+	target := createTestItem(t, s, ws.ID, col.ID, "Weird ] Title", "the item being renamed")
+	source := createTestItem(t, s, ws.ID, col.ID, "Source A", `See [[Weird \] Title]] for details.`)
+
+	// Precondition: the escaped link indexed and resolved to the target. If it
+	// did not, the cascade would have nothing to carry and this test would pass
+	// for the wrong reason.
+	var resolved int
+	if err := s.db.QueryRow(s.q(`
+		SELECT COUNT(*) FROM item_wiki_links
+		WHERE source_item_id = ? AND target_item_id = ? AND target_kind = 'title'
+	`), source.ID, target.ID).Scan(&resolved); err != nil {
+		t.Fatalf("precondition query: %v", err)
+	}
+	if resolved != 1 {
+		t.Fatalf("precondition: escaped link indexed %d resolved rows, want 1", resolved)
+	}
+
+	newTitle := "Weird Renamed Title"
+	if _, err := s.UpdateItem(target.ID, models.ItemUpdate{Title: &newTitle}); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+
+	got, err := s.GetItem(source.ID)
+	if err != nil {
+		t.Fatalf("re-read source: %v", err)
+	}
+	if strings.Contains(got.Content, `Weird \] Title`) {
+		t.Errorf("source content still carries the OLD escaped title: %q — the cascade left the "+
+			"link stale (BUG-2805 direction 1)", got.Content)
+	}
+	if want := "See [[Weird Renamed Title]] for details."; got.Content != want {
+		t.Errorf("content = %q, want %q", got.Content, want)
+	}
+
+	// And the index followed the content rather than flipping broken.
+	if err := s.db.QueryRow(s.q(`
+		SELECT COUNT(*) FROM item_wiki_links
+		WHERE source_item_id = ? AND target_item_id = ? AND target_kind = 'title'
+	`), source.ID, target.ID).Scan(&resolved); err != nil {
+		t.Fatalf("post query: %v", err)
+	}
+	if resolved != 1 {
+		t.Errorf("index has %d resolved rows after the rename, want 1 — content and index "+
+			"disagree", resolved)
+	}
+}
+
+// TestCascade_EmitsEscapedTitlesAndDoesNotDestroyTheIndex is BUG-2805
+// direction 2a, the data-destroying one.
+//
+// Before: renaming TO a title containing `]` emitted `[[New ] Name]]`, which the
+// grammar cannot parse, so the re-parse found no link and DELETED the index row.
+// The damage was permanent — a later recovery rename had no row left to cascade,
+// so the source content stayed wrong forever. This test pins the emission AND
+// the recovery, because the permanence is the part that made it medium severity.
+func TestCascade_EmitsEscapedTitlesAndDoesNotDestroyTheIndex(t *testing.T) {
+	for _, tc := range []struct{ name, newTitle, wantContent string }{
+		{"closing bracket", "New ] Name", `Ref [[New \] Name]] here.`},
+		{"pipe", "New | Name", `Ref [[New \| Name]] here.`},
+		{"backslash then bracket", `Odd \] Name`, `Ref [[Odd \\\] Name]] here.`},
+		{"bare backslash", `Odd \ Name`, `Ref [[Odd \\ Name]] here.`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := testStore(t)
+			ws := createTestWorkspace(t, s, "EscapeEmit")
+			col := createTestCollection(t, s, ws.ID, "Notes")
+			target := createTestItem(t, s, ws.ID, col.ID, "Plain Target", "the item being renamed")
+			source := createTestItem(t, s, ws.ID, col.ID, "Source B", "Ref [[Plain Target]] here.")
+
+			if _, err := s.UpdateItem(target.ID, models.ItemUpdate{Title: &tc.newTitle}); err != nil {
+				t.Fatalf("rename: %v", err)
+			}
+
+			got, err := s.GetItem(source.ID)
+			if err != nil {
+				t.Fatalf("re-read: %v", err)
+			}
+			if got.Content != tc.wantContent {
+				t.Errorf("content = %q, want %q", got.Content, tc.wantContent)
+			}
+
+			// The emitted bracket must parse back to exactly the new title.
+			parsed := links.ExtractWikiLinks(got.Content)
+			if len(parsed) != 1 {
+				t.Fatalf("emitted content %q parses to %d links, want 1 — an unparseable "+
+					"bracket is what deletes the index row", got.Content, len(parsed))
+			}
+			if parsed[0].Title != tc.newTitle {
+				t.Errorf("emitted content parses to title %q, want %q", parsed[0].Title, tc.newTitle)
+			}
+
+			// The index row survived AND still resolves.
+			var resolved int
+			if err := s.db.QueryRow(s.q(`
+				SELECT COUNT(*) FROM item_wiki_links
+				WHERE source_item_id = ? AND target_item_id = ? AND target_kind = 'title'
+			`), source.ID, target.ID).Scan(&resolved); err != nil {
+				t.Fatalf("index query: %v", err)
+			}
+			if resolved != 1 {
+				t.Fatalf("index has %d resolved rows, want 1 — the row was destroyed, which is "+
+					"the permanent-damage shape", resolved)
+			}
+
+			// PERMANENCE CHECK: a second rename must still find the row and
+			// carry the link. Without it this test would pass on a fix that
+			// merely delayed the destruction by one rename.
+			recovered := "Recovered Name"
+			if _, err := s.UpdateItem(target.ID, models.ItemUpdate{Title: &recovered}); err != nil {
+				t.Fatalf("recovery rename: %v", err)
+			}
+			got2, err := s.GetItem(source.ID)
+			if err != nil {
+				t.Fatalf("re-read after recovery: %v", err)
+			}
+			if want := "Ref [[Recovered Name]] here."; got2.Content != want {
+				t.Errorf("after recovery rename content = %q, want %q — the cascade could not "+
+					"find the link, which is the permanence failure", got2.Content, want)
+			}
+		})
+	}
+}

--- a/internal/store/items_rename_escape_test.go
+++ b/internal/store/items_rename_escape_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"database/sql"
 	"strings"
 	"testing"
 
@@ -146,5 +147,100 @@ func TestCascade_EmitsEscapedTitlesAndDoesNotDestroyTheIndex(t *testing.T) {
 					"find the link, which is the permanence failure", got2.Content, want)
 			}
 		})
+	}
+}
+
+// TestCascade_RenameToEmptyTitleDoesNotDestroyLinks closes a second door onto
+// BUG-2805's data-destruction shape, found while probing the TitleEscaper's
+// zero value rather than by review.
+//
+// `handleUpdateItem` has NO empty-title guard — the "Title is required" check
+// lives only in `handleCreateItem` — and the store tolerates it, mapping an
+// empty slug to "untitled". So a rename to "" reaches the cascade, and the
+// rewriter emitted `[[]]`: not a link under the parser's `+` production, so the
+// re-parse deleted the index row. Measured before the guard: content became
+// `Ref [[]] here.`, parsed to 0 links, 0 index rows. Identical damage to
+// direction 2a, and PRE-EXISTING — escaping does not help, since escape("")
+// is "".
+//
+// The rewriter now refuses rather than emitting an unparseable bracket. The
+// link keeps naming the old title, stays clickable, and a later valid rename
+// can still repair it. The door-level validation gap is filed separately; this
+// pins that the rewriter will not be the instrument of destruction even if that
+// gap is never closed.
+func TestCascade_RenameToEmptyTitleDoesNotDestroyLinks(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "EmptyRenameGuard")
+	col := createTestCollection(t, s, ws.ID, "Notes")
+	target := createTestItem(t, s, ws.ID, col.ID, "Plain Target", "the item being renamed")
+	source := createTestItem(t, s, ws.ID, col.ID, "Src", "Ref [[Plain Target]] here.")
+
+	empty := ""
+	if _, err := s.UpdateItem(target.ID, models.ItemUpdate{Title: &empty}); err != nil {
+		// The store currently ALLOWS this. If a future change starts refusing
+		// it at the store or handler layer that is a fine outcome too — but say
+		// so loudly rather than letting this test silently stop exercising the
+		// path it was written for.
+		t.Skipf("rename to an empty title is now refused by the store (%v) — the door-level "+
+			"gap this test guards against may have been closed; re-read before deleting", err)
+	}
+
+	got, err := s.GetItem(source.ID)
+	if err != nil {
+		t.Fatalf("re-read source: %v", err)
+	}
+	if got.Content != "Ref [[Plain Target]] here." {
+		t.Errorf("content = %q, want the link left intact — emitting an empty bracket destroys "+
+			"the link and its index row", got.Content)
+	}
+	if n := len(links.ExtractWikiLinks(got.Content)); n != 1 {
+		t.Errorf("content parses to %d links, want 1 — the bracket must stay parseable", n)
+	}
+
+	// INDEX STATE IN FULL, not a row count. Codex R2 was right that the first
+	// version of this assertion was blind: it counted rows, so it would have
+	// passed with the row present but target_item_id cleared — a broken
+	// backlink reported as success.
+	//
+	// What SHOULD happen, and does: the row survives with target_item_id NULL.
+	// That is correct rather than damage — the target no longer has any title,
+	// so no title-form link can resolve to it, and a NULL target mirrors exactly
+	// what a renderer would resolve. The index is supposed to track
+	// resolvability. What must NOT happen is the row disappearing, which is what
+	// an unparseable `[[]]` emission caused.
+	var rows int
+	var resolvedTarget sql.NullString
+	if err := s.db.QueryRow(s.q(
+		`SELECT COUNT(*) FROM item_wiki_links WHERE source_item_id = ?`), source.ID).Scan(&rows); err != nil {
+		t.Fatalf("index query: %v", err)
+	}
+	if rows != 1 {
+		t.Fatalf("index has %d rows for the source, want 1 — the row was destroyed", rows)
+	}
+	if err := s.db.QueryRow(s.q(
+		`SELECT target_item_id FROM item_wiki_links WHERE source_item_id = ?`), source.ID).Scan(&resolvedTarget); err != nil {
+		t.Fatalf("target query: %v", err)
+	}
+	if resolvedTarget.Valid {
+		t.Errorf("target_item_id is still set after the target lost its title — the index claims " +
+			"a resolution the renderer cannot reproduce")
+	}
+
+	// RECOVERY, which is the leg that distinguishes "broken but honest" from
+	// "irrecoverable". Codex R2 called this unrecoverable; it is not. Renaming
+	// back re-resolves the row through resolveBrokenTitleLinks, because the
+	// CONTENT was never destroyed — which is precisely what the emission guard
+	// protects.
+	back := "Plain Target"
+	if _, err := s.UpdateItem(target.ID, models.ItemUpdate{Title: &back}); err != nil {
+		t.Fatalf("recovery rename: %v", err)
+	}
+	if err := s.db.QueryRow(s.q(
+		`SELECT target_item_id FROM item_wiki_links WHERE source_item_id = ?`), source.ID).Scan(&resolvedTarget); err != nil {
+		t.Fatalf("target query after recovery: %v", err)
+	}
+	if !resolvedTarget.Valid {
+		t.Errorf("backlink did not recover when the title came back — THAT would make the empty " +
+			"rename irrecoverable, which is the claim this leg exists to test")
 	}
 }

--- a/internal/store/wiki_links.go
+++ b/internal/store/wiki_links.go
@@ -705,6 +705,14 @@ func (s *Store) cascadeTitleRename(tx *sql.Tx, renamedItemID, workspaceID, oldTi
 	// Members of the item.bulk_updated emitted after the loop — only sources
 	// whose content this cascade actually rewrote, not every candidate it
 	// examined.
+	// ONE escaper for the whole cascade (BUG-2805). The rename has one new
+	// title, but the projection and rewrite below run once per SOURCE — and the
+	// scan bound admits a very large number of sources when their titles are
+	// short. Escaping inside those calls would multiply an unbounded new title
+	// by an unbounded source count, which is BUG-2804's R5 defect in a new
+	// costume.
+	esc := links.NewTitleEscaper(newTitle, collSlug)
+
 	var cascaded []string
 	for _, work := range works {
 		// One read per SOURCE, not per link (BUG-2804 M1).
@@ -728,7 +736,7 @@ func (s *Store) cascadeTitleRename(tx *sql.Tx, renamedItemID, workspaceID, oldTi
 		// per-bracket decision and skip rules as the rewrite itself, so a
 		// source whose brackets no longer match is charged only for its read
 		// and never for a rewrite that will not happen.
-		projected, willApply := links.ProjectRewrittenLen(content, work.rewrites, newTitle, collSlug)
+		projected, willApply := links.ProjectRewrittenLen(content, work.rewrites, esc)
 		cost := int64(len(content))
 		if willApply > 0 {
 			cost += int64(projected)
@@ -738,7 +746,7 @@ func (s *Store) cascadeTitleRename(tx *sql.Tx, renamedItemID, workspaceID, oldTi
 			return newItemRenameCascadeTooLargeError(newTitle, processed)
 		}
 
-		newContent, applied := s.buildCascadeBody(content, work.rewrites, newTitle, collSlug)
+		newContent, applied := s.buildCascadeBody(content, work.rewrites, esc)
 		if applied == 0 {
 			// No bracket matched the expected shape at the recorded
 			// positions — possible if a previous content edit shifted
@@ -1633,8 +1641,8 @@ func (s *Store) SetCascadeBuildObserver(fn func(bytes int)) {
 // With the build and the count inside one function, a cap check can only be
 // before this call or after it, and "after" always means the count already
 // happened. There is no third position for the defect to hide in.
-func (s *Store) buildCascadeBody(content string, rewrites []links.BracketRewrite, newTitle, collSlug string) (string, int) {
-	newContent, applied := links.RewriteBracketsAt(content, rewrites, newTitle, collSlug)
+func (s *Store) buildCascadeBody(content string, rewrites []links.BracketRewrite, esc links.TitleEscaper) (string, int) {
+	newContent, applied := links.RewriteBracketsAt(content, rewrites, esc)
 	if s.onItemCascadeBodyBuilt != nil && applied > 0 {
 		s.onItemCascadeBodyBuilt(len(newContent))
 	}


### PR DESCRIPTION
Item titles containing `]`, `|` or `\` did not survive a rename. Fixes BUG-2805.

Reproduced through the real API before any fix (TASK-2826, Rook, with hex receipts), then fixed in both directions plus a third the repro did not name.

## What was wrong

**Direction 1 — matching.** The rewriter compared the RAW bracket body against the unescaped title, so a link stored as `[[Weird \] Title]]` never matched. The link was left naming the OLD title while the reparse flipped its index row to broken — content and index disagreeing, with a working, clickable link silently going stale.

**Direction 2 — emission.** The new title was emitted by plain concatenation. A title containing `]` produced a bracket the grammar cannot parse, so the reparse found no link and **deleted the index row** — permanent damage from an ordinary rename, since a later rename has no row left to cascade over. A title containing `\]` produced valid syntax for a *different* title.

**Third half — the close scan**, not in the filing or the repro. The rewriter found its closing `]]` with `strings.Index`, which is not the grammar: in `[[A\]]]` it stops at the `]` belonging to the `\]` escape. That was latent only while the rewriter never emitted escapes. This fix makes escaped bodies routine, so without it each rename would corrupt what the last one wrote.

## The fix

Matching runs on the **unescaped** body, full-body first and then the split-on-unescaped-pipe form — the same preference order the parser and renderer use, which is what keeps literal-pipe titles like `A|B` working. Emission escapes, byte-for-byte the same rule as the editor's `escapeWikiBody`. `scanBracketBody` implements the parser's body production exactly.

Escaping happens **once per cascade** via a `TitleEscaper`, never per source or per bracket — the allocation discipline BUG-2804 established, since the scan bound admits very many sources when their titles are short.

The rewriter also refuses to emit an **empty** title segment, which produced `[[]]` — not a link, so the reparse deleted the row. Reachable both from a zero-value escaper and from `UpdateItem` accepting a rename to `""`.

## How it is established

The pre-refactor implementation is frozen in the test file as an oracle. It is now **scoped rather than blanket** — still authoritative for bodies with no escape characters, with every deliberate departure listed by name and reason. Instruments:

- a 4000-iteration property that every emitted title parses back to itself;
- a scanner/parser parity property, plus twelve constructed delimiter edges;
- end-to-end cascade tests for both directions, including a **permanence** check, since a fix that merely delayed the index-row destruction by one rename would otherwise pass.

Every guard is mutation-verified, including several mutants that initially survived and forced better instruments.

## Review

Three codex rounds: CLEAN on a generic frame (rejected as insufficient), four findings under rotated framing, CLEAN under blast-radius. Codex ran read-only and executed no tests; the dialect and `-race` gates are the implementer's runs at this SHA.

Four side items filed rather than bundled: BUG-2830 (dedup receipt), BUG-2832 (citation drift), BUG-2833 (empty-title door), BUG-2834 (Go/JS regex host-language divergence).

## Gates

`gofmt` · `go vet ./internal/...` · `go build ./...` clean. `go test ./...` PASS on **SQLite and Postgres**. `go test -race` PASS on `internal/links` and `internal/store`. Zero failures, zero data races.

https://claude.ai/code/session_01L7iUFWjoBY7V59Gu7mvZJq
