### PR TITLE
fix(links): wiki-link grammar parity — Go/JS divergence and slug-prefix retarget (BUG-2830, BUG-2834, BUG-2832)

### DIFF
--- a/internal/links/extract.go
+++ b/internal/links/extract.go
@@ -77,7 +77,7 @@ type WikiLinkRef struct {
 	// before the first unescaped pipe, or the whole body if no
 	// pipe). Populated for `WikiLinkKindRef` so the ref→title
 	// fallback in the store layer can mirror the renderer's
-	// untrimmed title lookup at web/src/lib/utils/markdown.ts:541-543
+	// untrimmed title lookup at web/src/lib/utils/markdown.ts::resolveWikiBody
 	// — an item literally titled `" TASK-5 "` (with surrounding
 	// whitespace) resolves via the renderer's untrimmed key but
 	// would miss a canonical-trimmed `"TASK-5"` lookup. Codex
@@ -100,28 +100,47 @@ type WikiLinkRef struct {
 var refPattern = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9]*-\d+$`)
 
 // wikiLinkPattern matches `[[...]]` while allowing the body to
-// contain escaped chars (`\]`, `\|`, `\\`). Mirrors the editor's
-// `wikiLinksToMarkdown` grammar in web/src/lib/utils/markdown.ts:461
-// (`(?:\\.|[^\]\\])+`), so any link the editor saves can be indexed
-// — even if its display text contains a literal `]` or `|`.
+// contain escaped chars (`\]`, `\|`, `\\`). It is the SERVER half of a
+// grammar the web client also implements, as
+// `markdown.ts::WIKI_LINK_PATTERN_SOURCE`, so any link the editor saves
+// can be indexed — even if its display text contains a literal `]`
+// or `|`.
+//
+// ## The two halves are pinned by a shared corpus, not by looking alike
+//
+// testdata/wiki_grammar_corpus.json carries the expectations; this side
+// is asserted against it by grammar_parity_test.go and the client side
+// by markdown.grammarParity.test.ts. Read that corpus before changing
+// this pattern — and add cases THERE, not to one language's test.
+//
+// The corpus exists because "the two regexes are byte-identical source
+// text" turned out not to mean "the two grammars agree" (BUG-2834). The
+// escape alternative was spelled `\\.` on both sides, and `.` is not the
+// same character class in the two languages: Go's RE2 excludes only LF,
+// while ECMAScript also excludes CR, U+2028 and U+2029. So a body with a
+// backslash immediately before one of those three was indexed here and
+// NOT rendered there — the backlink panel claimed a link the document
+// refused to draw. The client now spells the class `[^\n]` explicitly to
+// match RE2, which is why the two patterns no longer read identically:
+// they agree by construction instead. Nothing changed on this side.
+//
+// LF remains excluded on both sides, and scanBracketBody in links.go
+// depends on that; it is not part of the BUG-2834 divergence.
 //
 // CORRECTED 2026-08-31 (BUG-2805): this comment used to say that
-// renderMarkdown at markdown.ts:300 uses a simpler regex (`[^\]]+`)
-// and therefore REJECTS escaped bodies, making escaped links an
-// index-only citizen that never renders. That is no longer true, and
-// the citation had gone stale — markdown.ts:300 is inside a doc
-// comment now, and BOTH wiki-link regexes in that file
-// (renderMarkdown at :326 and wikiLinksToMarkdown at :625) use this
-// exact escape-aware production. The renderer comment at :323-325
-// names BUG-1744 as the change that aligned them.
+// renderMarkdown used a simpler regex (`[^\]]+`) and therefore REJECTED
+// escaped bodies, making escaped links an index-only citizen that never
+// renders. That was false — BUG-1744 had already aligned both client
+// regexes on this exact escape-aware production. Escaped links DO render
+// as clickable. The stale claim survived long enough to be quoted into a
+// bug repro (TASK-2826) as a live constraint, where it understated
+// BUG-2805: the link a rename left stale was a WORKING, clickable link,
+// not an invisible artifact.
 //
-// So the grammars agree across server and client, and escaped links
-// DO render as clickable. Verified by reading both regexes, not by
-// re-citing this comment — which is how the stale version survived
-// long enough to be quoted into a bug repro (TASK-2826) as a live
-// constraint. It matters for BUG-2805 in the direction that makes the
-// bug worse: the stale link that rename left behind was a WORKING,
-// clickable link, not an invisible one.
+// That is also why the citations here name SYMBOLS rather than line
+// numbers (BUG-2832). Nothing checks a cross-language line citation —
+// no compiler, no test, no linter — and seven of them across four files
+// had silently drifted onto unrelated code by the time anyone looked.
 //
 // Original rationale, still accurate: matching the permissive grammar
 // here keeps the index consistent with what the editor saves. Codex
@@ -529,7 +548,7 @@ func parseBody(body string) *WikiLinkRef {
 	// Split on the FIRST UNESCAPED `|`. `\|` is part of the key or
 	// display text (depending on which side of the split it's on)
 	// and must NOT cleave the body. Mirrors splitWikiBody at
-	// markdown.ts:664. The display side is preserved verbatim
+	// markdown.ts::splitWikiBody. The display side is preserved verbatim
 	// (post-unescape) — the renderer doesn't trim it, and the
 	// WikiLinkRef.Display doc comment promises verbatim storage.
 	// Trimming would silently differ from client behavior on
@@ -546,7 +565,7 @@ func parseBody(body string) *WikiLinkRef {
 	// fallthrough so the index mirrors the renderer's whitespace-
 	// sensitive title resolution: the renderer compares items.title
 	// against `key` directly with no implicit trim
-	// (web/src/lib/utils/markdown.ts:541-543). If we trimmed here,
+	// (web/src/lib/utils/markdown.ts::resolveWikiBody). If we trimmed here,
 	// `[[ Foo ]]` would index a backlink to item "Foo" that the UI
 	// renders as broken, creating ghost entries in the backlinks
 	// panel. Codex round 9 P2.
@@ -623,7 +642,7 @@ func isWorkspaceSlug(s string) bool {
 
 // splitOnUnescapedPipe scans `body` for the first `|` that isn't
 // preceded by an unescaped `\`, splitting the body into (key,
-// display, found). Mirrors splitWikiBody at markdown.ts:664. A `\`
+// display, found). Mirrors splitWikiBody at markdown.ts::splitWikiBody. A `\`
 // always consumes the following byte (even if it's not a recognized
 // escape) so the algorithm can't get desynced by stray backslashes.
 func splitOnUnescapedPipe(body string) (key, suffix string, found bool) {
@@ -644,7 +663,7 @@ func splitOnUnescapedPipe(body string) (key, suffix string, found bool) {
 // unescapeWikiBody undoes the editor's body-escape sequences:
 // `\]` → `]`, `\|` → `|`, `\\` → `\`. Other backslash sequences are
 // left as-is (the renderer does the same — see unescapeWikiBody at
-// markdown.ts:657). Idempotent on already-unescaped strings.
+// markdown.ts::unescapeWikiBody). Idempotent on already-unescaped strings.
 func unescapeWikiBody(s string) string {
 	if !strings.ContainsRune(s, '\\') {
 		return s

--- a/internal/links/extract_test.go
+++ b/internal/links/extract_test.go
@@ -137,7 +137,7 @@ func TestExtractWikiLinks_TitleForms(t *testing.T) {
 
 // TestExtractWikiLinks_TitlePreservesWhitespace regresses Codex
 // round 9 P2 against PR #621. The renderer doesn't trim before
-// title matching (web/src/lib/utils/markdown.ts:541-543), so an
+// title matching (web/src/lib/utils/markdown.ts::resolveWikiBody), so an
 // item titled "Foo" doesn't match `[[ Foo ]]`. The extractor must
 // preserve whitespace in the title kind too, or the index would
 // surface backlinks the UI can't actually click on. Ref/workspace_ref
@@ -658,7 +658,7 @@ func TestExtractWikiLinks_RefVsTitleFallback(t *testing.T) {
 
 // TestExtractWikiLinks_EscapedBodyChars regresses Codex rounds
 // 4/7/10 P2: the editor's wikiLinksToMarkdown can produce bodies
-// containing `\]`, `\|`, `\\` escapes (markdown.ts:461). The
+// containing `\]`, `\|`, `\\` escapes (markdown.ts::WIKI_LINK_PATTERN_SOURCE). The
 // extractor must parse those — both the regex and the body parser —
 // so the resulting link is indexed with the unescaped display text.
 func TestExtractWikiLinks_EscapedBodyChars(t *testing.T) {
@@ -769,7 +769,7 @@ func TestExtractWikiLinks_EscapedBodyChars(t *testing.T) {
 
 // TestSplitOnUnescapedPipe / TestUnescapeWikiBody — direct unit
 // tests for the helpers. Round-trip safety against the editor's
-// serializer (escapeWikiBody/unescapeWikiBody in markdown.ts:652-658)
+// serializer (escapeWikiBody/unescapeWikiBody in markdown.ts::escapeWikiBody / ::unescapeWikiBody)
 // is the property we care about.
 func TestSplitOnUnescapedPipe(t *testing.T) {
 	cases := []struct {

--- a/internal/links/grammar_parity_test.go
+++ b/internal/links/grammar_parity_test.go
@@ -1,0 +1,114 @@
+package links
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The Go half of the cross-language wiki-link grammar harness (BUG-2834).
+//
+// The JS half is web/src/lib/utils/markdown.grammarParity.test.ts. Both read
+// the SAME corpus and assert against the expectations recorded IN it, so
+// neither language's current behaviour is what the other is measured against.
+// That indirection is the whole point: the two patterns are byte-identical
+// source text, so a reviewer comparing them concludes they agree, and BUG-2834
+// lived entirely in the host languages' disagreement about what `.` means.
+// Comparing implementation to implementation would have reproduced the same
+// blind spot in test form.
+//
+// If you add a case, add it to the corpus — not to one language's test.
+
+const grammarCorpusRelPath = "../../testdata/wiki_grammar_corpus.json"
+
+type grammarExpect struct {
+	Match bool   `json:"match"`
+	Body  string `json:"body"`
+}
+
+type grammarCase struct {
+	Name    string        `json:"name"`
+	Why     string        `json:"why"`
+	Content string        `json:"content"`
+	Expect  grammarExpect `json:"expect"`
+}
+
+type grammarCorpus struct {
+	Cases []grammarCase `json:"cases"`
+}
+
+func loadGrammarCorpus(t *testing.T) grammarCorpus {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Clean(grammarCorpusRelPath))
+	if err != nil {
+		t.Fatalf("read shared grammar corpus: %v", err)
+	}
+	var corpus grammarCorpus
+	if err := json.Unmarshal(raw, &corpus); err != nil {
+		t.Fatalf("parse shared grammar corpus: %v", err)
+	}
+	// An empty or unparsed corpus would make every assertion below vacuous and
+	// the suite would report PASS having measured nothing. The count is asserted
+	// rather than assumed for the same reason the corpus carries its own
+	// expectations: a harness that cannot fail is not an instrument.
+	if len(corpus.Cases) < 20 {
+		t.Fatalf("shared grammar corpus looks truncated: %d cases (expected >= 20)", len(corpus.Cases))
+	}
+	return corpus
+}
+
+// TestWikiLinkGrammarMatchesSharedCorpus drives the REAL wikiLinkPattern — not
+// a copy of its source text — over the shared corpus.
+func TestWikiLinkGrammarMatchesSharedCorpus(t *testing.T) {
+	t.Parallel()
+	corpus := loadGrammarCorpus(t)
+
+	for _, tc := range corpus.Cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+			m := wikiLinkPattern.FindStringSubmatch(tc.Content)
+
+			if !tc.Expect.Match {
+				if m != nil {
+					t.Fatalf("expected NO match but Go matched, body=%s\ncontent=%s\nwhy this case exists: %s",
+						quoteCodePoints(m[1]), quoteCodePoints(tc.Content), tc.Why)
+				}
+				return
+			}
+			if m == nil {
+				t.Fatalf("expected a match, Go found none\ncontent=%s\nwhy this case exists: %s",
+					quoteCodePoints(tc.Content), tc.Why)
+			}
+			if m[1] != tc.Expect.Body {
+				t.Fatalf("captured body mismatch\n got: %s\nwant: %s\ncontent=%s\nwhy this case exists: %s",
+					quoteCodePoints(m[1]), quoteCodePoints(tc.Expect.Body),
+					quoteCodePoints(tc.Content), tc.Why)
+			}
+		})
+	}
+}
+
+// quoteCodePoints renders a string with every non-printable rune as \uXXXX.
+//
+// %q alone is not enough here: this corpus is ENTIRELY about characters that
+// are invisible or that terminate a line in a terminal, and a failure message
+// that prints a raw U+2028 is a failure message that lies about what it
+// compared. The bug being tested is itself a case of an invisible character
+// being mistaken for something else.
+func quoteCodePoints(s string) string {
+	var b strings.Builder
+	b.Grow(len(s) + 8)
+	b.WriteByte('"')
+	for _, r := range s {
+		if r < 0x20 || r == 0x7f || r == 0x85 || r == 0x2028 || r == 0x2029 {
+			fmt.Fprintf(&b, `\u%04X`, r)
+			continue
+		}
+		b.WriteRune(r)
+	}
+	b.WriteByte('"')
+	return b.String()
+}

--- a/internal/links/links.go
+++ b/internal/links/links.go
@@ -40,7 +40,7 @@ func ReplaceTitle(content, oldTitle, newTitle string) string {
 //
 // Known limitation: titles containing the wiki-link escape characters
 // (`]`, `|`, `\`) get stored in source content as `\]`, `\|`, `\\`,
-// which the editor's grammar at web/src/lib/utils/markdown.ts:461
+// which the editor's grammar at web/src/lib/utils/markdown.ts::WIKI_LINK_PATTERN_SOURCE
 // supports. This rewriter does NOT attempt escape-aware matching on
 // the TITLE segment — a title literally containing `]` would be
 // stored escaped and would fail to match the regex's `oldTitle`
@@ -59,7 +59,7 @@ func RewriteWikiTitle(content, oldTitle, newTitle, collSlug string) string {
 	//   3: optional `|display` suffix including the pipe (or empty)
 	//
 	// The display segment uses the same `(?:\\.|[^\]\\])*` grammar as
-	// the editor (markdown.ts:461) so an alias with escaped `]`/`|`
+	// the editor (markdown.ts::WIKI_LINK_PATTERN_SOURCE) so an alias with escaped `]`/`|`
 	// inside doesn't end the match early. Inline `(?i:...)` scopes
 	// the case-insensitivity to the title segment only — the slug
 	// portion compares against c.slug which is canonically lowercase,
@@ -119,9 +119,15 @@ func RewriteWikiTitle(content, oldTitle, newTitle, collSlug string) string {
 // sibling, which compare against the pre-refactor code frozen as an oracle —
 // comparing this function to RewriteBracketsAt-of-one would be vacuous, since
 // that is now its definition. BUG-2804.
-func RewriteBracketAt(content string, position int, targetTitle, newTitle, collSlug string) string {
+// oldTitle is the renamed item's title before the rename. It is separate from
+// targetTitle — which is what the INDEX ROW recorded for this bracket — because
+// the two differ for a collection-qualified reference: a `[[tasks/Setup]]` row
+// pointing at an item titled `Setup` stores targetTitle `tasks/Setup` and has
+// oldTitle `Setup`. Only their relationship says whether the rewritten bracket
+// keeps a `<slug>/` prefix; see TitleEscaper.qualifiedFor (BUG-2830).
+func RewriteBracketAt(content string, position int, targetTitle, oldTitle, newTitle, collSlug string) string {
 	out, _ := RewriteBracketsAt(content, []BracketRewrite{{Position: position, TargetTitle: targetTitle}},
-		NewTitleEscaper(newTitle, collSlug))
+		NewTitleEscaper(oldTitle, newTitle, collSlug))
 	return out
 }
 
@@ -199,7 +205,7 @@ func RewriteBracketsAt(content string, rewrites []BracketRewrite, esc TitleEscap
 			// Overlaps a rewrite already applied (or a duplicate offset).
 			continue
 		}
-		qualified, displaySuffix, bracketEnd, ok := bracketRewriteAt(content, rw.Position, rw.TargetTitle, esc.collSlugForMatch())
+		qualified, displaySuffix, bracketEnd, ok := bracketRewriteAt(content, rw.Position, rw.TargetTitle, esc)
 		if !ok {
 			continue
 		}
@@ -272,7 +278,7 @@ func ProjectRewrittenLen(content string, rewrites []BracketRewrite, esc TitleEsc
 		if rw.Position < cursor {
 			continue
 		}
-		qualified, displaySuffix, bracketEnd, ok := bracketRewriteAt(content, rw.Position, rw.TargetTitle, esc.collSlugForMatch())
+		qualified, displaySuffix, bracketEnd, ok := bracketRewriteAt(content, rw.Position, rw.TargetTitle, esc)
 		if !ok {
 			continue
 		}
@@ -310,7 +316,7 @@ func ProjectRewrittenLen(content string, rewrites []BracketRewrite, esc TitleEsc
 // parser reads back exactly the title that went in.
 //
 // Byte-for-byte the same rule as the editor's escapeWikiBody
-// (web/src/lib/utils/markdown.ts:748): backslash first, then `]` and `|`.
+// (web/src/lib/utils/markdown.ts::escapeWikiBody): backslash first, then `]` and `|`.
 // Doing backslash first is what keeps it the exact inverse of
 // unescapeWikiBody — escaping `]` first would leave the introduced backslashes
 // to be escaped again.
@@ -367,6 +373,12 @@ type TitleEscaper struct {
 	escSlug  string
 	// rawSlug is the UNESCAPED slug; matching compares unescaped values.
 	rawSlug string
+	// rawOldTitle is the renamed item's title BEFORE the rename, unescaped.
+	//
+	// It is what distinguishes a bracket that was collection-qualified from one
+	// whose literal title merely looks qualified — see qualifiedFor (BUG-2830).
+	// Per-cascade like everything else here: one rename, one old title.
+	rawOldTitle string
 	// Lengths are carried separately so the projection path can measure
 	// without touching the strings at all.
 	titleLen int
@@ -374,14 +386,103 @@ type TitleEscaper struct {
 }
 
 // NewTitleEscaper precomputes the escaped forms for one rename.
-func NewTitleEscaper(newTitle, collSlug string) TitleEscaper {
+//
+// oldTitle is REQUIRED, not optional, and that is deliberate: it is the only
+// thing that can tell a qualified reference from a literal slash-bearing title
+// (BUG-2830), and a caller that forgets it would silently get the old, wrong
+// behaviour back. Making it a parameter puts that in the compiler's hands.
+func NewTitleEscaper(oldTitle, newTitle, collSlug string) TitleEscaper {
 	return TitleEscaper{
-		escTitle: escapeWikiBody(newTitle),
-		escSlug:  escapeWikiBody(collSlug),
-		rawSlug:  collSlug,
-		titleLen: escapedWikiBodyLen(newTitle),
-		slugLen:  escapedWikiBodyLen(collSlug),
+		escTitle:    escapeWikiBody(newTitle),
+		escSlug:     escapeWikiBody(collSlug),
+		rawSlug:     collSlug,
+		rawOldTitle: oldTitle,
+		titleLen:    escapedWikiBodyLen(newTitle),
+		slugLen:     escapedWikiBodyLen(collSlug),
 	}
+}
+
+// qualifiedFor decides whether the bracket that stored `targetTitle` carried a
+// `<collSlug>/` prefix that must be re-emitted after the rename.
+//
+// ## Why this is a comparison and not a prefix test (BUG-2830)
+//
+// The previous rule was "targetTitle starts with collSlug + `/`". That cannot
+// distinguish two situations whose stored rows are BYTE-IDENTICAL:
+//
+//	A) an item literally titled `tasks/Setup`, in collection `tasks`, linked as
+//	   [[tasks/Setup]] and resolved by stage 1 (exact title match);
+//	B) an item titled `Setup`, in collection `tasks`, linked as [[tasks/Setup]]
+//	   and resolved by stage-2 qualified fallback, which stores target_title as
+//	   the FULL body — also `tasks/Setup`.
+//
+// Both rows read `target_title = "tasks/Setup"`, `collSlug = "tasks"`. Renaming
+// to `Renamed`, (A) must become [[Renamed]] and (B) must become
+// [[tasks/Renamed]]. The prefix test answered (B) for both, so a rename of (A)
+// silently rewrote a literal-title reference into a qualified one — a different
+// kind of reference than the author wrote, resolved by a different rule.
+//
+// What that costs depends on what else the workspace holds, and both cases are
+// measured in internal/store:
+//
+//   - With an item LITERALLY titled `tasks/Renamed` (slash included), the link
+//     is STOLEN outright. resolveTitleTx tries an exact full-title match before
+//     the qualified fallback, so that item wins and the renamed item loses its
+//     backlink — a silent retarget, pinned by
+//     TestItemRename_LiteralSlashTitleRetargetsOntoALiteralSlashSibling.
+//   - With no such item, the emitted bracket still finds the renamed item,
+//     because collSlug is that item's own collection and it now carries the new
+//     title. The cost there is that resolution becomes ambiguous wherever a
+//     same-titled sibling exists, and that a later collection move breaks
+//     `[[tasks/X]]` where `[[X]]` would have followed the item.
+//
+// Stated as two cases because I got it wrong as one, twice: first asserting the
+// steal with a decoy that could not be stolen, then over-correcting to "the
+// renamed item always wins". The stage order in resolveTitleTx is what settles
+// it, and it had to be read rather than remembered.
+//
+// The old title is the discriminator, and it is exact in both directions:
+//
+//	targetTitle == oldTitle                  -> literal  (case A)
+//	targetTitle == collSlug + "/" + oldTitle  -> qualified (case B)
+//
+// Case A wins when both could apply (oldTitle is itself `tasks/Setup` in
+// collection `tasks`), and that is the correct precedence, not a tiebreak of
+// convenience: the renderer's stage 1 beats stage 2, so a row pointing at this
+// item resolved literally. resolveBrokenTitleLinks in internal/store makes the
+// same stage-1-over-stage-2 ruling for the same reason — the discriminator
+// already existed in the codebase and was simply discarded before reaching the
+// rewriter.
+//
+// Anything else is index drift: the row's target_title corresponds to neither
+// form of this item's old title. We report NO match rather than guessing, which
+// routes the bracket to the existing leave-it-alone path so the trailing
+// replaceWikiLinks reconciles the index.
+func (e TitleEscaper) qualifiedFor(targetTitle string) (qualified, ok bool) {
+	if strings.EqualFold(targetTitle, e.rawOldTitle) {
+		return false, true
+	}
+	// NO byte-length precondition on the title comparison. strings.EqualFold is
+	// Unicode simple case folding, and case-equivalent strings can differ in
+	// byte length — EqualFold("K", "K") (KELVIN SIGN) is true at 1 byte vs
+	// 3. A length check in front of it is therefore not a cheap pre-filter but
+	// a strictly narrower predicate, and it made a qualified bracket whose title
+	// folds across lengths read as index drift, leaving the link stale through
+	// the rename (codex R1 P2).
+	//
+	// The slug boundary is still located by BYTE offset, and that one is sound:
+	// collection slugs are ASCII-lowercase by construction (store.slugify), so
+	// no case fold can change their length. The comparison against rawSlug stays
+	// EqualFold anyway, because target_title preserves the case the author
+	// typed.
+	if e.rawSlug != "" &&
+		len(targetTitle) > len(e.rawSlug) &&
+		targetTitle[len(e.rawSlug)] == '/' &&
+		strings.EqualFold(targetTitle[:len(e.rawSlug)], e.rawSlug) &&
+		strings.EqualFold(targetTitle[len(e.rawSlug)+1:], e.rawOldTitle) {
+		return true, true
+	}
+	return false, false
 }
 
 // scanBracketBody finds the body of the wiki-link bracket starting at
@@ -448,11 +549,6 @@ func (e TitleEscaper) segmentLen(qualified bool) int {
 	return e.titleLen
 }
 
-// collSlugForMatch returns the RAW slug the matcher compares target_title
-// against. Matching works on unescaped values, so the escaped form must not
-// leak into it.
-func (e TitleEscaper) collSlugForMatch() string { return e.rawSlug }
-
 // bracketUnchanged reports whether rewriting the bracket at [position,
 // bracketEnd) would reproduce it byte-for-byte.
 //
@@ -487,7 +583,7 @@ func bracketUnchanged(content string, position, bracketEnd int, qualified bool, 
 //
 // It reads only content[position:bracketEnd] — that locality is what makes a
 // single pass possible, since the rest of the body is pure carry.
-func bracketRewriteAt(content string, position int, targetTitle, collSlug string) (qualified bool, displaySuffix string, bracketEnd int, ok bool) {
+func bracketRewriteAt(content string, position int, targetTitle string, esc TitleEscaper) (qualified bool, displaySuffix string, bracketEnd int, ok bool) {
 	if position < 0 || position+2 > len(content) {
 		return false, "", 0, false
 	}
@@ -531,15 +627,18 @@ func bracketRewriteAt(content string, position int, targetTitle, collSlug string
 	}
 
 	// Only now, on a confirmed match: does the `<collSlug>/` prefix carry over?
-	// A qualified body like `[[tasks/Old Title]]` becomes `[[tasks/New Title]]`
-	// — the cascade SELECT already proved this row points at the renamed item
-	// via stage-2 qualified-fallback resolution, so the slug is guaranteed to
-	// match collSlug. Reported as a flag; the caller writes the escaped slug
-	// and "/" directly rather than receiving them spliced onto the title.
-	if collSlug != "" && len(targetTitle) > len(collSlug) &&
-		targetTitle[len(collSlug)] == '/' &&
-		strings.EqualFold(targetTitle[:len(collSlug)], collSlug) {
-		qualified = true
+	// A qualified body like `[[tasks/Old Title]]` becomes `[[tasks/New Title]]`,
+	// while an item whose LITERAL title is `tasks/Old Title` must not acquire a
+	// prefix it never had. Those two cases are indistinguishable from
+	// targetTitle alone — see qualifiedFor, which decides it against the old
+	// title instead (BUG-2830). Reported as a flag; the caller writes the
+	// escaped slug and "/" directly rather than receiving them spliced onto the
+	// title.
+	qualified, decided := esc.qualifiedFor(targetTitle)
+	if !decided {
+		// Index drift: this row's target_title is neither form of the old
+		// title. Leave the bracket alone rather than emit a guess.
+		return false, "", 0, false
 	}
 	return qualified, displaySuffix, bracketEnd, true
 }

--- a/internal/links/links_test.go
+++ b/internal/links/links_test.go
@@ -15,7 +15,8 @@ func TestRewriteBracketAt(t *testing.T) {
 		name     string
 		content  string
 		bracket  string // for position lookup via strings.Index
-		target   string
+		target   string // what the INDEX ROW recorded for this bracket
+		old      string // the renamed item's title BEFORE the rename
 		newTitle string
 		slug     string
 		want     string
@@ -25,6 +26,7 @@ func TestRewriteBracketAt(t *testing.T) {
 			content:  "prose [[Old Title]] more",
 			bracket:  "[[Old Title]]",
 			target:   "Old Title",
+			old:      "Old Title",
 			newTitle: "New Title",
 			slug:     "tasks",
 			want:     "prose [[New Title]] more",
@@ -34,6 +36,7 @@ func TestRewriteBracketAt(t *testing.T) {
 			content:  "prose [[Old Title|see this]] more",
 			bracket:  "[[Old Title|see this]]",
 			target:   "Old Title",
+			old:      "Old Title",
 			newTitle: "New Title",
 			slug:     "tasks",
 			want:     "prose [[New Title|see this]] more",
@@ -43,6 +46,7 @@ func TestRewriteBracketAt(t *testing.T) {
 			content:  "see [[tasks/Old Title]] here",
 			bracket:  "[[tasks/Old Title]]",
 			target:   "tasks/Old Title",
+			old:      "Old Title",
 			newTitle: "New Title",
 			slug:     "tasks",
 			want:     "see [[tasks/New Title]] here",
@@ -52,6 +56,7 @@ func TestRewriteBracketAt(t *testing.T) {
 			content:  "see [[tasks/Old Title|qual]] here",
 			bracket:  "[[tasks/Old Title|qual]]",
 			target:   "tasks/Old Title",
+			old:      "Old Title",
 			newTitle: "New Title",
 			slug:     "tasks",
 			want:     "see [[tasks/New Title|qual]] here",
@@ -61,6 +66,7 @@ func TestRewriteBracketAt(t *testing.T) {
 			content:  "see [[old title]] here",
 			bracket:  "[[old title]]",
 			target:   "old title",
+			old:      "Old Title",
 			newTitle: "New Title",
 			slug:     "tasks",
 			want:     "see [[New Title]] here",
@@ -70,6 +76,7 @@ func TestRewriteBracketAt(t *testing.T) {
 			content:  "see [[Something Else]] here",
 			bracket:  "[[Something Else]]",
 			target:   "Old Title",
+			old:      "Old Title",
 			newTitle: "New Title",
 			slug:     "tasks",
 			want:     "see [[Something Else]] here",
@@ -79,16 +86,76 @@ func TestRewriteBracketAt(t *testing.T) {
 			content:  "see [[Old Title|alias]] here",
 			bracket:  "[[Old Title|alias]]",
 			target:   "Old Title|alias", // row stored target_title=full body
+			old:      "Old Title|alias",
 			newTitle: "New Title",
 			slug:     "tasks",
 			// Renaming the item titled "Old Title|alias" → whole body becomes "New Title".
 			want: "see [[New Title]] here",
 		},
 		{
+			// BUG-2830, case A. The item's LITERAL title is "tasks/Setup" and it
+			// lives in collection "tasks", so a `[[tasks/Setup]]` bracket resolved
+			// to it by stage-1 exact-title match — it was never a qualified
+			// reference. Re-emitting a `tasks/` prefix would produce a bracket
+			// resolved by a different rule than the exact-title match the author
+			// actually wrote. Where an item literally titled `tasks/Renamed`
+			// exists, that item takes the link outright; otherwise resolution
+			// merely becomes ambiguous. Both measured in internal/store's
+			// items_rename_slug_prefix_test.go.
+			name:     "literal slash-bearing title does not acquire a slug prefix",
+			content:  "see [[tasks/Setup]] here",
+			bracket:  "[[tasks/Setup]]",
+			target:   "tasks/Setup",
+			old:      "tasks/Setup",
+			newTitle: "Renamed",
+			slug:     "tasks",
+			want:     "see [[Renamed]] here",
+		},
+		{
+			// BUG-2830, case B — the TWIN, and the reason the fix is a
+			// comparison rather than a prefix test. Content, bracket, target and
+			// slug are BYTE-IDENTICAL to case A above. Only `old` differs, and
+			// the correct answers differ with it: here the item is titled
+			// "Setup", the bracket really was collection-qualified, and the
+			// prefix must survive the rename.
+			//
+			// Keep these two adjacent. Either one alone can be satisfied by a
+			// constant, and a fix that passed A while breaking B would be a
+			// regression wearing a fix's clothes.
+			name:     "genuinely qualified bracket keeps its slug prefix",
+			content:  "see [[tasks/Setup]] here",
+			bracket:  "[[tasks/Setup]]",
+			target:   "tasks/Setup",
+			old:      "Setup",
+			newTitle: "Renamed",
+			slug:     "tasks",
+			want:     "see [[tasks/Renamed]] here",
+		},
+		{
+			// BUG-2830, codex R1 P2. `strings.EqualFold` is UNICODE simple case
+			// folding, and case-equivalent strings can differ in BYTE LENGTH:
+			// EqualFold("K", "\u212A") — KELVIN SIGN — is true at 1 byte vs 3.
+			//
+			// So a byte-length precondition in front of EqualFold is not a cheap
+			// pre-filter, it is a narrower predicate. Here the item is titled
+			// "K" and the stored qualified body is "tasks/<KELVIN>"; a length
+			// check rejects the pair, the bracket is treated as index drift, and
+			// the rename silently leaves a stale qualified link behind.
+			name:     "qualified match survives a case fold that changes byte length",
+			content:  "see [[tasks/\u212A]] here",
+			bracket:  "[[tasks/\u212A]]",
+			target:   "tasks/\u212A",
+			old:      "K",
+			newTitle: "Renamed",
+			slug:     "tasks",
+			want:     "see [[tasks/Renamed]] here",
+		},
+		{
 			name:     "split-key row preserves pipe-suffix",
 			content:  "see [[Old Title|alias]] here",
 			bracket:  "[[Old Title|alias]]",
 			target:   "Old Title", // row stored target_title=split key, display preserved
+			old:      "Old Title",
 			newTitle: "New Title",
 			slug:     "tasks",
 			// Renaming "Old Title" rewrites the title segment, preserves |alias.
@@ -101,7 +168,7 @@ func TestRewriteBracketAt(t *testing.T) {
 			if pos < 0 {
 				t.Fatalf("bracket %q not found in content %q", c.bracket, c.content)
 			}
-			got := RewriteBracketAt(c.content, pos, c.target, c.newTitle, c.slug)
+			got := RewriteBracketAt(c.content, pos, c.target, c.old, c.newTitle, c.slug)
 			if got != c.want {
 				t.Errorf("RewriteBracketAt: got %q, want %q", got, c.want)
 			}
@@ -109,17 +176,46 @@ func TestRewriteBracketAt(t *testing.T) {
 	}
 }
 
+// TestRewriteBracketAt_RefusesIndexDrift covers the branch BUG-2830 introduced:
+// a row whose target_title is NEITHER the old title nor its `<slug>/` qualified
+// form.
+//
+// Every row the cascade selects points at the one item being renamed, so its
+// target_title can only be that item's old title (in any case) or the qualified
+// form. Anything else is index drift — the row and the item disagree about what
+// the item is called. The rewriter leaves the bracket alone and lets the
+// caller's trailing replaceWikiLinks re-parse reconcile the index, which is the
+// same conservative posture the body-mismatch path has always had.
+//
+// This test exists because a mutation exposed the branch as unreachable by the
+// rest of the suite: reverting qualifiedFor's `false, false` to `false, true`
+// left every other test green. The mixed-changed-and-unchanged test could not
+// see it either — there the drifted bracket happens to be byte-identical
+// afterwards, so refusing and matching produce the same output. This fixture
+// makes the two answers differ.
+func TestRewriteBracketAt_RefusesIndexDrift(t *testing.T) {
+	const content = "see [[Other]] here"
+	// The row says this bracket points at the renamed item and records
+	// target_title "Other"; the item's old title is "Old". Both cannot be true.
+	got := RewriteBracketAt(content, 4, "Other", "Old", "New", "")
+	if got != content {
+		t.Errorf("drifted row rewrote the bracket: got %q, want it left alone (%q).\n"+
+			"Matching on target_title alone would emit [[New]] here, silently "+
+			"acting on a row whose recorded title is not the renamed item's.", got, content)
+	}
+}
+
 // TestRewriteBracketAt_OutOfBoundsNoop covers the defensive guards:
 // invalid position returns content unchanged.
 func TestRewriteBracketAt_OutOfBoundsNoop(t *testing.T) {
 	content := "see [[Old]] here"
-	if got := RewriteBracketAt(content, -1, "Old", "New", ""); got != content {
+	if got := RewriteBracketAt(content, -1, "Old", "Old", "New", ""); got != content {
 		t.Errorf("negative position: got %q, want unchanged", got)
 	}
-	if got := RewriteBracketAt(content, len(content)+10, "Old", "New", ""); got != content {
+	if got := RewriteBracketAt(content, len(content)+10, "Old", "Old", "New", ""); got != content {
 		t.Errorf("past-EOF position: got %q, want unchanged", got)
 	}
-	if got := RewriteBracketAt(content, 0, "Old", "New", ""); got != content {
+	if got := RewriteBracketAt(content, 0, "Old", "Old", "New", ""); got != content {
 		t.Errorf("position not at `[[`: got %q, want unchanged", got)
 	}
 }
@@ -127,7 +223,7 @@ func TestRewriteBracketAt_OutOfBoundsNoop(t *testing.T) {
 // TestRewriteWikiTitle covers the four title-form shapes the
 // item-rename cascade depends on. Case-insensitive title matching
 // mirrors resolveTitleTx (and the renderer's title resolution at
-// web/src/lib/utils/markdown.ts:543). Display aliases must be
+// web/src/lib/utils/markdown.ts::resolveWikiBody). Display aliases must be
 // preserved verbatim — including padding and escaped chars — so
 // the renderer's user-facing text doesn't silently change.
 func TestRewriteWikiTitle(t *testing.T) {

--- a/internal/links/markdown_citation_test.go
+++ b/internal/links/markdown_citation_test.go
@@ -1,0 +1,214 @@
+package links
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// BUG-2832: Go comments describe the web renderer's behaviour constantly, and
+// nothing verifies those references. They cross a language boundary, so no
+// compiler, test or linter has ever checked them — and they had drifted: seven
+// citations across four files pointed at unrelated code, one of them
+// substantively wrong in a way that got quoted forward into a bug repro
+// (TASK-2826) and understated BUG-2805's severity.
+//
+// Line numbers cannot be checked. Symbol names can, and that is the whole
+// reason the citations were converted to `markdown.ts::<symbol>` form. This
+// file is the check that makes the conversion worth something: rename or delete
+// a cited symbol in markdown.ts and the Go build's tests go red, naming the
+// stale citation.
+//
+// It is a cheap, coarse instrument on purpose — a substring search for a
+// declaration, not a TypeScript parse. It catches the failure that actually
+// happens (a symbol is renamed or removed) without pulling a TS toolchain into
+// `go test`.
+
+const markdownTSRelPath = "../../web/src/lib/utils/markdown.ts"
+
+// repoRootRelPath is where the sweep starts. internal/links -> repo root.
+const repoRootRelPath = "../.."
+
+var (
+	// A citation of the form `markdown.ts::` + an identifier. The
+	// captured symbol stops at the first character that cannot be part of a JS
+	// identifier, so trailing prose ("::resolveWikiBody step 2") is ignored.
+	symbolCitation = regexp.MustCompile(`markdown\.ts::([A-Za-z_$][A-Za-z0-9_$]*)`)
+
+	// The form this test BANS. A line number is unverifiable by construction:
+	// it is correct only until anyone inserts a line above it, and nothing
+	// anywhere reports when that happens.
+	lineCitation = regexp.MustCompile(`markdown\.ts:\d`)
+)
+
+func goSourceFiles(t *testing.T) []string {
+	t.Helper()
+	var out []string
+	err := filepath.Walk(repoRootRelPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			switch info.Name() {
+			case ".git", "node_modules", "web", "vendor":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if strings.HasSuffix(path, ".go") {
+			out = append(out, path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk repo: %v", err)
+	}
+	if len(out) < 50 {
+		// The sweep is the instrument; if it stops finding files it would
+		// report a clean bill of health having examined nothing.
+		t.Fatalf("sweep found only %d Go files — the walk is broken, not the citations", len(out))
+	}
+	return out
+}
+
+// TestMarkdownCitationsNameLiveSymbols is the mechanical check line numbers
+// could never have.
+func TestMarkdownCitationsNameLiveSymbols(t *testing.T) {
+	t.Parallel()
+
+	tsBytes, err := os.ReadFile(filepath.Clean(markdownTSRelPath))
+	if err != nil {
+		t.Fatalf("read markdown.ts: %v", err)
+	}
+	ts := string(tsBytes)
+
+	// Where each cited symbol was found, so a failure names the file to fix.
+	citedIn := map[string][]string{}
+	for _, f := range goSourceFiles(t) {
+		b, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("read %s: %v", f, err)
+		}
+		for _, m := range symbolCitation.FindAllStringSubmatch(string(b), -1) {
+			citedIn[m[1]] = append(citedIn[m[1]], f)
+		}
+	}
+
+	if len(citedIn) == 0 {
+		t.Fatal("no `markdown.ts::` symbol citations found anywhere — either the " +
+			"citation form changed or the sweep is broken; both make this test vacuous")
+	}
+
+	symbols := make([]string, 0, len(citedIn))
+	for s := range citedIn {
+		symbols = append(symbols, s)
+	}
+	sort.Strings(symbols)
+
+	for _, sym := range symbols {
+		// A declaration, not a mere mention: `function foo`, `const foo`,
+		// `export function foo`, etc. Requiring the keyword is what stops a
+		// citation from being "verified" by the very comment that cites it.
+		//
+		// The trailing character class is load-bearing and was added after this
+		// check FAILED its negative control. The first version asked
+		// `strings.Contains(ts, "function "+sym)`, which is a PREFIX match:
+		// renaming `resolveWikiBody` to `resolveWikiBodyRENAMED` left
+		// "function resolveWikiBody" a substring of the renamed declaration, so
+		// the guard stayed green through exactly the rename it exists to catch.
+		// A guard that passes on its own target is worse than no guard, because
+		// it is also a claim that someone checked.
+		if !declaredIn(ts, sym) {
+			files := citedIn[sym]
+			sort.Strings(files)
+			t.Errorf("Go comments cite `markdown.ts::%s`, but markdown.ts declares no such symbol.\n"+
+				"  cited from: %s\n"+
+				"Either the symbol was renamed or removed on the web side and these comments now "+
+				"describe code that does not exist, or the citation was wrong when written. "+
+				"Fix the comments — do not weaken this check.",
+				sym, strings.Join(dedupe(files), ", "))
+		}
+	}
+
+	t.Logf("verified %d distinct cited symbols across %d citation sites", len(symbols), countSites(citedIn))
+}
+
+// TestMarkdownCitationsAreNotLineNumbers keeps the fix from eroding.
+//
+// Converting the citations is worth nothing if the next comment reaches for a
+// line number again, and a line number is exactly what a person reads off their
+// editor's gutter. This is the guard that makes the symbol form the path of
+// least resistance.
+func TestMarkdownCitationsAreNotLineNumbers(t *testing.T) {
+	t.Parallel()
+
+	var offenders []string
+	for _, f := range goSourceFiles(t) {
+		b, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("read %s: %v", f, err)
+		}
+		for i, line := range strings.Split(string(b), "\n") {
+			if lineCitation.MatchString(line) {
+				offenders = append(offenders, filepath.ToSlash(f)+":"+itoa(i+1)+": "+strings.TrimSpace(line))
+			}
+		}
+	}
+	if len(offenders) > 0 {
+		t.Errorf("Go comments cite markdown.ts by LINE NUMBER in %d place(s):\n  %s\n\n"+
+			"Nothing verifies a cross-language line citation, and they drift silently — "+
+			"BUG-2832 found seven that had rotted onto unrelated code. Cite the symbol "+
+			"instead (`markdown.ts::resolveWikiBody`), which "+
+			"TestMarkdownCitationsNameLiveSymbols can actually check.",
+			len(offenders), strings.Join(offenders, "\n  "))
+	}
+}
+
+// declaredIn reports whether markdown.ts declares `sym` as its own symbol.
+//
+// The symbol must be followed by something that cannot continue a JavaScript
+// identifier (or by end-of-input), so a citation is not satisfied by a LONGER
+// declaration that merely starts with it. See the note at the call site: the
+// prefix-matching version of this check survived its own negative control.
+func declaredIn(ts, sym string) bool {
+	re := regexp.MustCompile(
+		`(?:function|const|let|var|class|type|interface)\s+` +
+			regexp.QuoteMeta(sym) +
+			`(?:[^A-Za-z0-9_$]|$)`)
+	return re.MatchString(ts)
+}
+
+func dedupe(in []string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, s := range in {
+		if !seen[s] {
+			seen[s] = true
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func countSites(m map[string][]string) int {
+	n := 0
+	for _, v := range m {
+		n += len(v)
+	}
+	return n
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}

--- a/internal/links/probe_alloc_test.go
+++ b/internal/links/probe_alloc_test.go
@@ -21,7 +21,7 @@ func TestProbeRewriteBracketAtAllocation(t *testing.T) {
 		runtime.ReadMemStats(&before)
 		const n = 200
 		for i := 0; i < n; i++ {
-			_ = RewriteBracketAt(body, 0, "A", tc.newTitle, "")
+			_ = RewriteBracketAt(body, 0, "A", "A", tc.newTitle, "")
 		}
 		runtime.ReadMemStats(&after)
 		per := (after.TotalAlloc - before.TotalAlloc) / n
@@ -58,7 +58,7 @@ func TestProjectRewrittenLenDoesNotAllocatePerBracket(t *testing.T) {
 	var before, after runtime.MemStats
 	runtime.GC()
 	runtime.ReadMemStats(&before)
-	length, applied := ProjectRewrittenLen(content, rewrites, NewTitleEscaper(newTitle, "tasks"))
+	length, applied := ProjectRewrittenLen(content, rewrites, NewTitleEscaper("A", newTitle, "tasks"))
 	runtime.ReadMemStats(&after)
 
 	if applied != brackets {

--- a/internal/links/rewrite_brackets_diff_test.go
+++ b/internal/links/rewrite_brackets_diff_test.go
@@ -66,6 +66,34 @@ func rewriteBracketAtV0(content string, position int, targetTitle, newTitle, col
 	return content
 }
 
+// v0OldTitle reconstructs the old title that the code BEFORE BUG-2830
+// implicitly assumed when it decided whether a bracket was collection-
+// qualified.
+//
+// V0 had no oldTitle parameter: it inferred "this bracket was qualified" from
+// targetTitle merely STARTING WITH collSlug + "/". That inference is exactly
+// the BUG-2830 defect, because a literal title like `tasks/Setup` in collection
+// `tasks` starts with the prefix without ever having been qualified.
+//
+// This helper exists so the differential tests can keep using the frozen oracle
+// where it is still authoritative. Feeding the new function the old title V0
+// would have inferred makes the two agree on every input where V0's inference
+// happened to be RIGHT — which is the whole guarded corpus. The inputs where
+// the inference was WRONG cannot be produced by this derivation at all, and are
+// pinned by name in TestRewriteBracketAt_IntentionalDivergencesFromV0 instead.
+//
+// Deliberately NOT a call into the production code: it is a statement about
+// what the old implementation assumed, so it has to be written out here to stay
+// an independent oracle.
+func v0OldTitle(targetTitle, collSlug string) string {
+	if collSlug != "" && len(targetTitle) > len(collSlug) &&
+		targetTitle[len(collSlug)] == '/' &&
+		strings.EqualFold(targetTitle[:len(collSlug)], collSlug) {
+		return targetTitle[len(collSlug)+1:]
+	}
+	return targetTitle
+}
+
 // diffCase is one (content, position, targetTitle, newTitle, collSlug) probe.
 type diffCase struct {
 	name        string
@@ -153,13 +181,15 @@ func TestRewriteBracketAt_IntentionalDivergencesFromV0(t *testing.T) {
 		content         string
 		position        int
 		targetTitle     string
+		oldTitle        string
+		collSlug        string
 		newTitle        string
 		wantV0, wantNew string
 		why             string
 	}{
 		{
 			name: "empty body is not a link", content: "x [[]] y", position: 2,
-			targetTitle: "", newTitle: "New",
+			targetTitle: "", oldTitle: "", newTitle: "New",
 			wantV0: "x [[New]] y", wantNew: "x [[]] y",
 			why: "the parser's body production is `+`, so `[[]]` is not a link and no " +
 				"position is ever recorded for one. V0 would MINT a link out of a non-link " +
@@ -167,14 +197,14 @@ func TestRewriteBracketAt_IntentionalDivergencesFromV0(t *testing.T) {
 		},
 		{
 			name: "escaped body now MATCHES", content: `see [[Weird \] Title]] here`, position: 4,
-			targetTitle: "Weird ] Title", newTitle: "Renamed",
+			targetTitle: "Weird ] Title", oldTitle: "Weird ] Title", newTitle: "Renamed",
 			wantV0: `see [[Weird \] Title]] here`, wantNew: "see [[Renamed]] here",
 			why: "BUG-2805 direction 1: V0 compared the RAW body against the unescaped " +
 				"title, never matched, and left the link stale while the index flipped broken.",
 		},
 		{
 			name: "empty new title is REFUSED, not emitted", content: "x [[Old]] y", position: 2,
-			targetTitle: "Old", newTitle: "",
+			targetTitle: "Old", oldTitle: "Old", newTitle: "",
 			wantV0: "x [[]] y", wantNew: "x [[Old]] y",
 			why: "V0's expected output IS the damage: `[[]]` is not a link under the `+` " +
 				"production, so the reparse deletes the index row. Reachable two ways — a " +
@@ -184,19 +214,41 @@ func TestRewriteBracketAt_IntentionalDivergencesFromV0(t *testing.T) {
 		},
 		{
 			name: "emission now ESCAPES", content: "Ref [[Plain Target]] here.", position: 4,
-			targetTitle: "Plain Target", newTitle: "New ] Name",
+			targetTitle: "Plain Target", oldTitle: "Plain Target", newTitle: "New ] Name",
 			wantV0: "Ref [[New ] Name]] here.", wantNew: `Ref [[New \] Name]] here.`,
 			why: "BUG-2805 direction 2a: V0's plain concatenation emitted an unparseable " +
 				"bracket, so the reparse deleted the index row — permanent damage.",
 		},
+		{
+			name: "literal slash-bearing title is NOT re-qualified", content: "see [[tasks/Setup]] here", position: 4,
+			targetTitle: "tasks/Setup", oldTitle: "tasks/Setup", collSlug: "tasks", newTitle: "Renamed",
+			wantV0: "see [[tasks/Renamed]] here", wantNew: "see [[Renamed]] here",
+			why: "BUG-2830. The item's LITERAL title is `tasks/Setup` and it lives in " +
+				"collection `tasks`, so the bracket was resolved by stage 1, not by " +
+				"qualified fallback. V0 inferred `qualified` from the prefix alone and " +
+				"emitted `[[tasks/Renamed]]`, converting a literal-title reference into a " +
+				"qualified one — which an item literally titled `tasks/Renamed` then takes " +
+				"outright. The old title is what distinguishes the two cases, and V0 never " +
+				"had it.",
+		},
+		{
+			name: "genuinely qualified bracket still keeps its prefix", content: "see [[tasks/Setup]] here", position: 4,
+			targetTitle: "tasks/Setup", oldTitle: "Setup", collSlug: "tasks", newTitle: "Renamed",
+			wantV0: "see [[tasks/Renamed]] here", wantNew: "see [[tasks/Renamed]] here",
+			why: "The TWIN of the case above, and the reason it is here rather than in the " +
+				"guarded corpus: byte-identical content, position, targetTitle and collSlug, " +
+				"differing ONLY in the old title, and the correct outputs differ. It agrees " +
+				"with V0 — the point is not divergence but that the fix did not buy case A " +
+				"by breaking case B, which a one-sided test would not have shown.",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := rewriteBracketAtV0(tc.content, tc.position, tc.targetTitle, tc.newTitle, ""); got != tc.wantV0 {
+			if got := rewriteBracketAtV0(tc.content, tc.position, tc.targetTitle, tc.newTitle, tc.collSlug); got != tc.wantV0 {
 				t.Fatalf("fixture drift: V0 = %q, want %q — this test documents a divergence "+
 					"FROM a specific old behaviour, so the old behaviour must be what it says", got, tc.wantV0)
 			}
-			if got := RewriteBracketAt(tc.content, tc.position, tc.targetTitle, tc.newTitle, ""); got != tc.wantNew {
+			if got := RewriteBracketAt(tc.content, tc.position, tc.targetTitle, tc.oldTitle, tc.newTitle, tc.collSlug); got != tc.wantNew {
 				t.Errorf("new = %q, want %q\nwhy this diverges: %s", got, tc.wantNew, tc.why)
 			}
 		})
@@ -210,7 +262,7 @@ func TestRewriteBracketAt_MatchesPreRefactorImplementation(t *testing.T) {
 				t.Skip("outside the V0-guarded domain — see TestRewriteBracketAt_IntentionalDivergencesFromV0")
 			}
 			want := rewriteBracketAtV0(tc.content, tc.position, tc.targetTitle, tc.newTitle, tc.collSlug)
-			got := RewriteBracketAt(tc.content, tc.position, tc.targetTitle, tc.newTitle, tc.collSlug)
+			got := RewriteBracketAt(tc.content, tc.position, tc.targetTitle, v0OldTitle(tc.targetTitle, tc.collSlug), tc.newTitle, tc.collSlug)
 			if got != want {
 				t.Errorf("behaviour changed across the refactor\n content=%q pos=%d target=%q new=%q slug=%q\n  v0=%q\n new=%q",
 					tc.content, tc.position, tc.targetTitle, tc.newTitle, tc.collSlug, want, got)
@@ -242,7 +294,7 @@ func TestRewriteBracketAt_MatchesPreRefactorOnRandomInput(t *testing.T) {
 			continue
 		}
 		want := rewriteBracketAtV0(content, pos, target, newTitle, slug)
-		got := RewriteBracketAt(content, pos, target, newTitle, slug)
+		got := RewriteBracketAt(content, pos, target, v0OldTitle(target, slug), newTitle, slug)
 		if got != want {
 			t.Fatalf("divergence at iteration %d\n content=%q pos=%d target=%q new=%q slug=%q\n  v0=%q\n new=%q",
 				i, content, pos, target, newTitle, slug, want, got)
@@ -325,7 +377,7 @@ func TestRewriteBracketsAt_MatchesSequentialDescendingFold(t *testing.T) {
 		for _, p := range shuffled {
 			rewrites = append(rewrites, BracketRewrite{Position: p, TargetTitle: target})
 		}
-		got, applied := RewriteBracketsAt(content, rewrites, NewTitleEscaper(newTitle, ""))
+		got, applied := RewriteBracketsAt(content, rewrites, NewTitleEscaper(target, newTitle, ""))
 
 		if got != want {
 			t.Fatalf("single pass diverges from the descending fold at iteration %d\n content=%q positions=%v target=%q new=%q\n fold=%q\n pass=%q (applied=%d)",
@@ -342,11 +394,11 @@ func TestRewriteBracketsAt_MatchesSequentialDescendingFold(t *testing.T) {
 // no-op path the cascade relies on to skip a write.
 func TestRewriteBracketsAt_NoRewritesReturnsInputUnchanged(t *testing.T) {
 	const content = "nothing [[Other]] to do here"
-	got, applied := RewriteBracketsAt(content, nil, NewTitleEscaper("New", ""))
+	got, applied := RewriteBracketsAt(content, nil, NewTitleEscaper("Old", "New", ""))
 	if got != content || applied != 0 {
 		t.Fatalf("empty rewrites: got %q applied=%d, want %q applied=0", got, applied, content)
 	}
-	got, applied = RewriteBracketsAt(content, []BracketRewrite{{Position: 8, TargetTitle: "Old"}}, NewTitleEscaper("New", ""))
+	got, applied = RewriteBracketsAt(content, []BracketRewrite{{Position: 8, TargetTitle: "Old"}}, NewTitleEscaper("Old", "New", ""))
 	if got != content || applied != 0 {
 		t.Fatalf("non-matching rewrite: got %q applied=%d, want %q applied=0", got, applied, content)
 	}
@@ -366,7 +418,7 @@ func TestRewriteBracketsAt_DoesNotMutateCallerSlice(t *testing.T) {
 	before := make([]BracketRewrite, len(rewrites))
 	copy(before, rewrites)
 
-	if _, applied := RewriteBracketsAt(content, rewrites, NewTitleEscaper("New", "")); applied != 3 {
+	if _, applied := RewriteBracketsAt(content, rewrites, NewTitleEscaper("Old", "New", "")); applied != 3 {
 		t.Fatalf("applied = %d, want 3", applied)
 	}
 	for i := range before {
@@ -389,7 +441,7 @@ func TestRewriteBracketsAt_AppliesEveryBracketInOnePass(t *testing.T) {
 	for _, p := range offs {
 		rewrites = append(rewrites, BracketRewrite{Position: p, TargetTitle: "Old"})
 	}
-	got, applied := RewriteBracketsAt(content, rewrites, NewTitleEscaper("New", ""))
+	got, applied := RewriteBracketsAt(content, rewrites, NewTitleEscaper("Old", "New", ""))
 	if applied != n {
 		t.Fatalf("applied = %d, want %d", applied, n)
 	}
@@ -459,7 +511,7 @@ func TestRewriteBracketsAt_ByteIdenticalRewriteIsNotAChange(t *testing.T) {
 				t.Fatalf("fixture: %d brackets, want 1", len(offs))
 			}
 			got, applied := RewriteBracketsAt(tc.content,
-				[]BracketRewrite{{Position: offs[0], TargetTitle: tc.targetTitle}}, NewTitleEscaper(tc.newTitle, tc.collSlug))
+				[]BracketRewrite{{Position: offs[0], TargetTitle: tc.targetTitle}}, NewTitleEscaper(v0OldTitle(tc.targetTitle, tc.collSlug), tc.newTitle, tc.collSlug))
 			if got != tc.content {
 				t.Errorf("content changed: got %q, want %q", got, tc.content)
 			}
@@ -482,10 +534,17 @@ func TestRewriteBracketsAt_MixedChangedAndUnchangedCountsOnlyTheChanged(t *testi
 	}
 	rewrites := []BracketRewrite{
 		{Position: offs[0], TargetTitle: "Old"},
-		{Position: offs[1], TargetTitle: "New"}, // already reads [[New]] — no change
+		// Middle bracket already reads [[New]]. Since BUG-2830 its row is also
+		// index drift — target_title "New" is neither the old title nor its
+		// qualified form, so the rewriter refuses it rather than matching and
+		// then finding it byte-identical. Either way it is not counted, which
+		// is what this test asserts. The byte-identical-match path itself is
+		// pinned by TestRewriteBracketsAt_ByteIdenticalRewriteIsNotAChange,
+		// where newTitle == oldTitle makes it reachable.
+		{Position: offs[1], TargetTitle: "New"},
 		{Position: offs[2], TargetTitle: "Old"},
 	}
-	got, applied := RewriteBracketsAt(content, rewrites, NewTitleEscaper("New", ""))
+	got, applied := RewriteBracketsAt(content, rewrites, NewTitleEscaper("Old", "New", ""))
 	if want := "[[New]] and [[New]] and [[New]]"; got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
@@ -522,15 +581,24 @@ func TestProjectRewrittenLen_IsLockstepWithTheRealPass(t *testing.T) {
 		"[[A[[B]]]] [[Old]]",
 	}
 
-	check := func(t *testing.T, content string, rewrites []BracketRewrite, newTitle, collSlug string) {
+	// Counts rewrites the corpus actually APPLIED. Lockstep is trivially true
+	// when both sides refuse everything, and BUG-2830 made the rewriter refuse
+	// more inputs than before (a row whose target_title is neither form of the
+	// old title is now index drift). Without this counter the suite could drift
+	// into asserting lockstep over an empty set and still report green.
+	totalApplied := 0
+
+	check := func(t *testing.T, content string, rewrites []BracketRewrite, oldTitle, newTitle, collSlug string) {
 		t.Helper()
-		wantLen, wantApplied := ProjectRewrittenLen(content, rewrites, NewTitleEscaper(newTitle, collSlug))
-		got, gotApplied := RewriteBracketsAt(content, rewrites, NewTitleEscaper(newTitle, collSlug))
+		esc := NewTitleEscaper(oldTitle, newTitle, collSlug)
+		wantLen, wantApplied := ProjectRewrittenLen(content, rewrites, esc)
+		got, gotApplied := RewriteBracketsAt(content, rewrites, esc)
 		if len(got) != wantLen || gotApplied != wantApplied {
-			t.Fatalf("projection and the real pass disagree\n content=%q rewrites=%+v new=%q slug=%q\n"+
+			t.Fatalf("projection and the real pass disagree\n content=%q rewrites=%+v old=%q new=%q slug=%q\n"+
 				" projected len=%d applied=%d\n actual    len=%d applied=%d (result %q)",
-				content, rewrites, newTitle, collSlug, wantLen, wantApplied, len(got), gotApplied, got)
+				content, rewrites, oldTitle, newTitle, collSlug, wantLen, wantApplied, len(got), gotApplied, got)
 		}
+		totalApplied += gotApplied
 	}
 
 	// MIXED target titles per position, not one title for the whole call.
@@ -550,18 +618,40 @@ func TestProjectRewrittenLen_IsLockstepWithTheRealPass(t *testing.T) {
 						TargetTitle: titles[(ti+j)%len(titles)],
 					})
 				}
-				check(t, content, rewrites, newTitle, "")
+				check(t, content, rewrites, titles[ti], newTitle, "")
 			}
 		}
 	}
 
-	// The exact shape codex R2 named, asserted directly so the regression has
-	// a named home rather than depending on the random search rediscovering it:
-	// bracket [0,8) is a no-op, bracket [3,8) overlaps it and changes.
-	check(t, "[[A[[B]]]]", []BracketRewrite{
-		{Position: 0, TargetTitle: "A[[B"},
-		{Position: 3, TargetTitle: "B"},
-	}, "A[[B", "")
+	// The exact shape codex R2 named, asserted directly so the regression has a
+	// named home rather than depending on the random search rediscovering it:
+	// an earlier bracket that does NOT advance the cursor, followed by an
+	// overlapping one that APPLIES. That pairing is what made the projection
+	// and the pass disagree.
+	//
+	// Rewritten for BUG-2830. The original spelled it with two unrelated target
+	// titles ("A[[B" at 0, "B" at 3), which a real cascade cannot produce — all
+	// its rows point at ONE renamed item, so their target_titles can only be
+	// that item's old title or its `<slug>/` qualified form. The rewriter now
+	// refuses anything else, which would have made BOTH brackets no-ops and
+	// quietly emptied this regression of its content.
+	//
+	// Same shape, reachable inputs: in `[[A[[A]]]]` the outer bracket [0,8) has
+	// body "A[[A" and does not match target "A", so it is skipped WITHOUT
+	// advancing the cursor; the overlapping inner bracket [3,8) has body "A",
+	// matches, and applies. Verified to still apply exactly one rewrite — if a
+	// future change made it zero, totalApplied below would not notice on its
+	// own, so it is asserted here directly.
+	before := totalApplied
+	check(t, "[[A[[A]]]]", []BracketRewrite{
+		{Position: 0, TargetTitle: "A"},
+		{Position: 3, TargetTitle: "A"},
+	}, "A", "N", "")
+	if totalApplied-before != 1 {
+		t.Fatalf("the codex-R2 overlap fixture applied %d rewrites, want exactly 1 — "+
+			"a no-op-then-overlapping-change is the shape this regression exists to pin",
+			totalApplied-before)
+	}
 
 	const iterations = 20000
 	for i := 0; i < iterations; i++ {
@@ -592,8 +682,14 @@ func TestProjectRewrittenLen_IsLockstepWithTheRealPass(t *testing.T) {
 			}
 			rewrites = append(rewrites, BracketRewrite{Position: p, TargetTitle: tt})
 		}
-		check(t, content, rewrites, newTitle, "")
+		check(t, content, rewrites, target, newTitle, "")
 	}
+
+	if totalApplied == 0 {
+		t.Fatal("the corpus applied ZERO rewrites — lockstep held only because both " +
+			"sides refused everything, which asserts nothing about the invariant")
+	}
+	t.Logf("lockstep corpus applied %d rewrites", totalApplied)
 }
 
 // TestRewriteBracketsAt_EmissionRoundTripsThroughTheParser is the property that
@@ -623,7 +719,7 @@ func TestRewriteBracketsAt_EmissionRoundTripsThroughTheParser(t *testing.T) {
 		offs := bracketOffsets(content)
 		got, applied := RewriteBracketsAt(content,
 			[]BracketRewrite{{Position: offs[0], TargetTitle: "Plain Target"}},
-			NewTitleEscaper(newTitle, ""))
+			NewTitleEscaper("Plain Target", newTitle, ""))
 		if applied != 1 {
 			t.Fatalf("iteration %d: applied = %d, want 1 (newTitle=%q)", i, applied, newTitle)
 		}
@@ -817,7 +913,7 @@ func TestBUG2805_AccidentalCompatibilitiesSurvive(t *testing.T) {
 		offs := bracketOffsets(content)
 		got, _ := RewriteBracketsAt(content,
 			[]BracketRewrite{{Position: offs[0], TargetTitle: "Plain Target"}},
-			NewTitleEscaper("New | Name", ""))
+			NewTitleEscaper("Plain Target", "New | Name", ""))
 		if want := `Ref [[New \| Name]] here.`; got != want {
 			t.Fatalf("emitted %q, want %q", got, want)
 		}
@@ -833,7 +929,7 @@ func TestBUG2805_AccidentalCompatibilitiesSurvive(t *testing.T) {
 		offs := bracketOffsets(content)
 		got, _ := RewriteBracketsAt(content,
 			[]BracketRewrite{{Position: offs[0], TargetTitle: "BS Target"}},
-			NewTitleEscaper(`Odd \ Name`, ""))
+			NewTitleEscaper("BS Target", `Odd \ Name`, ""))
 		links := ExtractWikiLinks(got)
 		if len(links) != 1 {
 			t.Fatalf("emitted %q — parser found %d links, want 1", got, len(links))

--- a/internal/models/document.go
+++ b/internal/models/document.go
@@ -112,7 +112,7 @@ const MaxDocumentTitleRunes = 255
 // is therefore derived from the two mechanisms that actually consume a stored
 // bracket, both in web/src/lib/utils/markdown.ts:
 //
-//  1. THE GRAMMAR (markdown.ts:327, shared by renderMarkdown and
+//  1. THE GRAMMAR (markdown.ts::WIKI_LINK_PATTERN_SOURCE, shared by renderMarkdown and
 //     wikiLinksToMarkdown since BUG-1744): a bracket body is
 //     `(?:\\.|[^\]\\])+` — escape pairs, or anything that is neither `]` nor
 //     `\`. A raw `]` ends the bracket early, which IS BUG-2796's defect:
@@ -121,7 +121,7 @@ const MaxDocumentTitleRunes = 255
 //     title ending in `\` fails the same way — the trailing backslash pairs
 //     with the first `]` of the terminator and the bracket never closes.
 //
-//  2. THE UNESCAPER (markdown.ts:753, `\\(\\|\]|\|)` → `$1`): resolution
+//  2. THE UNESCAPER (markdown.ts::unescapeWikiBody, `\\(\\|\]|\|)` → `$1`): resolution
 //     unescapes the body before comparing it to a title, and the editor may
 //     therefore STORE a link in escaped form. That matters twice over: a
 //     title containing `\\` or `\|` emitted raw comes back as a different

--- a/internal/models/document_title_test.go
+++ b/internal/models/document_title_test.go
@@ -18,9 +18,9 @@ import (
 // can check the two by eye at the cited line numbers. Closing the drift for
 // real would need a shared fixture driven from both languages.
 var (
-	// markdown.ts:327 — shared by renderMarkdown and wikiLinksToMarkdown.
+	// markdown.ts::WIKI_LINK_PATTERN_SOURCE — shared by renderMarkdown and wikiLinksToMarkdown.
 	storedWikiLinkBracket = regexp.MustCompile(`\[\[((?:\\.|[^\]\\])+)\]\]`)
-	// markdown.ts:753 — unescapeWikiBody, applied before title comparison.
+	// markdown.ts::unescapeWikiBody — unescapeWikiBody, applied before title comparison.
 	wikiBodyEscape = regexp.MustCompile(`\\(\\|\]|\|)`)
 )
 

--- a/internal/store/items_rename_slug_prefix_test.go
+++ b/internal/store/items_rename_slug_prefix_test.go
@@ -1,0 +1,215 @@
+package store
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// BUG-2830 end-to-end, through the real rename cascade.
+//
+// The unit tests in internal/links pin TitleEscaper.qualifiedFor directly.
+// These pin the BINDING: that cascadeTitleRename actually hands the escaper the
+// renamed item's OLD title, and hands it the right one. A direct-call test
+// cannot show that (CONVE-19) — and the binding is the whole fix here, because
+// the discriminating value existed in the cascade all along and simply never
+// reached the rewriter.
+//
+// The filing asked for a repro before any fix landed: create the ambiguous
+// literal title, link it, rename it, observe what the cascade emits. It also
+// predicted a "retarget" as the outcome; see the boundary note at the bottom of
+// the first test for what was actually observed.
+
+// TestItemRename_LiteralSlashTitleIsNotRewrittenAsQualified is the repro.
+//
+// An item whose LITERAL title is "tasks/Setup", living in the collection whose
+// slug is "tasks". A `[[tasks/Setup]]` bracket resolves to it by exact-title
+// match, and the index row records target_title = "tasks/Setup" — byte-for-byte
+// what a genuinely qualified reference to an item titled "Setup" would record.
+//
+// Renaming it must produce `[[Renamed]]`. The pre-fix cascade produced
+// `[[tasks/Renamed]]`, which is a QUALIFIED reference — a different kind of
+// reference than the author wrote, resolved by a different rule. What that
+// costs in practice is recorded in the boundary note at the bottom of this
+// test, which is narrower than the filing predicted.
+func TestItemRename_LiteralSlashTitleIsNotRewrittenAsQualified(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	if col.Slug != "tasks" {
+		t.Fatalf("fixture depends on the collection slug being %q, got %q — "+
+			"the whole ambiguity is between that slug and the literal title's prefix", "tasks", col.Slug)
+	}
+
+	// The item under rename. Its title CONTAINS the collection's own slug plus
+	// a slash, which is what makes the stored row ambiguous.
+	target := createTestItem(t, s, ws.ID, col.ID, "tasks/Setup", "")
+
+	const newTitle = "Renamed 2"
+
+	source := createTestItem(t, s, ws.ID, col.ID, "Source",
+		"Please see [[tasks/Setup]] for details.")
+
+	// Baseline: the bracket resolves to the literal-titled item.
+	bls, _ := s.GetBacklinks(target.ID, ws.ID, 50, 0, BacklinksVisibility{Unrestricted: true})
+	if len(bls) != 1 {
+		t.Fatalf("baseline: expected the bracket to resolve to the literal-titled item, got %d backlinks", len(bls))
+	}
+
+	title := newTitle
+	if _, err := s.UpdateItem(target.ID, models.ItemUpdate{Title: &title}); err != nil {
+		t.Fatalf("UpdateItem rename: %v", err)
+	}
+
+	updated, err := s.GetItem(source.ID)
+	if err != nil {
+		t.Fatalf("GetItem source: %v", err)
+	}
+
+	if strings.Contains(updated.Content, "[[tasks/Renamed 2]]") {
+		t.Errorf("cascade emitted a QUALIFIED bracket for an item whose title merely "+
+			"starts with the collection slug.\n content = %q\n"+
+			"The author wrote a literal-title reference; `[[tasks/Renamed 2]]` is a "+
+			"collection-qualified one, resolved by a different rule and ambiguous "+
+			"wherever a same-titled sibling exists. See the boundary note below for "+
+			"what this does and does not demonstrate.",
+			updated.Content)
+	}
+	if !strings.Contains(updated.Content, "[[Renamed 2]]") {
+		t.Errorf("expected the literal title to be rewritten plainly as [[Renamed 2]], got %q", updated.Content)
+	}
+
+	got, _ := s.GetBacklinks(target.ID, ws.ID, 50, 0, BacklinksVisibility{Unrestricted: true})
+	if len(got) != 1 {
+		t.Errorf("post-rename: expected the link to still resolve to the renamed item, got %d backlinks", len(got))
+	}
+	// SCOPE — what this test shows, and where the rest of the evidence is.
+	//
+	// This one pins the CONTENT: the cascade must not rewrite a literal-title
+	// reference into a collection-qualified one. That is the defect itself,
+	// independent of what any particular workspace happens to contain.
+	//
+	// It deliberately has NO decoy. With no item literally titled
+	// `tasks/Renamed 2`, the wrongly-emitted bracket still finds the renamed
+	// item — collSlug is that item's own collection and it now carries the new
+	// title, so it satisfies the qualified fallback itself. A decoy here would
+	// therefore assert nothing, and an assertion that cannot fire is worse than
+	// none because it reads as evidence.
+	//
+	// The retarget the filing predicted IS real, and it needs a decoy whose
+	// literal title contains the slash, so that resolveTitleTx's stage-1
+	// full-title match beats the qualified fallback. That is
+	// TestItemRename_LiteralSlashTitleRetargetsOntoALiteralSlashSibling below,
+	// where the decoy demonstrably gains the backlink under the unfixed code.
+	//
+	// Recorded because I got this wrong in both directions before measuring it:
+	// first asserting a retarget with a decoy that could not be stolen, then
+	// over-correcting to "the renamed item always wins", which codex R4 caught
+	// by reading resolveTitleTx's stage order rather than my summary of it.
+}
+
+// TestItemRename_LiteralSlashTitleRetargetsOntoALiteralSlashSibling is the
+// DETERMINISTIC retarget, and it exists because my first boundary note was
+// wrong in the other direction (codex R4).
+//
+// Having measured that the wrongly-qualified bracket still found the renamed
+// item, I wrote that it "always" does. It does not. resolveTitleTx tries an
+// exact FULL-TITLE match (stage 1) before the qualified fallback (stage 2), so
+// an item literally titled `tasks/<newTitle>` — slash and all — captures
+// `[[tasks/<newTitle>]]` outright and beats the renamed item to it.
+//
+// That makes the filing's "silent retarget" real after all, with a decoy the
+// earlier fixture did not have: the decoy's title must contain the slash. The
+// link moves off the renamed item entirely, and nothing in the UI says so.
+func TestItemRename_LiteralSlashTitleRetargetsOntoALiteralSlashSibling(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	target := createTestItem(t, s, ws.ID, col.ID, "tasks/Setup", "")
+
+	// The decoy that CAN be stolen: its literal title is what the pre-fix
+	// cascade would emit, so stage 1 hands the link to it.
+	decoy := createTestItem(t, s, ws.ID, col.ID, "tasks/Renamed 2", "")
+
+	source := createTestItem(t, s, ws.ID, col.ID, "Source",
+		"Please see [[tasks/Setup]] for details.")
+
+	// Premise, asserted rather than assumed: before the rename the link belongs
+	// to the target and the decoy has nothing. Without this leg a decoy that was
+	// never linked would "prove" the fix by staying at zero.
+	if bls, _ := s.GetBacklinks(target.ID, ws.ID, 50, 0, BacklinksVisibility{Unrestricted: true}); len(bls) != 1 {
+		t.Fatalf("baseline: target should own the link, got %d backlinks", len(bls))
+	}
+	if pre, _ := s.GetBacklinks(decoy.ID, ws.ID, 50, 0, BacklinksVisibility{Unrestricted: true}); len(pre) != 0 {
+		t.Fatalf("baseline: decoy should own nothing, got %d backlinks", len(pre))
+	}
+
+	title := "Renamed 2"
+	if _, err := s.UpdateItem(target.ID, models.ItemUpdate{Title: &title}); err != nil {
+		t.Fatalf("UpdateItem rename: %v", err)
+	}
+
+	stolen, _ := s.GetBacklinks(decoy.ID, ws.ID, 50, 0, BacklinksVisibility{Unrestricted: true})
+	if len(stolen) != 0 {
+		updated, _ := s.GetItem(source.ID)
+		t.Errorf("the rename RETARGETED the link onto a different item.\n"+
+			" content  = %q\n"+
+			" decoy %q gained %d backlink(s) from a rename it had nothing to do with.\n"+
+			"Emitting `[[tasks/Renamed 2]]` for an item whose literal title was "+
+			"`tasks/Setup` hands the link to whatever item is LITERALLY titled "+
+			"`tasks/Renamed 2`, because resolveTitleTx matches the full title before "+
+			"falling back to the qualified form.",
+			updated.Content, decoy.Title, len(stolen))
+	}
+
+	kept, _ := s.GetBacklinks(target.ID, ws.ID, 50, 0, BacklinksVisibility{Unrestricted: true})
+	if len(kept) != 1 {
+		t.Errorf("post-rename: the renamed item should still own its link, got %d backlinks", len(kept))
+	}
+}
+
+// TestItemRename_GenuinelyQualifiedBracketKeepsItsPrefix is the twin, and it is
+// what stops the fix above from being "never emit a prefix".
+//
+// Here the item really IS titled "Setup" and the `[[tasks/Setup]]` bracket
+// really was a collection-qualified reference. The stored target_title is
+// identical to the case above — "tasks/Setup" — so only the old title tells
+// them apart, and this one must KEEP its prefix across the rename.
+func TestItemRename_GenuinelyQualifiedBracketKeepsItsPrefix(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	target := createTestItem(t, s, ws.ID, col.ID, "Setup", "")
+	source := createTestItem(t, s, ws.ID, col.ID, "Source",
+		"Please see [[tasks/Setup]] for details.")
+
+	bls, _ := s.GetBacklinks(target.ID, ws.ID, 50, 0, BacklinksVisibility{Unrestricted: true})
+	if len(bls) != 1 {
+		t.Fatalf("baseline: expected the qualified bracket to resolve, got %d backlinks", len(bls))
+	}
+
+	newTitle := "Setup Renamed"
+	if _, err := s.UpdateItem(target.ID, models.ItemUpdate{Title: &newTitle}); err != nil {
+		t.Fatalf("UpdateItem rename: %v", err)
+	}
+
+	updated, err := s.GetItem(source.ID)
+	if err != nil {
+		t.Fatalf("GetItem source: %v", err)
+	}
+	if !strings.Contains(updated.Content, "[[tasks/Setup Renamed]]") {
+		t.Errorf("a genuinely qualified bracket LOST its slug prefix: got %q, want it to keep `tasks/`.\n"+
+			"Dropping the prefix here would be the BUG-2830 fix overshooting — the two cases "+
+			"are distinguished by the old title, not by refusing to qualify at all.",
+			updated.Content)
+	}
+
+	got, _ := s.GetBacklinks(target.ID, ws.ID, 50, 0, BacklinksVisibility{Unrestricted: true})
+	if len(got) != 1 {
+		t.Errorf("post-rename: expected the qualified link to still resolve, got %d backlinks", len(got))
+	}
+}

--- a/internal/store/wiki_links.go
+++ b/internal/store/wiki_links.go
@@ -164,7 +164,7 @@ func (s *Store) replaceWikiLinks(tx *sql.Tx, sourceItemID, workspaceID, content 
 			}
 			// Ref didn't resolve — try title fallback. Mirrors the
 			// renderer's "If the ref doesn't resolve we FALL THROUGH
-			// to the legacy title path" at web/src/lib/utils/markdown.ts:513.
+			// to the legacy title path" at web/src/lib/utils/markdown.ts::resolveWikiBody.
 			// Order matches the renderer:
 			//   (a) If HasDisplay, try FULL body (RawKey+"|"+Display)
 			//       as a title — covers literal-pipe titles like
@@ -243,7 +243,7 @@ func (s *Store) replaceWikiLinks(tx *sql.Tx, sourceItemID, workspaceID, content 
 			// in WHATEVER FORM RESOLVED so the rename cascade can
 			// reconstruct the literal bracket string in source
 			// content. Resolution mirrors the renderer's order at
-			// web/src/lib/utils/markdown.ts:516-558:
+			// web/src/lib/utils/markdown.ts::resolveWikiBody:
 			//
 			//   (a) If a pipe was present (HasDisplay), try the
 			//       FULL body (Title + "|" + Display) as a title.
@@ -294,7 +294,7 @@ func (s *Store) replaceWikiLinks(tx *sql.Tx, sourceItemID, workspaceID, content 
 			// Codex round 4: when nothing resolved AND there was a
 			// pipe, key the broken row on the FULL BODY rather than
 			// the split key. The renderer's preferred interpretation
-			// for `[[A|B]]` is "title A|B" (markdown.ts:516); if an
+			// for `[[A|B]]` is "title A|B" (markdown.ts::resolveWikiBody); if an
 			// item literally titled "A|B" arrives later,
 			// resolveBrokenTitleLinks needs target_title="A|B" to
 			// find this row. Storing the split key would orphan it
@@ -334,7 +334,7 @@ func (s *Store) replaceWikiLinks(tx *sql.Tx, sourceItemID, workspaceID, content 
 			// = NULL — broken-link semantics, identical to the way
 			// broken ref-form rows persist with target_item_id=NULL.
 			// The renderer's resolver-route fallback (`/-/r/<ws>/<ref>`
-			// at markdown.ts:485) returns 404 in that case; the index
+			// at markdown.ts::renderMarkdown (cross-workspace branch)) returns 404 in that case; the index
 			// matches that behavior.
 			cachedWS, hit := resolvedWorkspaces[link.WorkspaceSlug]
 			if !hit {
@@ -404,7 +404,7 @@ func resolveRefTx(tx *sql.Tx, s *Store, workspaceID, prefix string, number int) 
 }
 
 // resolveTitleTx mirrors the renderer's title-resolution logic
-// (web/src/lib/utils/markdown.ts:541–558) inside the parse-time
+// (web/src/lib/utils/markdown.ts::resolveWikiBody) inside the parse-time
 // transaction. Two-stage lookup:
 //
 //  1. Exact case-insensitive match on items.title against the full
@@ -460,7 +460,7 @@ func resolveTitleTx(tx *sql.Tx, s *Store, workspaceID, title string) sql.NullStr
 	// title contains a `/`. Split on the FIRST `/` because an item's
 	// title can legitimately contain additional slashes after the
 	// collection delimiter (e.g. "docs/api/auth-flow"). The renderer
-	// at markdown.ts:548 uses `key.split('/')` then `rest.join('/')`
+	// at markdown.ts::resolveWikiBody uses `key.split('/')` then `rest.join('/')`
 	// — equivalent to "split once, keep the rest verbatim."
 	slash := strings.IndexByte(title, '/')
 	if slash <= 0 || slash >= len(title)-1 {
@@ -711,7 +711,15 @@ func (s *Store) cascadeTitleRename(tx *sql.Tx, renamedItemID, workspaceID, oldTi
 	// short. Escaping inside those calls would multiply an unbounded new title
 	// by an unbounded source count, which is BUG-2804's R5 defect in a new
 	// costume.
-	esc := links.NewTitleEscaper(newTitle, collSlug)
+	//
+	// oldTitle rides along because it is the ONLY thing that distinguishes a
+	// collection-qualified bracket from one whose literal title merely starts
+	// with `<collSlug>/` — both store the same target_title, and guessing from
+	// its shape silently rewrote the literal case into a qualified reference,
+	// which can hand the link to a different item outright (BUG-2830). See
+	// links.TitleEscaper.qualifiedFor for the two measured cases and
+	// items_rename_slug_prefix_test.go for both fixtures.
+	esc := links.NewTitleEscaper(oldTitle, newTitle, collSlug)
 
 	var cascaded []string
 	for _, work := range works {
@@ -1283,7 +1291,7 @@ func (s *Store) CountBacklinks(targetItemID, workspaceID string, vis BacklinksVi
 // applied below.
 //
 // `targetRef` matches case-insensitively (mirrors the renderer's
-// resolver-route handling at markdown.ts:485 which forwards
+// resolver-route handling at markdown.ts::renderMarkdown (cross-workspace branch) which forwards
 // ref-shapes verbatim to the server-side resolver, which is itself
 // case-insensitive).
 //

--- a/internal/store/wiki_links_test.go
+++ b/internal/store/wiki_links_test.go
@@ -884,7 +884,7 @@ func TestWikiLinks_SecondItemSameTitleDoesNotStealBacklinks(t *testing.T) {
 // TestWikiLinks_LiteralTitleArrivalRetargetsQualifiedFallback regresses
 // Codex round 2 P2: a row resolved via qualified-fallback (stage 2)
 // must flip to point at a later-arriving literal-title match (stage 1
-// always wins per renderer order at markdown.ts:541).
+// always wins per renderer order at markdown.ts::resolveWikiBody).
 //
 //	Step 1: source writes `[[tasks/Setup]]`. No literal "tasks/Setup"
 //	        item exists; item "Setup" exists in collection "tasks".
@@ -1022,7 +1022,7 @@ func TestWikiLinks_TitleRenameRewritesSelfReferences(t *testing.T) {
 // Codex round 10 P2: a ref-shaped body with surrounding whitespace
 // (`[[ TASK-5 ]]`) that doesn't match any actual ref falls through
 // to title lookup using the UNTRIMMED key — matches the renderer's
-// `key.toLowerCase()` (no trim) at markdown.ts:541-543. An item
+// `key.toLowerCase()` (no trim) at markdown.ts::resolveWikiBody. An item
 // literally titled " TASK-5 " (with spaces) must resolve via the
 // fallback when no real TASK-5 ref exists.
 func TestWikiLinks_RefShapedWithWhitespaceFallsThroughToTitle(t *testing.T) {
@@ -1135,7 +1135,7 @@ func TestWikiLinks_CascadeDoesNotCorruptLiteralPipeNeighbor(t *testing.T) {
 // TestWikiLinks_RefShapedFallsThroughToTitle regresses Codex round 6
 // finding 1. A ref-shaped body like `[[ISO-9001]]` should resolve to
 // an item literally titled "ISO-9001" when no ISO-9001 ref-item
-// exists — the renderer falls through (markdown.ts:513), so the
+// exists — the renderer falls through (markdown.ts::resolveWikiBody), so the
 // index must too. Without the fallback, GetBacklinks would never
 // find the backlink even though the renderer renders the link.
 func TestWikiLinks_RefShapedFallsThroughToTitle(t *testing.T) {

--- a/internal/store/wiki_links_xws_test.go
+++ b/internal/store/wiki_links_xws_test.go
@@ -283,7 +283,7 @@ func TestWikiLinks_CrossWorkspaceSourceWorkspaceSlugPopulated(t *testing.T) {
 
 // TestWikiLinks_CrossWorkspaceSameWorkspaceQualifiedNormalized regresses
 // Codex round 4 P2. The renderer treats `[[<current-ws>::TASK-1]]`
-// identically to `[[TASK-1]]` (markdown.ts:307 short-circuit), so an
+// identically to `[[TASK-1]]` (markdown.ts::renderMarkdown (cross-workspace branch) short-circuit), so an
 // indexed workspace_ref row pointing at the current workspace must
 // be normalized to a ref-kind row at write time — otherwise the
 // link surfaces in the renderer but produces no backlink: the
@@ -323,7 +323,7 @@ func TestWikiLinks_CrossWorkspaceSameWorkspaceQualifiedNormalized(t *testing.T) 
 // Codex round 5 P2. `[[<current-ws>::ISO-9001]]` where no ISO-9001
 // ref-item exists must NOT fall through to title lookup the way
 // bare `[[ISO-9001]]` does. The renderer's same-ws qualified path
-// (markdown.ts:478-481) treats ref-misses as broken without title
+// (markdown.ts::wikiLinksToMarkdown (cross-workspace branch)) treats ref-misses as broken without title
 // fallback; the index must match or it creates ghost backlinks the
 // UI doesn't render.
 func TestWikiLinks_SameWorkspaceQualifiedRefNoTitleFallback(t *testing.T) {
@@ -350,7 +350,7 @@ func TestWikiLinks_SameWorkspaceQualifiedRefNoTitleFallback(t *testing.T) {
 	}
 
 	// For contrast: bare `[[ISO-9001]]` SHOULD title-fallback per
-	// markdown.ts:513 (preserves the Phase 2a behavior).
+	// markdown.ts::resolveWikiBody (preserves the Phase 2a behavior).
 	createTestItem(t, s, ws.ID, col.ID, "Source2", "See [[ISO-9001]].")
 	got2, _ := s.GetBacklinks(titledItem.ID, ws.ID, 50, 0, BacklinksVisibility{Unrestricted: true})
 	if len(got2) != 1 {

--- a/testdata/wiki_grammar_corpus.json
+++ b/testdata/wiki_grammar_corpus.json
@@ -1,0 +1,250 @@
+{
+  "_comment": [
+    "SHARED cross-language corpus for the wiki-link bracket grammar (BUG-2834).",
+    "",
+    "GENERATED FILE -- pure ASCII by construction. Every control character and",
+    "non-ASCII code point below is a \\uXXXX escape, never a raw byte, so this",
+    "file survives editors, diffs, terminals and copy-paste intact. An early",
+    "probe for this very bug typed U+2028/U+2029 into a shell heredoc, silently",
+    "lost them, and would have 'confirmed' the divergence on two cases that were",
+    "actually spaces. Do not hand-edit a raw control character into this file.",
+    "",
+    "Consumed by BOTH implementations of the grammar, which are written as the",
+    "same pattern text in two languages that do not agree on what it means:",
+    "",
+    "  Go: internal/links/extract.go      wikiLinkPattern",
+    "      asserted by internal/links/grammar_parity_test.go",
+    "  JS: web/src/lib/utils/markdown.ts  renderMarkdown + wikiLinksToMarkdown",
+    "      asserted by web/src/lib/utils/markdown.grammarParity.test.ts",
+    "",
+    "THE POINT: neither implementation defines truth. The `expect` fields are",
+    "derived from the grammar SPEC and both languages are asserted against them,",
+    "so a divergence introduced on EITHER side fails on that side. This file",
+    "exists because the two patterns are BYTE-IDENTICAL SOURCE TEXT -- a reviewer",
+    "comparing them side by side concludes they agree, and BUG-2834 lived in the",
+    "gap between that reading and the host languages' definition of `.`.",
+    "",
+    "THE SPEC. The body production is `(?:\\\\.|[^\\]\\\\])+` where `.` means ANY",
+    "CHARACTER EXCEPT LINE FEED (U+000A) -- Go's RE2 definition. JavaScript's `.`",
+    "additionally excludes CR, U+2028 and U+2029, which IS the divergence; the JS",
+    "patterns therefore spell it `[^\\n]` explicitly rather than `.`.",
+    "",
+    "`content` is the FULL input string. `expect.match` is whether the grammar",
+    "matches anywhere in it; `expect.body` is capture group 1 of the FIRST match",
+    "and is absent when match is false."
+  ],
+  "cases": [
+    {
+      "name": "plain body",
+      "why": "baseline: the ordinary form must match in both languages",
+      "content": "[[Title]]",
+      "expect": {
+        "match": true,
+        "body": "Title"
+      }
+    },
+    {
+      "name": "pipe display segment",
+      "why": "the `|` display separator is an ordinary body byte to the grammar",
+      "content": "[[Title|Display]]",
+      "expect": {
+        "match": true,
+        "body": "Title|Display"
+      }
+    },
+    {
+      "name": "escaped close bracket",
+      "why": "the `\\\\.` alternative's primary job: `\\]` must not terminate the body",
+      "content": "[[A\\]B]]",
+      "expect": {
+        "match": true,
+        "body": "A\\]B"
+      }
+    },
+    {
+      "name": "escaped pipe",
+      "why": "escapeWikiBody emits `\\|` for a literal pipe in a title",
+      "content": "[[A\\|B]]",
+      "expect": {
+        "match": true,
+        "body": "A\\|B"
+      }
+    },
+    {
+      "name": "escaped backslash",
+      "why": "escapeWikiBody doubles backslashes first; the pair must be one unit",
+      "content": "[[A\\\\B]]",
+      "expect": {
+        "match": true,
+        "body": "A\\\\B"
+      }
+    },
+    {
+      "name": "empty body",
+      "why": "the production is `+`, so an empty body is not a link",
+      "content": "[[]]",
+      "expect": {
+        "match": false
+      }
+    },
+    {
+      "name": "escaped close consumes the first of a bare pair",
+      "why": "`[[A\\]]` has nothing left to close with -- the naive strings.Index scan got this wrong (BUG-2805)",
+      "content": "[[A\\]]",
+      "expect": {
+        "match": false
+      }
+    },
+    {
+      "name": "escaped close then real close",
+      "why": "`[[A\\]]]` closes on the LAST two brackets, body keeps the escape",
+      "content": "[[A\\]]]",
+      "expect": {
+        "match": true,
+        "body": "A\\]"
+      }
+    },
+    {
+      "name": "trailing backslash with nothing to consume",
+      "why": "`\\\\.` needs a byte after the backslash; there is none",
+      "content": "[[A\\",
+      "expect": {
+        "match": false
+      }
+    },
+    {
+      "name": "surplus closing brackets",
+      "why": "the match ends at the first legal close; the extra `]]` is outside it",
+      "content": "[[A]]]]",
+      "expect": {
+        "match": true,
+        "body": "A"
+      }
+    },
+    {
+      "name": "inner open brackets are ordinary body bytes",
+      "why": "`[` is not excluded by `[^\\]\\\\]`, so the body swallows it -- checks greediness agrees across RE2 and backtracking",
+      "content": "[[A[[B]]]]",
+      "expect": {
+        "match": true,
+        "body": "A[[B"
+      }
+    },
+    {
+      "name": "raw LF inside body",
+      "why": "a RAW line terminator is matched by the `[^\\]\\\\]` alternative in BOTH languages -- this is why `.` excluding them was never a deliberate rule about titles",
+      "content": "[[A\nB]]",
+      "expect": {
+        "match": true,
+        "body": "A\nB"
+      }
+    },
+    {
+      "name": "raw CR inside body",
+      "why": "same as raw LF: the second alternative admits it, so only the ESCAPED form ever diverged",
+      "content": "[[A\rB]]",
+      "expect": {
+        "match": true,
+        "body": "A\rB"
+      }
+    },
+    {
+      "name": "backslash before LF",
+      "why": "BUG-2834 control: Go's `.` excludes LF, so this is NOT an escape pair and the bracket fails -- both languages already agreed here, and the fix must not change it (scanBracketBody in links.go depends on it)",
+      "content": "[[A\\\nB]]",
+      "expect": {
+        "match": false
+      }
+    },
+    {
+      "name": "backslash before CR",
+      "why": "BUG-2834 divergence 1 of 3: Go matched, JS did not. CRLF line endings make this the plausible one -- a body ending in a backslash immediately before a CRLF break",
+      "content": "[[A\\\rB]]",
+      "expect": {
+        "match": true,
+        "body": "A\\\rB"
+      }
+    },
+    {
+      "name": "backslash before U+2028 LINE SEPARATOR",
+      "why": "BUG-2834 divergence 2 of 3: excluded by ECMAScript's LineTerminator, not by RE2's",
+      "content": "[[A\\\u2028B]]",
+      "expect": {
+        "match": true,
+        "body": "A\\\u2028B"
+      }
+    },
+    {
+      "name": "backslash before U+2029 PARAGRAPH SEPARATOR",
+      "why": "BUG-2834 divergence 3 of 3",
+      "content": "[[A\\\u2029B]]",
+      "expect": {
+        "match": true,
+        "body": "A\\\u2029B"
+      }
+    },
+    {
+      "name": "backslash before U+000B VERTICAL TAB",
+      "why": "BOUNDS the divergence: a vertical whitespace control that is NOT an ECMAScript LineTerminator. Agreement here is what makes the population exactly three rather than 'the whitespace controls'",
+      "content": "[[A\\\u000bB]]",
+      "expect": {
+        "match": true,
+        "body": "A\\\u000bB"
+      }
+    },
+    {
+      "name": "backslash before U+000C FORM FEED",
+      "why": "BOUNDS the divergence: same role as VT",
+      "content": "[[A\\\fB]]",
+      "expect": {
+        "match": true,
+        "body": "A\\\fB"
+      }
+    },
+    {
+      "name": "backslash before U+0085 NEXT LINE",
+      "why": "BOUNDS the divergence: a Unicode line break that ECMAScript does NOT count as a LineTerminator. The 'it is all Unicode line breaks' hypothesis dies here",
+      "content": "[[A\\\u0085B]]",
+      "expect": {
+        "match": true,
+        "body": "A\\\u0085B"
+      }
+    },
+    {
+      "name": "backslash before space",
+      "why": "ordinary escape of a non-special byte: legal in both, and the negative control for the divergence cases above",
+      "content": "[[A\\ B]]",
+      "expect": {
+        "match": true,
+        "body": "A\\ B"
+      }
+    },
+    {
+      "name": "backslash before tab",
+      "why": "ordinary escape, horizontal whitespace",
+      "content": "[[A\\\tB]]",
+      "expect": {
+        "match": true,
+        "body": "A\\\tB"
+      }
+    },
+    {
+      "name": "collection-qualified body",
+      "why": "the `<slug>/<title>` form is ordinary body text to the GRAMMAR -- the ambiguity it creates is BUG-2830's, decided above the grammar, not inside it",
+      "content": "[[tasks/Setup]]",
+      "expect": {
+        "match": true,
+        "body": "tasks/Setup"
+      }
+    },
+    {
+      "name": "cross-workspace form",
+      "why": "`::` is likewise ordinary body text to the grammar",
+      "content": "[[team::TASK-5]]",
+      "expect": {
+        "match": true,
+        "body": "team::TASK-5"
+      }
+    }
+  ]
+}

--- a/web/src/lib/utils/markdown.grammarParity.svelte.test.ts
+++ b/web/src/lib/utils/markdown.grammarParity.svelte.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { renderMarkdown } from './markdown';
+import type { Item } from '$lib/types';
+
+// The `renderMarkdown` half of the BUG-2834 binding assertions.
+//
+// Lives in the jsdom project (`*.svelte.test.ts`) rather than beside the rest
+// of the parity suite because renderMarkdown finishes through DOMPurify and
+// returns '' with no DOM present — in the node project it fails for a reason
+// that has nothing to do with the grammar, which is worse than not running.
+// markdown.shareAttachments{,.svelte}.test.ts splits for the same reason.
+//
+// The corpus assertions and the wikiLinksToMarkdown binding live in
+// markdown.grammarParity.test.ts. This file is only the second call site.
+
+function show(s: string): string {
+	return JSON.stringify(s).replace(/[\u0000-\u001f\u007f-\uffff]/g, (c) => {
+		return '\\u' + c.charCodeAt(0).toString(16).padStart(4, '0').toUpperCase();
+	});
+}
+
+describe('renderMarkdown consumes the parity-fixed grammar (BUG-2834 binding)', () => {
+	const noItems: Item[] = [];
+
+	// The three code points where Go's `.` and JavaScript's `.` disagreed.
+	// Before the fix the renderer left these as literal `[[...]]` text while
+	// the server had already indexed them as links — so the backlink panel and
+	// the rendered document disagreed about whether a link existed.
+	const divergent: Array<[string, number]> = [
+		['CR U+000D', 0x000d],
+		['LS U+2028', 0x2028],
+		['PS U+2029', 0x2029]
+	];
+
+	for (const [label, cp] of divergent) {
+		it(`consumes a bracket whose body has a backslash before ${label}`, () => {
+			const body = 'A\\' + String.fromCodePoint(cp) + 'B';
+			const html = renderMarkdown(`see [[${body}]] here`, noItems, 'ws');
+
+			// With no matching item the bracket resolves to the broken-link
+			// span. That is the honest outcome, and — the point of the test —
+			// it is NOT the literal `[[` passthrough the unfixed renderer
+			// produced. Asserting on the span rather than on a resolved link
+			// keeps this leg independent of item-fixture shape.
+			expect(html, `body=${show(body)}`).toContain('doc-link broken');
+			expect(html, `body=${show(body)}`).not.toContain('[[');
+		});
+	}
+
+	// Negative control. LF is the code point both languages have always
+	// rejected and the fix must not have changed it; `scanBracketBody` in
+	// internal/links/links.go depends on that agreement. Without this leg the
+	// three assertions above would also pass for `[\s\S]`, the other candidate
+	// fix, which would have over-matched.
+	it('still refuses a backslash before LF, like the Go parser', () => {
+		const html = renderMarkdown('see [[A\\\nB]] here', noItems, 'ws');
+
+		expect(html).toContain('[[');
+		expect(html).not.toContain('doc-link broken');
+	});
+
+	// Guards the DOM precondition itself. If DOMPurify ever silently returns
+	// '' here again, every assertion above would still "pass" its not.toContain
+	// leg while measuring nothing — the empty string contains neither '[[' nor
+	// 'doc-link broken'. This is the leg that fails loudly instead.
+	it('renders a plain wiki-link, proving the DOM path is live', () => {
+		const html = renderMarkdown('see [[Anything]] here', noItems, 'ws');
+		expect(html).not.toBe('');
+		expect(html).toContain('doc-link broken');
+	});
+});

--- a/web/src/lib/utils/markdown.grammarParity.test.ts
+++ b/web/src/lib/utils/markdown.grammarParity.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { WIKI_LINK_PATTERN_SOURCE, wikiLinksToMarkdown } from './markdown';
+import type { Item } from '$lib/types';
+
+// The JavaScript half of the cross-language wiki-link grammar harness
+// (BUG-2834). The Go half is internal/links/grammar_parity_test.go.
+//
+// Both halves read the SAME corpus and assert against the expectations
+// recorded IN it, rather than against each other. That indirection is the
+// entire point. The two patterns used to be byte-identical source text, so a
+// reviewer comparing them side by side concluded they agreed — and they did
+// not, because the divergence was in the host languages' definition of `.`,
+// which is invisible to inspection. A test that compared one implementation to
+// the other would have inherited exactly that blind spot; a test that pins
+// each implementation to an independently-stated spec cannot.
+//
+// If you add a case, add it to the corpus — not to one language's test.
+
+const CORPUS_PATH = fileURLToPath(
+	new URL('../../../../testdata/wiki_grammar_corpus.json', import.meta.url)
+);
+
+type GrammarCase = {
+	name: string;
+	why: string;
+	content: string;
+	expect: { match: boolean; body?: string };
+};
+
+const corpus: { cases: GrammarCase[] } = JSON.parse(readFileSync(CORPUS_PATH, 'utf8'));
+
+// A truncated or unparsed corpus would make every assertion below vacuous
+// while the suite still reported green. Asserted, not assumed — a harness that
+// cannot fail is not an instrument.
+if (corpus.cases.length < 20) {
+	throw new Error(`shared grammar corpus looks truncated: ${corpus.cases.length} cases`);
+}
+
+// Render invisible code points as \uXXXX. This corpus is ENTIRELY about
+// characters that are invisible or that break a line in a terminal, so a
+// failure message printing them raw would misreport what it compared — the
+// same class of mistake as the bug under test.
+function show(s: string): string {
+	return JSON.stringify(s).replace(/[\u0000-\u001f\u007f-\uffff]/g, (c) => {
+		return '\\u' + c.charCodeAt(0).toString(16).padStart(4, '0').toUpperCase();
+	});
+}
+
+describe('wiki-link grammar parity with the Go server (BUG-2834)', () => {
+	// A fresh RegExp per case: the exported value is SOURCE TEXT precisely so
+	// that no `lastIndex` state is shared between this suite and the renderer.
+	function firstMatch(content: string): RegExpExecArray | null {
+		return new RegExp(WIKI_LINK_PATTERN_SOURCE).exec(content);
+	}
+
+	for (const tc of corpus.cases) {
+		it(tc.name, () => {
+			const m = firstMatch(tc.content);
+
+			if (!tc.expect.match) {
+				expect(
+					m,
+					`expected NO match for ${show(tc.content)}\nwhy this case exists: ${tc.why}`
+				).toBeNull();
+				return;
+			}
+
+			expect(
+				m,
+				`expected a match for ${show(tc.content)}\nwhy this case exists: ${tc.why}`
+			).not.toBeNull();
+			expect(
+				show(m![1]),
+				`captured body mismatch for ${show(tc.content)}\nwhy this case exists: ${tc.why}`
+			).toBe(show(tc.expect.body!));
+		});
+	}
+});
+
+// The suite above vouches for the exported PATTERN. On its own that is a
+// direct-call test: it proves the source text is right and says nothing about
+// whether anything USES it (CONVE-19 — wiring is a claim). The original bug was
+// in rendering behaviour, not in a constant, so both call sites get asserted
+// through their public entry points.
+//
+// This file covers `wikiLinksToMarkdown` (pure string in, string out).
+// `renderMarkdown` is covered in markdown.grammarParity.svelte.test.ts, because
+// it finishes through DOMPurify and returns '' without a DOM — in the node
+// project it would appear to "fail" for a reason that has nothing to do with
+// the grammar. Same node/jsdom split, and same reason, as
+// markdown.shareAttachments{,.svelte}.test.ts.
+describe('wikiLinksToMarkdown consumes the parity-fixed grammar (BUG-2834 binding)', () => {
+	// An UNRESOLVED body is useless as a discriminator here: on a miss
+	// wikiLinksToMarkdown deliberately returns the match verbatim, so a bracket
+	// the grammar rejected and a bracket it accepted-but-could-not-resolve
+	// produce byte-identical output. The fixture therefore has to RESOLVE, so
+	// that "was the bracket matched at all" becomes observable as a link.
+	//
+	// resolveWikiBody step 3 matches on unescapeWikiBody(key), and that only
+	// unescapes `\\`, `\]` and `\|` — a backslash before CR/LS/PS is none of
+	// those, so it survives into the key and the item title must carry it too.
+	function itemTitled(title: string): Item {
+		return {
+			id: 'id-1',
+			title,
+			collection_slug: 'tasks',
+			slug: 'fixture'
+		} as unknown as Item;
+	}
+
+	const divergent: Array<[string, number]> = [
+		['CR U+000D', 0x000d],
+		['LS U+2028', 0x2028],
+		['PS U+2029', 0x2029]
+	];
+
+	for (const [label, cp] of divergent) {
+		it(`links a body with a backslash before ${label}`, () => {
+			const title = 'A\\' + String.fromCodePoint(cp) + 'B';
+			const out = wikiLinksToMarkdown(`see [[${title}]] here`, [itemTitled(title)], 'ws');
+
+			expect(out, `title=${show(title)}`).toContain('](/ws/tasks/');
+			expect(out, `title=${show(title)}`).not.toContain('[[');
+		});
+	}
+
+	// Negative control for the three legs above. LF is the code point BOTH
+	// languages have always rejected, and the fix must not have changed it.
+	// Without this leg, "the renderer now consumes more brackets" would be
+	// satisfied by a pattern that consumes everything — including by
+	// `[\s\S]`, which was the other candidate fix and is WRONG here.
+	it('still refuses a backslash before LF, like the Go parser', () => {
+		const title = 'A\\\nB';
+		const out = wikiLinksToMarkdown(`see [[${title}]] here`, [itemTitled(title)], 'ws');
+
+		expect(out).toContain('[[');
+		expect(out).not.toContain('](/ws/tasks/');
+	});
+});

--- a/web/src/lib/utils/markdown.ts
+++ b/web/src/lib/utils/markdown.ts
@@ -10,6 +10,49 @@ import {
 	resolveAttachmentLink
 } from '$lib/markdown/attachments';
 
+/**
+ * The wiki-link bracket grammar — the ONE copy on the JS side.
+ *
+ * Body production: a backslash-escaped character, or any character that is
+ * neither `]` nor `\`. Kept deliberately permissive so anything the editor can
+ * save is also indexable; see `wikiLinkPattern` in internal/links/extract.go,
+ * which is the server-side half of the same grammar.
+ *
+ * ## Why `\\[^\n]` and not `\\.` (BUG-2834)
+ *
+ * The Go and JS patterns used to be BYTE-IDENTICAL source text — both spelled
+ * the escape alternative `\\.` — and they still did not mean the same thing,
+ * because the two languages do not agree on `.`:
+ *
+ *   - Go (RE2): `.` matches everything except LF (U+000A).
+ *   - JavaScript: `.` additionally excludes CR, U+2028 and U+2029 — the full
+ *     ECMAScript LineTerminator set.
+ *
+ * So a body containing a backslash immediately before CR / U+2028 / U+2029 was
+ * INDEXED by the server and NOT RENDERED here: the backlink panel claimed a
+ * link the document refused to draw. CRLF line endings make the CR case the
+ * plausible one — a body ending in a backslash right before a CRLF break.
+ *
+ * `[^\n]` states Go's definition explicitly, so the two sides now agree by
+ * construction rather than by looking alike. Measured, not reasoned: the three
+ * divergent code points plus VT / FF / U+0085 (which always agreed, and which
+ * bound the divergence to exactly the LineTerminator set) are pinned in
+ * testdata/wiki_grammar_corpus.json and asserted from both languages.
+ *
+ * LF stays excluded on BOTH sides — that was never the divergence, and
+ * `scanBracketBody` in internal/links/links.go depends on it.
+ *
+ * Exported as SOURCE TEXT rather than as a shared RegExp object: a `/g` regex
+ * carries `lastIndex` state, and handing the same object to both a `replace()`
+ * and a test's `exec()` would couple them through it.
+ */
+export const WIKI_LINK_PATTERN_SOURCE = String.raw`\[\[((?:\\[^\n]|[^\]\\])+)\]\]`;
+
+// The shared instance for this module's two rewrite sites. Safe to reuse
+// despite the `/g` flag because `String.prototype.replace` resets `lastIndex`
+// both before and after a global match — unlike `exec`/`test`, which do not.
+const WIKI_LINK_PATTERN = new RegExp(WIKI_LINK_PATTERN_SOURCE, 'g');
+
 // Mirror of marked's internal cleanUrl() — percent-encodes the href so the
 // rendered HTML stays well-formed even when input contains spaces, quotes, or
 // other URL-unsafe characters. The %25 → % round-trip avoids double-encoding
@@ -320,10 +363,11 @@ export function renderMarkdown(
 	attachmentResolver?: AttachmentResolver,
 	attachmentImageVariant: 'thumb-sm' | 'thumb-md' = 'thumb-md'
 ): string {
-	// Body may contain backslash-escaped chars (`\]`, `\\`, `\|`) — same
-	// capture as wikiLinksToMarkdown so the two renderers accept identical
-	// stored syntax (BUG-1744).
-	const withLinks = content.replace(/\[\[((?:\\.|[^\]\\])+)\]\]/g, (_match, body: string) => {
+	// Body may contain backslash-escaped chars (`\]`, `\\`, `\|`) — the SAME
+	// pattern object as wikiLinksToMarkdown, so the two renderers cannot drift
+	// apart in accepted syntax (BUG-1744 aligned them; BUG-2834 removed the
+	// second copy that let them look aligned while diverging).
+	const withLinks = content.replace(WIKI_LINK_PATTERN, (_match, body: string) => {
 		// Cross-workspace form: [[workspace-slug::REF]] or [[workspace-slug::REF|Display]].
 		// `::` is the unambiguous separator. The workspace prefix is recognized
 		// only when both the slug AND the right-hand side match their expected
@@ -620,9 +664,10 @@ function resolveWikiBody(body: string, items: Item[]): { item: Item | null; disp
  */
 export function wikiLinksToMarkdown(content: string, items: Item[], workspaceSlug: string, username?: string): string {
 	// Body may contain backslash-escaped chars (`\]`, `\\`, `\|`) so the tokens
-	// we emit can carry arbitrary display text. The capture is (\\.|[^\]\\])+,
-	// i.e. "a backslash-escaped char OR any non-`]`/non-`\` char".
-	return content.replace(/\[\[((?:\\.|[^\]\\])+)\]\]/g, (_match, body: string) => {
+	// we emit can carry arbitrary display text. Shares WIKI_LINK_PATTERN with
+	// renderMarkdown — see its definition for why the escape alternative is
+	// spelled `\\[^\n]` rather than `\\.` (BUG-2834).
+	return content.replace(WIKI_LINK_PATTERN, (_match, body: string) => {
 		const prefix = username ? `/${username}/${workspaceSlug}` : `/${workspaceSlug}`;
 
 		// Cross-workspace form: [[workspace::REF]] / [[workspace::REF|Display]].


### PR DESCRIPTION
## Summary

Two wiki-link grammar divergences between the Go server and the web client, closed against one cross-language differential harness — which is the deliverable meant to outlive both fixes.

**BUG-2834 — `.` does not mean the same thing in Go and JavaScript.** The two patterns were byte-identical source text and still disagreed: Go's RE2 `.` excludes only LF, ECMAScript's also excludes CR, U+2028 and U+2029. A body with a backslash immediately before one of those three was indexed by the server and not rendered by the client — the backlink panel claimed a link the document refused to draw.

**BUG-2830 — a literal title that looks qualified.** An item titled `tasks/Setup` in collection `tasks` stores an index row byte-identical to a genuinely qualified reference to an item titled `Setup`. The rewriter inferred "qualified" from the prefix alone, so renaming the literal-titled item emitted `[[tasks/Renamed]]` — silently converting a literal-title reference into a collection-qualified one, which changes what the stored markdown *means*.

> **Severity, settled after getting it wrong twice (codex R1 → R4).** The filing called this a "silent retarget". I first asserted it with a decoy that could not be stolen; then, finding that decoy inert, I over-corrected and wrote "the renamed item always wins" into a production doc comment. Both were generalisations from one fixture. `resolveTitleTx` settles it, and it had to be read rather than remembered: it tries an exact **full-title** match before the qualified fallback, so the outcome depends on what else the workspace holds —
>
> - an item literally titled `tasks/<newTitle>` (slash included) **takes the link outright** — the renamed item loses its backlink. Deterministic, and pinned by `TestItemRename_LiteralSlashTitleRetargetsOntoALiteralSlashSibling`, which was measured failing against the unfixed code (decoy gains 1 backlink).
> - with no such item, the emitted bracket still finds the renamed item, and the cost is ambiguity wherever a same-titled sibling exists, plus a later collection move breaking `[[tasks/X]]` where `[[X]]` would have followed.
>
> The two fixtures are split along exactly that line, and each says which case it pins.

## The harness

`testdata/wiki_grammar_corpus.json` is read by both languages and carries expectations derived from the grammar **spec**, not from either implementation. Comparing the two implementations to each other would have reproduced the exact blind spot that hid BUG-2834 — looking identical is what they already did.

24 cases, pure ASCII, every control character a `\uXXXX` escape. An early probe typed U+2028/U+2029 into a shell heredoc, silently lost them, and would have "confirmed" the bug on two cases that were actually spaces.

## Which direction BUG-2834 aligns, and why it wasn't a coin flip

The filing left this open. Aligned JS **up** to Go, three independent reasons:

1. The grammar's other alternative already admits **raw** CR/LS/PS in both languages, so only the *escaped* form ever diverged. Narrowing Go would make `[[A<CR>B]]` legal and `[[A\<CR>B]]` illegal — not a rule anyone would write on purpose.
2. Narrowing Go would stop `ExtractWikiLinks` returning rows it currently returns, and the next reconcile would **delete** them. That is BUG-2805's damage shape.
3. `markdown.ts`'s own `splitWikiBody` already treats `\<CR>` as an escape pair; only its regex disagreed.

LF stays excluded on both sides — `scanBracketBody` depends on that and is untouched.

## Measured, not reasoned

Nine code points, both sides, before deciding anything:

| code point | Go | JS | |
|---|---|---|---|
| LF U+000A | no | no | agree |
| **CR U+000D** | **YES** | **no** | **diverge** |
| **LS U+2028** | **YES** | **no** | **diverge** |
| **PS U+2029** | **YES** | **no** | **diverge** |
| space, tab, VT, FF, NEL | YES | YES | agree |

VT/FF/NEL weren't in the filing. They're the "maybe it's all whitespace / all Unicode line breaks" hypotheses, and they agree — which bounds the population at exactly three rather than leaving it open.

## Test plan

Run from the worktree, so `make check` was **not** used — it reaches `npm ci`, which is unsafe with a symlinked `node_modules`. Legs run individually; naming the narrowing rather than reporting it under `make check`'s name:

- [x] `gofmt -l .` — clean
- [x] `go build ./...` — exit 0
- [x] `go vet ./...` — exit 0
- [x] `golangci-lint run --timeout=5m ./...` — **0 issues**
- [x] `go test ./...` — exit 0, 28 packages
- [x] `npm run build` (vite build) — exit 0
- [x] `npm run test` (vitest) — **113 files, 1931 tests**, all passing
- [x] `npm run check` (svelte-check) — **0 errors**, 6 pre-existing warnings in untouched files

## Negative controls

Every instrument here was run against broken code before being believed.

### Codex review loop — 5 rounds to CLEAN

**R1 (2 findings).** *P2* — `qualifiedFor` gated its `EqualFold` calls behind a byte-length equality. `EqualFold` is Unicode simple case folding, so case-equivalent strings can differ in length: `EqualFold("K", "K")` (KELVIN SIGN) is true at 1 vs 3 bytes. A qualified link whose title folds across lengths was classified as index drift and left stale. *P3* — the end-to-end decoy assertion could not fire.

**R2 (1).** My R1 fix left stale and overstated prose behind — including "no decoy can be stolen", which was stronger than what I had measured.

**R3 (2).** Two more copies of the same overstatement, phrased differently, including one in a **production** doc comment. R2 had missed them because I swept by grepping the wording I remembered writing, which verifies the prediction rather than the prose.

**R4 (1).** The correction had over-shot — see the severity note above. Added the deterministic-retarget test.

**R5 — CLEAN.**

Worth stating plainly: three of the five rounds were about my own claims, not the code. The fix was right from R1 onward; what kept failing review was prose asserting more than I had measured.

### Pre-review controls

1. JS pattern reverted to `\\.` → exactly **9** failures (3 corpus + 3 `wikiLinksToMarkdown` + 3 `renderMarkdown`); the LF control and VT/FF/NEL bounds unmoved.
2. Go pattern narrowed to JS semantics → the same 3 cases fail from the other side. Both halves are live instruments.
3. `qualifiedFor` reverted to the prefix rule → kills the BUG-2830 case-A regression in both homes; the twin correctly survives.
4. `qualifiedFor` accepting drift → kills the drift test. That test exists *because* the first mutation run showed the branch was unreachable by the entire suite.
5. **Binding control** — store call site passing the wrong `oldTitle` → kills 5 tests including 3 pre-existing. The unit tests pin `qualifiedFor`; only this shows the cascade hands it the right value, which was the whole bug.
6. Citation guard, symbol renamed → **did not fire.** See below.

## The instrument defect, stated plainly

The symbol guard first asked `strings.Contains(ts, "function "+sym)` — a prefix match. Renaming `resolveWikiBody` to `resolveWikiBodyRENAMED` leaves `function resolveWikiBody` a substring of the renamed declaration, so the guard stayed **green through precisely the rename it exists to catch**. It passed its first real run and would have shipped as coverage. Found only by running the negative control; fixed by requiring the next character to be one that cannot continue a JS identifier.

A guard that passes on its own target is worse than no guard, because it is also a claim that someone checked.

## Scope note for the reviewer

The rider was dispatched as "fix stale citations in files you touch anyway". It became all 32 because commit 1 shifted `markdown.ts` by +45 lines, invalidating every line citation into it — including the three that were still accurate. Leaving 13 knowingly-wrong citations outside the bound isn't neutral when this branch is what broke them. The citation work is isolated in its own commit and can be split back out.

Also settled five of the filing's six "suspect, not established" citations: `:307`, `:478-481`, `:485`, `:513`, `:516` all pointed at unrelated code. Substantively stale, not off-by-lines.

## Merge method

Three commits, each a distinct concern, each green on its own. Suggest `--merge` to keep them separable, but the rider commit is the one to drop if you'd rather it went separately — your call.

