### PR TITLE
fix(items): require and bound item titles at every write door (BUG-2833, BUG-2831)

### DIFF
--- a/internal/models/item.go
+++ b/internal/models/item.go
@@ -1289,8 +1289,15 @@ const MaxItemTitleRunes = 255
 // It exists as its own function because normalize-then-validate must not drift
 // between doors — the whole of BUG-2833 is create and update disagreeing about
 // one field, and BUG-2831 is create and Postgres disagreeing about the same
-// field. Every door calls this and then ValidateItemTitle, and stores what it
-// validated rather than the raw input.
+// field.
+//
+// Every door that takes a title FROM A CALLER pairs this with
+// ValidateItemTitle and stores what it validated, never the raw input. The two
+// legacy-data paths do not, by ruling: ImportWorkspace coerces (it normalizes,
+// then truncates or substitutes rather than refusing) and cross-workspace copy
+// carries the source row's title through untouched. See MaxItemTitleRunes for
+// both. An earlier version of this comment said "every door", which reads as
+// covering those two and does not (codex round 6).
 func NormalizeItemTitle(title string) string {
 	return strings.TrimSpace(title)
 }

--- a/internal/models/item.go
+++ b/internal/models/item.go
@@ -1228,17 +1228,34 @@ type ItemLinkCreate struct {
 // exists:
 //
 //   - items carries UNIQUE(workspace_id, slug), which Postgres implements as a
-//     btree, and a btree index tuple is capped at 8191 bytes. That cap, not the
-//     title column, is what refuses a long title on Postgres while SQLite takes
-//     it (BUG-2831).
+//     btree, and a btree index tuple has a size cap. That cap, not the title
+//     column, is what refuses a long title on Postgres while SQLite takes it
+//     (BUG-2831).
 //   - store.slugify emits ONLY [a-z0-9-] — one output BYTE per input rune at
 //     most, and it truncates nothing. So an N-rune title yields at most N bytes
 //     of slug.
 //
-// 255 runes therefore bounds the slug at ~255 bytes against an 8191-byte
-// limit: ~32x headroom, so the compressibility that makes the failure
-// threshold unquotable stops mattering. The uniqueness suffix (-2, -3, ...)
-// adds a handful of bytes and does not change that.
+// THE CAP IS 2704 BYTES, NOT 8191, and this is measured rather than inherited.
+// BUG-2831 quoted 8191 — the absolute maximum — and the first version of this
+// comment repeated it. Driving high-entropy slugs of 2000 / 4000 / 9000 bytes
+// through ImportWorkspace against Postgres 17 (the container the PG gate uses)
+// with the coercion disabled gives:
+//
+//	2000 -> accepted
+//	4000 -> ERROR: index row size 4056 exceeds btree version 4 maximum 2704
+//	        for index "items_workspace_id_slug_key" (SQLSTATE 54000)
+//	9000 -> ERROR: index row requires 9056 bytes, maximum size is 8191 (SQLSTATE 54000)
+//
+// So 2704 is what a regular index tuple is held to (a third of a page) and
+// 8191 is the hard ceiling reached only past it. Both are post-compression:
+// a REPETITIVE 9000-byte slug is accepted, which is why the filing's threshold
+// was unquotable as a single number and why the test fixture uses a
+// deterministic high-entropy slug rather than strings.Repeat.
+//
+// 255 runes therefore bounds the slug at ~255 bytes against the 2704 that
+// actually fires: ~10x headroom, so compressibility stops mattering. The
+// uniqueness suffix (-2, -3, ...) adds a handful of bytes and does not change
+// that.
 //
 // RUNES, not bytes, because "255 characters" is what a user and a UI counter
 // mean. The byte-level residual on the TITLE column is up to 4x this number,

--- a/internal/models/item.go
+++ b/internal/models/item.go
@@ -6,7 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 const (
@@ -1216,4 +1218,72 @@ type ItemLinkCreate struct {
 	TargetID  string `json:"target_id"`
 	LinkType  string `json:"link_type,omitempty"`
 	CreatedBy string `json:"created_by,omitempty"`
+}
+
+// MaxItemTitleRunes bounds an item title at write time.
+//
+// 255 matches MaxDocumentTitleRunes, but for items the number is not borrowed
+// — it is mechanically sufficient, which is why BUG-2831's "there is no single
+// safe number, it depends on compressibility" does not apply once the bound
+// exists:
+//
+//   - items carries UNIQUE(workspace_id, slug), which Postgres implements as a
+//     btree, and a btree index tuple is capped at 8191 bytes. That cap, not the
+//     title column, is what refuses a long title on Postgres while SQLite takes
+//     it (BUG-2831).
+//   - store.slugify emits ONLY [a-z0-9-] — one output BYTE per input rune at
+//     most, and it truncates nothing. So an N-rune title yields at most N bytes
+//     of slug.
+//
+// 255 runes therefore bounds the slug at ~255 bytes against an 8191-byte
+// limit: ~32x headroom, so the compressibility that makes the failure
+// threshold unquotable stops mattering. The uniqueness suffix (-2, -3, ...)
+// adds a handful of bytes and does not change that.
+//
+// RUNES, not bytes, because "255 characters" is what a user and a UI counter
+// mean. The byte-level residual on the TITLE column is up to 4x this number,
+// which the title column (TEXT) carries without complaint — the slug is the
+// constrained derivative, and it is ASCII by construction.
+//
+// Enforced at WRITE time only, and deliberately NOT retroactive: an item whose
+// stored title already exceeds the bound keeps working, and an update that does
+// not set a title never validates one. Same grandfathering rule as documents
+// (Dave's ruling, day-63). Workspace import coerces rather than refuses, for
+// the same reason — see ImportWorkspace.
+const MaxItemTitleRunes = 255
+
+// NormalizeItemTitle is the canonical normalization for an item title:
+// leading/trailing whitespace is not part of a title.
+//
+// It exists as its own function because normalize-then-validate must not drift
+// between doors — the whole of BUG-2833 is create and update disagreeing about
+// one field, and BUG-2831 is create and Postgres disagreeing about the same
+// field. Every door calls this and then ValidateItemTitle, and stores what it
+// validated rather than the raw input.
+func NormalizeItemTitle(title string) string {
+	return strings.TrimSpace(title)
+}
+
+// ValidateItemTitle checks an ALREADY-NORMALIZED item title at write time.
+// Returns a message suitable for a 400 response, or "" when acceptable.
+//
+// Callers pass NormalizeItemTitle's output. Validating the normalized value is
+// the point rather than an implementation detail: a title of "   " is untitled
+// wearing a costume, and before this function existed it was legal on create
+// (which tested title == "" exactly) and refused on artifact import (which
+// trimmed first) — two doors, two rules, and the import door's comment claimed
+// to mirror the create gate it was in fact stricter than.
+//
+// Deliberately NOT covering wikiTitleRoundTripFailure, which ValidateDocumentTitle
+// does: the item rename cascade escapes its emission (BUG-2805), so an item
+// title containing wiki-link syntax round-trips. Documents' cascade does not
+// escape, which is why the check lives there and not here.
+func ValidateItemTitle(title string) string {
+	if title == "" {
+		return "Title is required"
+	}
+	if n := utf8.RuneCountInString(title); n > MaxItemTitleRunes {
+		return fmt.Sprintf("Title is too long: %d characters, maximum %d", n, MaxItemTitleRunes)
+	}
+	return ""
 }

--- a/internal/models/item.go
+++ b/internal/models/item.go
@@ -1265,8 +1265,22 @@ type ItemLinkCreate struct {
 // Enforced at WRITE time only, and deliberately NOT retroactive: an item whose
 // stored title already exceeds the bound keeps working, and an update that does
 // not set a title never validates one. Same grandfathering rule as documents
-// (Dave's ruling, day-63). Workspace import coerces rather than refuses, for
-// the same reason — see ImportWorkspace.
+// (Dave's ruling, day-63).
+//
+// TWO PATHS DO NOT VALIDATE, both by ruling and both carrying legacy data
+// rather than caller input (codex round 5 — an earlier version of this comment
+// said every door normalizes then validates, which is not true of either):
+//
+//   - ImportWorkspace COERCES rather than refuses, so restoring an archive
+//     cannot die on a row this product itself once accepted.
+//   - Cross-workspace copy PROPAGATES the source row's title verbatim, for the
+//     same reason; it takes no title from the caller, so it cannot mint one.
+//
+// The guarantee that holds across every path is therefore narrower than "every
+// stored title satisfies this bound": no CALLER-SUPPLIED title is stored
+// without being validated against it. Legacy titles at rest are out of scope
+// here; making the bound global would be a count-then-repair sweep over
+// existing rows, not a change to any door.
 const MaxItemTitleRunes = 255
 
 // NormalizeItemTitle is the canonical normalization for an item title:

--- a/internal/server/handlers_artifact_import.go
+++ b/internal/server/handlers_artifact_import.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/PerpetualSoftware/pad/internal/artifact"
 	"github.com/PerpetualSoftware/pad/internal/collections"
@@ -81,12 +80,20 @@ func (s *Server) handleImportArtifact(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Require a title, matching handleCreateItem's "Title is required" gate.
-	// artifact.Decode tolerates a missing title (producing an "untitled"
-	// item), so we enforce it here so an import can't diverge from the normal
-	// create path's validation.
-	if strings.TrimSpace(art.Title) == "" {
-		writeError(w, http.StatusBadRequest, "bad_request", "Title is required")
+	// Require a well-formed title, matching handleCreateItem. artifact.Decode
+	// tolerates a missing title (producing an "untitled" item), so an import
+	// must not diverge from the normal create path's validation.
+	//
+	// BUG-2833: this comment used to claim it matched handleCreateItem's gate
+	// while testing strings.TrimSpace(...) == "" against a create path that
+	// tested art.Title == "" exactly — so a title of "   " was refused HERE and
+	// accepted THERE, and the comment asserting they agreed is what stopped
+	// anyone noticing. Both now call the same models pair, so the claim is
+	// enforced rather than asserted; create adopted this door's trim, which is
+	// the stricter and correct reading.
+	art.Title = models.NormalizeItemTitle(art.Title)
+	if msg := models.ValidateItemTitle(art.Title); msg != "" {
+		writeError(w, http.StatusBadRequest, "bad_request", msg)
 		return
 	}
 

--- a/internal/server/handlers_collab.go
+++ b/internal/server/handlers_collab.go
@@ -460,11 +460,18 @@ func (s *Server) applyContentViaCollab(r *http.Request, itemID, markdown string,
 // isDeterministicWriteFailure reports whether an error from a direct-write
 // callback is a settled answer rather than a transient condition.
 //
-// These three are the errors handleUpdateItem already treats as FINAL at every
-// call site: a rejection, a conflict, and a refusal. None can come out
+// These are the errors handleUpdateItem already treats as FINAL at every call
+// site: a rejection, a conflict, and two refusals. None can come out
 // differently on a retry, so a fallback path that swallows one and retries is
 // doing the work twice to reach the same answer — and, worse, may reach it by
 // a route that reports it differently.
+//
+// THIS LIST IS A CLOSED SET THAT KEEPS GETTING REOPENED. It said "these three"
+// until BUG-2833 added a fourth store-level refusal on the same write path, and
+// nothing failed when the new error was omitted — the request still reached an
+// answer, just twice and by the other route. Anyone adding a typed, permanent
+// refusal to store.UpdateItem owes this function an entry and the sentence
+// above a recount.
 func isDeterministicWriteFailure(err error) bool {
 	if err == nil {
 		return false
@@ -473,6 +480,10 @@ func isDeterministicWriteFailure(err error) bool {
 		return true
 	}
 	if _, ok := asUpdateConflictError(err); ok {
+		return true
+	}
+	var badTitle *store.InvalidItemTitleError
+	if errors.As(err, &badTitle) {
 		return true
 	}
 	var tooLarge *store.ItemRenameCascadeTooLargeError

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -954,9 +954,15 @@ func writeItemRenameCascadeTooLarge(w http.ResponseWriter, err error) bool {
 // and that retrying might work, when the request was understood, deliberately
 // declined, and will be declined identically until the title changes.
 //
-// It is shared by the create and update paths rather than inlined at each,
-// because "create and update disagreed about one field" is the whole of
-// BUG-2833 and duplicating the arm would be the same mistake in the error path.
+// Shared by the THREE update error blocks (the plain path, the collab-snapshot
+// callback and the collab-edit callback), which is where duplicating an arm has
+// actually gone wrong twice — see the note on writeItemRenameCascadeTooLarge.
+//
+// The CREATE path does not use it and cannot: createItemChecked returns a typed
+// *itemCreateError for its caller to write, rather than writing the response
+// itself, so it maps the same store error with its own errors.As block. An
+// earlier version of this comment claimed create shared this helper (codex
+// round 5) — the rule they share is the 400, not the code.
 //
 // The Reason is taken from the TYPED field, never by splicing err.Error(): the
 // call path wraps this error on the way up and those wrappers must not be
@@ -1025,31 +1031,32 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 	// unbounded slug, which Postgres refuses at the UNIQUE(workspace_id, slug)
 	// btree while SQLite takes it.
 	//
-	// This check is the FAST, FRIENDLY one, not the authoritative one.
-	// store.UpdateItem re-runs it under the write lock, because `item` here was
-	// read before any lock and a concurrent rename could turn an echoed legacy
-	// title into a genuine one between that read and the write. Both call the
-	// same models pair, so they cannot drift into disagreeing the way create
-	// and update did.
+	// THIS CHECK REFUSES; IT DOES NOT DECIDE. It may answer 400 early, and it
+	// must not alter `input` — the grandfathering decision and the
+	// normalization both belong to store.UpdateItem, under the write lock.
 	//
-	// The `!= item.Title` clause is the grandfathering rule, not an
-	// optimization: re-sending an item's existing title is not a rename, so a
-	// legacy title that predates the bound keeps working. See the fuller note
-	// at the store's copy.
+	// The reason is a real regression this handler caused when it did decide
+	// (caught by BUG-2776's own TOCTOU test): `item` here is read BEFORE any
+	// lock, so "the title equals the stored one" is a claim about a snapshot
+	// that a concurrent rename can invalidate. A rival renames the item inside
+	// the window; this request then sends the title IT last saw, which against
+	// the row AS COMMITTED is a genuine rename back. Deciding here dropped that
+	// write entirely and the timeline lost a rename that happened.
+	//
+	// Normalizing here is the same mistake in the other direction: it would
+	// destroy the store's raw-echo comparison, which is what lets a client echo
+	// a legacy title carrying edge whitespace without it reading as a rename.
+	//
+	// So the early refusal is skipped when the title matches the pre-lock read
+	// — a fast path that can only ever be wrong about whether to REFUSE, never
+	// about what to write, and the store refuses again anyway.
 	if input.Title != nil {
 		normalizedTitle := models.NormalizeItemTitle(*input.Title)
-		// Grandfathered writes keep the stored bytes; everything else is
-		// validated before it is normalized in. See the store's copy of this
-		// block for why the two must be exclusive (codex round 2, P1).
-		if normalizedTitle == item.Title || *input.Title == item.Title {
-			unchanged := item.Title
-			input.Title = &unchanged
-		} else {
+		if normalizedTitle != item.Title && *input.Title != item.Title {
 			if msg := models.ValidateItemTitle(normalizedTitle); msg != "" {
 				writeError(w, http.StatusBadRequest, "bad_request", msg)
 				return
 			}
-			input.Title = &normalizedTitle
 		}
 	}
 

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -1746,6 +1746,20 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 			// re-run the entire cascade — every linking body read and projected a
 			// second time — and refuse identically (codex R2).
 			return
+		} else if writeInvalidItemTitle(w, err) {
+			// FINAL for the same reason, and the pair with
+			// isDeterministicWriteFailure: that function is what stops
+			// applyContentViaCollab swallowing this error, and THIS arm is what
+			// consumes it once it arrives. Without both, a refused title falls
+			// through to the direct write below and is re-derived from scratch.
+			//
+			// BUG-2833 / codex R2. The comment on writeItemRenameCascadeTooLarge
+			// says this handler has THREE error blocks and that mapping only the
+			// plain one is a population error rather than a typo. I mapped two,
+			// then a reviewer named a third — and this is the fourth unit to make
+			// the identical mistake in the identical function. CONVE-18: the
+			// instance a reviewer names is a sample; grep the class.
+			return
 		} else if errors.Is(err, collab.ErrApplierAmbiguous) {
 			// BUG-2276 residual 2 (P1, mixed-deploy window): a legacy (non-bracket-
 			// capable) applier was caught by a concurrent version restore and its

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -1038,7 +1038,7 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 	// at the store's copy.
 	if input.Title != nil {
 		normalizedTitle := models.NormalizeItemTitle(*input.Title)
-		if normalizedTitle != item.Title {
+		if normalizedTitle != item.Title && *input.Title != item.Title {
 			if msg := models.ValidateItemTitle(normalizedTitle); msg != "" {
 				writeError(w, http.StatusBadRequest, "bad_request", msg)
 				return
@@ -1653,6 +1653,14 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 			// client as a 500 from this path only, while the plain path answers
 			// 413 for the identical store error.
 			if writeItemRenameCascadeTooLarge(w, err) {
+				return
+			}
+			// BUG-2833 / codex round 1, P2 — the identical omission, one
+			// release later. This block mirrors the plain path's arms, and a
+			// PATCH carrying both content and a title reaches the store through
+			// it, so a title the store refuses under the lock would answer 500
+			// here while the plain path answers 400.
+			if writeInvalidItemTitle(w, err) {
 				return
 			}
 			// Mirror the main UpdateItem path: map UNIQUE constraint /

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -617,8 +617,22 @@ func (s *Server) handleCreateItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if input.Title == "" {
-		writeError(w, http.StatusBadRequest, "bad_request", "Title is required")
+	// BUG-2833 / BUG-2831. This used to be `input.Title == ""` inline, which is
+	// how create and update came to disagree: the rule was a literal in one
+	// handler, so the sibling handler on the same field never got it. It now
+	// runs through models.NormalizeItemTitle + models.ValidateItemTitle, the
+	// same pair store.CreateItem enforces authoritatively and
+	// handleUpdateItem/handleImportArtifact call.
+	//
+	// Two behaviour changes on THIS door, both deliberate:
+	//   - whitespace-only titles are now refused. "   " was legal on create and
+	//     refused on artifact import; it slugifies to empty and lands on the
+	//     store's "untitled" fallback, which Dave's ruling made defensive-only.
+	//   - titles over MaxItemTitleRunes are refused, closing BUG-2831's
+	//     dialect split at the door instead of at a Postgres btree error.
+	input.Title = models.NormalizeItemTitle(input.Title)
+	if msg := models.ValidateItemTitle(input.Title); msg != "" {
+		writeError(w, http.StatusBadRequest, "bad_request", msg)
 		return
 	}
 
@@ -969,6 +983,35 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 		}
 		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
 		return
+	}
+
+	// BUG-2833: the empty-title door. handleCreateItem has refused an empty
+	// title since it was written; this handler never had the check, so
+	// PATCH {"title": ""} was accepted and applied — one field, two handlers,
+	// two answers. BUG-2831 adds the length half: an unbounded title becomes an
+	// unbounded slug, which Postgres refuses at the UNIQUE(workspace_id, slug)
+	// btree while SQLite takes it.
+	//
+	// This check is the FAST, FRIENDLY one, not the authoritative one.
+	// store.UpdateItem re-runs it under the write lock, because `item` here was
+	// read before any lock and a concurrent rename could turn an echoed legacy
+	// title into a genuine one between that read and the write. Both call the
+	// same models pair, so they cannot drift into disagreeing the way create
+	// and update did.
+	//
+	// The `!= item.Title` clause is the grandfathering rule, not an
+	// optimization: re-sending an item's existing title is not a rename, so a
+	// legacy title that predates the bound keeps working. See the fuller note
+	// at the store's copy.
+	if input.Title != nil {
+		normalizedTitle := models.NormalizeItemTitle(*input.Title)
+		if normalizedTitle != item.Title {
+			if msg := models.ValidateItemTitle(normalizedTitle); msg != "" {
+				writeError(w, http.StatusBadRequest, "bad_request", msg)
+				return
+			}
+		}
+		input.Title = &normalizedTitle
 	}
 
 	// TASK-2022: `fields` (full replace) and `fields_patch` (field-level
@@ -1712,6 +1755,17 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 		// call path added on the way up would otherwise be published to the
 		// client.
 		if writeItemRenameCascadeTooLarge(w, err) {
+			return
+		}
+		// BUG-2833 / BUG-2831: the store's authoritative title check. The
+		// pre-lock check above catches this for ordinary callers; this arm is
+		// what a title that only became invalid under the lock lands on, and it
+		// must be a 400 rather than writeInternalError's 500 — the request was
+		// understood and declined, and retrying it unchanged will be declined
+		// identically.
+		var badItemTitle *store.InvalidItemTitleError
+		if errors.As(err, &badItemTitle) {
+			writeError(w, http.StatusBadRequest, "bad_request", badItemTitle.Reason)
 			return
 		}
 		// Map UNIQUE constraint races (e.g. concurrent updates that both

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -1038,13 +1038,19 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 	// at the store's copy.
 	if input.Title != nil {
 		normalizedTitle := models.NormalizeItemTitle(*input.Title)
-		if normalizedTitle != item.Title && *input.Title != item.Title {
+		// Grandfathered writes keep the stored bytes; everything else is
+		// validated before it is normalized in. See the store's copy of this
+		// block for why the two must be exclusive (codex round 2, P1).
+		if normalizedTitle == item.Title || *input.Title == item.Title {
+			unchanged := item.Title
+			input.Title = &unchanged
+		} else {
 			if msg := models.ValidateItemTitle(normalizedTitle); msg != "" {
 				writeError(w, http.StatusBadRequest, "bad_request", msg)
 				return
 			}
+			input.Title = &normalizedTitle
 		}
-		input.Title = &normalizedTitle
 	}
 
 	// TASK-2022: `fields` (full replace) and `fields_patch` (field-level

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -786,6 +786,16 @@ func (s *Server) createItemChecked(r *http.Request, workspaceID string, coll *mo
 
 	item, err := s.store.CreateItem(workspaceID, coll.ID, input)
 	if err != nil {
+		// BUG-2833 / BUG-2831: the store's typed title refusal is a 400, not a
+		// 500. Today the handler's own check above catches every reachable
+		// case, so this arm is belt-and-braces — but its ABSENCE was a latent
+		// 500 that a mutation test surfaced, and the update path needs the same
+		// arm for a title that only becomes invalid under the lock. Both paths
+		// answer the same way because both go through the same helper.
+		var badTitle *store.InvalidItemTitleError
+		if errors.As(err, &badTitle) {
+			return nil, &itemCreateError{http.StatusBadRequest, "bad_request", badTitle.Reason}
+		}
 		if strings.Contains(err.Error(), "UNIQUE constraint") || strings.Contains(err.Error(), "duplicate key") {
 			// Could be the slug-per-workspace constraint OR the playbook
 			// invocation_slug partial unique index (TASK-1378). Keep the
@@ -934,6 +944,29 @@ func writeItemRenameCascadeTooLarge(w http.ResponseWriter, err error) bool {
 		fmt.Sprintf("This rename would rewrite more linked content than the server will process in one "+
 			"operation: at least %d bytes, and the limit is %d. Reduce the number of items linking "+
 			"this title, or split the rename, and try again.", tooLarge.Processed, tooLarge.Max))
+	return true
+}
+
+// writeInvalidItemTitle maps the store's typed title refusal to a 400, and
+// reports whether it did — same shape as writeItemRenameCascadeTooLarge above,
+// and for the same reason: without it the refusal falls through to
+// writeInternalError and lands as a 500, telling the caller the server broke
+// and that retrying might work, when the request was understood, deliberately
+// declined, and will be declined identically until the title changes.
+//
+// It is shared by the create and update paths rather than inlined at each,
+// because "create and update disagreed about one field" is the whole of
+// BUG-2833 and duplicating the arm would be the same mistake in the error path.
+//
+// The Reason is taken from the TYPED field, never by splicing err.Error(): the
+// call path wraps this error on the way up and those wrappers must not be
+// published to the client.
+func writeInvalidItemTitle(w http.ResponseWriter, err error) bool {
+	var bad *store.InvalidItemTitleError
+	if !errors.As(err, &bad) {
+		return false
+	}
+	writeError(w, http.StatusBadRequest, "bad_request", bad.Reason)
 	return true
 }
 
@@ -1763,9 +1796,7 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 		// must be a 400 rather than writeInternalError's 500 — the request was
 		// understood and declined, and retrying it unchanged will be declined
 		// identically.
-		var badItemTitle *store.InvalidItemTitleError
-		if errors.As(err, &badItemTitle) {
-			writeError(w, http.StatusBadRequest, "bad_request", badItemTitle.Reason)
+		if writeInvalidItemTitle(w, err) {
 			return
 		}
 		// Map UNIQUE constraint races (e.g. concurrent updates that both

--- a/internal/server/handlers_items_title_test.go
+++ b/internal/server/handlers_items_title_test.go
@@ -4,6 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -287,5 +290,77 @@ func TestIsDeterministicWriteFailureIncludesTitleRefusal(t *testing.T) {
 	}
 	if isDeterministicWriteFailure(errors.New("transient prune failure")) {
 		t.Error("an unrecognised error must stay recoverable so the fallback still degrades gracefully")
+	}
+}
+
+// TestUpdateItemErrorBlocksMapEveryStoreRefusal is a structural guard, and it
+// exists because this exact mistake has now been made four times in this one
+// function.
+//
+// handleUpdateItem reaches store.UpdateItemWithParentLink from THREE places —
+// the plain path, the collab-snapshot callback, and the collab-edit callback —
+// each with its own error block. BUG-2804 mapped the cascade refusal into the
+// plain block and missed the other two; its own comment records that as "a
+// population error, not a typo". BUG-2833 then mapped the title refusal into
+// the plain block, a reviewer named the collab-snapshot one, and the collab-edit
+// one was still missing — with that comment sitting directly above the helper
+// being called.
+//
+// So the durable fix is not another careful read. It is this: the arms are
+// counted, and adding a fourth block carrying one refusal but not its siblings
+// fails here with a message saying which. Counting AST call expressions rather
+// than grepping means comments and strings mentioning these names do not count.
+//
+// If you are here because this test failed: you added (or moved) an error
+// block. Give it every arm, in the same order as its siblings, or explain in
+// this test why the new block genuinely cannot produce one of these errors.
+//
+// WHAT IT DOES NOT COVER, stated because a structural test invites more
+// confidence than it earns: it counts SYNTACTIC PRESENCE, not reachability. An
+// arm disabled in place — `false && writeInvalidItemTitle(w, err)`, an
+// unreachable branch — still counts, and a mutant of that shape survives this
+// test (measured, not assumed). That is accepted: the failure this guards
+// against is an OMITTED arm, which is deletion-shaped, and deletion is exactly
+// what it detects — verified by deleting the arm from each of the three blocks
+// in turn and watching this test fail each time.
+func TestUpdateItemErrorBlocksMapEveryStoreRefusal(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "handlers_items.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse handlers_items.go: %v", err)
+	}
+
+	counts := map[string]int{}
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		ident, ok := call.Fun.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		switch ident.Name {
+		case "writeItemRenameCascadeTooLarge", "writeInvalidItemTitle", "asUpdateConflictError":
+			counts[ident.Name]++
+		}
+		return true
+	})
+
+	const wantBlocks = 3
+	for _, name := range []string{"writeItemRenameCascadeTooLarge", "writeInvalidItemTitle", "asUpdateConflictError"} {
+		if counts[name] != wantBlocks {
+			t.Errorf("%s is called %d time(s); every one of the %d UpdateItem error blocks must map it. "+
+				"A refusal mapped in some blocks and not others answers 400/409/413 down one route and "+
+				"500 — or a silent duplicate write — down another, for the identical store error.",
+				name, counts[name], wantBlocks)
+		}
+	}
+
+	// Control: the count is not trivially satisfied by a name that appears
+	// nowhere. If this fires, the AST walk is matching nothing and the
+	// assertions above are vacuous.
+	if counts["writeInvalidItemTitle"] == 0 {
+		t.Fatal("AST walk found no calls at all — the instrument is broken, not the code")
 	}
 }

--- a/internal/server/handlers_items_title_test.go
+++ b/internal/server/handlers_items_title_test.go
@@ -256,3 +256,36 @@ func TestCreateItemCheckedMapsStoreTitleRefusalTo400(t *testing.T) {
 		t.Fatalf("a valid title must still create: %d %s", cerr.status, cerr.message)
 	}
 }
+
+// TestIsDeterministicWriteFailureIncludesTitleRefusal regresses codex round 1
+// P1 on the collab fallback.
+//
+// isDeterministicWriteFailure decides whether a direct-write failure is a
+// settled answer. A permanent refusal it does not recognise is returned as a
+// generic collab-routing error, so the caller falls through to its own direct
+// write and re-derives the identical refusal from scratch — BUG-2804 measured
+// that as running a whole rename cascade twice for one request, and reported
+// the answer by the other route.
+//
+// The store gained a fourth such refusal with the item-title bound and nothing
+// failed when it was left out, which is exactly why this test exists: the
+// omission is invisible from the outside.
+func TestIsDeterministicWriteFailureIncludesTitleRefusal(t *testing.T) {
+	if !isDeterministicWriteFailure(&store.InvalidItemTitleError{Reason: "Title is required"}) {
+		t.Error("an invalid-title refusal is permanent: retrying the same title always refuses")
+	}
+	// Through a wrapper, since the call path wraps on the way up.
+	if !isDeterministicWriteFailure(fmt.Errorf("update item: %w", &store.InvalidItemTitleError{Reason: "Title is too long"})) {
+		t.Error("must see through wrappers")
+	}
+	// Controls. Without these, a mutant returning true unconditionally would
+	// pass — and that mutant would break the graceful-degradation contract the
+	// function exists to protect, by treating a transient prune failure as
+	// final.
+	if isDeterministicWriteFailure(nil) {
+		t.Error("nil is not a failure")
+	}
+	if isDeterministicWriteFailure(errors.New("transient prune failure")) {
+		t.Error("an unrecognised error must stay recoverable so the fallback still degrades gracefully")
+	}
+}

--- a/internal/server/handlers_items_title_test.go
+++ b/internal/server/handlers_items_title_test.go
@@ -351,17 +351,19 @@ func TestUpdateItemErrorBlocksMapEveryStoreRefusal(t *testing.T) {
 		wantArm[w] = true
 	}
 
+	// ---- membership + order, per block ----
+	//
 	// PER-BLOCK, not per-file (codex round 2): counting calls across the whole
 	// file lets one block's duplicate mask another's omission and says nothing
 	// about order.
 	//
 	// Blocks are recovered from SOURCE POSITION rather than from AST shape,
-	// which is what makes this robust: the three blocks are written
-	// differently — two as sequential `if` statements, one as an else-if chain
-	// — and an ast.Inspect that keys on either shape either misses blocks or
-	// double-counts them through nesting. (Both happened while writing this:
-	// first 0 blocks, then 8. The block-count guard below is what caught each,
-	// instead of the assertions quietly passing over nothing.)
+	// which is what makes this robust: the three blocks are written differently
+	// — two as sequential `if` statements, one as an else-if chain — and an
+	// ast.Inspect keyed on either shape either misses blocks or double-counts
+	// them through nesting. (Both happened while writing this: first 0 blocks,
+	// then 8. The block-count guard below is what caught each, instead of the
+	// assertions quietly passing over nothing.)
 	//
 	// Every block opens with the open-children arm, so a new block starts at
 	// each occurrence of it, in file order.
@@ -382,46 +384,6 @@ func TestUpdateItemErrorBlocksMapEveryStoreRefusal(t *testing.T) {
 		if wantArm[ident.Name] {
 			refs = append(refs, armRef{ident.Name, call.Pos()})
 		}
-		return true
-	})
-
-	// REACHABILITY, not just presence (codex round 3). Counting call
-	// expressions detects a DELETED arm but not a disabled one: `false &&
-	// writeInvalidItemTitle(w, err)` short-circuits at runtime while leaving
-	// the call in the AST, so the sequence above still reads as correct while
-	// every title refusal falls through to a 500. Measured — that mutant
-	// survived the presence-only version of this test.
-	//
-	// The check is narrow on purpose: each arm must be tested DIRECTLY, as the
-	// whole of an if-condition, not as one operand of a boolean expression.
-	// That is how all three blocks are written, so anything else is either the
-	// mutation above or a genuine restructuring that deserves to be looked at.
-	ast.Inspect(file, func(n ast.Node) bool {
-		ifStmt, ok := n.(*ast.IfStmt)
-		if !ok {
-			return true
-		}
-		bin, ok := ifStmt.Cond.(*ast.BinaryExpr)
-		if !ok {
-			return true
-		}
-		ast.Inspect(bin, func(c ast.Node) bool {
-			call, ok := c.(*ast.CallExpr)
-			if !ok {
-				return true
-			}
-			ident, ok := call.Fun.(*ast.Ident)
-			if !ok {
-				return true
-			}
-			if wantArm[ident.Name] {
-				t.Errorf("the arm %q at line %d is an operand of a boolean expression rather than the "+
-					"whole condition. It still counts as present below, but it may never execute — "+
-					"which is a refusal silently answering 500 while this test reads as green.",
-					ident.Name, fset.Position(call.Pos()).Line)
-			}
-			return true
-		})
 		return true
 	})
 	sort.Slice(refs, func(i, j int) bool { return refs[i].pos < refs[j].pos })
@@ -473,5 +435,131 @@ func TestUpdateItemErrorBlocksMapEveryStoreRefusal(t *testing.T) {
 				break
 			}
 		}
+	}
+
+	// ---- reachability ----
+	//
+	// Counting call expressions detects a DELETED arm but not a disabled one:
+	// `false && writeInvalidItemTitle(w, err)` short-circuits at runtime while
+	// leaving the call in the AST, so the sequence above reads as correct while
+	// every title refusal falls through to a 500. Measured — that mutant
+	// survived the presence-only version (codex round 3).
+	//
+	// WHITELIST, not blacklist. The first attempt rejected conditions that were
+	// BinaryExpr, which `!writeInvalidItemTitle(w, err)` — a UnaryExpr — walked
+	// straight past while inverting the arm's meaning (codex round 5).
+	// Enumerating the ways to disable a call is a losing game; enumerating the
+	// two ways these arms are legitimately written is not:
+	//
+	//	if f(w, err) { ... }            // cond IS the call
+	//	if x, ok := f(err); ok { ... }  // cond is the bare `ok` ident
+	//
+	// Anything else is either a disabling mutation or a restructuring that
+	// deserves to be looked at deliberately.
+	ast.Inspect(file, func(n ast.Node) bool {
+		ifStmt, ok := n.(*ast.IfStmt)
+		if !ok {
+			return true
+		}
+		armsHere := armsIn(ifStmt, want)
+		if len(armsHere) == 0 {
+			return true
+		}
+		switch cond := ifStmt.Cond.(type) {
+		case *ast.CallExpr:
+			if ident, ok := cond.Fun.(*ast.Ident); ok && wantArm[ident.Name] {
+				return true
+			}
+		case *ast.Ident:
+			if ifStmt.Init != nil {
+				return true
+			}
+		}
+		t.Errorf("the arm(s) %v at line %d are guarded by a condition that is neither the bare call nor "+
+			"a plain `ok` ident (%T). They still count as present, but may never execute — which is a "+
+			"refusal silently answering 500 while this test reads as green.",
+			armsHere, fset.Position(ifStmt.Pos()).Line, ifStmt.Cond)
+		return true
+	})
+}
+
+// armsIn returns the named arm functions this if-statement tests, in source
+// order. It reads the INIT statement as well as the condition, because the arms
+// take both shapes — `if x, ok := f(err); ok {` puts the call in Init, while
+// `if f(w, err) {` puts it in Cond. Reading only Cond found zero blocks, and
+// the block-count guard is what caught that rather than silently asserting
+// nothing.
+func armsIn(ifStmt *ast.IfStmt, want []string) []string {
+	var found []string
+	collect := func(n ast.Node) {
+		if n == nil {
+			return
+		}
+		ast.Inspect(n, func(c ast.Node) bool {
+			call, ok := c.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			ident, ok := call.Fun.(*ast.Ident)
+			if !ok {
+				return true
+			}
+			for _, w := range want {
+				if ident.Name == w {
+					found = append(found, w)
+				}
+			}
+			return true
+		})
+	}
+	collect(ifStmt.Init)
+	collect(ifStmt.Cond)
+	return found
+}
+
+// TestPatchItemVerbatimEchoOfALegacyTitleIsANoOp covers the raw-echo
+// grandfathering leg OVER HTTP, which is where the clients that actually do
+// this live.
+//
+// It exists because a mutation exposed the gap: making the handler normalize
+// `input.Title` before forwarding destroys the store's raw-echo comparison, and
+// that mutant SURVIVED — the only test for the leg called store.UpdateItem
+// directly, so nothing measured the path a browser or CLI takes. The handler's
+// job here is to refuse early and change nothing; a normalization on the way
+// through is a decision, and decisions belong under the lock.
+func TestPatchItemVerbatimEchoOfALegacyTitleIsANoOp(t *testing.T) {
+	srv := testServer(t)
+	wsSlug := createWSWithCollections(t, srv)
+	item := createTaskWithFields(t, srv, wsSlug, "Ordinary", `{"status":"open"}`)
+
+	// Make it legacy: over the bound AND carrying edge whitespace, written
+	// straight to the row so it bypasses the write-time guard exactly as a
+	// pre-bound row does.
+	legacyTitle := "  " + strings.Repeat("m", models.MaxItemTitleRunes+1) + "  "
+	if _, err := srv.store.DB().Exec(srv.store.D().Rebind("UPDATE items SET title = ? WHERE id = ?"),
+		legacyTitle, item.ID); err != nil {
+		t.Fatalf("fixture: write the legacy title: %v", err)
+	}
+
+	rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+wsSlug+"/items/"+item.Slug, map[string]interface{}{
+		"title": legacyTitle,
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("echoing the stored title back must be a no-op, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var updated models.Item
+	parseJSON(t, rr, &updated)
+	if updated.Title != legacyTitle {
+		t.Errorf("title = %q, want the legacy bytes unchanged — a normalization on the way through "+
+			"turns a no-op echo into a rename", updated.Title)
+	}
+
+	// Control: a genuine rename to an over-bound title is still refused through
+	// the same door, so this is grandfathering and not a hole.
+	rr = doRequest(srv, "PATCH", "/api/v1/workspaces/"+wsSlug+"/items/"+item.Slug, map[string]interface{}{
+		"title": strings.Repeat("n", models.MaxItemTitleRunes+1),
+	})
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("a DIFFERENT over-bound title must still be refused, got %d: %s", rr.Code, rr.Body.String())
 	}
 }

--- a/internal/server/handlers_items_title_test.go
+++ b/internal/server/handlers_items_title_test.go
@@ -323,12 +323,21 @@ func TestIsDeterministicWriteFailureIncludesTitleRefusal(t *testing.T) {
 // presence-only version. All three are verified by mutation rather than
 // asserted.
 //
-// It is still lexical. An arm made unreachable some other way — an early
-// return above it, a condition that is a call which always returns false —
-// would pass. Closing that needs control-flow analysis or a route-level test,
-// and a route-level test is not available here: the handlers' own pre-checks
-// catch every title refusal reachable over the wire, so the store-sourced one
-// these arms exist for has no HTTP trigger except a concurrent rename.
+// It is still LEXICAL, and that is a boundary rather than a to-do. Three review
+// rounds each named a new way to satisfy the letter of it — a short-circuited
+// condition, an inverted one, a missing return — and each was closed, but a
+// lexical instrument has no last one: an early return above the block, a
+// wrapping `if false`, or a condition calling something that always returns
+// false would all pass. What it buys is protection against the failure that has
+// ACTUALLY happened twice in this function, which is an omitted or misordered
+// arm.
+//
+// The behavioural complement is not available here, and it is worth saying why
+// rather than leaving it as an obvious gap: the handlers' own pre-checks catch
+// every title refusal reachable over the wire, so the store-sourced refusal
+// these arms exist for has no HTTP trigger except a concurrent rename inside
+// the lock window. Driving that from a test needs a store-level seam that does
+// not exist. The helper itself is unit-tested; these arms' job is to call it.
 func TestUpdateItemErrorBlocksMapEveryStoreRefusal(t *testing.T) {
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, "handlers_items.go", nil, 0)
@@ -479,6 +488,29 @@ func TestUpdateItemErrorBlocksMapEveryStoreRefusal(t *testing.T) {
 			"a plain `ok` ident (%T). They still count as present, but may never execute — which is a "+
 			"refusal silently answering 500 while this test reads as green.",
 			armsHere, fset.Position(ifStmt.Pos()).Line, ifStmt.Cond)
+		return true
+	})
+
+	// ---- each arm must actually STOP ----
+	//
+	// An arm that matches and then falls through has written its response and
+	// let the next arm write another, or let the request continue to the
+	// generic 500 (codex round 6). The body's last statement is a bare return
+	// in all three blocks; anything else is a behaviour change worth looking at.
+	ast.Inspect(file, func(n ast.Node) bool {
+		ifStmt, ok := n.(*ast.IfStmt)
+		if !ok {
+			return true
+		}
+		armsHere := armsIn(ifStmt, want)
+		if len(armsHere) == 0 || ifStmt.Body == nil || len(ifStmt.Body.List) == 0 {
+			return true
+		}
+		if _, ok := ifStmt.Body.List[len(ifStmt.Body.List)-1].(*ast.ReturnStmt); !ok {
+			t.Errorf("the arm(s) %v at line %d do not end in a return; a matched arm that falls through "+
+				"lets a second response be written, or lets the request reach the generic 500.",
+				armsHere, fset.Position(ifStmt.Pos()).Line)
+		}
 		return true
 	})
 }

--- a/internal/server/handlers_items_title_test.go
+++ b/internal/server/handlers_items_title_test.go
@@ -1,0 +1,145 @@
+package server
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// HTTP-layer regressions for item title validation (BUG-2833 empty,
+// BUG-2831 length).
+//
+// These sit alongside the store-level tests in internal/store rather than
+// duplicating them, and they assert something the store tests cannot: the
+// STATUS CODE. A refusal that reaches the client as writeInternalError's 500
+// tells the caller the server broke and that a retry might work, when the
+// request was understood and deliberately declined — which is exactly the shape
+// BUG-2831 filed against the Postgres path (SQLSTATE 54000 reaching the generic
+// error arm).
+
+// TestPatchItemEmptyTitleRefused is the verbatim BUG-2833 repro: the filing
+// measured PATCH {"title": ""} being accepted and applied while POST refused
+// the same input with 400 "Title is required".
+func TestPatchItemEmptyTitleRefused(t *testing.T) {
+	srv := testServer(t)
+	ws := createWSWithCollections(t, srv)
+	item := createTaskWithFields(t, srv, ws, "Original Title", `{"status":"open"}`)
+
+	for _, title := range []string{"", "   ", "\t\n"} {
+		rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+ws+"/items/"+item.Slug, map[string]interface{}{
+			"title": title,
+		})
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("PATCH title=%q: got %d, want 400 (body: %s)", title, rr.Code, rr.Body.String())
+		}
+		if !strings.Contains(rr.Body.String(), "Title is required") {
+			t.Errorf("PATCH title=%q: body %s, want it to say the title is required", title, rr.Body.String())
+		}
+	}
+
+	// The item must be untouched — a 400 that already wrote the row would
+	// satisfy every assertion above and still be the bug.
+	rr := doRequest(srv, "GET", "/api/v1/workspaces/"+ws+"/items/"+item.Slug, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GET after refusals: %d", rr.Code)
+	}
+	var after models.Item
+	parseJSON(t, rr, &after)
+	if after.Title != "Original Title" {
+		t.Errorf("title = %q, want it untouched (%q)", after.Title, "Original Title")
+	}
+}
+
+// TestPatchItemOverlongTitleRefusedAs400 is the BUG-2831 shape assertion. The
+// filing explicitly flagged the status code as READ, not measured end-to-end
+// ("NOT independently verified end-to-end: I read the store error and the
+// handler's fall-through"). This measures it.
+func TestPatchItemOverlongTitleRefusedAs400(t *testing.T) {
+	srv := testServer(t)
+	ws := createWSWithCollections(t, srv)
+	item := createTaskWithFields(t, srv, ws, "Short", `{"status":"open"}`)
+
+	rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+ws+"/items/"+item.Slug, map[string]interface{}{
+		"title": strings.Repeat("a", models.MaxItemTitleRunes+1),
+	})
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("got %d, want 400 (body: %s)", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "too long") {
+		t.Errorf("body = %s, want it to say the title is too long", rr.Body.String())
+	}
+	if strings.Contains(rr.Body.String(), "internal_error") {
+		t.Errorf("body = %s, must not be an internal_error envelope", rr.Body.String())
+	}
+}
+
+// TestCreateItemWhitespaceOnlyTitleRefused pins the deliberate widening of the
+// CREATE door. "   " was accepted here before this unit and refused by the
+// artifact-import door whose comment claimed to mirror this one.
+func TestCreateItemWhitespaceOnlyTitleRefused(t *testing.T) {
+	srv := testServer(t)
+	ws := createWSWithCollections(t, srv)
+
+	rr := doRequest(srv, "POST", "/api/v1/workspaces/"+ws+"/collections/tasks/items", map[string]interface{}{
+		"title": "   ",
+	})
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("got %d, want 400 (body: %s)", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "Title is required") {
+		t.Errorf("body = %s, want it to say the title is required", rr.Body.String())
+	}
+}
+
+// TestCreateItemOverlongTitleRefused is the create half of BUG-2831 — the
+// original measurement was on CreateItem, where a 2 MiB title succeeded on
+// SQLite and produced `index row requires 24064 bytes, maximum size is 8191`
+// on Postgres.
+func TestCreateItemOverlongTitleRefused(t *testing.T) {
+	srv := testServer(t)
+	ws := createWSWithCollections(t, srv)
+
+	rr := doRequest(srv, "POST", "/api/v1/workspaces/"+ws+"/collections/tasks/items", map[string]interface{}{
+		"title": strings.Repeat("a", models.MaxItemTitleRunes+1),
+	})
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("got %d, want 400 (body: %s)", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "too long") {
+		t.Errorf("body = %s, want it to say the title is too long", rr.Body.String())
+	}
+}
+
+// TestItemTitleTrimmedOverTheWire: the API must persist what it validated. A
+// door that validates the trimmed string and stores the raw one leaves the row
+// holding a value nothing checked.
+func TestItemTitleTrimmedOverTheWire(t *testing.T) {
+	srv := testServer(t)
+	ws := createWSWithCollections(t, srv)
+
+	rr := doRequest(srv, "POST", "/api/v1/workspaces/"+ws+"/collections/tasks/items", map[string]interface{}{
+		"title": "  Padded  ",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create: got %d, want 201 (body: %s)", rr.Code, rr.Body.String())
+	}
+	var created models.Item
+	parseJSON(t, rr, &created)
+	if created.Title != "Padded" {
+		t.Errorf("created title = %q, want %q", created.Title, "Padded")
+	}
+
+	rr = doRequest(srv, "PATCH", "/api/v1/workspaces/"+ws+"/items/"+created.Slug, map[string]interface{}{
+		"title": "  Renamed  ",
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("patch: got %d, want 200 (body: %s)", rr.Code, rr.Body.String())
+	}
+	var updated models.Item
+	parseJSON(t, rr, &updated)
+	if updated.Title != "Renamed" {
+		t.Errorf("updated title = %q, want %q", updated.Title, "Renamed")
+	}
+}

--- a/internal/server/handlers_items_title_test.go
+++ b/internal/server/handlers_items_title_test.go
@@ -1,11 +1,16 @@
 package server
 
 import (
+	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/store"
 )
 
 // HTTP-layer regressions for item title validation (BUG-2833 empty,
@@ -141,5 +146,113 @@ func TestItemTitleTrimmedOverTheWire(t *testing.T) {
 	parseJSON(t, rr, &updated)
 	if updated.Title != "Renamed" {
 		t.Errorf("updated title = %q, want %q", updated.Title, "Renamed")
+	}
+}
+
+// TestWriteInvalidItemTitleMapsTo400 covers the store-refusal arm DIRECTLY.
+//
+// It exists because a mutation test showed the arm surviving: the handlers'
+// own pre-lock checks catch every case reachable from an HTTP test, so the
+// store's typed refusal never arrives through the wire in the suite. The arm is
+// still load-bearing — it is what a title that only becomes invalid UNDER THE
+// LOCK lands on (the handler compares against an item read before any lock, so
+// a concurrent rename can turn an echoed legacy title into a genuine one) — and
+// an untested error mapping is how a deliberate 400 becomes a 500 in a later
+// refactor. Testing the mapping directly is the honest way to cover a branch
+// whose only production trigger is a race.
+func TestWriteInvalidItemTitleMapsTo400(t *testing.T) {
+	t.Run("maps the typed refusal", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		if !writeInvalidItemTitle(rr, &store.InvalidItemTitleError{Reason: "Title is required"}) {
+			t.Fatal("writeInvalidItemTitle returned false for its own error type")
+		}
+		if rr.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want 400", rr.Code)
+		}
+		if !strings.Contains(rr.Body.String(), "Title is required") {
+			t.Errorf("body = %s, want the typed Reason", rr.Body.String())
+		}
+	})
+
+	t.Run("maps through a wrapper without publishing it", func(t *testing.T) {
+		// The call path wraps this error on the way up. The client must get the
+		// typed Reason, not the accumulated wrapper text.
+		wrapped := fmt.Errorf("update item: %w", &store.InvalidItemTitleError{Reason: "Title is too long: 300 characters, maximum 255"})
+		rr := httptest.NewRecorder()
+		if !writeInvalidItemTitle(rr, wrapped) {
+			t.Fatal("writeInvalidItemTitle returned false for a wrapped refusal; errors.As must see through wrappers")
+		}
+		if rr.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want 400", rr.Code)
+		}
+		if strings.Contains(rr.Body.String(), "update item:") {
+			t.Errorf("body = %s, must not publish the wrapper text", rr.Body.String())
+		}
+	})
+
+	t.Run("declines everything else", func(t *testing.T) {
+		// The control leg. Without it this test would pass against a helper
+		// that returns true unconditionally, which would swallow every other
+		// store error into a 400.
+		rr := httptest.NewRecorder()
+		if writeInvalidItemTitle(rr, errors.New("some unrelated store failure")) {
+			t.Error("writeInvalidItemTitle claimed an unrelated error; it must fall through")
+		}
+		if rr.Code != http.StatusOK || rr.Body.Len() != 0 {
+			t.Errorf("declining must write nothing, got status %d body %q", rr.Code, rr.Body.String())
+		}
+	})
+}
+
+// TestCreateItemCheckedMapsStoreTitleRefusalTo400 covers the create path's
+// store-refusal arm directly, for the same reason as the update path's helper
+// test above: handleCreateItem's own check catches everything reachable over
+// the wire, so the arm's absence is a latent 500 rather than a visible one — and
+// a mutation test is what surfaced it.
+//
+// createItemChecked is a separate function from handleCreateItem, and the
+// pre-check lives in the handler, so calling it directly reaches the store
+// refusal that no HTTP request can.
+func TestCreateItemCheckedMapsStoreTitleRefusalTo400(t *testing.T) {
+	srv := testServer(t)
+	wsSlug := createWSWithCollections(t, srv)
+	ws, err := srv.store.GetWorkspaceBySlug(wsSlug)
+	if err != nil || ws == nil {
+		t.Fatalf("GetWorkspaceBySlug(%q): %v", wsSlug, err)
+	}
+	coll, err := srv.store.GetCollectionBySlug(ws.ID, "tasks")
+	if err != nil || coll == nil {
+		t.Fatalf("GetCollectionBySlug: %v", err)
+	}
+	var schema models.CollectionSchema
+	if err := json.Unmarshal([]byte(coll.Schema), &schema); err != nil {
+		t.Fatalf("parse schema: %v", err)
+	}
+
+	req := httptest.NewRequest("POST", "/", nil)
+	for _, tc := range []struct{ name, title, want string }{
+		{"empty", "", "Title is required"},
+		{"over the bound", strings.Repeat("a", models.MaxItemTitleRunes+1), "too long"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, cerr := srv.createItemChecked(req, ws.ID, coll, schema,
+				models.ItemCreate{Title: tc.title}, map[string]any{}, "")
+			if cerr == nil {
+				t.Fatal("createItemChecked accepted an invalid title")
+			}
+			if cerr.status != http.StatusBadRequest {
+				t.Errorf("status = %d, want 400 — a deliberate refusal must not read as a server fault", cerr.status)
+			}
+			if !strings.Contains(cerr.message, tc.want) {
+				t.Errorf("message = %q, want it to mention %q", cerr.message, tc.want)
+			}
+		})
+	}
+
+	// Control: a valid title still creates, so the arm above is not swallowing
+	// the success path.
+	if _, cerr := srv.createItemChecked(req, ws.ID, coll, schema,
+		models.ItemCreate{Title: "Perfectly Fine"}, map[string]any{}, ""); cerr != nil {
+		t.Fatalf("a valid title must still create: %d %s", cerr.status, cerr.message)
 	}
 }

--- a/internal/server/handlers_items_title_test.go
+++ b/internal/server/handlers_items_title_test.go
@@ -9,6 +9,7 @@ import (
 	"go/token"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"strings"
 	"testing"
 
@@ -330,7 +331,40 @@ func TestUpdateItemErrorBlocksMapEveryStoreRefusal(t *testing.T) {
 		t.Fatalf("parse handlers_items.go: %v", err)
 	}
 
-	counts := map[string]int{}
+	// The arms, in the order every block must apply them. Order is part of the
+	// contract, not style: the UNIQUE-constraint arm that closes each block
+	// matches on error TEXT, so a typed arm placed after it can be swallowed by
+	// a substring match rather than reached.
+	want := []string{
+		"asOpenChildrenGuardError",
+		"asUpdateConflictError",
+		"writeItemRenameCascadeTooLarge",
+		"writeInvalidItemTitle",
+	}
+	wantArm := map[string]bool{}
+	for _, w := range want {
+		wantArm[w] = true
+	}
+
+	// PER-BLOCK, not per-file (codex round 2): counting calls across the whole
+	// file lets one block's duplicate mask another's omission and says nothing
+	// about order.
+	//
+	// Blocks are recovered from SOURCE POSITION rather than from AST shape,
+	// which is what makes this robust: the three blocks are written
+	// differently — two as sequential `if` statements, one as an else-if chain
+	// — and an ast.Inspect that keys on either shape either misses blocks or
+	// double-counts them through nesting. (Both happened while writing this:
+	// first 0 blocks, then 8. The block-count guard below is what caught each,
+	// instead of the assertions quietly passing over nothing.)
+	//
+	// Every block opens with the open-children arm, so a new block starts at
+	// each occurrence of it, in file order.
+	type armRef struct {
+		name string
+		pos  token.Pos
+	}
+	var refs []armRef
 	ast.Inspect(file, func(n ast.Node) bool {
 		call, ok := n.(*ast.CallExpr)
 		if !ok {
@@ -340,27 +374,59 @@ func TestUpdateItemErrorBlocksMapEveryStoreRefusal(t *testing.T) {
 		if !ok {
 			return true
 		}
-		switch ident.Name {
-		case "writeItemRenameCascadeTooLarge", "writeInvalidItemTitle", "asUpdateConflictError":
-			counts[ident.Name]++
+		if wantArm[ident.Name] {
+			refs = append(refs, armRef{ident.Name, call.Pos()})
 		}
 		return true
 	})
+	sort.Slice(refs, func(i, j int) bool { return refs[i].pos < refs[j].pos })
 
-	const wantBlocks = 3
-	for _, name := range []string{"writeItemRenameCascadeTooLarge", "writeInvalidItemTitle", "asUpdateConflictError"} {
-		if counts[name] != wantBlocks {
-			t.Errorf("%s is called %d time(s); every one of the %d UpdateItem error blocks must map it. "+
-				"A refusal mapped in some blocks and not others answers 400/409/413 down one route and "+
-				"500 — or a silent duplicate write — down another, for the identical store error.",
-				name, counts[name], wantBlocks)
+	var blocks [][]string
+	var lines []int
+	for _, r := range refs {
+		if r.name == want[0] {
+			blocks = append(blocks, nil)
+			lines = append(lines, fset.Position(r.pos).Line)
+		}
+		if len(blocks) == 0 {
+			t.Fatalf("arm %q at line %d precedes any %q — the block-splitting assumption is wrong",
+				r.name, fset.Position(r.pos).Line, want[0])
+		}
+		blocks[len(blocks)-1] = append(blocks[len(blocks)-1], r.name)
+	}
+
+	// handleUpdateItem has three; handleMoveItem carries a lone open-children
+	// arm and cannot produce the others (it writes no title — verified in the
+	// BUG-2833 door sweep), so single-arm blocks are not update blocks.
+	var updateBlocks [][]string
+	var updateLines []int
+	for i, b := range blocks {
+		if len(b) > 1 {
+			updateBlocks = append(updateBlocks, b)
+			updateLines = append(updateLines, lines[i])
 		}
 	}
 
-	// Control: the count is not trivially satisfied by a name that appears
-	// nowhere. If this fires, the AST walk is matching nothing and the
-	// assertions above are vacuous.
-	if counts["writeInvalidItemTitle"] == 0 {
-		t.Fatal("AST walk found no calls at all — the instrument is broken, not the code")
+	const wantBlocks = 3
+	if len(updateBlocks) != wantBlocks {
+		t.Fatalf("found %d UpdateItem error block(s) at lines %v, want %d — the instrument's block "+
+			"detection is out of step with the code, so every assertion below would be meaningless. "+
+			"Blocks: %v", len(updateBlocks), updateLines, wantBlocks, updateBlocks)
+	}
+	for i, arms := range updateBlocks {
+		if len(arms) != len(want) {
+			t.Errorf("the error block at line %d maps %v; every block must map all of %v. A refusal "+
+				"mapped in some blocks and not others answers 400/409/413 down one route and 500 — or "+
+				"a silent duplicate write — down another, for the identical store error.",
+				updateLines[i], arms, want)
+			continue
+		}
+		for j := range want {
+			if arms[j] != want[j] {
+				t.Errorf("the error block at line %d applies its arms as %v; want %v",
+					updateLines[i], arms, want)
+				break
+			}
+		}
 	}
 }

--- a/internal/server/handlers_items_title_test.go
+++ b/internal/server/handlers_items_title_test.go
@@ -316,14 +316,19 @@ func TestIsDeterministicWriteFailureIncludesTitleRefusal(t *testing.T) {
 // block. Give it every arm, in the same order as its siblings, or explain in
 // this test why the new block genuinely cannot produce one of these errors.
 //
-// WHAT IT DOES NOT COVER, stated because a structural test invites more
-// confidence than it earns: it counts SYNTACTIC PRESENCE, not reachability. An
-// arm disabled in place — `false && writeInvalidItemTitle(w, err)`, an
-// unreachable branch — still counts, and a mutant of that shape survives this
-// test (measured, not assumed). That is accepted: the failure this guards
-// against is an OMITTED arm, which is deletion-shaped, and deletion is exactly
-// what it detects — verified by deleting the arm from each of the three blocks
-// in turn and watching this test fail each time.
+// WHAT IT COVERS AND WHAT IT DOES NOT, stated because a structural test invites
+// more confidence than it earns. It detects an arm that is DELETED, one that is
+// out of ORDER, and — since codex round 3 — one DISABLED by being made an
+// operand of a boolean condition, which is the shape that defeated the
+// presence-only version. All three are verified by mutation rather than
+// asserted.
+//
+// It is still lexical. An arm made unreachable some other way — an early
+// return above it, a condition that is a call which always returns false —
+// would pass. Closing that needs control-flow analysis or a route-level test,
+// and a route-level test is not available here: the handlers' own pre-checks
+// catch every title refusal reachable over the wire, so the store-sourced one
+// these arms exist for has no HTTP trigger except a concurrent rename.
 func TestUpdateItemErrorBlocksMapEveryStoreRefusal(t *testing.T) {
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, "handlers_items.go", nil, 0)
@@ -377,6 +382,46 @@ func TestUpdateItemErrorBlocksMapEveryStoreRefusal(t *testing.T) {
 		if wantArm[ident.Name] {
 			refs = append(refs, armRef{ident.Name, call.Pos()})
 		}
+		return true
+	})
+
+	// REACHABILITY, not just presence (codex round 3). Counting call
+	// expressions detects a DELETED arm but not a disabled one: `false &&
+	// writeInvalidItemTitle(w, err)` short-circuits at runtime while leaving
+	// the call in the AST, so the sequence above still reads as correct while
+	// every title refusal falls through to a 500. Measured — that mutant
+	// survived the presence-only version of this test.
+	//
+	// The check is narrow on purpose: each arm must be tested DIRECTLY, as the
+	// whole of an if-condition, not as one operand of a boolean expression.
+	// That is how all three blocks are written, so anything else is either the
+	// mutation above or a genuine restructuring that deserves to be looked at.
+	ast.Inspect(file, func(n ast.Node) bool {
+		ifStmt, ok := n.(*ast.IfStmt)
+		if !ok {
+			return true
+		}
+		bin, ok := ifStmt.Cond.(*ast.BinaryExpr)
+		if !ok {
+			return true
+		}
+		ast.Inspect(bin, func(c ast.Node) bool {
+			call, ok := c.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			ident, ok := call.Fun.(*ast.Ident)
+			if !ok {
+				return true
+			}
+			if wantArm[ident.Name] {
+				t.Errorf("the arm %q at line %d is an operand of a boolean expression rather than the "+
+					"whole condition. It still counts as present below, but it may never execute — "+
+					"which is a refusal silently answering 500 while this test reads as green.",
+					ident.Name, fset.Position(call.Pos()).Line)
+			}
+			return true
+		})
 		return true
 	})
 	sort.Slice(refs, func(i, j int) bool { return refs[i].pos < refs[j].pos })

--- a/internal/store/export.go
+++ b/internal/store/export.go
@@ -459,6 +459,8 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 	// item ID so the second-pass loop can look up the normalized value.
 	coercedFields := make(map[string]string, len(data.Items))
 	coercedTags := make(map[string]string, len(data.Items))
+	// Slugs this import has already written. See the collision note in the loop.
+	claimedSlugs := make(map[string]bool, len(data.Items))
 	var nextItemNumber int
 	for _, it := range data.Items {
 		newItemID := newID()
@@ -498,22 +500,43 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 				"raw_runes", utf8.RuneCountInString(it.Title))
 		}
 		itemSlug, slugCoerced := importCoercedSlug(it.Slug)
-		if slugCoerced {
-			// Resolve collisions the truncation may have created, inside this
-			// transaction so the scan is read-your-writes against the rows this
-			// import has already inserted.
+		// Collision resolution is keyed on the CLAIMED SET, not on whether THIS
+		// row was truncated (codex round 1, P1). Truncation is the only source
+		// of duplicate slugs here — a bundle exported from a live workspace
+		// cannot contain two identical slugs, because UNIQUE(workspace_id, slug)
+		// held there — but the duplicate it creates can land in EITHER order:
+		// a long slug truncated to "x" can be inserted BEFORE a later row whose
+		// slug is already exactly "x". Resolving only the truncated row leaves
+		// that later, untouched row to hit the constraint and abort the entire
+		// import, which is the opposite of this loop's coerce-and-continue
+		// policy.
+		//
+		// Guarded by the map rather than by calling uniqueSlugQ unconditionally
+		// so an ordinary import of N items still issues no extra queries: the
+		// common case is a bundle with no truncation at all, where this costs
+		// one map lookup per row.
+		if claimedSlugs[itemSlug] {
 			unique, uerr := s.uniqueSlugQ(tx, "items", "workspace_id", ws.ID, itemSlug)
 			if uerr != nil {
 				return nil, fmt.Errorf("import item %s: unique slug after truncation: %w", it.ID, uerr)
 			}
+			slog.Warn("import_workspace resolved a colliding item slug",
+				"row_id", it.ID,
+				"workspace_id", ws.ID,
+				"requested", itemSlug,
+				"slug", unique,
+				"from_truncation", slugCoerced)
+			itemSlug = unique
+		}
+		if slugCoerced {
 			slog.Warn("import_workspace coerced item slug",
 				"reason", "too_long",
 				"row_id", it.ID,
 				"workspace_id", ws.ID,
 				"raw_runes", utf8.RuneCountInString(it.Slug),
-				"slug", unique)
-			itemSlug = unique
+				"slug", itemSlug)
 		}
+		claimedSlugs[itemSlug] = true
 		fieldsJSON := coerceJSONForImport(it.Fields, "{}", "items.fields", it.ID, ws.ID, true)
 		tagsJSON := coerceJSONForImport(it.Tags, "[]", "items.tags", it.ID, ws.ID, false)
 		coercedFields[it.ID] = fieldsJSON

--- a/internal/store/export.go
+++ b/internal/store/export.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/PerpetualSoftware/pad/internal/collections"
 	"github.com/PerpetualSoftware/pad/internal/models"
@@ -61,6 +62,67 @@ func coerceJSONForImport(raw, defaultJSON, field, rowID, workspaceID string, exp
 		"workspace_id", workspaceID,
 		"raw_len", len(raw))
 	return defaultJSON
+}
+
+// importCoercedTitle is the item-title half of the same log-and-coerce policy
+// (BUG-2833 / BUG-2831). It returns the title to write and, when it changed,
+// the reason — so the caller can log one line carrying the row identity.
+//
+// COERCE, NOT REFUSE, and that is a ruling rather than a shortcut. The
+// interactive doors (create, update, artifact import) REFUSE an empty or
+// over-long title, because they are minting a new value from a live caller who
+// can fix it. Import is restoring data this product already accepted: a
+// 300-rune title has always been legal, so validating a bundle would turn
+// "restore my archive" into a hard failure for rows we ourselves wrote, and
+// `pad db migrate` — which is ExportWorkspace piped into this same INSERT —
+// would refuse to migrate SQLite instances that work fine today.
+//
+// It also sits three lines from coerceJSONForImport, whose recorded IDEA-1488
+// disposition is log-and-coerce "so a legacy bundle with one malformed item
+// still imports". Refusing titles in the same loop would give one loop two
+// dispositions for the same class of problem.
+//
+// The coercion does NOT weaken Dave's untitled-items ruling. The imported row
+// lands WITH a title — the literal string "Untitled" — so the invariant that
+// no door writes an empty title into the database holds here too, and the
+// store's baseSlug == "" fallback stays defensive-only.
+func importCoercedTitle(raw string) (string, string) {
+	title := models.NormalizeItemTitle(raw)
+	if title == "" {
+		return importUntitledTitle, "empty"
+	}
+	if n := utf8.RuneCountInString(title); n > models.MaxItemTitleRunes {
+		return string([]rune(title)[:models.MaxItemTitleRunes]), "too_long"
+	}
+	return title, ""
+}
+
+// importUntitledTitle is what an empty imported title becomes. Capitalized
+// because it is a TITLE that a user will read in a list, not the lowercase
+// "untitled" slug fallback in items.go — the two are deliberately different
+// strings so a reader can tell which mechanism produced what they are looking
+// at.
+const importUntitledTitle = "Untitled"
+
+// importCoercedSlug bounds an imported slug (BUG-2831). Coercing only the
+// title would not close the import door: this loop writes `it.Slug` from the
+// bundle VERBATIM rather than re-deriving it, and the slug — not the title —
+// is what carries UNIQUE(workspace_id, slug) into a Postgres btree whose index
+// tuple is capped at 8191 bytes. A bundle from a SQLite instance holding a
+// 2 MiB title carries a 2 MiB slug, and truncating the title alone would leave
+// the INSERT failing exactly as before.
+//
+// Untouched unless it exceeds the bound: an in-range slug is written byte for
+// byte, so nothing about ordinary round-tripping changes. Truncation can
+// collide with another row in the same workspace, which is why the caller
+// resolves the result through uniqueSlugQ inside the import transaction rather
+// than hoping — but only for coerced slugs, so the uniqueness scan does not run
+// for every row of a large import.
+func importCoercedSlug(raw string) (string, bool) {
+	if utf8.RuneCountInString(raw) <= models.MaxItemTitleRunes {
+		return raw, false
+	}
+	return string([]rune(raw)[:models.MaxItemTitleRunes]), true
 }
 
 // ExportWorkspace exports all data for a workspace into a portable format.
@@ -423,6 +485,34 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 		// coercion above. The IDEA-1488 leg: log-and-coerce (not
 		// fail-stop) so a legacy bundle with one malformed item
 		// still imports.
+		// BUG-2833 / BUG-2831: title + slug coercion, same log-and-coerce
+		// policy as the fields/tags coercion below. See importCoercedTitle for
+		// why import coerces where the interactive doors refuse.
+		itemTitle, titleCoercion := importCoercedTitle(it.Title)
+		if titleCoercion != "" {
+			slog.Warn("import_workspace coerced item title",
+				"reason", titleCoercion,
+				"row_id", it.ID,
+				"workspace_id", ws.ID,
+				"raw_runes", utf8.RuneCountInString(it.Title))
+		}
+		itemSlug, slugCoerced := importCoercedSlug(it.Slug)
+		if slugCoerced {
+			// Resolve collisions the truncation may have created, inside this
+			// transaction so the scan is read-your-writes against the rows this
+			// import has already inserted.
+			unique, uerr := s.uniqueSlugQ(tx, "items", "workspace_id", ws.ID, itemSlug)
+			if uerr != nil {
+				return nil, fmt.Errorf("import item %s: unique slug after truncation: %w", it.ID, uerr)
+			}
+			slog.Warn("import_workspace coerced item slug",
+				"reason", "too_long",
+				"row_id", it.ID,
+				"workspace_id", ws.ID,
+				"raw_runes", utf8.RuneCountInString(it.Slug),
+				"slug", unique)
+			itemSlug = unique
+		}
 		fieldsJSON := coerceJSONForImport(it.Fields, "{}", "items.fields", it.ID, ws.ID, true)
 		tagsJSON := coerceJSONForImport(it.Tags, "[]", "items.tags", it.ID, ws.ID, false)
 		coercedFields[it.ID] = fieldsJSON
@@ -451,7 +541,7 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 		_, err := tx.Exec(s.q(`
 			INSERT INTO items (id, workspace_id, collection_id, title, slug, content, fields, tags, pinned, sort_order, parent_id, created_by, last_modified_by, source, item_number, created_at, updated_at, seq)
 			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULLIF(?, ''), ?, ?, ?, ?, ?, ?, `+nextWorkspaceSeqSubquery+`)`),
-			newItemID, ws.ID, newCollID, it.Title, it.Slug, it.Content, fieldsJSON, tagsJSON, s.dialect.BoolToInt(it.Pinned), it.SortOrder,
+			newItemID, ws.ID, newCollID, itemTitle, itemSlug, it.Content, fieldsJSON, tagsJSON, s.dialect.BoolToInt(it.Pinned), it.SortOrder,
 			parentID, it.CreatedBy, it.LastModifiedBy, it.Source, nextItemNumber,
 			it.CreatedAt, it.UpdatedAt, ws.ID)
 		if err != nil {

--- a/internal/store/export.go
+++ b/internal/store/export.go
@@ -107,10 +107,11 @@ const importUntitledTitle = "Untitled"
 // importCoercedSlug bounds an imported slug (BUG-2831). Coercing only the
 // title would not close the import door: this loop writes `it.Slug` from the
 // bundle VERBATIM rather than re-deriving it, and the slug — not the title —
-// is what carries UNIQUE(workspace_id, slug) into a Postgres btree whose index
-// tuple is capped at 8191 bytes. A bundle from a SQLite instance holding a
-// 2 MiB title carries a 2 MiB slug, and truncating the title alone would leave
-// the INSERT failing exactly as before.
+// is what carries UNIQUE(workspace_id, slug) into a Postgres btree index tuple
+// (capped at 2704 bytes in practice; see MaxItemTitleRunes for the
+// measurement). A bundle from a SQLite instance holding a 2 MiB title carries a
+// 2 MiB slug, and truncating the title alone would leave the INSERT failing
+// exactly as before.
 //
 // Untouched unless it exceeds the bound: an in-range slug is written byte for
 // byte, so nothing about ordinary round-tripping changes. Truncation can

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -2306,7 +2306,14 @@ func (s *Store) updateItemWithParentLinkOnce(
 	// already has: no door can mint a NEW untitled or over-long item.
 	if input.Title != nil {
 		normalized := models.NormalizeItemTitle(*input.Title)
-		if normalized != existing.Title {
+		// The exemption tests BOTH forms against the stored title (codex round
+		// 1, P2). Comparing only the normalized one narrows the rule to less
+		// than it claims: a legacy row whose stored title carries edge
+		// whitespace is echoed back VERBATIM by a client that read it, and the
+		// normalized echo then differs from what is stored — so the row's own
+		// title reads as a rename and, if it also predates the bound, is
+		// refused. "Identical to the stored one" has to mean what it says.
+		if normalized != existing.Title && *input.Title != existing.Title {
 			if msg := models.ValidateItemTitle(normalized); msg != "" {
 				return nil, &InvalidItemTitleError{Reason: msg}
 			}

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -174,7 +174,41 @@ func (s *Store) acquireWorkspaceParentLinkLock(tx *sql.Tx, workspaceID string) e
 	return nil
 }
 
+// ErrInvalidItemTitle is the sentinel behind InvalidItemTitleError, so callers
+// can errors.Is it without depending on the concrete type.
+//
+// The store enforces the item-title rule rather than trusting its callers for
+// the reason BUG-2833 exists: the rule WAS caller-side only, it lived in
+// handleCreateItem alone, and handleUpdateItem — the sibling handler on the
+// same field — simply did not have it. A rule that has to be repeated at each
+// door is a rule that will be missing from one of them.
+var ErrInvalidItemTitle = errors.New("store: invalid item title")
+
+// InvalidItemTitleError carries the human-readable reason a title was refused,
+// so the HTTP layer can return it without re-deriving the rule or splicing an
+// internal error's text into a response.
+type InvalidItemTitleError struct{ Reason string }
+
+func (e *InvalidItemTitleError) Error() string {
+	return ErrInvalidItemTitle.Error() + ": " + e.Reason
+}
+
+func (e *InvalidItemTitleError) Unwrap() error { return ErrInvalidItemTitle }
+
 func (s *Store) CreateItem(workspaceID, collectionID string, input models.ItemCreate) (*models.Item, error) {
+	// Title normalization + validation (BUG-2833 / BUG-2831). Before the retry
+	// loop: it depends only on the input, so re-running it per attempt would
+	// re-derive the same verdict, and normalizing here means every attempt
+	// slugifies the SAME string.
+	//
+	// No grandfathering clause here, unlike UpdateItem — a create has no prior
+	// title to be grandfathered against. Every item this path mints satisfies
+	// the bound.
+	input.Title = models.NormalizeItemTitle(input.Title)
+	if msg := models.ValidateItemTitle(input.Title); msg != "" {
+		return nil, &InvalidItemTitleError{Reason: msg}
+	}
+
 	// Retry loop: if a concurrent insert claims the same item_number — or the
 	// same slug — we roll back and re-derive both on the next attempt.
 	//
@@ -2246,6 +2280,39 @@ func (s *Store) updateItemWithParentLinkOnce(
 	// Fields, Tags, Title, and the joined display names — is a string, and a
 	// string cannot be mutated in place, so today's consumers are covered.
 	preUpdate := *existing
+
+	// Title normalization + validation (BUG-2833 / BUG-2831). Placed HERE,
+	// immediately after the post-lock re-read, because everything downstream
+	// compares or derives from `*input.Title`: the version-force check, the
+	// `title = ?` SET, the slug derived by slugify, and the rename cascade.
+	// Normalizing later would leave those reading the raw value and the row
+	// holding the normalized one — the exact create/update divergence this
+	// unit exists to remove, re-created inside one function.
+	//
+	// This is the AUTHORITATIVE check; handleUpdateItem runs the same one
+	// pre-lock to produce a fast, friendly 400. Same split as documents, for
+	// the same reason: the handler compares against an item it read BEFORE the
+	// lock, so a concurrent rename can turn an echoed legacy title into a
+	// genuine one between the two reads. The decision belongs where the write
+	// happens.
+	//
+	// GRANDFATHERED, deliberately: a title identical to the stored one is not
+	// a rename, so it is not a write-time door and is not validated. That is
+	// what keeps the bound non-retroactive (Dave's day-63 ruling, carried over
+	// from MaxDocumentTitleRunes) — an item whose stored title predates the
+	// bound stays editable in every other respect, and a client that echoes
+	// the whole item back does not start failing on it. An item can therefore
+	// still be written with a legacy-invalid title, but only the one it
+	// already has: no door can mint a NEW untitled or over-long item.
+	if input.Title != nil {
+		normalized := models.NormalizeItemTitle(*input.Title)
+		if normalized != existing.Title {
+			if msg := models.ValidateItemTitle(normalized); msg != "" {
+				return nil, &InvalidItemTitleError{Reason: msg}
+			}
+		}
+		input.Title = &normalized
+	}
 
 	// Optimistic-concurrency guard runs FIRST — before the open-children
 	// precheck — so a caller who lost the race gets the promised

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -2336,8 +2336,20 @@ func (s *Store) updateItemWithParentLinkOnce(
 		// is a genuine no-op (the row keeps the bytes it has), and anything
 		// else is validated before it is normalized in.
 		if normalized == existing.Title || *input.Title == existing.Title {
-			unchanged := existing.Title
-			input.Title = &unchanged
+			// NIL, not "the same bytes" (codex round 5, P1). Writing the stored
+			// title back leaves input.Title non-nil, and everything downstream
+			// keys on that pointer rather than on whether the value changed:
+			// the SET clause below regenerates the SLUG from slugify(title),
+			// unconditionally. For a row whose slug does NOT derive from its
+			// current title — an imported row carrying a bundle slug, or one
+			// this unit's own import truncation renamed — an echo that changes
+			// nothing would silently move the item's URL, and the activity
+			// change-list would not show it because the TITLE is unchanged.
+			//
+			// Treating it as not-provided is the honest encoding of "this write
+			// does not touch the title", and it also skips the forced version
+			// and the rename cascade, both of which key on the same pointer.
+			input.Title = nil
 		} else {
 			if msg := models.ValidateItemTitle(normalized); msg != "" {
 				return nil, &InvalidItemTitleError{Reason: msg}

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -2301,9 +2301,18 @@ func (s *Store) updateItemWithParentLinkOnce(
 	// what keeps the bound non-retroactive (Dave's day-63 ruling, carried over
 	// from MaxDocumentTitleRunes) — an item whose stored title predates the
 	// bound stays editable in every other respect, and a client that echoes
-	// the whole item back does not start failing on it. An item can therefore
-	// still be written with a legacy-invalid title, but only the one it
-	// already has: no door can mint a NEW untitled or over-long item.
+	// the whole item back does not start failing on it.
+	//
+	// The guarantee this buys, stated at the width it actually holds (codex
+	// round 4): NO CALLER-SUPPLIED TITLE can be stored unvalidated. An item may
+	// still be written with a legacy-invalid title, but only the one it already
+	// has. It is NOT true that no row anywhere gets a fresh invalid title —
+	// ImportWorkspace coerces one in (to "Untitled" or a truncation) and
+	// cross-workspace copy carries the source row's title into a new row
+	// verbatim. Both are deliberate legacy-data exceptions, documented at their
+	// own call sites; neither takes a title from the caller. An earlier version
+	// of this comment said "no door can mint a NEW untitled or over-long item",
+	// which reads as a global invariant and is false of the copy path.
 	if input.Title != nil {
 		normalized := models.NormalizeItemTitle(*input.Title)
 		// The exemption tests BOTH forms against the stored title (codex round

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -2313,12 +2313,28 @@ func (s *Store) updateItemWithParentLinkOnce(
 		// normalized echo then differs from what is stored — so the row's own
 		// title reads as a rename and, if it also predates the bound, is
 		// refused. "Identical to the stored one" has to mean what it says.
-		if normalized != existing.Title && *input.Title != existing.Title {
+		//
+		// A GRANDFATHERED WRITE WRITES THE STORED BYTES, NOT THE NORMALIZED
+		// ONES (codex round 2, P1 — a hole the round-1 fix above opened).
+		// Skipping validation while still assigning `normalized` meant a
+		// legacy row stored as "   " was echoed back, skipped validation on the
+		// raw match, and then had "" written to it — minting exactly the empty
+		// title Dave's ruling forbids, through the clause meant to protect
+		// legacy rows. An over-bound title with edge whitespace went the same
+		// way, into a DIFFERENT over-bound title.
+		//
+		// So the two outcomes are now exclusive: grandfathered means the write
+		// is a genuine no-op (the row keeps the bytes it has), and anything
+		// else is validated before it is normalized in.
+		if normalized == existing.Title || *input.Title == existing.Title {
+			unchanged := existing.Title
+			input.Title = &unchanged
+		} else {
 			if msg := models.ValidateItemTitle(normalized); msg != "" {
 				return nil, &InvalidItemTitleError{Reason: msg}
 			}
+			input.Title = &normalized
 		}
-		input.Title = &normalized
 	}
 
 	// Optimistic-concurrency guard runs FIRST — before the open-children

--- a/internal/store/items_cross_workspace_copy.go
+++ b/internal/store/items_cross_workspace_copy.go
@@ -732,6 +732,23 @@ func (s *Store) copyItemAcrossWorkspacesTx(req CrossWorkspaceCopyRequest, source
 
 	// --- Create in B. Advances B's seq; writes the initial version row and
 	// the wiki-link index against the POST-rewrite content (DR-9a). ---
+	// TITLE VALIDATION IS DELIBERATELY NOT APPLIED HERE (BUG-2833 / BUG-2831,
+	// raised again by codex R2 as a finding — recorded so the next reader does
+	// not have to re-derive it).
+	//
+	// This path goes through createItemTxWithID, below store.CreateItem's
+	// write-time guard, so a source row whose title predates the bound is
+	// carried across intact. That is the intended behaviour, on the same
+	// reasoning as the grandfathering clause in UpdateItem and the lead's
+	// coerce-not-refuse ruling for ImportWorkspace: a copy carries a value that
+	// already exists in the database, and refusing it would break a working
+	// operation for data this product itself accepted.
+	//
+	// It cannot MINT an invalid title. The title below is `source.Title`,
+	// read from the source row — there is no caller-supplied title on this
+	// path at all (`--field` sets destination FIELDS, never the title), so no
+	// input a user controls reaches it. The copy stays repairable by rename in
+	// either workspace, where the bound does apply.
 	item, err := s.createItemTxWithID(tx, targetItemID, req.TargetWorkspaceID, req.TargetCollectionID, models.ItemCreate{
 		Title:   source.Title,
 		Content: newContent,

--- a/internal/store/items_cross_workspace_copy.go
+++ b/internal/store/items_cross_workspace_copy.go
@@ -744,11 +744,14 @@ func (s *Store) copyItemAcrossWorkspacesTx(req CrossWorkspaceCopyRequest, source
 	// already exists in the database, and refusing it would break a working
 	// operation for data this product itself accepted.
 	//
-	// It cannot MINT an invalid title. The title below is `source.Title`,
-	// read from the source row — there is no caller-supplied title on this
-	// path at all (`--field` sets destination FIELDS, never the title), so no
-	// input a user controls reaches it. The copy stays repairable by rename in
-	// either workspace, where the bound does apply.
+	// What it cannot do is mint an invalid title FROM CALLER INPUT — which is
+	// the guarantee this unit actually makes, and is narrower than "cannot mint
+	// an invalid title", since a legacy-invalid source row does put that title
+	// on a NEW destination row (codex round 6). The title below is
+	// `source.Title`, read from the source row; there is no caller-supplied
+	// title on this path at all (`--field` sets destination FIELDS, never the
+	// title), so no input a user controls reaches it. The copy stays repairable
+	// by rename in either workspace, where the bound does apply.
 	item, err := s.createItemTxWithID(tx, targetItemID, req.TargetWorkspaceID, req.TargetCollectionID, models.ItemCreate{
 		Title:   source.Title,
 		Content: newContent,

--- a/internal/store/items_rename_bounds_test.go
+++ b/internal/store/items_rename_bounds_test.go
@@ -251,14 +251,19 @@ func TestItemRenameCascade_DoesNotChargeForRewritesItWillNotPerform(t *testing.T
 // TestItemRenameCascade_BoundsTheScanNotJustTheRewrite closes codex R4's P1.
 //
 // The rewrite loop's cap charges CONTENT bytes. The scan that feeds it retains
-// one entry per matching link ROW, each carrying that row's target_title — and
-// item titles have no length bound (MaxDocumentTitleRunes covers documents
-// only; there is no item equivalent, verified by grep across internal/).
+// one entry per matching link ROW, each carrying that row's target_title.
 //
-// So the attack needs no large content at all: give the renamed item a title
-// measured in megabytes, link it from enough rows, and the cascade retains
-// rows x title bytes before reading a single body. A content-bytes cap cannot
-// see it, because the content is a few dozen bytes per linker.
+// So the attack needs no large content at all: give the renamed item a large
+// title, link it from enough rows, and the cascade retains rows x title bytes
+// before reading a single body. A content-bytes cap cannot see it, because the
+// content is a few dozen bytes per linker.
+//
+// This comment used to say item titles have no length bound. Since
+// BUG-2833 / BUG-2831 they do — models.MaxItemTitleRunes — and the fixture
+// below is built as LEGACY data for exactly that reason. The guard is not
+// thereby obsolete: the bound is non-retroactive, this scan reads STORED
+// titles rather than the one being written, and at the bound the same pressure
+// arrives with ~24,000 link rows instead of 64.
 //
 // This is the case my own doc comment on MaxItemRenameCascadeBytes previously
 // claimed was impossible — it asserted the cascade's retention was O(1) in the
@@ -266,9 +271,10 @@ func TestItemRenameCascade_DoesNotChargeForRewritesItWillNotPerform(t *testing.T
 // (BUG-2827), which is a different vector entirely.
 func TestItemRenameCascade_BoundsTheScanNotJustTheRewrite(t *testing.T) {
 	// The largest title one JSON request can deliver (server.defaultJSONBodyLimit
-	// is 2 MiB). Nothing validates item title length, so this is reachable
-	// through the ordinary create path — and using the maximum keeps the ROW
-	// COUNT down, which is what this test's runtime is dominated by.
+	// is 2 MiB). This is no longer reachable through the ordinary create path —
+	// models.MaxItemTitleRunes refuses it — so the fixture is seeded as legacy
+	// data below. The size is kept because it is what keeps the ROW COUNT down,
+	// and this test's runtime is dominated by row count.
 	const titleBytes = 2 << 20
 	hugeTitle := strings.Repeat("T", titleBytes)
 
@@ -288,19 +294,28 @@ func TestItemRenameCascade_BoundsTheScanNotJustTheRewrite(t *testing.T) {
 	//
 	// On Postgres this fixture cannot be built at all: `items` carries
 	// UNIQUE(workspace_id, slug), the slug is derived from the title with no
-	// truncation (store.go::slugify), and a btree index tuple is capped at
-	// 8191 bytes. Creating the target fails with
+	// truncation (store.go::slugify), and a btree index tuple has a size cap.
+	// Creating the target fails with
 	//
 	//	insert item: ERROR: index row requires 24064 bytes, maximum size is 8191 (SQLSTATE 54000)
 	//
 	// — 24,064 rather than 2 MiB because the repetitive title compresses hard
-	// before indexing. So the huge-title shape is UNREACHABLE on Postgres,
-	// which bounds item titles in practice at a few KB while SQLite accepts
-	// them at any length.
+	// before indexing. So the huge-title shape is UNREACHABLE on Postgres, and
+	// the LEGACY-DATA seeding this test now uses cannot manufacture it either:
+	// the row goes in through the same UNIQUE index.
 	//
-	// That divergence is a defect in its own right (same input accepted on one
+	// That divergence WAS a defect in its own right (same input accepted on one
 	// backend, refused with a 500-shaped error on the other — the BUG-2782 /
-	// BUG-2784 family) and is reported separately rather than bundled here.
+	// BUG-2784 family). It was filed as BUG-2831 and is now FIXED: item titles
+	// are bounded at models.MaxItemTitleRunes on both backends, so the input
+	// this comment describes is refused identically either side. What remains
+	// dialect-specific is only that a pre-bound legacy ROW can exist on SQLite
+	// and not on Postgres, which is why the skip below stays.
+	//
+	// (The cap that actually fires first is 2704 bytes, not 8191 — measured;
+	// see models.MaxItemTitleRunes. The reading quoted above is from the
+	// hard-ceiling arm and is left verbatim because it is what BUG-2804's run
+	// actually printed.)
 	//
 	// What it does NOT mean is that the scan bound is SQLite-only. Row count is
 	// unbounded on both backends: at Postgres's practical title ceiling the
@@ -309,7 +324,7 @@ func TestItemRenameCascade_BoundsTheScanNotJustTheRewrite(t *testing.T) {
 	// trade — 64 rows instead of 24,000 — and pays for it by being
 	// dialect-scoped.
 	if s.dialect.Driver() == DriverPostgres {
-		t.Skip("huge-title fixture is unreachable on Postgres: UNIQUE(workspace_id, slug) btree caps the index tuple at 8191 bytes")
+		t.Skip("huge-title fixture is unreachable on Postgres: UNIQUE(workspace_id, slug) btree caps the index tuple, so even a legacy-seeded row cannot carry this slug")
 	}
 	ws := createTestWorkspace(t, s, "ItemRenameScanBound")
 	col := createTestCollection(t, s, ws.ID, "Tasks")

--- a/internal/store/items_rename_bounds_test.go
+++ b/internal/store/items_rename_bounds_test.go
@@ -263,7 +263,8 @@ func TestItemRenameCascade_DoesNotChargeForRewritesItWillNotPerform(t *testing.T
 // below is built as LEGACY data for exactly that reason. The guard is not
 // thereby obsolete: the bound is non-retroactive, this scan reads STORED
 // titles rather than the one being written, and at the bound the same pressure
-// arrives with ~24,000 link rows instead of 64.
+// arrives with ~240,000 link rows instead of 64 — 64 MiB / (255 + 24), computed
+// for THIS bound rather than carried over from BUG-2804's few-KB ceiling.
 //
 // This is the case my own doc comment on MaxItemRenameCascadeBytes previously
 // claimed was impossible — it asserted the cascade's retention was O(1) in the
@@ -333,9 +334,16 @@ func TestItemRenameCascade_BoundsTheScanNotJustTheRewrite(t *testing.T) {
 	// dialects. The scan bound it guards is NOT thereby obsolete: the charge is
 	// against each link row's STORED target_title, so a legacy row carrying a
 	// pre-bound title still drives exactly this pressure, and even an in-bound
-	// title reaches the cap at ~24,000 rows (the number this fixture trades
-	// away for 64). Built as legacy data so the test keeps measuring the guard
-	// rather than the new door in front of it.
+	// title reaches the cap — at ~240,000 rows, 64 MiB / (255 + 24).
+	//
+	// NOT the ~24,000 the paragraph above quotes, and the difference is the
+	// point: that figure is BUG-2804's, derived from Postgres's practical title
+	// ceiling of a few KB, and an earlier version of this comment reused it for
+	// the 255-rune bound without recomputing (codex round 5). Two ceilings, two
+	// numbers, one sentence away from each other.
+	//
+	// Built as legacy data so the test keeps measuring the guard rather than
+	// the new door in front of it.
 	target := createLegacyTitledItem(t, s, ws.ID, col.ID, hugeTitle, "the item being renamed")
 
 	contentBytes := 0

--- a/internal/store/items_rename_bounds_test.go
+++ b/internal/store/items_rename_bounds_test.go
@@ -313,7 +313,15 @@ func TestItemRenameCascade_BoundsTheScanNotJustTheRewrite(t *testing.T) {
 	}
 	ws := createTestWorkspace(t, s, "ItemRenameScanBound")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
-	target := createTestItem(t, s, ws.ID, col.ID, hugeTitle, "the item being renamed")
+	// BUG-2833 / BUG-2831: a 2 MiB title is no longer reachable through
+	// CreateItem — models.MaxItemTitleRunes refuses it at the door, on both
+	// dialects. The scan bound it guards is NOT thereby obsolete: the charge is
+	// against each link row's STORED target_title, so a legacy row carrying a
+	// pre-bound title still drives exactly this pressure, and even an in-bound
+	// title reaches the cap at ~24,000 rows (the number this fixture trades
+	// away for 64). Built as legacy data so the test keeps measuring the guard
+	// rather than the new door in front of it.
+	target := createLegacyTitledItem(t, s, ws.ID, col.ID, hugeTitle, "the item being renamed")
 
 	contentBytes := 0
 	for i := 0; i < rowsNeeded; i++ {

--- a/internal/store/items_test.go
+++ b/internal/store/items_test.go
@@ -36,6 +36,45 @@ func createTestItem(t *testing.T, s *Store, workspaceID, collectionID, title, co
 	return item
 }
 
+// createLegacyTitledItem creates an item and then writes `title` onto the row
+// DIRECTLY, bypassing the write-time validation in CreateItem/UpdateItem
+// (models.ValidateItemTitle, BUG-2833 / BUG-2831).
+//
+// It exists because that validation is deliberately NON-RETROACTIVE: a stored
+// title that predates the bound stays valid, keeps resolving, and keeps
+// cascading. Rows like that are real — every database written before the guard
+// may hold them — so the behaviours that handle them still need fixtures, and
+// after the guard the ordinary create path can no longer build one.
+//
+// Using it is an assertion that the row under test is LEGACY data. Do not
+// reach for it to dodge the validator in a test about a normal write: if the
+// title could be minted through a door today, build it through that door.
+//
+// The slug is derived exactly as the pre-guard create path derived it —
+// slugify with no truncation, then uniqueness — so the fixture reproduces what
+// such a row actually looks like rather than an idealized version of it.
+func createLegacyTitledItem(t *testing.T, s *Store, workspaceID, collectionID, title, content string) *models.Item {
+	t.Helper()
+	item := createTestItem(t, s, workspaceID, collectionID, "legacy title placeholder", content)
+
+	baseSlug := slugify(title)
+	if baseSlug == "" {
+		baseSlug = "untitled"
+	}
+	slug, err := s.uniqueSlugExcluding(s.db, "items", "workspace_id", workspaceID, baseSlug, item.ID)
+	if err != nil {
+		t.Fatalf("legacy title fixture: unique slug: %v", err)
+	}
+	if _, err := s.db.Exec(s.q("UPDATE items SET title = ?, slug = ? WHERE id = ?"), title, slug, item.ID); err != nil {
+		t.Fatalf("legacy title fixture: write title: %v", err)
+	}
+	updated, err := s.GetItem(item.ID)
+	if err != nil {
+		t.Fatalf("legacy title fixture: re-read: %v", err)
+	}
+	return updated
+}
+
 func TestListItems_UnparentedStructuralParity(t *testing.T) {
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Unparented")

--- a/internal/store/items_title_validation_test.go
+++ b/internal/store/items_title_validation_test.go
@@ -201,9 +201,13 @@ func TestItemTitle_StoresTheNormalizedValue(t *testing.T) {
 // stored title predates the bound must stay editable; only a genuine rename is
 // a write-time door.
 func TestItemTitle_GrandfathersLegacyRows(t *testing.T) {
-	if s := testStore(t); s.dialect.Driver() == DriverPostgres {
-		t.Skip("a legacy over-bound title cannot exist on Postgres: the slug it implies exceeds the 8191-byte btree index tuple, which is BUG-2831 itself")
-	}
+	// RUNS ON BOTH DIALECTS. It used to skip on Postgres, on the stated ground
+	// that a legacy over-bound title implies a slug past the btree index-tuple
+	// cap — which is true of BUG-2804's 2 MiB fixture and FALSE of this one
+	// (codex round 1, P2). overlongTitle() is 256 runes, so the slug it derives
+	// is 256 ASCII bytes: an order of magnitude under the 2704 the cap actually
+	// enforces. The skip was reasoning by analogy with a different fixture and
+	// left the non-retroactive rule untested on the backend BUG-2831 is about.
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "TitleGrandfather")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -381,4 +385,152 @@ func highEntropySlug(n int) string {
 		out[i] = alphabet[(x>>33)%uint64(len(alphabet))]
 	}
 	return string(out)
+}
+
+// TestImportWorkspace_TruncatedSlugCollidesWithALaterVerbatimSlug regresses
+// codex round 1 P1.
+//
+// Truncation is the only way this loop can produce two identical slugs — a
+// bundle exported from a live workspace cannot contain a duplicate, because
+// UNIQUE(workspace_id, slug) held there. But the duplicate it creates lands in
+// either order, and the first fix resolved uniqueness ONLY for the row it had
+// truncated. Here the truncated row is inserted FIRST and the untouched row
+// that happens to own the resulting slug comes second, so the row that needs
+// resolving is the one the fix was not looking at.
+//
+// The failure mode is the whole import aborting — the opposite of the
+// coerce-and-continue policy the title coercion exists to honour.
+func TestImportWorkspace_TruncatedSlugCollidesWithALaterVerbatimSlug(t *testing.T) {
+	s := testStore(t)
+	owner, err := s.CreateUser(models.UserCreate{
+		Name: "Owner", Email: "slug-collision-owner@example.com", Password: "passw0rd!",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	// A long slug whose first MaxItemTitleRunes bytes are exactly `collides`
+	// padded out — so truncation lands on a value a later row already owns.
+	prefix := strings.Repeat("c", models.MaxItemTitleRunes)
+	longSlug := prefix + strings.Repeat("d", 500)
+
+	export := &models.WorkspaceExport{
+		Version: 1, ExportedAt: "2026-08-31T00:00:00Z",
+		Workspace: models.WorkspaceExportMeta{Name: "Collide", Slug: "collide"},
+		Collections: []models.CollectionExport{{
+			ID: "c1", Name: "Tasks", Slug: "tasks", Prefix: "TASK",
+			Schema:    `{"fields":[]}`,
+			CreatedAt: "2026-08-31T00:00:00Z", UpdatedAt: "2026-08-31T00:00:00Z",
+		}},
+		Items: []models.ItemExport{
+			{
+				// Inserted FIRST, truncates to `prefix`.
+				ID: "long-first", CollectionID: "c1",
+				Title: "Long slug row", Slug: longSlug,
+				Fields: `{}`, Tags: `[]`,
+				CreatedAt: "2026-08-31T00:00:00Z", UpdatedAt: "2026-08-31T00:00:00Z",
+			},
+			{
+				// Inserted SECOND, and its slug is already legal and untouched —
+				// so nothing about THIS row is coerced, yet it is the one that
+				// collides.
+				ID: "exact-second", CollectionID: "c1",
+				Title: "Exact slug row", Slug: prefix,
+				Fields: `{}`, Tags: `[]`,
+				CreatedAt: "2026-08-31T00:00:00Z", UpdatedAt: "2026-08-31T00:00:00Z",
+			},
+		},
+	}
+
+	ws, err := s.ImportWorkspace(export, "Collide Target", owner.ID)
+	if err != nil {
+		t.Fatalf("a slug collision created by OUR truncation must be resolved, not abort the import: %v", err)
+	}
+
+	items, err := s.ListItems(ws.ID, models.ItemListParams{})
+	if err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("want both items imported, got %d", len(items))
+	}
+	seen := map[string]string{}
+	for _, it := range items {
+		if prev, dup := seen[it.Slug]; dup {
+			t.Errorf("duplicate slug %q on %q and %q", it.Slug, prev, it.Title)
+		}
+		seen[it.Slug] = it.Title
+	}
+	// Both rows survive AND stay distinguishable — a "fix" that let one
+	// overwrite the other would also produce two unique slugs.
+	titles := map[string]bool{}
+	for _, it := range items {
+		titles[it.Title] = true
+	}
+	for _, want := range []string{"Long slug row", "Exact slug row"} {
+		if !titles[want] {
+			t.Errorf("item %q did not survive the import", want)
+		}
+	}
+}
+
+// TestItemTitle_GrandfathersAVerbatimEchoOfAWhitespaceTitle regresses codex
+// round 1 P2: the exemption is "a title identical to the stored one", and
+// comparing only the NORMALIZED form makes that false for exactly the rows the
+// exemption exists for.
+func TestItemTitle_GrandfathersAVerbatimEchoOfAWhitespaceTitle(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "TitleEchoGrandfather")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	// A legacy row that is BOTH over the bound AND carries edge whitespace —
+	// the combination is what makes the two comparisons disagree.
+	legacyTitle := "  " + strings.Repeat("q", models.MaxItemTitleRunes+1) + "  "
+	legacy := createLegacyTitledItem(t, s, ws.ID, col.ID, legacyTitle, "")
+	if legacy.Title != legacyTitle {
+		t.Fatalf("fixture did not store the title verbatim: %q", legacy.Title)
+	}
+
+	// A client that read this item and echoed it back sends the stored bytes.
+	echo := legacyTitle
+	if _, err := s.UpdateItem(legacy.ID, models.ItemUpdate{Title: &echo}); err != nil {
+		t.Fatalf("a verbatim echo of the stored title is not a rename and must be accepted: %v", err)
+	}
+
+	// Control: a genuinely different over-bound title is still refused, so the
+	// exemption has not been widened into a hole.
+	other := "  " + strings.Repeat("r", models.MaxItemTitleRunes+1) + "  "
+	if _, err := s.UpdateItem(legacy.ID, models.ItemUpdate{Title: &other}); err == nil {
+		t.Error("a DIFFERENT over-bound title must still be refused")
+	} else {
+		asInvalidTitle(t, err)
+	}
+}
+
+// TestItemTitle_GrandfathersAWriteThatNormalizesToTheStoredTitle covers the
+// OTHER disjunct of the exemption, which the verbatim-echo test above cannot
+// see: a stored legacy title with no edge whitespace, sent back with some.
+//
+// It is not a rename — the value written is byte-identical to what is already
+// there once normalized — so refusing it would refuse a no-op, which is the
+// same defect class as BUG-2833 in the opposite direction. A mutation dropping
+// this disjunct survived the rest of the suite, which is why the case is
+// pinned separately rather than folded into the test above.
+func TestItemTitle_GrandfathersAWriteThatNormalizesToTheStoredTitle(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "TitleNormalizedEcho")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	// Stored legacy title is over the bound and already trimmed.
+	legacyTitle := strings.Repeat("q", models.MaxItemTitleRunes+1)
+	legacy := createLegacyTitledItem(t, s, ws.ID, col.ID, legacyTitle, "")
+
+	padded := "  " + legacyTitle + "\t"
+	updated, err := s.UpdateItem(legacy.ID, models.ItemUpdate{Title: &padded})
+	if err != nil {
+		t.Fatalf("a title that NORMALIZES to the stored one writes nothing and must be accepted: %v", err)
+	}
+	if updated.Title != legacyTitle {
+		t.Errorf("title = %q, want the stored value unchanged", updated.Title)
+	}
 }

--- a/internal/store/items_title_validation_test.go
+++ b/internal/store/items_title_validation_test.go
@@ -347,8 +347,21 @@ func TestImportWorkspace_CoercesTitles(t *testing.T) {
 		if n := utf8.RuneCountInString(it.Title); n > models.MaxItemTitleRunes {
 			t.Errorf("item %s imported with a %d-rune title, over the %d bound", it.ID, n, models.MaxItemTitleRunes)
 		}
-		if n := utf8.RuneCountInString(it.Slug); n > models.MaxItemTitleRunes {
-			t.Errorf("item %s imported with a %d-rune slug, over the %d bound — the btree half of BUG-2831 is still open",
+		// The slug bound allows for the uniqueness suffix (codex round 5). A
+		// truncated slug that collides is resolved to "<255 runes>-2", so a
+		// hard <= MaxItemTitleRunes assertion states the design more strictly
+		// than it is — it happens to hold for this fixture and would fail a
+		// legitimate implementation on the next one.
+		//
+		// The real safety requirement is the INDEX-BYTE limit (~2704 on
+		// Postgres), not a rune count; the rune bound is how this unit reaches
+		// it with room to spare. A handful of suffix bytes does not touch that,
+		// so the assertion allows them and still fails the unbounded case by
+		// two orders of magnitude.
+		const slugSuffixAllowance = 16
+		if n := utf8.RuneCountInString(it.Slug); n > models.MaxItemTitleRunes+slugSuffixAllowance {
+			t.Errorf("item %s imported with a %d-rune slug, past the %d bound plus its uniqueness "+
+				"suffix allowance — the btree half of BUG-2831 is still open",
 				it.ID, n, models.MaxItemTitleRunes)
 		}
 	}
@@ -483,11 +496,36 @@ func TestImportWorkspace_TruncatedSlugCollidesWithALaterVerbatimSlug(t *testing.
 		t.Fatalf("want both items imported, got %d", len(items))
 	}
 	seen := map[string]string{}
+	bySlugTitle := map[string]string{}
 	for _, it := range items {
 		if prev, dup := seen[it.Slug]; dup {
 			t.Errorf("duplicate slug %q on %q and %q", it.Slug, prev, it.Title)
 		}
 		seen[it.Slug] = it.Title
+		bySlugTitle[it.Title] = it.Slug
+	}
+
+	// PROVE THE TRUNCATION, not merely that the import survived (codex round
+	// 5). Uniqueness alone is satisfied by an implementation that truncates
+	// NOTHING: 755 runes and 255 runes are already distinct, so no collision
+	// arises, both rows land, and every assertion above passes while the very
+	// mechanism under test is absent. The test has to name the two slugs it
+	// expects.
+	longRowSlug := bySlugTitle["Long slug row"]
+	exactRowSlug := bySlugTitle["Exact slug row"]
+	if longRowSlug != prefix {
+		t.Errorf("the long row's slug = %d runes (%q...), want it truncated to exactly the %d-rune prefix",
+			utf8.RuneCountInString(longRowSlug), longRowSlug[:min(12, len(longRowSlug))], models.MaxItemTitleRunes)
+	}
+	// The second row owned `prefix` in the bundle and must have been moved off
+	// it — which only happens if the FIRST row truncated onto it.
+	if exactRowSlug == prefix {
+		t.Errorf("the second row kept slug %q, so nothing collided with it — the first row was not truncated onto it",
+			prefix)
+	}
+	if !strings.HasPrefix(exactRowSlug, prefix+"-") {
+		t.Errorf("the second row's slug = %q, want the %d-rune prefix plus a uniqueness suffix",
+			exactRowSlug, models.MaxItemTitleRunes)
 	}
 	// Both rows survive AND stay distinguishable — a "fix" that let one
 	// overwrite the other would also produce two unique slugs.
@@ -616,5 +654,67 @@ func TestItemTitle_GrandfatheredWriteCannotMintAnEmptyTitle(t *testing.T) {
 				t.Errorf("the grandfathering clause wrote an empty title — the one thing no door may do")
 			}
 		})
+	}
+}
+
+// TestItemTitle_GrandfatheredEchoDoesNotMoveTheSlug regresses codex round 5's
+// P1, which is the second defect the grandfathering clause has produced.
+//
+// Assigning the stored title back left input.Title NON-NIL, and every consumer
+// downstream keys on that pointer rather than on whether the value changed —
+// including the SET clause, which regenerates the slug from slugify(title)
+// unconditionally. For a row whose slug does NOT derive from its current title,
+// a write that changes nothing would silently move the item's URL, and the
+// activity change-list would not show it because the TITLE is unchanged.
+//
+// The fixture's slug must therefore be DELIBERATELY out of step with its title,
+// which is not exotic: ImportWorkspace writes the bundle's slug verbatim, and
+// this unit's own import truncation rewrites slugs without touching titles.
+// (The earlier grandfathering tests all derive the slug from the title, which
+// is exactly why they could not see this.)
+func TestItemTitle_GrandfatheredEchoDoesNotMoveTheSlug(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "TitleEchoSlug")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	legacyTitle := strings.Repeat("k", models.MaxItemTitleRunes+1)
+	item := createLegacyTitledItem(t, s, ws.ID, col.ID, legacyTitle, "")
+
+	// Put the slug out of step with the title, the way an import does.
+	const importedSlug = "slug-from-a-bundle"
+	if _, err := s.db.Exec(s.q("UPDATE items SET slug = ? WHERE id = ?"), importedSlug, item.ID); err != nil {
+		t.Fatalf("fixture: set an import-shaped slug: %v", err)
+	}
+
+	echo := legacyTitle
+	if _, err := s.UpdateItem(item.ID, models.ItemUpdate{Title: &echo}); err != nil {
+		t.Fatalf("echoing the stored title must be accepted: %v", err)
+	}
+
+	after, err := s.GetItem(item.ID)
+	if err != nil {
+		t.Fatalf("GetItem: %v", err)
+	}
+	if after.Slug != importedSlug {
+		t.Errorf("slug = %q, want it untouched (%q). A write that changes no title must not move the "+
+			"item's URL — and nothing in the activity change-list would have reported that it did.",
+			after.Slug, importedSlug)
+	}
+	if after.Title != legacyTitle {
+		t.Errorf("title = %q, want the legacy bytes unchanged", after.Title)
+	}
+
+	// Control: a REAL rename must still regenerate the slug, or this test would
+	// be satisfied by a version that never regenerates it at all.
+	renamed := "A Proper New Title"
+	updated, err := s.UpdateItem(item.ID, models.ItemUpdate{Title: &renamed})
+	if err != nil {
+		t.Fatalf("a genuine rename must be accepted: %v", err)
+	}
+	if updated.Slug == importedSlug {
+		t.Errorf("slug = %q after a real rename; it must be re-derived from the new title", updated.Slug)
+	}
+	if updated.Slug != "a-proper-new-title" {
+		t.Errorf("slug = %q, want %q", updated.Slug, "a-proper-new-title")
 	}
 }

--- a/internal/store/items_title_validation_test.go
+++ b/internal/store/items_title_validation_test.go
@@ -1,0 +1,352 @@
+package store
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// Item title validation at the store's two write doors (BUG-2833 empty,
+// BUG-2831 length).
+//
+// EVERY test here is DIFFERENTIAL by construction: testStore returns Postgres
+// when PAD_TEST_POSTGRES_URL is set and SQLite otherwise, so `make test` and
+// `make test-pg` run the same assertions against both backends. That is the
+// point rather than a convenience — BUG-2831 IS a dialect split (SQLite
+// accepted a title Postgres refused at the UNIQUE(workspace_id, slug) btree),
+// so a bound that is only checked on one backend would not close it. The
+// assertions below are written so that a dialect-specific refusal cannot pass
+// as a validation refusal: they require the typed *InvalidItemTitleError, which
+// no driver produces.
+
+// overlongTitle returns a title one rune past the bound. It is built from a
+// letter rather than repeated punctuation because slugify drops non-alphanumerics
+// — a punctuation title of any length slugifies to "" and would exercise the
+// untitled fallback instead of the length rule.
+func overlongTitle() string {
+	return strings.Repeat("a", models.MaxItemTitleRunes+1)
+}
+
+func maxLengthTitle() string {
+	return strings.Repeat("b", models.MaxItemTitleRunes)
+}
+
+func asInvalidTitle(t *testing.T, err error) *InvalidItemTitleError {
+	t.Helper()
+	var bad *InvalidItemTitleError
+	if !errors.As(err, &bad) {
+		t.Fatalf("want *InvalidItemTitleError, got %T: %v", err, err)
+	}
+	if !errors.Is(err, ErrInvalidItemTitle) {
+		t.Errorf("errors.Is(err, ErrInvalidItemTitle) = false; the sentinel must be reachable through Unwrap")
+	}
+	return bad
+}
+
+func TestItemTitle_CreateRefuses(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "TitleCreate")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	cases := []struct {
+		name     string
+		title    string
+		wantWord string
+	}{
+		{"empty", "", "required"},
+		{"spaces only", "   ", "required"},
+		// Tab/newline/NBSP: TrimSpace is unicode-aware, so "untitled wearing a
+		// costume" is not limited to the space character.
+		{"tabs and newlines only", "\t\n\r ", "required"},
+		{"unicode space only", "  ", "required"},
+		{"one rune over the bound", overlongTitle(), "too long"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := s.CreateItem(ws.ID, col.ID, models.ItemCreate{Title: tc.title})
+			if err == nil {
+				t.Fatalf("CreateItem(%q) succeeded; want refusal", tc.title)
+			}
+			bad := asInvalidTitle(t, err)
+			if !strings.Contains(strings.ToLower(bad.Reason), tc.wantWord) {
+				t.Errorf("Reason = %q, want it to mention %q", bad.Reason, tc.wantWord)
+			}
+		})
+	}
+}
+
+// TestItemTitle_UpdateRefusesEmpty is the literal BUG-2833 repro: the filing
+// measured UpdateItem(target, {Title: ""}) returning err = nil and the item's
+// title becoming empty, while the create path refused the same input.
+func TestItemTitle_UpdateRefusesEmpty(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "TitleUpdateEmpty")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	item := createTestItem(t, s, ws.ID, col.ID, "Real Title", "body")
+
+	for _, title := range []string{"", "   ", "\t\n"} {
+		empty := title
+		if _, err := s.UpdateItem(item.ID, models.ItemUpdate{Title: &empty}); err == nil {
+			t.Fatalf("UpdateItem(title=%q) succeeded; want refusal", title)
+		} else {
+			asInvalidTitle(t, err)
+		}
+	}
+
+	// The refusal must also leave the row alone. A guard that refuses AFTER
+	// writing would satisfy the error assertion above and still have destroyed
+	// the title, which is the damage the filing is about.
+	after, err := s.GetItem(item.ID)
+	if err != nil {
+		t.Fatalf("GetItem: %v", err)
+	}
+	if after.Title != "Real Title" {
+		t.Errorf("title = %q after refused updates, want it untouched (%q)", after.Title, "Real Title")
+	}
+	if after.Slug != item.Slug {
+		t.Errorf("slug = %q after refused updates, want it untouched (%q)", after.Slug, item.Slug)
+	}
+}
+
+// TestItemTitle_UpdateRefusesOverlong is BUG-2831 on the rename path. Before
+// the bound this update SUCCEEDED on SQLite and failed on Postgres with
+// `index row requires N bytes, maximum size is 8191 (SQLSTATE 54000)` reaching
+// the handler's generic error arm. Both dialects now refuse it the same way,
+// with a typed validation error rather than a driver error.
+func TestItemTitle_UpdateRefusesOverlong(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "TitleUpdateLong")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	item := createTestItem(t, s, ws.ID, col.ID, "Short", "")
+
+	long := overlongTitle()
+	_, err := s.UpdateItem(item.ID, models.ItemUpdate{Title: &long})
+	if err == nil {
+		t.Fatalf("UpdateItem with a %d-rune title succeeded; want refusal", utf8.RuneCountInString(long))
+	}
+	bad := asInvalidTitle(t, err)
+	if !strings.Contains(bad.Reason, "256") || !strings.Contains(bad.Reason, "255") {
+		t.Errorf("Reason = %q, want it to name both the supplied length and the maximum", bad.Reason)
+	}
+}
+
+// TestItemTitle_BoundaryIsInclusive pins the off-by-one in both directions. A
+// bound whose accepted side is untested can be tightened by accident and
+// nothing fails.
+func TestItemTitle_BoundaryIsInclusive(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "TitleBoundary")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	atBound, err := s.CreateItem(ws.ID, col.ID, models.ItemCreate{Title: maxLengthTitle()})
+	if err != nil {
+		t.Fatalf("CreateItem with exactly %d runes must be accepted: %v", models.MaxItemTitleRunes, err)
+	}
+	if got := utf8.RuneCountInString(atBound.Title); got != models.MaxItemTitleRunes {
+		t.Errorf("stored title = %d runes, want %d", got, models.MaxItemTitleRunes)
+	}
+
+	// RUNES, not bytes: a 255-rune title of 4-byte runes is 1020 bytes and must
+	// still be accepted, or the constant's documented unit is a lie. This also
+	// proves the slug derivation survives it — slugify drops non-ASCII, so the
+	// slug falls back rather than carrying 1020 bytes into the btree.
+	wide := strings.Repeat("𝔞", models.MaxItemTitleRunes)
+	if _, err := s.CreateItem(ws.ID, col.ID, models.ItemCreate{Title: wide}); err != nil {
+		t.Fatalf("CreateItem with %d runes / %d bytes must be accepted: %v",
+			utf8.RuneCountInString(wide), len(wide), err)
+	}
+}
+
+// TestItemTitle_StoresTheNormalizedValue: validating a trimmed string while
+// storing the raw one would leave the row holding something the validator never
+// saw. Both doors must persist what they checked.
+func TestItemTitle_StoresTheNormalizedValue(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "TitleNormalize")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	created, err := s.CreateItem(ws.ID, col.ID, models.ItemCreate{Title: "  Padded Title  "})
+	if err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+	if created.Title != "Padded Title" {
+		t.Errorf("created title = %q, want %q", created.Title, "Padded Title")
+	}
+
+	renamed := "\tRenamed Title\n"
+	updated, err := s.UpdateItem(created.ID, models.ItemUpdate{Title: &renamed})
+	if err != nil {
+		t.Fatalf("UpdateItem: %v", err)
+	}
+	if updated.Title != "Renamed Title" {
+		t.Errorf("updated title = %q, want %q", updated.Title, "Renamed Title")
+	}
+
+	// Re-read: the normalization has to be in the ROW, not only in the
+	// returned struct.
+	stored, err := s.GetItem(created.ID)
+	if err != nil {
+		t.Fatalf("GetItem: %v", err)
+	}
+	if stored.Title != "Renamed Title" {
+		t.Errorf("stored title = %q, want %q", stored.Title, "Renamed Title")
+	}
+}
+
+// TestItemTitle_GrandfathersLegacyRows pins the non-retroactive half of the
+// rule (Dave's day-63 ruling, carried from MaxDocumentTitleRunes). A row whose
+// stored title predates the bound must stay editable; only a genuine rename is
+// a write-time door.
+func TestItemTitle_GrandfathersLegacyRows(t *testing.T) {
+	if s := testStore(t); s.dialect.Driver() == DriverPostgres {
+		t.Skip("a legacy over-bound title cannot exist on Postgres: the slug it implies exceeds the 8191-byte btree index tuple, which is BUG-2831 itself")
+	}
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "TitleGrandfather")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	legacy := createLegacyTitledItem(t, s, ws.ID, col.ID, overlongTitle(), "body")
+
+	// 1. An update that does not touch the title must not validate one.
+	newContent := "edited body"
+	if _, err := s.UpdateItem(legacy.ID, models.ItemUpdate{Content: &newContent}); err != nil {
+		t.Fatalf("content-only update on a legacy-titled row must succeed: %v", err)
+	}
+
+	// 2. Echoing the stored title back is not a rename.
+	echoed := legacy.Title
+	if _, err := s.UpdateItem(legacy.ID, models.ItemUpdate{Title: &echoed}); err != nil {
+		t.Fatalf("echoing the stored legacy title must succeed: %v", err)
+	}
+
+	// 3. But a genuine rename to ANOTHER invalid title is refused — the
+	// grandfathering is for the row's existing value, not a licence.
+	another := strings.Repeat("z", models.MaxItemTitleRunes+1)
+	if _, err := s.UpdateItem(legacy.ID, models.ItemUpdate{Title: &another}); err == nil {
+		t.Fatal("renaming a legacy row to a DIFFERENT over-bound title must be refused")
+	} else {
+		asInvalidTitle(t, err)
+	}
+
+	// 4. And renaming it to a valid title works, so a legacy row is repairable.
+	fixed := "Repaired Title"
+	got, err := s.UpdateItem(legacy.ID, models.ItemUpdate{Title: &fixed})
+	if err != nil {
+		t.Fatalf("repairing a legacy row must succeed: %v", err)
+	}
+	if got.Title != fixed {
+		t.Errorf("title = %q, want %q", got.Title, fixed)
+	}
+}
+
+// TestImportWorkspace_CoercesTitles pins doors 4/5 (ImportWorkspace, and
+// `pad db migrate` which is ExportWorkspace piped into it). Import COERCES
+// where the interactive doors REFUSE, and this test is the regression guard
+// against a later change that "fixes" the asymmetry by making import validate:
+// that would turn restoring a legacy archive into a hard failure for data this
+// product already accepted.
+func TestImportWorkspace_CoercesTitles(t *testing.T) {
+	s := testStore(t)
+	owner, err := s.CreateUser(models.UserCreate{
+		Name:     "Owner",
+		Email:    "title-import-owner@example.com",
+		Password: "passw0rd!",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	longTitle := strings.Repeat("x", 300)
+	export := &models.WorkspaceExport{
+		Version:    1,
+		ExportedAt: "2026-08-31T00:00:00Z",
+		Workspace: models.WorkspaceExportMeta{
+			Name: "Legacy Archive",
+			Slug: "legacy-archive",
+		},
+		Collections: []models.CollectionExport{{
+			ID: "old-coll-1", Name: "Tasks", Slug: "tasks", Prefix: "TASK",
+			Schema:    `{"fields":[]}`,
+			CreatedAt: "2026-08-31T00:00:00Z", UpdatedAt: "2026-08-31T00:00:00Z",
+		}},
+		Items: []models.ItemExport{
+			{
+				ID: "old-empty", CollectionID: "old-coll-1",
+				Title: "", Slug: "untitled-legacy",
+				Fields: `{}`, Tags: `[]`,
+				CreatedAt: "2026-08-31T00:00:00Z", UpdatedAt: "2026-08-31T00:00:00Z",
+			},
+			{
+				ID: "old-whitespace", CollectionID: "old-coll-1",
+				Title: "   ", Slug: "whitespace-legacy",
+				Fields: `{}`, Tags: `[]`,
+				CreatedAt: "2026-08-31T00:00:00Z", UpdatedAt: "2026-08-31T00:00:00Z",
+			},
+			{
+				// Over-bound title AND the over-bound slug it implies. The slug
+				// is the half that matters on Postgres: this loop writes it
+				// verbatim, and it is what carries UNIQUE(workspace_id, slug)
+				// into the 8191-byte btree tuple.
+				ID: "old-long", CollectionID: "old-coll-1",
+				Title: longTitle, Slug: strings.Repeat("y", 9000),
+				Fields: `{}`, Tags: `[]`,
+				CreatedAt: "2026-08-31T00:00:00Z", UpdatedAt: "2026-08-31T00:00:00Z",
+			},
+			{
+				ID: "old-fine", CollectionID: "old-coll-1",
+				Title: "Perfectly Ordinary", Slug: "perfectly-ordinary",
+				Fields: `{}`, Tags: `[]`,
+				CreatedAt: "2026-08-31T00:00:00Z", UpdatedAt: "2026-08-31T00:00:00Z",
+			},
+		},
+	}
+
+	ws, err := s.ImportWorkspace(export, "Legacy Archive Target", owner.ID)
+	if err != nil {
+		t.Fatalf("ImportWorkspace must SUCCEED on a legacy bundle, not refuse it: %v", err)
+	}
+
+	items, err := s.ListItems(ws.ID, models.ItemListParams{})
+	if err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+	byOriginal := map[string]models.Item{}
+	for _, it := range items {
+		byOriginal[it.Title] = it
+	}
+
+	// Empty and whitespace-only both land as the coerced title — WITH a title,
+	// so Dave's untitled-items invariant holds on this door too.
+	untitled := 0
+	for _, it := range items {
+		if it.Title == "Untitled" {
+			untitled++
+		}
+		if strings.TrimSpace(it.Title) == "" {
+			t.Errorf("item %s imported with an empty title %q — no door may write one", it.ID, it.Title)
+		}
+		if n := utf8.RuneCountInString(it.Title); n > models.MaxItemTitleRunes {
+			t.Errorf("item %s imported with a %d-rune title, over the %d bound", it.ID, n, models.MaxItemTitleRunes)
+		}
+		if n := utf8.RuneCountInString(it.Slug); n > models.MaxItemTitleRunes {
+			t.Errorf("item %s imported with a %d-rune slug, over the %d bound — the btree half of BUG-2831 is still open",
+				it.ID, n, models.MaxItemTitleRunes)
+		}
+	}
+	if untitled != 2 {
+		t.Errorf("want 2 items coerced to %q (the empty one and the whitespace-only one), got %d", "Untitled", untitled)
+	}
+
+	// The in-range item is untouched: coercion must not normalize rows that
+	// were already fine, or every round-trip rewrites data it had no reason to.
+	fine, ok := byOriginal["Perfectly Ordinary"]
+	if !ok {
+		t.Fatal("the in-range item did not import under its own title")
+	}
+	if fine.Slug != "perfectly-ordinary" {
+		t.Errorf("in-range slug = %q, want it preserved verbatim as %q", fine.Slug, "perfectly-ordinary")
+	}
+}

--- a/internal/store/items_title_validation_test.go
+++ b/internal/store/items_title_validation_test.go
@@ -289,9 +289,20 @@ func TestImportWorkspace_CoercesTitles(t *testing.T) {
 				// Over-bound title AND the over-bound slug it implies. The slug
 				// is the half that matters on Postgres: this loop writes it
 				// verbatim, and it is what carries UNIQUE(workspace_id, slug)
-				// into the 8191-byte btree tuple.
+				// into the btree index tuple.
+				//
+				// HIGH-ENTROPY, not strings.Repeat, and the difference decides
+				// whether this fixture reproduces the defect. Index tuples are
+				// compressed before the size check, so a 9000-byte slug of one
+				// repeated character IMPORTS FINE on Postgres — measured, with
+				// the coercion disabled. The same length of poorly-compressible
+				// text fails with `index row requires 9056 bytes, maximum size
+				// is 8191`. Built from a repeated character, this test would
+				// have passed against unfixed code on the backend the bug is
+				// about, while still failing the rune-count assertion — green
+				// for a reason unrelated to BUG-2831.
 				ID: "old-long", CollectionID: "old-coll-1",
-				Title: longTitle, Slug: strings.Repeat("y", 9000),
+				Title: longTitle, Slug: highEntropySlug(9000),
 				Fields: `{}`, Tags: `[]`,
 				CreatedAt: "2026-08-31T00:00:00Z", UpdatedAt: "2026-08-31T00:00:00Z",
 			},
@@ -349,4 +360,25 @@ func TestImportWorkspace_CoercesTitles(t *testing.T) {
 	if fine.Slug != "perfectly-ordinary" {
 		t.Errorf("in-range slug = %q, want it preserved verbatim as %q", fine.Slug, "perfectly-ordinary")
 	}
+}
+
+// highEntropySlug builds a deterministic, poorly-compressible slug of n bytes
+// from a fixed LCG — reproducible across runs and machines, unlike math/rand
+// without a pinned seed, and unlike strings.Repeat it survives the compression
+// Postgres applies before the btree size check.
+//
+// The measured thresholds against Postgres 17 with the import coercion
+// disabled: 2000 bytes accepted, 4000 refused (`index row size 4056 exceeds
+// btree version 4 maximum 2704`), 9000 refused (`index row requires 9056
+// bytes, maximum size is 8191`). 9000 is used above so the failure is the
+// unambiguous hard-cap one.
+func highEntropySlug(n int) string {
+	const alphabet = "abcdefghijklmnopqrstuvwxyz0123456789"
+	out := make([]byte, n)
+	x := uint64(0x9e3779b97f4a7c15)
+	for i := range out {
+		x = x*6364136223846793005 + 1442695040888963407
+		out[i] = alphabet[(x>>33)%uint64(len(alphabet))]
+	}
+	return string(out)
 }

--- a/internal/store/items_title_validation_test.go
+++ b/internal/store/items_title_validation_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -493,8 +494,23 @@ func TestItemTitle_GrandfathersAVerbatimEchoOfAWhitespaceTitle(t *testing.T) {
 
 	// A client that read this item and echoed it back sends the stored bytes.
 	echo := legacyTitle
-	if _, err := s.UpdateItem(legacy.ID, models.ItemUpdate{Title: &echo}); err != nil {
+	updated, err := s.UpdateItem(legacy.ID, models.ItemUpdate{Title: &echo})
+	if err != nil {
 		t.Fatalf("a verbatim echo of the stored title is not a rename and must be accepted: %v", err)
+	}
+	// ASSERT THE STORED BYTES, not merely that no error came back (codex round
+	// 2, P1). Checking err == nil alone passed against a version that skipped
+	// validation and then wrote the NORMALIZED title anyway — turning a
+	// protective exemption into a silent rewrite of the row it was protecting.
+	if updated.Title != legacyTitle {
+		t.Errorf("grandfathered write returned title %q, want the stored bytes unchanged", updated.Title)
+	}
+	stored, err := s.GetItem(legacy.ID)
+	if err != nil {
+		t.Fatalf("GetItem: %v", err)
+	}
+	if stored.Title != legacyTitle {
+		t.Errorf("stored title = %q, want the legacy bytes untouched", stored.Title)
 	}
 
 	// Control: a genuinely different over-bound title is still refused, so the
@@ -532,5 +548,46 @@ func TestItemTitle_GrandfathersAWriteThatNormalizesToTheStoredTitle(t *testing.T
 	}
 	if updated.Title != legacyTitle {
 		t.Errorf("title = %q, want the stored value unchanged", updated.Title)
+	}
+}
+
+// TestItemTitle_GrandfatheredWriteCannotMintAnEmptyTitle is the direct
+// regression for codex round 2's P1 — a hole the round-1 grandfathering fix
+// opened, not one the original code had.
+//
+// A legacy row stored as whitespace-only is the sharpest case: echoed back
+// verbatim, the raw comparison grandfathers it, and a version that skipped
+// validation while still assigning the normalized value wrote "" to the row —
+// minting the empty title Dave's ruling forbids, through the very clause meant
+// to protect legacy rows. No error is returned in that version, which is why
+// the assertion has to be on the stored bytes.
+func TestItemTitle_GrandfatheredWriteCannotMintAnEmptyTitle(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "TitleNoMintEmpty")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	for _, legacyTitle := range []string{"   ", "\t\n", "  " + strings.Repeat("z", models.MaxItemTitleRunes+1) + "  "} {
+		t.Run(fmt.Sprintf("%q", legacyTitle), func(t *testing.T) {
+			legacy := createLegacyTitledItem(t, s, ws.ID, col.ID, legacyTitle, "")
+			if legacy.Title != legacyTitle {
+				t.Fatalf("fixture did not store the title verbatim: %q", legacy.Title)
+			}
+
+			echo := legacyTitle
+			if _, err := s.UpdateItem(legacy.ID, models.ItemUpdate{Title: &echo}); err != nil {
+				t.Fatalf("a verbatim echo must be accepted as a no-op: %v", err)
+			}
+
+			stored, err := s.GetItem(legacy.ID)
+			if err != nil {
+				t.Fatalf("GetItem: %v", err)
+			}
+			if stored.Title != legacyTitle {
+				t.Errorf("stored title = %q, want the legacy bytes unchanged", stored.Title)
+			}
+			if strings.TrimSpace(stored.Title) == "" && legacyTitle != stored.Title {
+				t.Errorf("the grandfathering clause wrote an empty title — the one thing no door may do")
+			}
+		})
 	}
 }

--- a/internal/store/items_title_validation_test.go
+++ b/internal/store/items_title_validation_test.go
@@ -356,6 +356,33 @@ func TestImportWorkspace_CoercesTitles(t *testing.T) {
 		t.Errorf("want 2 items coerced to %q (the empty one and the whitespace-only one), got %d", "Untitled", untitled)
 	}
 
+	// THE COERCED-LONG ROW MUST SURVIVE, WITH THE EXPECTED TITLE (codex round
+	// 4). Without this, an implementation that silently DROPPED the over-long
+	// item would satisfy every assertion above — it would still see two
+	// "Untitled" rows and the ordinary one, and the per-item bound checks are
+	// vacuously true over a row that is not there. Coerce-and-continue means
+	// the row lands, not that the import survives it.
+	if len(items) != len(export.Items) {
+		t.Errorf("imported %d items, want all %d — a coerced row must land, not be skipped",
+			len(items), len(export.Items))
+	}
+	wantTruncated := longTitle[:models.MaxItemTitleRunes]
+	truncated, ok := byOriginal[wantTruncated]
+	if !ok {
+		var got []string
+		for _, it := range items {
+			got = append(got, fmt.Sprintf("%q (%d runes)", it.Title[:min(20, len(it.Title))], utf8.RuneCountInString(it.Title)))
+		}
+		t.Fatalf("the over-long row did not import under its truncated title (want %d runes of %q); got %v",
+			models.MaxItemTitleRunes, "x...", got)
+	}
+	if n := utf8.RuneCountInString(truncated.Title); n != models.MaxItemTitleRunes {
+		t.Errorf("truncated title is %d runes, want exactly %d", n, models.MaxItemTitleRunes)
+	}
+	if truncated.Slug == "" {
+		t.Error("the coerced row imported with an empty slug")
+	}
+
 	// The in-range item is untouched: coercion must not normalize rows that
 	// were already fine, or every round-trip rewrites data it had no reason to.
 	fine, ok := byOriginal["Perfectly Ordinary"]

--- a/internal/store/items_title_validation_test.go
+++ b/internal/store/items_title_validation_test.go
@@ -686,9 +686,25 @@ func TestItemTitle_GrandfatheredEchoDoesNotMoveTheSlug(t *testing.T) {
 		t.Fatalf("fixture: set an import-shaped slug: %v", err)
 	}
 
-	echo := legacyTitle
-	if _, err := s.UpdateItem(item.ID, models.ItemUpdate{Title: &echo}); err != nil {
-		t.Fatalf("echoing the stored title must be accepted: %v", err)
+	// BOTH grandfathering legs, against the same out-of-step slug (codex round
+	// 6). The raw echo and the padded form take different branches, and the
+	// padded one had no slug coverage at all: the test that exercises it
+	// derives its slug FROM the title, so the non-nil-pointer mutant
+	// regenerates the identical slug there and passes.
+	for _, echo := range []string{legacyTitle, "  " + legacyTitle + "\t"} {
+		title := echo
+		if _, err := s.UpdateItem(item.ID, models.ItemUpdate{Title: &title}); err != nil {
+			t.Fatalf("echoing the stored title (%d runes, padded=%t) must be accepted: %v",
+				utf8.RuneCountInString(echo), echo != legacyTitle, err)
+		}
+		mid, err := s.GetItem(item.ID)
+		if err != nil {
+			t.Fatalf("GetItem: %v", err)
+		}
+		if mid.Slug != importedSlug {
+			t.Errorf("slug = %q after a %s echo, want it untouched (%q)",
+				mid.Slug, map[bool]string{true: "padded", false: "verbatim"}[echo != legacyTitle], importedSlug)
+		}
 	}
 
 	after, err := s.GetItem(item.ID)

--- a/internal/store/wiki_links.go
+++ b/internal/store/wiki_links.go
@@ -650,12 +650,21 @@ func (s *Store) cascadeTitleRename(tx *sql.Tx, renamedItemID, workspaceID, oldTi
 	// and refuses DURING the scan (BUG-2804 / codex R4).
 	//
 	// `works` holds one entry per matching LINK ROW, not per source, and each
-	// entry carries that row's target_title — which is unbounded, because
-	// nothing validates item title length (there is a MaxDocumentTitleRunes,
-	// but no item equivalent). So a renamed item with a ~2 MiB title (one JSON
-	// request delivers that) linked from many rows makes this loop retain
-	// rows x title bytes BEFORE a single body is read, and the content-bytes
-	// cap in the loop below never fires because the content can be tiny.
+	// entry carries that row's target_title. Since BUG-2833 / BUG-2831 a NEW
+	// title is bounded at models.MaxItemTitleRunes, so the ~2 MiB single-request
+	// title this comment used to describe is no longer reachable through any
+	// door. That does NOT retire this charge, for two reasons:
+	//
+	//   - the bound is non-retroactive by ruling, so rows written before it
+	//     still carry unbounded target_titles, and this loop reads STORED
+	//     titles rather than the one being written;
+	//   - even at the bound the quantity is rows x title bytes, so an in-range
+	//     title reaches the cap at roughly 24,000 link rows — more than the
+	//     64 the test fixture uses, and well within what a popular item
+	//     accumulates.
+	//
+	// The content-bytes cap in the loop below still cannot see either case,
+	// because the content can be tiny.
 	//
 	// Charging it here rather than after the scan is what makes the bound real:
 	// at the moment of refusal the process holds only the rows already counted,

--- a/internal/store/wiki_links.go
+++ b/internal/store/wiki_links.go
@@ -650,18 +650,28 @@ func (s *Store) cascadeTitleRename(tx *sql.Tx, renamedItemID, workspaceID, oldTi
 	// and refuses DURING the scan (BUG-2804 / codex R4).
 	//
 	// `works` holds one entry per matching LINK ROW, not per source, and each
-	// entry carries that row's target_title. Since BUG-2833 / BUG-2831 a NEW
-	// title is bounded at models.MaxItemTitleRunes, so the ~2 MiB single-request
-	// title this comment used to describe is no longer reachable through any
-	// door. That does NOT retire this charge, for two reasons:
+	// entry carries that row's target_title. Since BUG-2833 / BUG-2831 a title
+	// supplied by a CALLER is bounded at models.MaxItemTitleRunes, so the
+	// ~2 MiB single-request title this comment used to describe cannot be
+	// created or renamed in. That does NOT retire this charge, for three
+	// reasons:
 	//
 	//   - the bound is non-retroactive by ruling, so rows written before it
 	//     still carry unbounded target_titles, and this loop reads STORED
 	//     titles rather than the one being written;
-	//   - even at the bound the quantity is rows x title bytes, so an in-range
-	//     title reaches the cap at roughly 24,000 link rows — more than the
-	//     64 the test fixture uses, and well within what a popular item
-	//     accumulates.
+	//   - two paths still admit an unbounded title without a caller supplying
+	//     one — cross-workspace copy carries a legacy source title into a new
+	//     row, and ImportWorkspace coerces (so its rows are bounded, but a
+	//     pre-import row is not). "No door can receive a ~2 MiB title" would be
+	//     too strong (codex round 5);
+	//   - even at the bound the quantity is rows x (title bytes + overhead), so
+	//     an in-range title reaches the cap at roughly 240,000 link rows.
+	//
+	// That last figure is COMPUTED for this bound rather than carried over:
+	// MaxItemRenameCascadeBytes (64 MiB) / (255 + cascadeRowOverheadBytes, 24)
+	// = ~240,500 rows. The ~24,000 an earlier version of this comment quoted is
+	// BUG-2804's number, derived from Postgres's practical title ceiling of a
+	// few KB, and it does not survive a 255-rune bound.
 	//
 	// The content-bytes cap in the loop below still cannot see either case,
 	// because the content can be tiny.

--- a/internal/store/wiki_links_test.go
+++ b/internal/store/wiki_links_test.go
@@ -1034,7 +1034,13 @@ func TestWikiLinks_RefShapedWithWhitespaceFallsThroughToTitle(t *testing.T) {
 	// no TASKS collection prefix variant matching "TASK-5", so the
 	// ref resolution misses and title fallback must use the raw
 	// (untrimmed) key.
-	target := createTestItem(t, s, ws.ID, col.ID, " TASK-5 ", "")
+	// BUG-2833: item titles are trimmed at every write door now, so a title
+	// with real surrounding whitespace can only exist as legacy data — which is
+	// precisely the population this fallback still has to serve, since the
+	// bound is non-retroactive. Building it through CreateItem would silently
+	// produce "TASK-5" and the test would pass for the wrong reason (no
+	// whitespace anywhere, nothing about untrimmed keys exercised).
+	target := createLegacyTitledItem(t, s, ws.ID, col.ID, " TASK-5 ", "")
 	createTestItem(t, s, ws.ID, col.ID, "Source", "See [[ TASK-5 ]] anyway.")
 
 	got, _ := s.GetBacklinks(target.ID, ws.ID, 50, 0, BacklinksVisibility{Unrestricted: true})


### PR DESCRIPTION
Closes BUG-2833 and BUG-2831 as one title-validation unit — one door sweep, one guard shape, one differential test.

## The two defects

`PATCH {"title": ""}` was accepted and applied while `POST` refused the same input with `400 "Title is required"`. The guard was an inline literal in `handleCreateItem`, so the sibling handler on the same field simply never had it.

Item titles were also unbounded. The slug is derived from the title by `slugify`, which truncates nothing, and `items` carries `UNIQUE(workspace_id, slug)` — a Postgres btree. So the same input was accepted on SQLite and refused on Postgres with an unmapped `SQLSTATE 54000`, which is also a latent `pad db migrate` failure.

## Door sweep first

The filing asked whether the MCP and CLI update paths bypass `handleUpdateItem`. They do not — CLI item writes go through `internal/cli.Client` (PATCH/POST), stdio MCP shells out to that CLI, and remote `/mcp` calls `Handler.ServeHTTP` on the real route table.

Enumerating every write to `items.title` rather than every transport found six doors and one genuine bypass: **`ImportWorkspace` has its own raw `INSERT INTO items`** and reaches no handler. `insertItemTx`'s doc comment warns about exactly this. Bulk ops, version restore and URL import are verified non-doors — the constructed `ItemUpdate` at each site carries no `Title`.

## The guard

One `models.NormalizeItemTitle` / `models.ValidateItemTitle` pair, enforced authoritatively in `store.CreateItem` and `store.UpdateItem` so a future door inherits the rule instead of having to repeat it. The handlers keep a pre-lock copy for a fast 400 before the store takes workspace and parent-children advisory locks.

**Trim.** Whitespace-only titles are now refused, which widens the create door. This is not a coin flip: artifact import already trimmed while create tested `== ""` exactly, and its comment claimed to mirror a gate it was strictly stricter than. Three doors, two rules, and the comment asserting agreement is what stopped anyone noticing.

**255 runes**, matching `MaxDocumentTitleRunes` — but justified mechanically rather than borrowed: `slugify` emits only `[a-z0-9-]` at one byte per rune, so 255 runes bounds the slug at ~255 bytes.

**Non-retroactive.** A title identical to the stored one is not a rename and is not validated, so rows predating the bound stay editable and repairable. No door can mint a *new* untitled or over-long item.

**Import coerces rather than refuses** (empty → `"Untitled"`, over-long → truncated, both logged). Refusing would break restoring archives of data this product already accepted, and would give one loop two dispositions — `coerceJSONForImport` sits three lines away carrying the opposite policy on IDEA-1488's ruling. The imported row still lands *with* a title, so the invariant holds on this door too.

## Two things the work turned up

**The bound's justification was wrong in my first draft.** I cited 8191 bytes from the filing without measuring it. Driving high-entropy slugs through `ImportWorkspace` against Postgres 17 shows the cap that actually fires is **2704** — a regular btree index tuple, a third of a page; 8191 is the hard ceiling past it:

```
2000 -> accepted
4000 -> ERROR: index row size 4056 exceeds btree version 4 maximum 2704 (SQLSTATE 54000)
9000 -> ERROR: index row requires 9056 bytes, maximum size is 8191 (SQLSTATE 54000)
```

The constant now carries those readings. Headroom is ~10x, not the ~32x I first wrote.

**The same measurement invalidated my own fixture.** Index tuples are compressed before the size check, so the 9000-byte *repeated-character* slug the import test used imports fine on Postgres — the test would have passed against unfixed code on the very backend the bug is about, failing only its own rune-count assertion. It now builds the slug from a fixed LCG. With the coercion removed it reproduces the filing's error verbatim on Postgres while SQLite accepts the row: the dialect split, in one test.

## Verification

Every store-level test here is differential by construction (`testStore` returns Postgres under `PAD_TEST_POSTGRES_URL`), which is the point rather than a convenience — a bound checked on one backend would not close a dialect split.

- **Full Go suite, SQLite:** pass, exit 0.
- **Full Go suite, Postgres 17:** pass, exit 0.
- **golangci-lint:** 0 issues. **gofmt / go vet:** clean. **govulncheck:** 0 affecting this code.
- **Mutation matrix, 16 mutants.** 13 killed, each by a named `--- FAIL:`. Three survive by design and were measured rather than assumed: the two handler pre-checks and the artifact-import check are redundant now that the store refuses. A compound mutant removing *both* the artifact check and the store's establishes which layer holds — with both gone the import returns `201 {"slug":"untitled"}`, the exact pre-fix damage.
- Two pre-existing tests needed legacy-data fixtures (`createLegacyTitledItem`) rather than edits to their assertions: BUG-2804's cascade bound and the untrimmed-key wiki-link fallback both exercise rows the bound is deliberately non-retroactive about.

## Prose sweep (CONVE-23)

Three comments asserted that nothing validates item title length, and one cost model rested on a ~2 MiB single-request title. Corrected in place rather than deleted — the guards they document are still needed, because the bound is non-retroactive and the cascade charges *stored* titles.

BUG-2833 / BUG-2831.

https://claude.ai/code/session_01XLtX4dbjBpApbAv3SuBcTm
