### PR TITLE
feat(attachments): preview markdown and plain-text attachments; surface the repo link in the nav

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,5 +59,9 @@ dist/
 # Playwright e2e artifacts (scoped to the test fixture, never the
 # developer's real ~/.pad)
 .pad-e2e/
+# Per-seat e2e data dirs: a shared checkout runs concurrent suites, so each
+# seat points PAD_E2E_DATA_DIR at its own. They hold a generated encryption.key
+# and a multi-MB WAL — never committable.
+.pad-e2e-*/
 web/playwright-report/
 web/test-results/

--- a/web/e2e/attachment-text-preview.spec.ts
+++ b/web/e2e/attachment-text-preview.spec.ts
@@ -1,0 +1,166 @@
+import { test, expect } from './fixtures';
+import { browserLogin, seedDoc } from './lib/collab-helpers';
+import {
+	DESKTOP,
+	TILE,
+	VIEWER,
+	itemUrl,
+	uploadAttachment,
+	viewerDialog
+} from './lib/attachment-viewer';
+
+/**
+ * THE TEXT-PREVIEW ARM, IN A REAL BROWSER (IDEA-2712 / GitHub #1169).
+ *
+ * DR-9's rule again: the interaction work is verified in a browser or it is not
+ * verified. This file exists because three of the arm's guarantees are CSS
+ * MECHANISMS, and the jsdom unit suite does not inject component styles at all —
+ * `getComputedStyle` there returns the engine default for every element, so an
+ * assertion like "the layer's pointer-events is none" cannot fail and is not an
+ * instrument. Two such assertions were written during codex R1 and deleted for
+ * exactly that reason.
+ *
+ * What lives here, and the escape each one closes:
+ *
+ *  - BACKDROP CLOSE over the arm. The first version of the arm gave its
+ *    full-bleed layer `pointer-events: auto`, so a click on the empty area
+ *    targeted the layer rather than the root and the viewer would not close —
+ *    for this arm alone, while a comment two lines away claimed it worked. Only
+ *    a real engine can hit-test that.
+ *  - SCROLLING. The wheel handler consumed every wheel before its exclusions;
+ *    the card could not scroll and the page behind must still not. Both halves
+ *    need real scroll behaviour and `overscroll-behavior`.
+ *  - SELECTION. The backdrop sets `user-select: none` for the pan gesture; the
+ *    card opts back out. jsdom has no selection model.
+ *
+ * The MIME-gating and loader logic are unit-tested; they are not repeated here.
+ */
+
+const MD_BODY = `# Preview heading\n\n${'Filler paragraph for scrolling. '.repeat(200)}\n\n## Tail heading\n`;
+const TEXT_ARM = `${VIEWER} .lightbox-text`;
+const TEXT_CARD = `${VIEWER} .lightbox-text-scroll`;
+const TEXT_RENDERED = `${VIEWER} .lightbox-text-body`;
+
+test.describe('attachment viewer — text preview (IDEA-2712)', () => {
+	test.beforeEach(async ({ page }, testInfo) => {
+		test.skip(testInfo.project.name !== 'desktop-chromium', 'desktop legs only');
+		await page.setViewportSize(DESKTOP);
+	});
+
+	async function openMarkdown(page, fixture, request, title: string) {
+		await browserLogin(page);
+		const doc = await seedDoc(fixture, request, title);
+		await uploadAttachment(
+			fixture,
+			request,
+			doc.id,
+			'preview.md',
+			'text/markdown',
+			Buffer.from(MD_BODY, 'utf8')
+		);
+		await page.goto(itemUrl(fixture, doc.slug));
+		await page.locator(TILE).first().click();
+		await expect(page.locator(TEXT_CARD)).toBeVisible();
+	}
+
+	test('renders the markdown, through the shared pipeline', async ({ page, fixture, request }) => {
+		await openMarkdown(page, fixture, request, 'Text preview render');
+		// A real heading element, not a literal '#': the pipeline ran.
+		await expect(page.locator(`${TEXT_RENDERED} h1`)).toHaveText('Preview heading');
+		// The no-preview fallback must NOT be painted over it — the negative
+		// control for the fallback arm's condition.
+		await expect(page.locator(`${VIEWER} .lightbox-fallback`)).toHaveCount(0);
+	});
+
+	test('BACKDROP CLICK over the arm still closes the viewer', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		await openMarkdown(page, fixture, request, 'Text preview backdrop');
+		const dialog = viewerDialog(page, 'preview.md');
+		await expect(dialog).toBeVisible();
+
+		// Click the far top-left of the stage — inside the arm's full-bleed layer,
+		// outside the centred card. With the layer interactive this hits the layer
+		// and nothing happens; with it inert the root receives it and closes.
+		const box = await page.locator(TEXT_ARM).boundingBox();
+		if (!box) throw new Error('text arm has no box');
+		await page.mouse.click(box.x + 4, box.y + 4);
+
+		await expect(dialog).toHaveCount(0);
+	});
+
+	test('the CARD scrolls, and the SURFACE BEHIND does NOT', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		await openMarkdown(page, fixture, request, 'Text preview scroll');
+		const card = page.locator(TEXT_CARD);
+
+		// THE RIGHT SCROLLER (codex R2 #5). The app does not scroll the window —
+		// `.main-content` is the `overflow-y: auto` element (`+layout.svelte`), so
+		// asserting `window.scrollY` would have held still whatever the wheel
+		// handler did, and the leak this test exists for would have passed. Read
+		// both, and fail if EITHER moves.
+		const behind = () =>
+			page.evaluate(() => ({
+				win: window.scrollY,
+				main: document.querySelector('.main-content')?.scrollTop ?? 0
+			}));
+		const before = await behind();
+		expect(await card.evaluate((el) => el.scrollTop)).toBe(0);
+
+		await card.hover();
+		await page.mouse.wheel(0, 600);
+		await expect
+			.poll(async () => card.evaluate((el) => el.scrollTop), { timeout: 2000 })
+			.toBeGreaterThan(0);
+
+		// The other half of the guarantee: the wheel handler stopped consuming this
+		// event, so `overscroll-behavior: contain` is what keeps the surface behind
+		// still. Scroll to the very end and keep going, which is when chaining
+		// would kick in.
+		await card.evaluate((el) => {
+			el.scrollTop = el.scrollHeight;
+		});
+		await page.mouse.wheel(0, 1200);
+		expect(await behind()).toEqual(before);
+	});
+
+	test('the document is SELECTABLE and touch-scrollable, unlike the pan surface', async ({
+		page,
+		fixture,
+		request
+	}) => {
+		await openMarkdown(page, fixture, request, 'Text preview selection');
+
+		// A `Range` + `addRange()` selects text even under `user-select: none`
+		// (codex R2 #4) — the first version of this test did exactly that and
+		// could not fail. The computed style IS the mechanism, and unlike jsdom a
+		// real engine actually applies it, so reading it here is a measurement
+		// rather than an engine default.
+		const style = await page.locator(TEXT_CARD).evaluate((el) => {
+			const cs = getComputedStyle(el);
+			return { userSelect: cs.userSelect || cs.webkitUserSelect, touchAction: cs.touchAction };
+		});
+		expect(style.userSelect).toBe('text');
+
+		// `touch-action` INTERSECTS down the ancestor chain, so the card's `pan-y`
+		// is worthless if an ancestor still says `none`. Assert the effective
+		// chain, not just this element: the stage must have given up its claim.
+		expect(style.touchAction).toBe('pan-y');
+		const stage = await page
+			.locator(`${VIEWER} .lightbox-stage`)
+			.evaluate((el) => getComputedStyle(el).touchAction);
+		expect(stage).not.toBe('none');
+
+		// The control leg: the backdrop around the card still refuses selection,
+		// so the card opted out for itself rather than the rule being dropped.
+		const backdrop = await page
+			.locator(VIEWER)
+			.evaluate((el) => getComputedStyle(el).userSelect || getComputedStyle(el).webkitUserSelect);
+		expect(backdrop).toBe('none');
+	});
+});

--- a/web/e2e/item-attachment-strip.spec.ts
+++ b/web/e2e/item-attachment-strip.spec.ts
@@ -3,6 +3,7 @@ import { browserLogin, seedDoc } from './lib/collab-helpers';
 import type { APIRequestContext, Page } from '@playwright/test';
 import type { SuiteFixture } from './fixtures';
 import {
+	REAL_PDF,
 	VIEWER,
 	VIEWER_FALLBACK,
 	VIEWER_FALLBACK_NAME,
@@ -77,11 +78,30 @@ async function uploadTo(
 }
 
 /**
- * Upload a NON-image bound to `itemId`. `text/plain` is in the server's
- * allowlist and is one of the types the panel offers Open for, so the tile it
- * produces is a file tile — the one that opens the options panel.
+ * Upload a NON-image bound to `itemId`, of a type NO RENDERER CLAIMS — so the
+ * surface it opens is the no-bytes fallback arm.
+ *
+ * WAS `text/plain` (IDEA-2712). That stopped being a fallback fixture when the
+ * viewer gained an in-app text renderer: a `.txt` now previews, which is the
+ * point of that change, so a test asserting "No preview available" over one
+ * would be asserting the bug. PDF is the replacement because it keeps every
+ * property this fixture was chosen for — allowlisted, non-image, and
+ * `canBrowserPreview`, so the toolbar still offers Open in new tab — while
+ * remaining unclaimed by any renderer (`'pdf'` is PLAN-2393's reserved slot,
+ * not built).
+ *
+ * WHEN PLAN-2393 BUILDS THAT SLOT, THESE TESTS WILL GO RED, AND THAT IS THE
+ * DESIGN. A PDF will then preview and stop being a fallback fixture, exactly as
+ * text did here. The failure is the signal to pick the next type no renderer
+ * claims — an archive is the obvious candidate — not to weaken the assertion.
+ * A fallback-arm test is only ever as durable as the emptiness of the renderer
+ * registry, so it is written to fail loudly when that changes rather than to
+ * survive by asserting less.
+ *
+ * The strip→surface wiring for a PREVIEWABLE text file is covered in
+ * `attachment-text-preview.spec.ts`, which opens its document from a tile.
  */
-async function uploadTextTo(
+async function uploadFallbackFileTo(
 	fixture: SuiteFixture,
 	request: APIRequestContext,
 	itemId: string,
@@ -93,7 +113,7 @@ async function uploadTextTo(
 		{
 			headers: { Authorization: `Bearer ${fixture.apiToken}` },
 			multipart: {
-				file: { name: filename, mimeType: 'text/plain', buffer: Buffer.from('notes\n') }
+				file: { name: filename, mimeType: 'application/pdf', buffer: REAL_PDF }
 			}
 		}
 	);
@@ -340,7 +360,7 @@ test.describe('item attachment strip', () => {
 		await browserLogin(page);
 
 		const doc = await seedDoc(fixture, request, 'Surface wiring');
-		await uploadTextTo(fixture, request, doc.id, 'notes.txt');
+		await uploadFallbackFileTo(fixture, request, doc.id, 'notes.pdf');
 
 		await page.goto(itemUrl(fixture, doc.slug));
 		const tile = page.locator(TILE).first();
@@ -349,23 +369,23 @@ test.describe('item attachment strip', () => {
 		// A file tile is a real button naming its action, not a download link —
 		// the whole point of the change (DR-1, DR-12).
 		await expect(tile).toHaveJSProperty('tagName', 'BUTTON');
-		await expect(tile).toHaveAttribute('aria-label', /^Options for notes\.txt/);
+		await expect(tile).toHaveAttribute('aria-label', /^Options for notes\.pdf/);
 
 		await tile.click();
 		// The converged surface opens — a role="dialog" naming the file, NOT a menu.
-		const surface = viewerDialog(page, 'notes.txt');
+		const surface = viewerDialog(page, 'notes.pdf');
 		await expect(surface).toHaveCount(1);
 		await expect(page.locator('[role="menu"]')).toHaveCount(0);
 		// The no-bytes fallback arm: the family icon, the file's name, an honest
 		// "No preview available" — no <img>, no bytes for a non-raster type.
 		await expect(page.locator(VIEWER_FALLBACK)).toBeVisible();
-		await expect(page.locator(VIEWER_FALLBACK_NAME)).toHaveText('notes.txt');
+		await expect(page.locator(VIEWER_FALLBACK_NAME)).toHaveText('notes.pdf');
 		await expect(page.locator(VIEWER_FALLBACK_NOTE)).toHaveText('No preview available');
 		await expect(page.locator(`${VIEWER} .lightbox-image`)).toHaveCount(0);
 		// The toolbar carries the real Download anchor with the filename — the DR-16
-		// save semantics a plain navigation would lose. text/plain is
-		// browser-previewable, so Open in new tab is offered too.
-		await expect(viewerDownloadAnchor(page)).toHaveAttribute('download', 'notes.txt');
+		// save semantics a plain navigation would lose. PDF is browser-previewable,
+		// so Open in new tab is offered too.
+		await expect(viewerDownloadAnchor(page)).toHaveAttribute('download', 'notes.pdf');
 		await expect(viewerOpenAnchor(page)).toBeVisible();
 
 		await page.keyboard.press('Escape');
@@ -379,7 +399,7 @@ test.describe('item attachment strip', () => {
 		for (const key of ['Enter', ' ']) {
 			await tile.focus();
 			await page.keyboard.press(key);
-			await expect(viewerDialog(page, 'notes.txt')).toHaveCount(1);
+			await expect(viewerDialog(page, 'notes.pdf')).toHaveCount(1);
 			await expect(page.locator(VIEWER)).toHaveCount(1);
 			await expect(page.locator('[role="menu"]')).toHaveCount(0);
 			await page.keyboard.press('Escape');
@@ -407,12 +427,14 @@ test.describe('item attachment strip', () => {
 		await page.goto(itemUrl(fixture, doc.slug));
 
 		// Drop a NON-image so the editor renders a file chip rather than an
-		// inline image.
+		// inline image — and one NO RENDERER CLAIMS, so the surface shows the
+		// fallback arm this test asserts. `text/plain` used to serve here and no
+		// longer can: it previews in-app since IDEA-2712.
 		await dropFileIntoEditor(
 			page,
-			'handbook.txt',
-			Buffer.from('chapter one\n').toString('base64'),
-			'text/plain'
+			'handbook.pdf',
+			REAL_PDF.toString('base64'),
+			'application/pdf'
 		);
 
 		const chip = page.locator('.editor-content .ProseMirror button.file-chip').first();
@@ -423,11 +445,11 @@ test.describe('item attachment strip', () => {
 
 		await chip.click();
 		// The same converged surface, addressed by the file's own name.
-		await expect(viewerDialog(page, 'handbook.txt')).toHaveCount(1);
+		await expect(viewerDialog(page, 'handbook.pdf')).toHaveCount(1);
 		await expect(page.locator('[role="menu"]')).toHaveCount(0);
-		await expect(page.locator(VIEWER_FALLBACK_NAME)).toHaveText('handbook.txt');
+		await expect(page.locator(VIEWER_FALLBACK_NAME)).toHaveText('handbook.pdf');
 		// The Download anchor carries the filename — even though a dropped chip's
 		// metadata may be partial, the download attribute is never dropped (DR-16).
-		await expect(viewerDownloadAnchor(page)).toHaveAttribute('download', 'handbook.txt');
+		await expect(viewerDownloadAnchor(page)).toHaveAttribute('download', 'handbook.pdf');
 	});
 });

--- a/web/src/lib/attachments/display.test.ts
+++ b/web/src/lib/attachments/display.test.ts
@@ -5,7 +5,8 @@ import {
 	describeAttachmentType,
 	formatBytes,
 	iconForAttachment,
-	isImage
+	isImage,
+	isMarkdownAttachment
 } from './display';
 import {
 	ACTION_ICON_IDS,
@@ -335,5 +336,36 @@ describe('describeAttachmentType', () => {
 
 	it('reads the filename when the stored MIME is uselessly generic', () => {
 		expect(describeAttachmentType('application/octet-stream', 'notes.md')).toBe('MD text');
+	});
+});
+
+describe('isMarkdownAttachment — IDEA-2712', () => {
+	it('honours an explicit text/markdown MIME, filename or not', () => {
+		expect(isMarkdownAttachment('text/markdown', null)).toBe(true);
+		expect(isMarkdownAttachment('text/markdown; charset=utf-8', 'x.bin')).toBe(true);
+	});
+
+	it('falls back to the EXTENSION, which is the path that actually fires', () => {
+		// An uploaded .md is stored as text/plain — the server sniffs the bytes
+		// and returns the sniffed entry (measured: ValidateUpload("# H", "a.md")
+		// → text/plain). A MIME-only test would never route a real markdown
+		// attachment to the markdown renderer.
+		expect(isMarkdownAttachment('text/plain', 'notes.md')).toBe(true);
+		expect(isMarkdownAttachment('text/plain', 'NOTES.MARKDOWN')).toBe(true);
+	});
+
+	it('is plain text without a markdown extension', () => {
+		expect(isMarkdownAttachment('text/plain', 'notes.txt')).toBe(false);
+		expect(isMarkdownAttachment('text/plain', null)).toBe(false);
+		expect(isMarkdownAttachment('text/plain', 'data.csv')).toBe(false);
+	});
+
+	it('the extension can never ADMIT a type the set excludes', () => {
+		// The filename chooses a RENDERER among admitted types; it must not widen
+		// what previews. A .md name on an HTML or PDF row stays false.
+		expect(isMarkdownAttachment('text/html', 'evil.md')).toBe(false);
+		expect(isMarkdownAttachment('text/javascript', 'payload.md')).toBe(false);
+		expect(isMarkdownAttachment('application/pdf', 'doc.md')).toBe(false);
+		expect(isMarkdownAttachment(null, 'notes.md')).toBe(false);
 	});
 });

--- a/web/src/lib/attachments/display.ts
+++ b/web/src/lib/attachments/display.ts
@@ -328,3 +328,140 @@ export function canBrowserPreview(mime: string | null | undefined): boolean {
 	const m = normalizeMime(mime);
 	return VIEWER_MIMES.has(m) || BROWSER_PREVIEW_MIMES.has(m);
 }
+
+/**
+ * The types the IN-APP text preview renders (IDEA-2712 / GitHub #1169).
+ *
+ * A THIRD predicate, deliberately not an edit to either sibling above.
+ * The three answer different questions and only look alike:
+ *
+ *  - `canOpenInViewer` (DR-16) — may the in-app IMAGE viewer decode this?
+ *  - `canBrowserPreview` (DR-5) — may the BROWSER be handed this in a new
+ *    tab? For `text/markdown` the honest answer stays NO: the browser
+ *    downloads it. Widening DR-5 to reach #1169 would route markdown to
+ *    the Open-in-new-tab action (`actions.ts`) and reproduce the exact
+ *    download-instead-of-render behaviour the issue reports.
+ *  - this one — do WE fetch the bytes and render them ourselves? That is
+ *    a question about our own renderer, and it is the only one #1169 asks.
+ *
+ * NOT PART OF THE SERVER MIRROR. `internal/attachments/mime.go`'s
+ * `inlineSafe` declares itself the mirror of `VIEWER_MIMES` +
+ * `BROWSER_PREVIEW_MIMES` — the set the server may send with
+ * `Content-Disposition: inline`. This set is deliberately outside that
+ * pair and must never be added to it: we never ask the browser to inline
+ * these bytes, we `fetch()` them (which a download disposition does not
+ * impede) and render sanitized HTML ourselves. Keeping it out of the
+ * mirror is what lets `text/markdown` preview in-app while still being
+ * served as an attachment.
+ *
+ * MIME-EXACT, NEVER BY CATEGORY. `CategoryText` server-side CONTAINS the
+ * force-download bucket — `text/html`, `text/javascript` and
+ * `application/javascript` are all `CategoryText` (mime.go). A
+ * category test would therefore admit exactly the types PLAN-2393 DR-6
+ * forbids inlining. An allowlist excludes them by construction rather
+ * than by anyone remembering to.
+ *
+ * SMALLER THAN WHAT WE COULD RENDER, on purpose. `text/csv`,
+ * `text/tab-separated-values`, JSON, XML, YAML and TOML are all
+ * allowlisted uploads and all renderable as raw text — and all left out,
+ * because each has an obviously better rendering (a table; syntax
+ * highlighting) that this unit does not build. Shipping them as raw text
+ * now would make that better rendering a REGRESSION for anyone who got
+ * used to the raw view.
+ */
+const TEXT_PREVIEW_MIMES: ReadonlySet<string> = new Set(['text/markdown', 'text/plain']);
+
+/**
+ * May the in-app text preview render this MIME? See
+ * {@link TEXT_PREVIEW_MIMES} for the set and the three reasons it is
+ * neither a category test nor a widening of `canBrowserPreview`.
+ *
+ * Fails closed like its siblings: unknown, unresolved and null MIMEs get
+ * no renderer, so the surface shows its existing file panel.
+ */
+export function canPreviewAsText(mime: string | null | undefined): boolean {
+	return TEXT_PREVIEW_MIMES.has(normalizeMime(mime));
+}
+
+/**
+ * Within the text-preview set, is this the MARKDOWN one? (IDEA-2712)
+ *
+ * The arm needs to tell the two members apart — markdown goes through the
+ * shared `marked` pipeline, plain text goes into a `<pre>` as text.
+ *
+ * THE EXTENSION IS CONSULTED, AND IT IS NOT BELT-AND-BRACES — IT IS THE PATH
+ * THAT ACTUALLY FIRES. An uploaded `.md` is stored as **`text/plain`**, not
+ * `text/markdown`. `attachments.ValidateUpload` sniffs the bytes with
+ * `http.DetectContentType`, which answers `text/plain` for any prose, and
+ * returns the SNIFFED entry; the extension is used only to REJECT a mismatch,
+ * and `.md` → `text/markdown` shares `CategoryText` with `text/plain`, so
+ * nothing rejects and the sniffed type is what lands in the row. Measured, not
+ * assumed: `ValidateUpload([]byte("# Heading\n..."), "preview.md")` returns
+ * `mime="text/plain"`.
+ *
+ * So a MIME-only test is a branch that never runs for the files this feature
+ * exists for. Every unit test that hand-sets `mime_type: 'text/markdown'`
+ * passes anyway, which is precisely why this was found in a browser and not
+ * here: those fixtures encode what the author believed the system stores.
+ *
+ * The MIME check stays FIRST because it is the stronger signal when present —
+ * an explicitly-typed row (a CLI upload that declares the type, or a future
+ * server that trusts the extension) should be honoured regardless of filename.
+ * The extension is the fallback, and it is gated on the MIME already being in
+ * the text-preview set so a filename can never widen what previews.
+ */
+const MARKDOWN_EXTENSIONS: ReadonlySet<string> = new Set(['md', 'markdown']);
+
+export function isMarkdownAttachment(
+	mime: string | null | undefined,
+	filename?: string | null
+): boolean {
+	if (normalizeMime(mime) === 'text/markdown') return true;
+	// Gate on the set, never on the filename alone: the extension chooses a
+	// RENDERER among types already admitted, and must not admit anything.
+	if (!canPreviewAsText(mime)) return false;
+	return MARKDOWN_EXTENSIONS.has(extensionOf(filename));
+}
+
+/**
+ * Byte ceiling above which the text preview offers the existing download
+ * affordance instead of rendering (IDEA-2712 / GitHub #1169).
+ *
+ * THE RECEIPT. Measured 2026-09-01 over two independent populations of
+ * real markdown:
+ *
+ *   | sample                                   |  n | p50    | p90    | max   |
+ *   |------------------------------------------|----|--------|--------|-------|
+ *   | `*.md` in this repo (no node_modules)    | 25 | 3.6 KB |  42 KB | 82 KB |
+ *   | `docs` collection item bodies (workspace) | 63 | 5.0 KB |  13 KB | 23 KB |
+ *
+ * Authored repo docs and Pad-native documents agree: real markdown is
+ * single-digit-to-tens of KB. 1 MiB is ~12x the largest document observed
+ * in either sample and ~25x the repo's p99.
+ *
+ * LOAD CONDITIONS. The cost this bounds is main-thread: `marked` plus
+ * DOMPurify plus DOM construction, synchronously, in the viewer.
+ *
+ * ERROR DIRECTION, chosen deliberately: err toward RENDERING. An unusually
+ * large but genuine document still previews; the cap exists for the
+ * pathological case a 25 MiB upload bound admits (a log renamed `.md`, a
+ * generated dump), not to enforce taste about document length. It sits
+ * well under `defaultAttachmentMaxBytes` (25 MiB, handlers_attachments.go)
+ * so it has a live range to act in.
+ *
+ * WHAT IT DOES NOT COVER: a small file that is expensive to render anyway
+ * — deeply nested lists, thousands of inline links. Byte count is a proxy
+ * for render cost, not a measure of it. If that bites, the answer is a
+ * render-time budget, not a smaller byte cap; shrinking this number cannot
+ * deliver that fix.
+ *
+ * Enforced from `size_bytes` METADATA where the surface HAS it — then no bytes
+ * are requested at all. Where it does not (`LightboxImage.size_bytes` is
+ * `number | null` by declaration, and most producers seed null, leaving the
+ * metadata HEAD to fill it) the load necessarily starts first: the response
+ * bound holds the line, and the late size re-decides and aborts what is in
+ * flight. So the cap always bounds what is RENDERED; it saves the TRANSFER only
+ * when the size is known before the load. Claiming otherwise would be false for
+ * the common seeding (codex R1 #1).
+ */
+export const TEXT_PREVIEW_MAX_BYTES = 1 << 20; // 1 MiB

--- a/web/src/lib/attachments/surfaceRenderers.test.ts
+++ b/web/src/lib/attachments/surfaceRenderers.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import { getSurfaceRenderer } from './surfaceRenderers';
 
-// The single decision of WHICH renderer draws an attachment (TASK-2476). It is
-// defined AS the DR-16 raster allowlist, so this pins that it fails closed on
-// everything else — the invariant the viewer's no-bytes fallback rests on.
+// The single decision of WHICH renderer draws an attachment (TASK-2476). Each id
+// is defined AS a predicate's allowlist — 'raster-image' as DR-16's, 'text' as
+// canPreviewAsText's (IDEA-2712) — so this pins that it fails closed on
+// everything else: the invariant the viewer's no-bytes fallback rests on.
 describe('getSurfaceRenderer', () => {
 	it("returns 'raster-image' for every DR-16 raster type", () => {
 		for (const mime of [
@@ -22,8 +23,52 @@ describe('getSurfaceRenderer', () => {
 		expect(getSurfaceRenderer('image/svg+xml')).toBeNull();
 	});
 
-	it('returns null for non-image types a browser cannot preview as a raster', () => {
-		for (const mime of ['application/pdf', 'text/plain', 'application/zip', 'image/tiff']) {
+	it("returns 'text' for the in-app text-preview allowlist", () => {
+		// IDEA-2712 / GitHub #1169. text/plain moved from the null arm to here —
+		// a deliberate contract change, not a widened raster set: it is the
+		// in-app renderer claiming it, and canBrowserPreview is untouched.
+		for (const mime of ['text/markdown', 'text/plain']) {
+			expect(getSurfaceRenderer(mime)).toBe('text');
+		}
+	});
+
+	it('returns null for types no renderer claims', () => {
+		// PDF is still PLAN-2393's reserved slot, not ours.
+		for (const mime of ['application/pdf', 'application/zip', 'image/tiff']) {
+			expect(getSurfaceRenderer(mime)).toBeNull();
+		}
+	});
+
+	it('fails closed on the force-download bucket, which is CategoryText server-side', () => {
+		// PLAN-2393 DR-6: these would XSS if inlined. They share a server-side
+		// CATEGORY with markdown, which is exactly why the predicate behind
+		// 'text' is a MIME allowlist and never a category test — a category
+		// selector would admit all three of these.
+		//
+		// HONEST ABOUT WHAT THIS IS (codex R3 #5): it passes against origin/main
+		// too, where EVERYTHING non-raster returned null. It is a REGRESSION
+		// GUARD against a future widening — the one that would follow from
+		// reaching for `CategoryText` — not evidence that this branch's change
+		// works. The discriminating tests for that are the `'text'` cases above.
+		for (const mime of ['text/html', 'text/javascript', 'application/javascript']) {
+			expect(getSurfaceRenderer(mime)).toBeNull();
+		}
+	});
+
+	it('fails closed on allowlisted text types this unit deliberately excludes', () => {
+		// Renderable as raw text, left out because each has an obviously better
+		// rendering (a table; syntax highlighting) that shipping raw now would
+		// turn into a regression later.
+		for (const mime of [
+			'text/csv',
+			'text/tab-separated-values',
+			'application/json',
+			'application/xml',
+			'text/xml',
+			'application/yaml',
+			'text/yaml',
+			'application/toml',
+		]) {
 			expect(getSurfaceRenderer(mime)).toBeNull();
 		}
 	});

--- a/web/src/lib/attachments/surfaceRenderers.ts
+++ b/web/src/lib/attachments/surfaceRenderers.ts
@@ -8,12 +8,19 @@
  * own markup arm internally, so a new renderer is a new id here plus an arm
  * there, nothing wired across a boundary.
  *
- * TODAY THERE IS ONE: `'raster-image'`, for exactly the DR-16 raster allowlist
- * (`canOpenInViewer`). Everything else — an unsafe/active type like SVG, an
- * office document, an archive, or an UNRESOLVED (null) MIME — returns `null`,
- * which the consumer renders as its no-bytes ICON FALLBACK. PLAN-2393 widens the
- * union with `'pdf'` and `'text'`; the `null` arm stays the fallback for what no
- * renderer claims.
+ * TODAY THERE ARE TWO. `'raster-image'` is exactly the DR-16 raster allowlist
+ * (`canOpenInViewer`). `'text'` is the in-app text preview (`canPreviewAsText`,
+ * IDEA-2712 / GitHub #1169) — markdown and plain text, rendered by us from bytes
+ * we fetch, never handed to the browser to inline. Everything else — an
+ * unsafe/active type like SVG, an office document, an archive, or an UNRESOLVED
+ * (null) MIME — returns `null`, which the consumer renders as its no-bytes ICON
+ * FALLBACK. `'pdf'` remains reserved for PLAN-2393; the `null` arm stays the
+ * fallback for what no renderer claims.
+ *
+ * ORDER IS NOT ARBITRARY: the two predicates are disjoint by construction (one
+ * is a raster-image allowlist, the other a text allowlist), so the sequence below
+ * cannot change an answer. It is written image-first only to match the union's
+ * declaration order.
  *
  * WHY IT WRAPS `canOpenInViewer` RATHER THAN RESTATING THE ALLOWLIST. DR-16 puts
  * "what may this MIME become on screen" in ONE module (the display helpers) on
@@ -25,20 +32,25 @@
  * IT FAILS CLOSED, like the predicate it wraps: a null / unknown / unresolved
  * MIME is not a renderer, so the caller shows the fallback, never a guessed arm.
  */
-import { canOpenInViewer } from '$lib/attachments/display';
+import { canOpenInViewer, canPreviewAsText } from '$lib/attachments/display';
 
 /**
  * The renderers a surface can draw an attachment through. A string-id union so
- * PLAN-2393 can add `'pdf' | 'text'` without a component contract; the consumer
- * switches on the id.
+ * a renderer can be added without a component contract; the consumer switches on
+ * the id. `'text'` arrived that way (IDEA-2712); `'pdf'` is still PLAN-2393's.
  */
-export type SurfaceRendererId = 'raster-image';
+export type SurfaceRendererId = 'raster-image' | 'text';
 
 /**
  * The renderer for a MIME, or `null` when none claims it (→ the icon fallback).
- * `'raster-image'` is exactly the DR-16 raster allowlist; unsafe, unknown and
- * unresolved (null) MIMEs all return `null`.
+ * `'raster-image'` is exactly the DR-16 raster allowlist and `'text'` exactly the
+ * `canPreviewAsText` allowlist; unsafe, unknown and unresolved (null) MIMEs all
+ * return `null`. In particular the force-download bucket (`text/html`,
+ * `text/javascript`, `application/javascript` — all `CategoryText` server-side)
+ * claims no renderer, per PLAN-2393 DR-6.
  */
 export function getSurfaceRenderer(mime: string | null): SurfaceRendererId | null {
-	return canOpenInViewer(mime) ? 'raster-image' : null;
+	if (canOpenInViewer(mime)) return 'raster-image';
+	if (canPreviewAsText(mime)) return 'text';
+	return null;
 }

--- a/web/src/lib/attachments/viewerTextLoader.svelte.test.ts
+++ b/web/src/lib/attachments/viewerTextLoader.svelte.test.ts
@@ -1,0 +1,371 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createViewerTextLoader } from './viewerTextLoader.svelte';
+import { TEXT_PREVIEW_MAX_BYTES } from './display';
+import type { LightboxImage } from './events';
+
+// IDEA-2712 / GitHub #1169 — the text loader. Unlike the image loader, whose
+// request IS its `displaySrc`, this one issues a real `fetch`, so the acceptance
+// is phrased in CALLS: a refused entry is "fetch was never called", a bounded
+// body is "the phase is too-large and no text reached the consumer", a stale
+// completion is "the state the user is looking at did not move".
+//
+// Every guard below is stated with the failure it exists to catch, because two
+// of them (the metadata gate and the response gate) look redundant and are not:
+// each has a case the other cannot see.
+
+function entry(over: Partial<LightboxImage> = {}): LightboxImage {
+	return {
+		id: 'a1',
+		alt: '',
+		filename: 'notes.md',
+		mime_type: 'text/markdown',
+		size_bytes: 100,
+		width: null,
+		height: null,
+		...over
+	};
+}
+
+/** A Response whose body is NOT a stream — exercises the `response.text()` leg. */
+function plainResponse(body: string, ok = true, status = 200): Response {
+	return {
+		ok,
+		status,
+		body: null,
+		text: async () => body
+	} as unknown as Response;
+}
+
+/**
+ * A Response that streams `body` in chunks, exercising the `getReader` leg.
+ *
+ * `text()` THROWS (codex R3 #4). The first version of this fixture exposed the
+ * whole body through `text()` as well, so an implementation that ignored the
+ * stream and buffered everything passed the "bounds a body whose size the
+ * metadata never declared" test — the exact behaviour those tests exist to
+ * forbid. A fixture that satisfies both the right and the wrong implementation
+ * discriminates nothing.
+ *
+ * The returned handle exposes `reads` and `cancelled` so a test can assert the
+ * read STOPPED rather than merely that the phase ended up right: an
+ * implementation that drains the whole stream and then measures reaches the
+ * same `too-large`, and only the read count tells them apart.
+ */
+function streamedResponse(body: string, chunkSize = 8) {
+	const bytes = new TextEncoder().encode(body);
+	let offset = 0;
+	const state = { reads: 0, cancelled: false };
+	const reader = {
+		read: async () => {
+			state.reads++;
+			if (offset >= bytes.length) return { done: true, value: undefined };
+			const value = bytes.slice(offset, offset + chunkSize);
+			offset += chunkSize;
+			return { done: false, value };
+		},
+		cancel: async () => {
+			state.cancelled = true;
+		}
+	};
+	const response = {
+		ok: true,
+		status: 200,
+		body: { getReader: () => reader },
+		text: async () => {
+			throw new Error('text() must not be used when a stream is available');
+		}
+	} as unknown as Response;
+	return { response, state, chunkSize, totalBytes: bytes.length };
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+	fetchMock = vi.fn();
+	vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+/** Let the loader's internal async chain settle. */
+const settle = () => new Promise((r) => setTimeout(r, 0));
+
+describe('createViewerTextLoader', () => {
+	it('starts idle and asks for nothing', () => {
+		const loader = createViewerTextLoader();
+		expect(loader.phase).toBe('idle');
+		expect(loader.text).toBe('');
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it('loads a claimed entry and delivers the document', async () => {
+		fetchMock.mockResolvedValue(plainResponse('# Title\n\nbody'));
+		const loader = createViewerTextLoader();
+		loader.load(entry(), 'ws');
+		expect(loader.phase).toBe('loading');
+		await settle();
+		expect(loader.phase).toBe('ready');
+		expect(loader.text).toBe('# Title\n\nbody');
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		// The ACL/variant path, not a raw storage read.
+		expect(String(fetchMock.mock.calls[0][0])).toBe('/api/v1/workspaces/ws/attachments/a1');
+	});
+
+	it('reads a STREAMED body across chunk boundaries without corrupting multi-byte text', async () => {
+		// The chunk size deliberately splits a multi-byte character, which a
+		// non-streaming decoder would mangle — the reason `TextDecoder` is used
+		// with `{ stream: true }` rather than decoding each chunk independently.
+		const doc = '# café — naïve ☕ résumé';
+		fetchMock.mockResolvedValue(streamedResponse(doc, 3).response);
+		const loader = createViewerTextLoader();
+		loader.load(entry({ size_bytes: null }), 'ws');
+		await settle();
+		expect(loader.phase).toBe('ready');
+		expect(loader.text).toBe(doc);
+	});
+
+	// ── The request chokepoint ────────────────────────────────────────────────
+
+	it('ISSUES NO REQUEST for a MIME this renderer does not claim', async () => {
+		const loader = createViewerTextLoader();
+		loader.load(entry({ mime_type: 'application/pdf', filename: 'x.pdf' }), 'ws');
+		await settle();
+		expect(loader.phase).toBe('idle');
+		// The counterfactual: a renderer that merely SHOWED nothing would still
+		// have fetched. The gate is at the request, so there is no call at all.
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it('ISSUES NO REQUEST for the force-download bucket, which shares CategoryText with markdown', async () => {
+		const loader = createViewerTextLoader();
+		for (const mime of ['text/html', 'text/javascript', 'application/javascript']) {
+			loader.load(entry({ mime_type: mime }), 'ws');
+			await settle();
+			expect(loader.phase).toBe('idle');
+		}
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	// ── Gate 1: metadata ──────────────────────────────────────────────────────
+
+	it('refuses an oversize entry from METADATA, without fetching', async () => {
+		const loader = createViewerTextLoader();
+		const size = TEXT_PREVIEW_MAX_BYTES + 1;
+		loader.load(entry({ size_bytes: size }), 'ws');
+		await settle();
+		expect(loader.phase).toBe('too-large');
+		expect(loader.oversizeBytes).toBe(size);
+		// This gate's whole value is the transfer it saves.
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it('admits an entry exactly AT the cap', async () => {
+		fetchMock.mockResolvedValue(plainResponse('ok'));
+		const loader = createViewerTextLoader();
+		loader.load(entry({ size_bytes: TEXT_PREVIEW_MAX_BYTES }), 'ws');
+		await settle();
+		// The bound is "more than", not "as much as" — pinned so an off-by-one
+		// tightening is a test failure rather than a silent behaviour change.
+		expect(loader.phase).toBe('ready');
+	});
+
+	// ── Gate 2: response ──────────────────────────────────────────────────────
+
+	it('bounds a body whose size the METADATA never declared', async () => {
+		// THE CASE GATE 1 CANNOT SEE. `LightboxImage.size_bytes` is `number | null`
+		// by declaration — an emitter knows only what its surface gave it — so a
+		// null-size entry passes the metadata gate vacuously. Deleting the response
+		// bound leaves exactly this entry unbounded, which is this test's mutant.
+		const huge = 'x'.repeat(TEXT_PREVIEW_MAX_BYTES + 10);
+		const stream = streamedResponse(huge, 4096);
+		fetchMock.mockResolvedValue(stream.response);
+		const loader = createViewerTextLoader();
+		loader.load(entry({ size_bytes: null }), 'ws');
+		await settle();
+		expect(loader.phase).toBe('too-large');
+		expect(loader.text).toBe('');
+		// No figure: nothing declared one, so there is none to show.
+		expect(loader.oversizeBytes).toBeNull();
+		// IT STOPPED, rather than draining and then measuring. Both reach
+		// `too-large`, so the phase alone cannot tell them apart — the read count
+		// and the cancel can. Ceiling is the reads needed to cross the bound plus
+		// the one that crosses it; draining would take ~257 at this chunk size.
+		expect(stream.state.cancelled).toBe(true);
+		expect(stream.state.reads).toBeLessThanOrEqual(
+			Math.ceil(TEXT_PREVIEW_MAX_BYTES / stream.chunkSize) + 1
+		);
+	});
+
+	it('bounds an UNDER-DECLARED body, and does NOT quote the false size', async () => {
+		const huge = 'x'.repeat(TEXT_PREVIEW_MAX_BYTES + 10);
+		fetchMock.mockResolvedValue(streamedResponse(huge, 4096).response);
+		const loader = createViewerTextLoader();
+		loader.load(entry({ size_bytes: 10 }), 'ws');
+		await settle();
+		expect(loader.phase).toBe('too-large');
+		expect(loader.text).toBe('');
+		// The declared 10 bytes is demonstrably wrong — the body outran a 1 MiB
+		// bound — so echoing it would render "This file is 10 B — too large to
+		// preview", which reads as a viewer bug rather than a file problem.
+		expect(loader.oversizeBytes).toBeNull();
+	});
+
+	it('measures the bound in BYTES, not characters, on the non-streaming leg', async () => {
+		// A multi-byte document just under the cap in characters but over it in
+		// bytes must be refused. `String.length` would admit it.
+		const chars = Math.floor(TEXT_PREVIEW_MAX_BYTES / 2) + 5; // 2 bytes each
+		fetchMock.mockResolvedValue(plainResponse('é'.repeat(chars)));
+		const loader = createViewerTextLoader();
+		loader.load(entry({ size_bytes: null }), 'ws');
+		await settle();
+		expect(loader.phase).toBe('too-large');
+	});
+
+	// ── Staleness and cancellation ────────────────────────────────────────────
+
+	it('drops a completion for an entry the user has already left', async () => {
+		let resolveFirst: (r: Response) => void = () => {};
+		fetchMock
+			.mockImplementationOnce(() => new Promise<Response>((r) => (resolveFirst = r)))
+			.mockResolvedValue(plainResponse('second doc'));
+
+		const loader = createViewerTextLoader();
+		loader.load(entry({ id: 'first' }), 'ws');
+		loader.load(entry({ id: 'second' }), 'ws');
+		await settle();
+		expect(loader.text).toBe('second doc');
+
+		// The first request now finishes, late.
+		resolveFirst(plainResponse('FIRST DOC — must not appear'));
+		await settle();
+		// The end state alone would be ambiguous, so assert what the WRONG
+		// behaviour would do: the first document's text reaching the consumer.
+		expect(loader.text).toBe('second doc');
+		expect(loader.phase).toBe('ready');
+	});
+
+	it('ABORTS the in-flight request when repointed', async () => {
+		const signals: AbortSignal[] = [];
+		fetchMock.mockImplementation((_url: string, init: RequestInit) => {
+			signals.push(init.signal as AbortSignal);
+			return new Promise<Response>(() => {});
+		});
+		const loader = createViewerTextLoader();
+		loader.load(entry({ id: 'first' }), 'ws');
+		expect(signals[0].aborted).toBe(false);
+		loader.load(entry({ id: 'second' }), 'ws');
+		// The registry-left-behind assertion: a loader that merely ignored the
+		// stale result would leave this signal unaborted and the request running.
+		expect(signals[0].aborted).toBe(true);
+	});
+
+	it('dispose() aborts and returns to idle', async () => {
+		const signals: AbortSignal[] = [];
+		fetchMock.mockImplementation((_url: string, init: RequestInit) => {
+			signals.push(init.signal as AbortSignal);
+			return new Promise<Response>(() => {});
+		});
+		const loader = createViewerTextLoader();
+		loader.load(entry(), 'ws');
+		loader.dispose();
+		expect(signals[0].aborted).toBe(true);
+		expect(loader.phase).toBe('idle');
+		expect(loader.text).toBe('');
+	});
+
+	it('does not report an abort as an error', async () => {
+		fetchMock.mockImplementation(
+			(_url: string, init: RequestInit) =>
+				new Promise<Response>((_res, rej) => {
+					(init.signal as AbortSignal).addEventListener('abort', () => {
+						const e = new Error('aborted');
+						e.name = 'AbortError';
+						rej(e);
+					});
+				})
+		);
+		const loader = createViewerTextLoader();
+		loader.load(entry(), 'ws');
+		loader.dispose();
+		await settle();
+		expect(loader.phase).toBe('idle');
+	});
+
+	// ── Errors and retry ──────────────────────────────────────────────────────
+
+	it('reports a non-OK response as a retryable error', async () => {
+		fetchMock.mockResolvedValue(plainResponse('nope', false, 500));
+		const loader = createViewerTextLoader();
+		loader.load(entry(), 'ws');
+		await settle();
+		expect(loader.phase).toBe('error');
+		expect(loader.text).toBe('');
+	});
+
+	it('retry() re-requests from error and bumps the load token', async () => {
+		fetchMock.mockResolvedValueOnce(plainResponse('nope', false, 500));
+		const loader = createViewerTextLoader();
+		loader.load(entry(), 'ws');
+		await settle();
+		const tokenAfterFail = loader.loadToken;
+
+		fetchMock.mockResolvedValue(plainResponse('recovered'));
+		loader.retry();
+		await settle();
+		expect(loader.phase).toBe('ready');
+		expect(loader.text).toBe('recovered');
+		expect(loader.loadToken).toBeGreaterThan(tokenAfterFail);
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+
+	it('retry() is INERT outside error — a too-large retry would reach the same answer', async () => {
+		const loader = createViewerTextLoader();
+		loader.load(entry({ size_bytes: TEXT_PREVIEW_MAX_BYTES + 1 }), 'ws');
+		await settle();
+		expect(loader.phase).toBe('too-large');
+		loader.retry();
+		await settle();
+		expect(loader.phase).toBe('too-large');
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it('retry() is INERT while LOADING — a second request would race the first', async () => {
+		// The case the mutation matrix found uncovered: for `too-large` the guard
+		// is redundant (`active` is already null), so removing `phase !== 'error'`
+		// survived until this test existed. Here `active` IS set, so only the
+		// phase check stands between one entry and two concurrent requests.
+		fetchMock.mockImplementation(() => new Promise<Response>(() => {}));
+		const loader = createViewerTextLoader();
+		loader.load(entry(), 'ws');
+		expect(loader.phase).toBe('loading');
+		const tokenBefore = loader.loadToken;
+		loader.retry();
+		await settle();
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(loader.loadToken).toBe(tokenBefore);
+	});
+
+	it('retry() is INERT from ready — there is nothing to recover', async () => {
+		fetchMock.mockResolvedValue(plainResponse('doc'));
+		const loader = createViewerTextLoader();
+		loader.load(entry(), 'ws');
+		await settle();
+		expect(loader.phase).toBe('ready');
+		loader.retry();
+		await settle();
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it('load(undefined) releases the entry', async () => {
+		fetchMock.mockResolvedValue(plainResponse('doc'));
+		const loader = createViewerTextLoader();
+		loader.load(entry(), 'ws');
+		await settle();
+		expect(loader.phase).toBe('ready');
+		loader.load(undefined, 'ws');
+		expect(loader.phase).toBe('idle');
+		expect(loader.text).toBe('');
+	});
+});

--- a/web/src/lib/attachments/viewerTextLoader.svelte.ts
+++ b/web/src/lib/attachments/viewerTextLoader.svelte.ts
@@ -1,0 +1,259 @@
+/**
+ * The attachment surface's TEXT loader (IDEA-2712 / GitHub #1169) — the
+ * markdown / plain-text counterpart to {@link ./viewerImageLoader}.
+ *
+ * MODEL, and how it differs from the image loader. The image loader hands a URL
+ * to an `<img>` and lets the BROWSER fetch, decode, cache and cancel. Text has
+ * no such element: we `fetch()` the bytes ourselves and render them. Three
+ * consequences the image loader does not have to think about, all handled here:
+ *
+ *  1. **We own cancellation.** No `src` reassignment drops the previous request,
+ *     so every load carries an `AbortController` and repointing aborts it. A
+ *     surface arrowed through twenty attachments must leave no request running.
+ *  2. **We own staleness.** A late `await` can resolve after the user has moved
+ *     on (the no-`{#key}` switch-safety class the image loader's `decoded()`
+ *     fence exists for). Every completion here is checked against the request
+ *     token that issued it AND the currently-active id; a stale one is dropped
+ *     without touching state.
+ *  3. **We own the size bound.** The browser will happily stream a 20 MB "log
+ *     file" renamed `.md` into memory. See the two gates below — with one honest
+ *     limit: the non-streaming fallback in {@link readBounded} measures AFTER
+ *     buffering, so on an environment with no `ReadableStream` the bytes are
+ *     held before they are refused. It bounds what is RENDERED everywhere; it
+ *     bounds what is HELD only on the streaming path, which is every real
+ *     browser. jsdom is the fallback's practical audience.
+ *
+ * WHY FETCHING IS SAFE FOR TYPES THE SERVER WILL NOT INLINE. `text/markdown` is
+ * served `Content-Disposition: attachment` (`internal/attachments/mime.go`'s
+ * `inlineSafe` admits only PDF and `text/plain` among non-media types). That
+ * disposition governs what the BROWSER does with a top-level navigation; it does
+ * not impede `fetch()`, and it is not what makes this safe. What makes it safe is
+ * that the bytes never become active same-origin content: they are rendered
+ * through the shared markdown pipeline and sanitized, exactly like item content.
+ * PLAN-2393 DR-6's rule — never inline a force-download type — is honoured by
+ * the ALLOWLIST (`canPreviewAsText` admits neither HTML nor JavaScript), not by
+ * the disposition header.
+ *
+ * TWO SIZE GATES, WITH INDEPENDENT REASONS. Both are load-bearing and neither
+ * subsumes the other:
+ *
+ *  - The METADATA gate (before any request) reads `size_bytes` and refuses to
+ *    fetch at all above {@link TEXT_PREVIEW_MAX_BYTES}. This is the one that
+ *    saves the transfer.
+ *  - The RESPONSE gate (while reading) bounds the bytes actually accepted.
+ *    `LightboxImage.size_bytes` is `number | null` BY DECLARATION — an emitter
+ *    knows only what its own surface gave it — so the metadata gate passes
+ *    VACUOUSLY for any entry that arrived without a size. Without the response
+ *    gate those entries are unbounded.
+ *
+ * Deleting either one leaves a real hole, which is the test each must fail.
+ */
+import { attachmentDownloadUrl } from '$lib/markdown/attachments';
+import { canPreviewAsText, TEXT_PREVIEW_MAX_BYTES } from '$lib/attachments/display';
+import type { LightboxImage } from './events';
+
+export type TextLoadPhase =
+	/** Nothing to load: no entry, or one this renderer does not claim. */
+	| 'idle'
+	/** A request is in flight. */
+	| 'loading'
+	/** `text` holds the document. */
+	| 'ready'
+	/** The fetch failed. Retryable. */
+	| 'error'
+	/**
+	 * The document is past {@link TEXT_PREVIEW_MAX_BYTES}. A TERMINAL state, not
+	 * an error: nothing went wrong and a retry would reach the same answer, so
+	 * the surface offers its existing download affordance instead of a retry.
+	 */
+	| 'too-large';
+
+export interface ViewerTextLoader {
+	/** The document text once `phase === 'ready'`, else `''`. */
+	readonly text: string;
+	readonly phase: TextLoadPhase;
+	/**
+	 * The size that tripped `too-large`, for the surface's message — set ONLY when
+	 * the METADATA gate refused (a trustworthy declared size). `null` otherwise,
+	 * including when the RESPONSE outran the bound: there the declared size is
+	 * absent or wrong by definition, so there is no honest figure to show.
+	 */
+	readonly oversizeBytes: number | null;
+	/** Changes on every fresh request, so a consumer can key off a real reload. */
+	readonly loadToken: number;
+	/** Point the loader at an entry (or `undefined` to release). */
+	load(img: LightboxImage | undefined, wsSlug: string): void;
+	/** Re-request the current entry after an `error`. Inert in any other phase. */
+	retry(): void;
+	/** Abort any in-flight request and return to `idle`. */
+	dispose(): void;
+}
+
+interface ActiveLoad {
+	img: LightboxImage;
+	wsSlug: string;
+	controller: AbortController;
+}
+
+/**
+ * Read a response body, refusing more than `max` bytes.
+ *
+ * Streams so an oversize body is abandoned mid-flight rather than buffered and
+ * then measured — the point is not to hold 20 MB in memory long enough to
+ * decide we did not want it.
+ *
+ * THE FALLBACK IS WEAKER, AND KNOWINGLY SO. Where the body is not a readable
+ * stream (jsdom, and any environment without `getReader`) this reads the whole
+ * response and then measures it: the RENDER bound still holds, the MEMORY bound
+ * does not. Stated rather than papered over, because the module header claims
+ * to own the size bound and that claim is only fully true on the streaming path
+ * (codex R1 #2). Every browser this ships to has streams; the fallback's real
+ * audience is the test environment.
+ *
+ * Returns `null` when the bound is exceeded.
+ */
+async function readBounded(response: Response, max: number): Promise<string | null> {
+	const body = response.body;
+	if (!body || typeof body.getReader !== 'function') {
+		const whole = await response.text();
+		// Byte length, not string length: the bound is a byte bound, and a
+		// multi-byte document would otherwise be measured short.
+		return new TextEncoder().encode(whole).length > max ? null : whole;
+	}
+	const reader = body.getReader();
+	const decoder = new TextDecoder();
+	let seen = 0;
+	let out = '';
+	for (;;) {
+		const { done, value } = await reader.read();
+		if (done) break;
+		seen += value?.byteLength ?? 0;
+		if (seen > max) {
+			await reader.cancel();
+			return null;
+		}
+		out += decoder.decode(value, { stream: true });
+	}
+	out += decoder.decode();
+	return out;
+}
+
+export function createViewerTextLoader(): ViewerTextLoader {
+	let text = $state('');
+	let phase = $state<TextLoadPhase>('idle');
+	let oversizeBytes = $state<number | null>(null);
+	let loadToken = $state(0);
+	// Non-reactive: never read inside an $effect's tracked scope, so writing it
+	// cannot self-invalidate a flush (CONVE-1688).
+	let active: ActiveLoad | null = null;
+
+	/** One cleanup, so every "give up on this entry" site leaves the same state. */
+	function toIdle(): void {
+		active?.controller.abort();
+		active = null;
+		text = '';
+		oversizeBytes = null;
+		phase = 'idle';
+	}
+
+	function start(): void {
+		const a = active;
+		if (!a) return;
+		// THE GATES, RESTATED AT THE REQUEST CHOKEPOINT — not only at the renderer.
+		// `load()` and `retry()` both funnel through here, so neither can issue a
+		// request for a type this renderer does not claim. The image loader states
+		// the reason and it holds identically: the renderer showing nothing is not
+		// the same as the loader asking for nothing.
+		if (!canPreviewAsText(a.img.mime_type)) {
+			toIdle();
+			return;
+		}
+		const declared = a.img.size_bytes;
+		if (typeof declared === 'number' && declared > TEXT_PREVIEW_MAX_BYTES) {
+			// Terminal, and no request is made at all.
+			active = null;
+			a.controller.abort();
+			text = '';
+			oversizeBytes = declared;
+			phase = 'too-large';
+			return;
+		}
+		const token = ++loadToken;
+		const id = a.img.id;
+		text = '';
+		oversizeBytes = null;
+		phase = 'loading';
+		void (async () => {
+			try {
+				const res = await fetch(attachmentDownloadUrl(a.wsSlug, id), {
+					signal: a.controller.signal
+				});
+				if (!res.ok) throw new Error(`HTTP ${res.status}`);
+				const body = await readBounded(res, TEXT_PREVIEW_MAX_BYTES);
+				// THE STALENESS FENCE. Both halves are needed: the token catches a
+				// retry of the SAME entry (id unchanged), the id catches navigation
+				// to a different one (token could coincide only by accident, but the
+				// id is the thing the user is actually looking at).
+				if (token !== loadToken || active?.img.id !== id) return;
+				if (body === null) {
+					// The response outran the bound. `oversizeBytes` stays NULL here
+					// (codex R2 #3): the declared size is either absent or — in the
+					// under-declaring case this branch exists to catch — WRONG, and
+					// echoing it produces "This file is 10 B — too large to preview",
+					// a sentence that reads as a bug in the viewer rather than a
+					// problem with the file. The true size is unknown by construction
+					// (we stopped reading), so the surface says "too large" without a
+					// figure. The metadata branch above, which HAS a trustworthy
+					// number, is the only one that reports one.
+					oversizeBytes = null;
+					text = '';
+					phase = 'too-large';
+					return;
+				}
+				text = body;
+				phase = 'ready';
+			} catch (err) {
+				if ((err as { name?: string })?.name === 'AbortError') return;
+				if (token !== loadToken || active?.img.id !== id) return;
+				text = '';
+				phase = 'error';
+			}
+		})();
+	}
+
+	function load(img: LightboxImage | undefined, wsSlug: string): void {
+		// Repoint: abort whatever was running. Unlike the image loader there is no
+		// `src` reassignment doing this for us.
+		toIdle();
+		if (!img) return;
+		active = { img, wsSlug, controller: new AbortController() };
+		start();
+	}
+
+	function retry(): void {
+		const a = active;
+		// Only from `error`. A `too-large` retry would reach the same answer, and
+		// retrying from `loading` would race two requests for one entry.
+		if (!a || phase !== 'error') return;
+		a.controller = new AbortController();
+		start();
+	}
+
+	return {
+		get text() {
+			return text;
+		},
+		get phase() {
+			return phase;
+		},
+		get oversizeBytes() {
+			return oversizeBytes;
+		},
+		get loadToken() {
+			return loadToken;
+		},
+		load,
+		retry,
+		dispose: toIdle
+	};
+}

--- a/web/src/lib/brand/links.ts
+++ b/web/src/lib/brand/links.ts
@@ -1,0 +1,24 @@
+/**
+ * Canonical off-property links (IDEA-2711 / GitHub #1168).
+ *
+ * ONE source of truth for the project's own URLs. The repo URL in particular
+ * was already written twice in `UserMenuResources.svelte` (the Cloud and
+ * self-hosted lists) before the sidebar wanted a third; a URL copied into every
+ * surface that shows it is a rename waiting to go half-applied.
+ *
+ * The visual contract these serve — link-list canonical order and the
+ * external-link convention — lives in `docs/brand.md` §6 / §7. This module
+ * holds the addresses only; ordering stays with the surface that renders a
+ * list, because the two lists are deliberately different lengths.
+ */
+
+/** The public repository. Shown in the app so a user never has to search for it. */
+export const GITHUB_REPO_URL = 'https://github.com/PerpetualSoftware/pad';
+
+/** Canonical project documentation — the same for Cloud and self-hosted. */
+export const DOCS_URL = 'https://getpad.dev/docs';
+
+/** Cloud-only surfaces. Self-hosted operators have their own, if any. */
+export const CHANGELOG_URL = 'https://getpad.dev/changelog';
+export const STATUS_URL = 'https://status.getpad.dev';
+export const SUPPORT_MAILTO = 'mailto:support@getpad.dev';

--- a/web/src/lib/components/common/Lightbox.svelte
+++ b/web/src/lib/components/common/Lightbox.svelte
@@ -39,6 +39,9 @@
 	// null → the no-bytes icon fallback. This is the single gate that decides the
 	// stage's ARM; the old `canOpenInViewer` last-mile FILTER is gone.
 	import { getSurfaceRenderer, type SurfaceRendererId } from '$lib/attachments/surfaceRenderers';
+	import { createViewerTextLoader } from '$lib/attachments/viewerTextLoader.svelte';
+	import { renderMarkdownDocument } from '$lib/utils/markdown';
+	import { formatAttachmentSize } from '$lib/markdown/attachments';
 	import {
 		reset as resetZoom,
 		clampState,
@@ -97,7 +100,12 @@
 	// Filename / type / size for the shown image, seeded from the LightboxImage
 	// and completed by the SAME B metadata module the panel uses (TASK-2473): it
 	// fetches only what the seed left null (DR-2 — open now, fill after).
-	import { describeAttachmentType, formatBytes, iconForAttachment } from '$lib/attachments/display';
+	import {
+		describeAttachmentType,
+		formatBytes,
+		iconForAttachment,
+		isMarkdownAttachment
+	} from '$lib/attachments/display';
 	import { createSurfaceMetadata } from '$lib/attachments/surfaceMetadata.svelte';
 
 	interface Props {
@@ -191,9 +199,11 @@
 	 *    the whole set. There is no MIME refusal left here.
 	 *  - THE ARM is where safety lives (`shownRenderer`, from `getSurfaceRenderer`
 	 *    on the RESOLVED MIME). `'raster-image'` mounts the `<img>` and loads
-	 *    bytes; `null` — an unsafe/active type, a file, or a still-unresolved MIME
-	 *    — mounts the NO-BYTES icon fallback (no `<img>`, no `src`, no fetch). The
-	 *    allowlist governs the ARM, never admission.
+	 *    bytes; `'text'` (IDEA-2712) fetches a markdown / plain-text document and
+	 *    renders it through the shared sanitized pipeline; `null` — an
+	 *    unsafe/active type, a file, or a still-unresolved MIME — mounts the
+	 *    NO-BYTES icon fallback (no `<img>`, no `src`, no fetch). The allowlist
+	 *    governs the ARM, never admission.
 	 *
 	 * WHY ADMITTING UNSAFE/UNRESOLVED IS SAFE. The DR-16 concern was never "a
 	 * hostile row in the set" — it was rendering hostile BYTES as active
@@ -205,6 +215,16 @@
 	 * the 3c-i filter did by DROPPING, the arm now does by CLASSIFYING — with the
 	 * file/unresolved rows kept and shown, which is the whole point of the
 	 * converged surface.
+	 *
+	 * TWO ARMS NOW LOAD BYTES, and the invariant is unchanged in kind: the text
+	 * arm's bytes never become active same-origin content either. They are
+	 * rendered through `sanitizeMarkdownHtml`, and the types for which that would
+	 * be the wrong bet — `text/html`, `text/javascript`, `application/javascript`,
+	 * which share the server's `CategoryText` with markdown — are excluded from
+	 * `canPreviewAsText` by allowlist, so they never reach the arm. Exactly one
+	 * loader is armed at a time; the load effect disposes the other, so an arm
+	 * flip releases the previous arm's bytes rather than leaving them behind
+	 * something new.
 	 *
 	 * (The producer-side resolve-before-emit contract on the legacy viewer
 	 * channel is unchanged and unrelated: that is the NodeView's obligation, not
@@ -339,6 +359,14 @@
 	// allowlisted RESOLVED MIME, so admitting unsafe/unresolved rows renders no
 	// hostile bytes (see the admission note above).
 	let resolvedMime = $derived(img ? headerMeta.fields.mime_type : null);
+	// The RESOLVED size, for the same reason `resolvedMime` exists (IDEA-2712,
+	// codex R1 #1). The `LightboxImage` seed carries `size_bytes: null` on most
+	// producers — it is the metadata HEAD that fills it — so handing the text
+	// loader the SEED would put its metadata gate permanently in the vacuous case
+	// and leave the response gate doing all the work. That is not a hole (the
+	// response gate bounds it) but it silently retires the gate whose entire value
+	// is the transfer it saves.
+	let resolvedSize = $derived(img ? headerMeta.fields.size_bytes : null);
 	let shownRenderer = $derived<SurfaceRendererId | null>(
 		img ? getSurfaceRenderer(resolvedMime) : null
 	);
@@ -607,6 +635,12 @@
 	// shows (`displaySrc`, the canonical attachment URL) and the load phase; this
 	// component drives it from the shown image and reports each decode / error.
 	const loader = createViewerImageLoader();
+	// The TEXT arm's loader (IDEA-2712). A separate instance rather than a mode on
+	// the image loader: the two have no shared state, opposite cancellation models
+	// (an `<img>` src reassignment vs an AbortController) and disjoint arms, so
+	// merging them would be one object with two unrelated halves. Exactly one is
+	// ever armed — the load effect below disposes the other.
+	const textLoader = createViewerTextLoader();
 	// The id AND the pixel dimensions, as ONE stable primitive string — never the
 	// `img` object. A prop re-emit with the same VALUES (a re-derived `navigable`
 	// array) must not re-fire the load effect, but a genuine dimension change (an
@@ -626,8 +660,32 @@
 	// within one open, so adding it would be inert anyway. The same-id
 	// safe→unsafe MIME flip that DOES need in-open coherence is already covered by
 	// `shownRenderer` above.
+	// `resolvedSize` JOINS THE KEY (IDEA-2712, codex R1 #1) for the same reason the
+	// dimensions do: the text arm's metadata gate is a function of the size, so a
+	// size that arrives LATE (the HEAD filling a null seed) is a policy that
+	// arrived late. Without it, an entry that begins with an unknown size and
+	// resolves to 4 MB has already been fetched and never re-decides.
+	//
+	// `revalidateToken` rides the same text-arm slot (codex R3 #2). A parent
+	// RESTORE bumps that token so an archived-at-open surface re-probes — and the
+	// image loader is driven by the probe's own answer, but a FAILED TEXT GET is
+	// not: its `error` phase is loader state, invisible to the metadata layer. So
+	// without the token in the key, a text preview that 404'd because the parent
+	// was archived stays permanently errored after the restore that fixed it, with
+	// only a manual Retry to escape. Scoped to the text arm for the same reason
+	// the size is — the raster arm has its own revalidation path and must not be
+	// reloaded twice.
+	//
+	// IT IS SCOPED TO THE TEXT ARM, and this key is SHARED (codex R2 #1). An
+	// earlier version appended the size unconditionally with a comment calling it
+	// "inert for the raster arm, which does not read it" — false, and false in a
+	// way the comment's own reasoning hid: the RASTER arm does not read the size,
+	// but the EFFECT does, and a late size fill would re-run it and re-issue
+	// `loader.load()`, restarting an image load and — on mobile — resetting an
+	// original the user had already triggered. Reading a value is not the only way
+	// to depend on it; being in the key is.
 	let loadKey = $derived(
-		`${img?.id ?? ''}:${img?.width ?? ''}:${img?.height ?? ''}:${shownRenderer ?? ''}:${soleMissing}`
+		`${img?.id ?? ''}:${img?.width ?? ''}:${img?.height ?? ''}:${shownRenderer ?? ''}:${soleMissing}:${shownRenderer === 'text' ? `${resolvedSize ?? ''}:${revalidateToken}` : ''}`
 	);
 	// Captured NON-reactively at load time (see the effect): a breakpoint flip
 	// alone must not reload — desktop→mobile must not abort an in-flight original,
@@ -771,6 +829,15 @@
 		if (!el || !isViewerFrontmost(el) || isBlockedByModal(el)) return;
 		// We own the wheel while frontmost — consume it even before the bitmap is
 		// measurable, so a scroll can never leak past the modal into the inert app.
+		// A wheel over the TEXT ARM's card is the one wheel this viewer does NOT own
+		// (IDEA-2712, codex R1 #3). It must reach the card so a document scrolls,
+		// which means returning BEFORE `preventDefault` — every other exclusion in
+		// this handler returns after it, because those surfaces want the wheel
+		// swallowed and this one wants it delivered. Scroll chaining to the inert
+		// page behind is stopped by `overscroll-behavior: contain` on the card
+		// rather than by consuming the event here: the CSS keeps the guarantee
+		// (nothing behind scrolls) while still letting the card scroll itself.
+		if ((e.target as Element | null)?.closest?.('.lightbox-text-scroll')) return;
 		e.preventDefault();
 		e.stopPropagation();
 		// A wheel over the TOOLBAR (or its delete drill-down) is consumed like every
@@ -1958,7 +2025,21 @@
 			// safe→unsafe flip actually re-runs this and reaches the dispose. The
 			// loader's own DR-16 gate (`start()`) is the backstop; the Lightbox
 			// decides no-bytes explicitly here.
-			if (shownRenderer === 'raster-image' && !soleMissing) {
+			if (shownRenderer === 'text' && !soleMissing) {
+				// The TEXT arm loads bytes too, so it takes the raster arm's whole
+				// discipline rather than the fallback's: the RESOLVED mime and the
+				// RESOLVED size (never the seed — see `resolvedSize`), both in
+				// `loadKey`, and the image loader disposed so the two can never both
+				// hold bytes for one entry. Its own gates (`canPreviewAsText` + the
+				// size bound) are the backstop at the request chokepoint; this is the
+				// Lightbox deciding the arm.
+				loader.dispose();
+				textLoader.load(
+					{ ...img, mime_type: resolvedMime, size_bytes: resolvedSize },
+					openWsSlug
+				);
+			} else if (shownRenderer === 'raster-image' && !soleMissing) {
+				textLoader.dispose();
 				// Pass the RESOLVED MIME, not the seed. A null-seed entry that
 				// reclassified to raster (its HEAD resolved an image) still carries a
 				// null seed `mime_type`, and the loader's own DR-16 gate (`start()`)
@@ -1970,11 +2051,15 @@
 				loader.load({ ...img, mime_type: resolvedMime }, openWsSlug, platform);
 			} else {
 				loader.dispose();
+				textLoader.dispose();
 			}
 		});
 	});
 	// Drop the load on unmount (close) — one teardown, no dependencies.
-	$effect(() => () => loader.dispose());
+	$effect(() => () => {
+		loader.dispose();
+		textLoader.dispose();
+	});
 
 	// Reactively abort a live gesture the instant the bitmap goes away (TASK-2476), or
 	// the instant a TOUCH gesture's paint arm is lost (TASK-2518). The pointer handlers
@@ -2090,6 +2175,13 @@
 		// control had focus — the Retry/tap-load button — and the fallback arm has no
 		// focusable content, so track the arm to re-home a stranded focus.
 		void shownRenderer;
+		// The TEXT arm's phase does the same thing and more (IDEA-2712, codex R3):
+		// its own Retry button unmounts on a successful retry, and — unlike every
+		// other arm — the arm's CONTENT is focusable, so a reload (a late size fill,
+		// a retry) unmounts whatever LINK inside the rendered document had focus.
+		// Tracking `loader.phase` alone missed all of it: that is the IMAGE loader,
+		// and on this arm it is disposed and never changes phase.
+		void textLoader.phase;
 		const el = rootEl;
 		if (!el || !isViewerFrontmost(el) || isBlockedByModal(el)) return;
 		handoffFocus(el);
@@ -2352,7 +2444,11 @@
 		and the tap-to-load / retry buttons use); on desktop that value was already the
 		inherited default, so nothing changes there.
 	-->
-	<div class="lightbox-stage" bind:this={stageEl}>
+	<div
+		class="lightbox-stage"
+		class:lightbox-stage-text={shownRenderer === 'text'}
+		bind:this={stageEl}
+	>
 		{#if hasMultiple}
 			<button
 				class="lightbox-nav prev"
@@ -2511,16 +2607,140 @@
 		{/if}
 
 		<!--
-			THE FALLBACK ARM (TASK-2476). A navigable entry the viewer cannot draw as an
-			image — an unsafe/active type that flipped or was added while open. NO
-			BYTES: no `<img>`, no `src`, no request (the load effect disposed the
-			loader on the arm flip). Just the file's identity — the large family icon,
-			its name, type · size — and an honest "No preview available". Same chrome,
-			same modal contract, same lease as the raster arm; zoom is disabled
-			(`bitmapPresent` is false here). `pointer-events: none` like the other
-			stage overlays, so a click on the empty area still reaches the backdrop.
+			THE TEXT ARM (IDEA-2712 / GitHub #1169). A markdown or plain-text document,
+			fetched by `textLoader` and rendered by US — never handed to the browser to
+			inline. This arm LOADS BYTES, so it takes the raster arm's discipline
+			rather than the fallback's: it is re-derived from the resolved MIME every
+			frame, `shownRenderer` is in the `loadKey`, and the load effect disposes
+			the other loader so one entry can never hold two.
+
+			WHY `{@html}` IS SAFE HERE, stated where it is used: the string comes from
+			`renderMarkdownDocument`, which is the shared `marked` pipeline followed by
+			the same `sanitizeMarkdownHtml` pass every other `{@html}` source in the app
+			goes through. The allowlist governing an attached document is by
+			construction the one governing item content. The types that would make this
+			dangerous — `text/html`, `text/javascript` — are not in `canPreviewAsText`,
+			so they never reach this arm at all (PLAN-2393 DR-6).
+
+			PLAIN TEXT IS NOT RENDERED AS MARKDOWN. A `.txt` goes into a `<pre>` as
+			TEXT, not through the pipeline: interpreting a plain-text file's asterisks
+			and underscores as formatting would be lying about its content. Svelte
+			escapes the interpolation, so that path emits no HTML at all.
+
+			POINTER SEMANTICS live on the CARD, not on this layer — see the comment at
+			the card itself. The first version of this arm put `pointer-events: auto`
+			on the full-bleed layer and asserted here that backdrop-click still
+			worked; it did not, and nothing tested it. Both are fixed and both are
+			now asserted.
 		-->
-		{#if img && shownRenderer !== 'raster-image' && !soleMissing}
+		{#if shownRenderer === 'text' && !soleMissing}
+			<div class="lightbox-text">
+				<!--
+					THE CARD IS THE INTERACTIVE SURFACE, the layer around it is not
+					(IDEA-2712, codex R1 #4). `.lightbox-text` spans the stage for
+					centring only and takes `pointer-events: none`, so a click on the
+					empty area still reaches the root and closes the viewer exactly as
+					it does on every other arm. An earlier version gave the full-bleed
+					layer `pointer-events: auto` and silently broke backdrop-close for
+					this arm alone — while a comment two lines away claimed it still
+					worked.
+
+					It is also the SCROLL container (`.lightbox-text-scroll`), which is
+					what the wheel handler excludes by class, and it carries
+					`overscroll-behavior: contain` so a scroll that reaches the end of
+					the document does not chain to the inert page behind.
+				-->
+				<!--
+					`tabindex="0"` because this is a SCROLLABLE REGION and nothing else
+					in the viewer can scroll it. Without a tab stop a keyboard-only
+					user can open a document and never reach past its first screen —
+					the arrow keys are owned by the viewer's own next/previous
+					navigation, so there is no fallback. It joins the focus trap by
+					design (it is a real destination), and `role="document"` with the
+					filename as its accessible name is what a screen reader announces
+					on arrival.
+				-->
+				<!--
+					svelte-ignore a11y_no_noninteractive_tabindex — the rule's premise
+					(only interactive elements earn a tab stop) has a documented
+					exception for SCROLLABLE REGIONS, which is exactly what this is:
+					WCAG 2.1.1 requires content reachable by keyboard, and a scroll
+					container that is not a tab stop strands everything past its first
+					screen. `role="document"` is the honest role for a previewed file
+					(it puts a screen reader into reading mode), and it is what makes
+					the linter call the element noninteractive — the label and the tab
+					stop together are the accessible pattern, not a workaround.
+				-->
+				<div
+					class="lightbox-text-scroll"
+					role="document"
+					aria-label={displayName}
+					tabindex="0"
+				>
+				{#if textLoader.phase === 'loading'}
+					<p class="lightbox-text-status" role="status">Loading preview…</p>
+				{:else if textLoader.phase === 'too-large'}
+					<!--
+						TERMINAL, AND DELIBERATELY NOT AN ERROR — nothing went wrong and a
+						retry reaches the same answer, so there is no Retry button here.
+						The toolbar's existing Download action is the way out, which is
+						why this text points at it rather than offering its own control.
+					-->
+					<p class="lightbox-text-status" role="status">
+						{#if textLoader.oversizeBytes !== null}
+							This file is {formatAttachmentSize(textLoader.oversizeBytes)} — too large to preview.
+						{:else}
+							This file is too large to preview.
+						{/if}
+						Use Download to open it.
+					</p>
+				{:else if textLoader.phase === 'error'}
+					<div class="lightbox-status lightbox-error" role="alert">
+						<p class="lightbox-error-text">This file couldn't be loaded.</p>
+						<!-- Hands focus off before disappearing, like the raster retry. -->
+						<button
+							class="lightbox-retry"
+							type="button"
+							onclick={() => {
+								handoffFocus(rootEl!, rootEl?.querySelector('.lightbox-text .lightbox-retry') ?? null);
+								textLoader.retry();
+							}}
+						>
+							Retry
+						</button>
+					</div>
+				{:else if textLoader.phase === 'ready'}
+					{#if isMarkdownAttachment(resolvedMime, headerMeta.fields.filename)}
+						<div class="lightbox-text-body markdown-body">
+							{@html renderMarkdownDocument(textLoader.text)}
+						</div>
+					{:else}
+						<pre class="lightbox-text-body lightbox-text-plain">{textLoader.text}</pre>
+					{/if}
+				{/if}
+				</div>
+			</div>
+		{/if}
+
+		<!--
+			THE FALLBACK ARM (TASK-2476). A navigable entry NO RENDERER CLAIMS — an
+			unsafe/active type that flipped or was added while open, a file, or a
+			still-unresolved MIME. NO BYTES: no `<img>`, no `src`, no request (the
+			load effect disposed both loaders on the arm flip). Just the file's
+			identity — the large family icon, its name, type · size — and an honest
+			"No preview available". Same chrome, same modal contract, same lease as
+			the raster arm; zoom is disabled (`bitmapPresent` is false here).
+			`pointer-events: none` like the other stage overlays, so a click on the
+			empty area still reaches the backdrop.
+
+			THE CONDITION IS `=== null`, NOT `!== 'raster-image'` (IDEA-2712). While
+			the union had one member those were the same test; they are not any more,
+			and the negated form would have claimed the text arm's entries and drawn
+			"No preview available" over a document that was loading fine. `null` IS
+			the registry's "no renderer claims this" answer, so this arm now says what
+			it means and stays correct when `'pdf'` lands.
+		-->
+		{#if img && shownRenderer === null && !soleMissing}
 			<div class="lightbox-fallback" role="group" aria-label="No preview available">
 				<span class="lightbox-fallback-icon" aria-hidden="true">
 					<AttachmentIcon id={fallbackIconId} size={72} />
@@ -2666,6 +2886,17 @@
 		touch-action: none;
 	}
 
+	/* TOUCH-ACTION INTERSECTS DOWN THE ANCESTOR CHAIN (codex R2 #2). The card's
+	   `pan-y` cannot override an ancestor's `none` — the allowed behaviours for a
+	   touch are the INTERSECTION along the chain, so `none` on the stage wins and
+	   a phone could not scroll the document at all. The stage claims `none` for
+	   the pan/zoom gesture, and on the text arm there is no such gesture (no
+	   bitmap, zoom disabled), so it gives the claim up for the duration. Scoped to
+	   the arm rather than relaxed globally: every other arm still needs it. */
+	.lightbox-stage-text {
+		touch-action: auto;
+	}
+
 	.lightbox-image {
 		max-width: 100%;
 		max-height: 100%;
@@ -2718,6 +2949,91 @@
 	   overlays; inert, so a click on the surrounding area still reaches the backdrop
 	   and closes. Logical properties + min-width:0 so a long filename ellipsizes
 	   (DR-13) rather than blowing the box out. */
+	/* THE TEXT ARM (IDEA-2712). Unlike every other stage overlay this one takes
+	   `pointer-events: auto`: a document must scroll and be selectable, which is
+	   the entire point of previewing it. It is a light card on the dark stage
+	   rather than white-on-black body text — a page of prose reversed out at
+	   stage contrast is unreadable at length, and this arm is the only one whose
+	   content is meant to be READ rather than looked at. */
+	/* The centring layer only — NOT interactive. `pointer-events: none` is what
+	   keeps backdrop-click-to-close working on this arm (codex R1 #4); the card
+	   inside turns them back on. */
+	.lightbox-text {
+		position: absolute;
+		inset: 0;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		padding: var(--space-4);
+		pointer-events: none;
+		overflow: hidden;
+		background: transparent;
+	}
+
+	/* The card: the interactive, scrollable, selectable surface. The wheel handler
+	   excludes this class by name, so the three properties below are what actually
+	   deliver the "scrollable and selectable" the arm promises:
+	     - `pointer-events: auto` — clicks, selection and the wheel land here
+	     - `overscroll-behavior: contain` — a scroll at the end of the document
+	       does NOT chain to the inert page behind, which is the guarantee the
+	       wheel handler's `preventDefault` was providing before this arm existed
+	     - `touch-action: pan-y` / `user-select: text` — the stage sets
+	       `touch-action: none` and the backdrop `user-select: none` for the pan
+	       gesture; a document has to opt back out of both. */
+	.lightbox-text-scroll {
+		pointer-events: auto;
+		width: min(80ch, 100%);
+		max-height: 100%;
+		overflow: auto;
+		overscroll-behavior: contain;
+		touch-action: pan-y;
+		user-select: text;
+		-webkit-user-select: text;
+	}
+
+	.lightbox-text-status {
+		margin: auto;
+		color: #fff;
+		text-align: center;
+		max-width: 40ch;
+		line-height: 1.5;
+	}
+
+	.lightbox-text-body {
+		margin: 0;
+		padding: var(--space-4);
+		border-radius: var(--radius-md, 8px);
+		background: var(--bg-primary, #fff);
+		color: var(--text-primary, #111);
+		/* Long words, URLs and code lines must not push the card wider than the
+		   stage — the page itself must never scroll horizontally. */
+		overflow-wrap: anywhere;
+	}
+
+	/* Plain text keeps its own line breaks and spacing (that is what makes it
+	   plain text), but still wraps rather than forcing a horizontal scrollbar
+	   across the whole stage. */
+	.lightbox-text-plain {
+		white-space: pre-wrap;
+		font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+		font-size: 0.875rem;
+		line-height: 1.6;
+	}
+
+	/* Wide content INSIDE a rendered document scrolls in its own box rather than
+	   widening the card (tables and code blocks are the two that do this). */
+	.lightbox-text-body :global(pre),
+	.lightbox-text-body :global(table) {
+		max-width: 100%;
+		overflow-x: auto;
+	}
+
+	.lightbox-text-body :global(img) {
+		max-width: 100%;
+		height: auto;
+	}
+
 	.lightbox-fallback {
 		position: absolute;
 		inset: 0;

--- a/web/src/lib/components/common/Lightbox.svelte.test.ts
+++ b/web/src/lib/components/common/Lightbox.svelte.test.ts
@@ -5013,3 +5013,286 @@ describe('Lightbox — deletion subscription (DR-5c / TASK-2477)', () => {
 		expect(root().querySelector('.lightbox-meta-error')).not.toBeNull();
 	});
 });
+
+// ── THE TEXT ARM (IDEA-2712 / GitHub #1169) ─────────────────────────────────
+//
+// CONVE-19: the loader is unit-tested on its own, which vouches for the LOADER,
+// not for its BINDING. These drive the component and assert the arm the viewer
+// actually mounts — including the negative control the union widening created,
+// where the fallback arm's old `!== 'raster-image'` condition would have drawn
+// "No preview available" over a document that was loading perfectly well.
+describe('Lightbox — the text arm', () => {
+	let textFetch: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		metaFetch.mockResolvedValue({ status: 'ok', mime: 'text/markdown', size: 128 });
+		metaRevalidate.mockResolvedValue({ status: 'ok', mime: 'text/markdown', size: 128 });
+		textFetch = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			body: null,
+			text: async () => '# Heading\n\nSome *emphasis*.'
+		});
+		vi.stubGlobal('fetch', textFetch);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	async function settleAsync() {
+		for (let i = 0; i < 8; i++) {
+			await Promise.resolve();
+			flushSync();
+		}
+	}
+
+	it('mounts the TEXT arm for a markdown attachment, not the fallback', async () => {
+		mountViewer({ images: [image(IMG_A, 'notes.md', 'text/markdown')] });
+		await settleAsync();
+		expect(root().querySelector('.lightbox-text')).not.toBeNull();
+		// THE NEGATIVE CONTROL for the fallback-condition change. With the old
+		// `shownRenderer !== 'raster-image'` test this element would be present
+		// AND say "No preview available" over the document — the arm would still
+		// have loaded, so asserting only the text arm's presence would pass on
+		// the broken condition too.
+		expect(root().querySelector('.lightbox-fallback')).toBeNull();
+		// No <img>, and the image loader was never pointed anywhere.
+		expect(root().querySelector('.lightbox-image')).toBeNull();
+	});
+
+	it('renders markdown through the shared pipeline, not as raw source', async () => {
+		mountViewer({ images: [image(IMG_A, 'notes.md', 'text/markdown')] });
+		await settleAsync();
+		const body = root().querySelector('.lightbox-text-body');
+		expect(body).not.toBeNull();
+		// The pipeline ran: a heading element exists rather than a literal '#'.
+		expect(body!.querySelector('h1')?.textContent).toBe('Heading');
+		expect(body!.querySelector('em')?.textContent).toBe('emphasis');
+	});
+
+	it('routes text/plain + a .md filename to the markdown renderer', async () => {
+		// A SYNTHETIC row in the shape the system actually stores — not a real
+		// upload; the metadata and download are both mocked here. What it pins is
+		// the ROUTING decision for that shape, and the reason the other markdown
+		// test above is not sufficient: `attachments.ValidateUpload` sniffs the
+		// bytes (`http.DetectContentType` → `text/plain` for prose) and returns the
+		// SNIFFED entry, so an uploaded `.md` row carries `text/plain`. A fixture
+		// that hand-sets `text/markdown` exercises a branch real uploads never
+		// take — which is exactly how the MIME-only split passed every unit test
+		// and rendered raw source in a browser.
+		metaFetch.mockResolvedValue({ status: 'ok', mime: 'text/plain', size: 128 });
+		metaRevalidate.mockResolvedValue({ status: 'ok', mime: 'text/plain', size: 128 });
+		mountViewer({
+			images: [{ ...image(IMG_A, 'notes', 'text/plain'), filename: 'notes.md' }]
+		});
+		await settleAsync();
+		const body = root().querySelector('.lightbox-text-body');
+		expect(body).not.toBeNull();
+		// Rendered, not shown as source.
+		expect(body!.querySelector('h1')?.textContent).toBe('Heading');
+		expect(body!.tagName).not.toBe('PRE');
+	});
+
+	it('renders PLAIN text as text, never as markdown', async () => {
+		textFetch.mockResolvedValue({
+			ok: true,
+			status: 200,
+			body: null,
+			text: async () => '# not a heading\n*not emphasis*'
+		});
+		mountViewer({
+			images: [{ ...image(IMG_A, 'notes', 'text/plain'), filename: 'notes.txt' }]
+		});
+		await settleAsync();
+		const pre = root().querySelector('.lightbox-text-plain');
+		expect(pre).not.toBeNull();
+		// The asterisks and hash survive as CHARACTERS — the assertion that the
+		// markdown pipeline did not touch this path.
+		expect(pre!.textContent).toBe('# not a heading\n*not emphasis*');
+		expect(pre!.querySelector('h1')).toBeNull();
+		expect(pre!.querySelector('em')).toBeNull();
+	});
+
+	it('SANITIZES a document carrying active content', async () => {
+		textFetch.mockResolvedValue({
+			ok: true,
+			status: 200,
+			body: null,
+			text: async () => 'before\n\n<script>window.__pwned = true;</script>\n\n<img src=x onerror="window.__pwned = true">\n\nafter'
+		});
+		mountViewer({ images: [image(IMG_A, 'evil.md', 'text/markdown')] });
+		await settleAsync();
+		const body = root().querySelector('.lightbox-text-body');
+		expect(body).not.toBeNull();
+		// Assert what the WRONG behaviour would leave behind (CONVE-12), not just
+		// that the page looks fine: no script element, and no inline handler.
+		expect(body!.querySelector('script')).toBeNull();
+		expect(body!.innerHTML).not.toContain('onerror');
+		expect((window as unknown as { __pwned?: boolean }).__pwned).toBeUndefined();
+		// ...and the surrounding document still rendered, so this is sanitization
+		// rather than the arm having failed to render at all.
+		expect(body!.textContent).toContain('before');
+		expect(body!.textContent).toContain('after');
+	});
+
+	// Also a guard rather than a discriminator: PDF stayed on the fallback before
+	// this branch too. It pins that widening the union did not accidentally claim
+	// PLAN-2393's reserved slot.
+	it('does not FETCH for a type the arm does not claim (PDF stays on the fallback)', async () => {
+		mountViewer({ images: [image(IMG_A, 'doc.pdf', 'application/pdf')] });
+		await settleAsync();
+		expect(root().querySelector('.lightbox-text')).toBeNull();
+		expect(root().querySelector('.lightbox-fallback')).not.toBeNull();
+		expect(textFetch).not.toHaveBeenCalled();
+	});
+
+	it('keeps the force-download bucket on the fallback arm, with no request', async () => {
+		// PLAN-2393 DR-6, asserted through the COMPONENT rather than the predicate:
+		// these share CategoryText with markdown server-side.
+		//
+		// Like its sibling in surfaceRenderers.test.ts, this passes against
+		// origin/main as well (codex R3 #5) — the old viewer already showed the
+		// fallback and made no request. Kept as a regression guard on the arm
+		// selection, labelled so nobody counts it as proof of the new behaviour.
+		for (const mime of ['text/html', 'text/javascript']) {
+			mountViewer({ images: [image(IMG_A, 'x', mime)] });
+			await settleAsync();
+			expect(root().querySelector('.lightbox-text')).toBeNull();
+			expect(root().querySelector('.lightbox-fallback')).not.toBeNull();
+		}
+		expect(textFetch).not.toHaveBeenCalled();
+	});
+
+	it('shows the too-large notice, and no Retry, for an oversize document', async () => {
+		const big = { ...image(IMG_A, 'huge.md', 'text/markdown'), size_bytes: 4 << 20 };
+		mountViewer({ images: [big] });
+		await settleAsync();
+		const status = root().querySelector('.lightbox-text .lightbox-text-status');
+		expect(status?.textContent).toContain('too large to preview');
+		// Terminal, not an error: a retry would reach the same answer, so the arm
+		// points at Download instead of offering one.
+		expect(root().querySelector('.lightbox-text .lightbox-retry')).toBeNull();
+		expect(textFetch).not.toHaveBeenCalled();
+	});
+
+	// ── codex R1 regressions ──────────────────────────────────────────────────
+
+	it('re-decides on a LATE resolved size, cutting the transfer short (R1 #1)', async () => {
+		// Most producers seed `size_bytes: null` and let the metadata HEAD fill it,
+		// so the arm necessarily starts fetching before the size is known — the
+		// response gate is what bounds it in the meantime.
+		//
+		// THE HONEST LIMIT, and the reason this test says "cuts short" rather than
+		// "never fetches": the metadata gate can only SAVE a transfer when the size
+		// is known before the load. For a null seed it cannot, and no amount of
+		// wiring changes that without making every text preview wait for a HEAD.
+		// What the fix buys is the re-decision: `resolvedSize` is in `loadKey`, so
+		// the late size re-runs the load effect, the loader aborts what is in
+		// flight and lands in `too-large`. Before the fix the late size was never
+		// consulted at all and a 4 MB document rendered.
+		const signals: AbortSignal[] = [];
+		textFetch.mockImplementation((_url: string, init: RequestInit) => {
+			signals.push(init.signal as AbortSignal);
+			return new Promise<Response>(() => {});
+		});
+		// BOTH probes: the opened entry is force-REVALIDATED (T6), so leaving
+		// `metaRevalidate` at the beforeEach size would overwrite the big one and
+		// this test would silently assert nothing.
+		metaFetch.mockResolvedValue({ status: 'ok', mime: 'text/markdown', size: 4 << 20 });
+		metaRevalidate.mockResolvedValue({ status: 'ok', mime: 'text/markdown', size: 4 << 20 });
+		mountViewer({ images: [image(IMG_A, 'huge.md', 'text/markdown')] });
+		await settleAsync();
+
+		expect(root().querySelector('.lightbox-text-status')?.textContent).toContain(
+			'too large to preview'
+		);
+		// Assert what the WRONG behaviour leaves behind (CONVE-12): a request still
+		// running. The end state "too-large is showing" is reachable with the abort
+		// removed, so the signal is the discriminating artifact.
+		expect(signals.length).toBe(1);
+		expect(signals[0].aborted).toBe(true);
+	});
+
+	// WHAT THIS SUITE CAN AND CANNOT DECIDE, stated because two of codex R1's
+	// findings are CSS-mechanism findings and a test that cannot see CSS would
+	// report the jsdom default and call it a pass. `getComputedStyle` here returns
+	// `pointer-events: auto` for EVERY element — component styles are not injected
+	// in this environment — so asserting the layer's `pointer-events: none` would
+	// have been an instrument that cannot fail. It is not written.
+	//
+	// So: the wheel exclusion (a HANDLER change) is asserted here, with a control
+	// leg. The pointer-events and overscroll guarantees (CSS) are asserted in
+	// `web/e2e/attachment-text-preview.spec.ts`, where a real engine applies them.
+	// This file's coverage of R1 #3/#4 is the structure the CSS keys off, and no
+	// more than that.
+
+	it('leaves the wheel to the CARD, while still owning it everywhere else (R1 #3)', async () => {
+		mountViewer({ images: [image(IMG_A, 'notes.md', 'text/markdown')] });
+		await settleAsync();
+		const card = root().querySelector<HTMLElement>('.lightbox-text-scroll');
+		expect(card).not.toBeNull();
+
+		// Over the document: the viewer must NOT consume it, or the card can never
+		// scroll. `preventDefault` before the exclusion is exactly the bug.
+		const overCard = new WheelEvent('wheel', { deltaY: 40, bubbles: true, cancelable: true });
+		card!.dispatchEvent(overCard);
+		expect(overCard.defaultPrevented).toBe(false);
+
+		// THE CONTROL LEG: a wheel elsewhere on the stage is still consumed, so the
+		// exclusion is narrow rather than a handler that stopped acting. Without
+		// this, deleting the whole wheel handler would pass the assertion above.
+		const overStage = new WheelEvent('wheel', { deltaY: 40, bubbles: true, cancelable: true });
+		root().dispatchEvent(overStage);
+		expect(overStage.defaultPrevented).toBe(true);
+	});
+
+	it('puts the interactive card INSIDE a layer that is not itself the target (R1 #4)', async () => {
+		const onClose = vi.fn();
+		mountViewer({ images: [image(IMG_A, 'notes.md', 'text/markdown')], onClose });
+		await settleAsync();
+		const layer = root().querySelector<HTMLElement>('.lightbox-text');
+		const card = layer?.querySelector<HTMLElement>('.lightbox-text-scroll');
+		// The structure the `pointer-events` rule keys off: a full-bleed layer that
+		// takes no pointer events, with the interactive surface nested inside it.
+		// The rule itself is asserted in e2e; this pins that the two elements exist
+		// and are nested, which is what makes the rule expressible at all.
+		expect(layer).not.toBeNull();
+		expect(card).not.toBeNull();
+		expect(card!.parentElement).toBe(layer);
+
+		// NO CLICK ASSERTION HERE, deliberately (codex R2 #6). Dispatching a click
+		// on `root()` FORCES `event.target === root`, which is the condition the
+		// close handler tests — so it passes just as happily with the old
+		// interactive full-bleed layer in place. jsdom does no hit-testing, so
+		// there is no way to ask it "what would a click at these coordinates
+		// hit?", and a test that cannot distinguish the bug from the fix is worse
+		// than no test: it reads as coverage.
+		//
+		// The real assertion lives in `web/e2e/attachment-text-preview.spec.ts`,
+		// which clicks REAL COORDINATES over the layer and expects the dialog to
+		// go. That leg was mutation-checked: reverting the layer to
+		// `pointer-events: auto` and rebuilding makes it fail.
+		void onClose;
+	});
+
+	it('the scrollable card is a KEYBOARD destination, inside the focus trap', async () => {
+		mountViewer({ images: [image(IMG_A, 'notes.md', 'text/markdown')] });
+		await settleAsync();
+		const card = root().querySelector<HTMLElement>('.lightbox-text-scroll')!;
+		expect(card.getAttribute('tabindex')).toBe('0');
+		// It must be a real trap stop, not merely focusable: the viewer's arrow
+		// keys are its own next/previous navigation, so a keyboard-only user with
+		// no tab stop here cannot reach past the document's first screen at all.
+		expect(paneFocusables(root()).includes(card)).toBe(true);
+		// And it carries a name, since a bare scroll region announces nothing.
+		expect(card.getAttribute('aria-label')).toBeTruthy();
+	});
+
+	it('offers a retry when the fetch fails', async () => {
+		textFetch.mockResolvedValue({ ok: false, status: 500, body: null, text: async () => '' });
+		mountViewer({ images: [image(IMG_A, 'notes.md', 'text/markdown')] });
+		await settleAsync();
+		expect(root().querySelector('.lightbox-text .lightbox-retry')).not.toBeNull();
+	});
+});

--- a/web/src/lib/components/layout/Sidebar.svelte
+++ b/web/src/lib/components/layout/Sidebar.svelte
@@ -6,6 +6,7 @@
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
 	import { collectionStore } from '$lib/stores/collections.svelte';
 	import { uiStore } from '$lib/stores/ui.svelte';
+	import { GITHUB_REPO_URL } from '$lib/brand/links';
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { goto } from '$app/navigation';
 	import { api, isPlanLimitError, planLimitMessage } from '$lib/api/client';
@@ -647,6 +648,30 @@
 						</svg>
 					{/if}
 				</button>
+				<!--
+					THE REPO LINK (IDEA-2711 / GitHub #1168). A running instance had no
+					visible connection to the project it is — the only in-app link lived
+					inside the user-menu dropdown, so people went to a search engine
+					instead, which is what the issue reports. Icon-only here to match the
+					collapse / theme / bell controls it sits beside; the accessible name
+					carries the destination, since the mark alone does not.
+
+					The URL comes from `$lib/brand/links`, not a literal: it was already
+					written twice in UserMenuResources and a third copy is how a rename
+					goes half-applied.
+				-->
+				<a
+					class="github-btn"
+					href={GITHUB_REPO_URL}
+					target="_blank"
+					rel="noopener noreferrer"
+					title="Pad on GitHub"
+					aria-label="Pad on GitHub (opens in a new tab)"
+				>
+					<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+						<path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/>
+					</svg>
+				</a>
 				<button
 					class="bell-btn"
 					onclick={() => { notificationPanelOpen = !notificationPanelOpen; }}
@@ -1196,6 +1221,18 @@
 		text-decoration: none;
 	}
 	.settings-btn:hover { background: var(--bg-hover); color: var(--text-secondary); text-decoration: none; }
+	/* IDEA-2711: sized and coloured off the sibling icon controls in this row so
+	   the mark reads as one of them rather than as content. */
+	.github-btn {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		padding: var(--space-2);
+		border-radius: var(--radius);
+		color: var(--text-muted);
+		text-decoration: none;
+	}
+	.github-btn:hover { background: var(--bg-hover); color: var(--text-secondary); text-decoration: none; }
 	.version-label {
 		display: block;
 		text-align: center;

--- a/web/src/lib/components/layout/Sidebar.svelte.test.ts
+++ b/web/src/lib/components/layout/Sidebar.svelte.test.ts
@@ -70,6 +70,9 @@ vi.mock('$lib/api/client', () => ({
 import Sidebar from './Sidebar.svelte';
 import { uiStore } from '$lib/stores/ui.svelte';
 import { acquire, __resetViewerBackdropForTests } from '$lib/a11y/viewerBackdrop';
+import { GITHUB_REPO_URL } from '$lib/brand/links';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 function aside(): HTMLElement {
 	const el = document.querySelector('aside.sidebar');
@@ -237,5 +240,75 @@ describe('Sidebar — mobile left-edge swipe-to-open (TASK-2430)', () => {
 		acquire(mountViewer());
 		window.dispatchEvent(touch('touchmove', 200, 300, document.body));
 		expect(uiStore.sidebarOpen).toBe(false);
+	});
+});
+
+// ── THE REPO LINK (IDEA-2711 / GitHub #1168) ────────────────────────────────
+//
+// CONVE-19 again, in its cheapest form: the constant is trivially correct on
+// its own, so what is worth asserting is the BINDING — that the anchor is
+// actually in the rendered footer and carries the external-link attributes.
+//
+// WHAT THE DOM TEST CANNOT SEE (codex R3 #6): comparing the rendered href to
+// the imported constant passes identically for a component that hardcoded the
+// same string, because both sides end up as the same characters. That
+// assertion pins the VALUE, not the source of it — and "points at the shared
+// constant rather than a literal someone retyped" was an overstatement of what
+// it proves. The single-source property is a SOURCE property, so the last test
+// below reads the source and asserts the literal is absent from the consumers.
+// That is the one a re-duplication actually fails.
+describe('sidebar — GitHub repo link', () => {
+	function githubLink(): HTMLAnchorElement {
+		const el = aside().querySelector<HTMLAnchorElement>('.sidebar-footer a.github-btn');
+		if (!el) throw new Error('github link not found in the sidebar footer');
+		return el;
+	}
+
+	it('renders in the footer, at the repo URL', () => {
+		expect(githubLink().getAttribute('href')).toBe(GITHUB_REPO_URL);
+	});
+
+	it('opens off-property safely', () => {
+		const a = githubLink();
+		expect(a.getAttribute('target')).toBe('_blank');
+		// `noopener` is the load-bearing half — without it the opened tab gets a
+		// handle on this one via `window.opener`.
+		const rel = (a.getAttribute('rel') ?? '').split(/\s+/);
+		expect(rel).toContain('noopener');
+		expect(rel).toContain('noreferrer');
+	});
+
+	it('has an accessible name, since the mark alone carries none', () => {
+		const a = githubLink();
+		expect(a.getAttribute('aria-label')).toContain('GitHub');
+		// The SVG must not be announced separately.
+		expect(a.querySelector('svg')?.getAttribute('aria-hidden')).toBe('true');
+	});
+
+	it('the URL literal lives ONLY in the shared module', () => {
+		// The single-source property the DOM test cannot decide. A component that
+		// re-hardcoded the same string renders an identical href and passes every
+		// assertion above; it fails this one.
+		//
+		// Deliberately narrow: it names the two consumers rather than sweeping the
+		// tree, so it cannot fail for an unrelated file (a doc, a fixture, a
+		// changelog entry legitimately quoting the URL) and cannot quietly stop
+		// covering them by drifting into a glob that no longer matches.
+		// `process.cwd()` is `web/` under vitest (the config's root); resolving
+		// from `import.meta.url` is unavailable here because vitest serves the
+		// module over a non-file URL.
+		const root = process.cwd();
+		for (const rel of [
+			'src/lib/components/layout/Sidebar.svelte',
+			'src/lib/components/layout/UserMenuResources.svelte'
+		]) {
+			const source = readFileSync(join(root, rel), 'utf8');
+			expect(source, `${rel} hardcodes the repo URL`).not.toContain(
+				'github.com/PerpetualSoftware/pad'
+			);
+			// ...and it does reference the constant, so the absence above is
+			// "imported from the module", not "the link was deleted".
+			expect(source).toContain('GITHUB_REPO_URL');
+		}
 	});
 });

--- a/web/src/lib/components/layout/UserMenuResources.svelte
+++ b/web/src/lib/components/layout/UserMenuResources.svelte
@@ -23,6 +23,14 @@
 	// (external-link convention). Companion to AuthHeader/AuthFooter/+error
 	// from PLAN-900.
 
+	import {
+		CHANGELOG_URL,
+		DOCS_URL,
+		GITHUB_REPO_URL,
+		STATUS_URL,
+		SUPPORT_MAILTO
+	} from '$lib/brand/links';
+
 	let {
 		cloudMode = false,
 		onclose
@@ -50,11 +58,11 @@
 	// footer means a user visiting both surfaces sees the same linear pattern
 	// — small cohesion win that Codex flagged on first review.
 	const cloudLinks: ResourceLink[] = [
-		{ label: 'GitHub', href: 'https://github.com/PerpetualSoftware/pad' },
-		{ label: 'Docs', href: 'https://getpad.dev/docs' },
-		{ label: 'Changelog', href: 'https://getpad.dev/changelog' },
-		{ label: 'Status', href: 'https://status.getpad.dev' },
-		{ label: 'Support', href: 'mailto:support@getpad.dev' }
+		{ label: 'GitHub', href: GITHUB_REPO_URL },
+		{ label: 'Docs', href: DOCS_URL },
+		{ label: 'Changelog', href: CHANGELOG_URL },
+		{ label: 'Status', href: STATUS_URL },
+		{ label: 'Support', href: SUPPORT_MAILTO }
 	];
 
 	// Self-hosted is a subset that preserves the relative canonical order —
@@ -62,8 +70,8 @@
 	// (operators have their own changelog/status if any; getpad.dev's
 	// support@ mailbox is not theirs to direct people to).
 	const selfHostedLinks: ResourceLink[] = [
-		{ label: 'GitHub', href: 'https://github.com/PerpetualSoftware/pad' },
-		{ label: 'Docs', href: 'https://getpad.dev/docs' }
+		{ label: 'GitHub', href: GITHUB_REPO_URL },
+		{ label: 'Docs', href: DOCS_URL }
 	];
 
 	const links = $derived(cloudMode ? cloudLinks : selfHostedLinks);

--- a/web/src/lib/utils/markdown.documentIsolation.svelte.test.ts
+++ b/web/src/lib/utils/markdown.documentIsolation.svelte.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { renderMarkdownDocument, renderMarkedWithAttachments } from './markdown';
+
+/**
+ * `renderMarkdownDocument`'s ISOLATION contract (IDEA-2712, codex R3 #3).
+ *
+ * jsdom, because the function ends in `sanitizeMarkdownHtml`, which needs a
+ * window and returns '' without one.
+ *
+ * The attachment context this module threads through `marked` is MODULE-LEVEL
+ * state. `renderMarkdownDocument` renders a FOREIGN document — a file attached
+ * to an item, authored elsewhere — so it must resolve none of that document's
+ * `pad-attachment:` references against whatever workspace happens to be
+ * rendering it. Leaving the context alone is not enough: a nested call inherits
+ * the outer one.
+ *
+ * The nesting is reachable, not theoretical — a resolver or a `missing` hook is
+ * caller-supplied and may itself render markdown, which is exactly why
+ * `renderMarkedWithAttachments` already saves and restores rather than clearing
+ * to null.
+ */
+
+const UUID = '01234567-89ab-cdef-0123-456789abcdef';
+const ATTACHMENT_MD = `![diagram](pad-attachment:${UUID})`;
+
+describe('renderMarkdownDocument — context isolation', () => {
+	it('does NOT inherit an outer attachment context', () => {
+		let inner = '';
+		// The outer render installs a context whose resolver would happily
+		// resolve the UUID against `outer-ws`; from inside it, the document
+		// renderer runs.
+		renderMarkedWithAttachments(ATTACHMENT_MD, {
+			resolver: (id) => {
+				inner = renderMarkdownDocument(ATTACHMENT_MD);
+				return {
+					id,
+					mime_type: 'image/png',
+					filename: 'outer.png',
+					size_bytes: 10,
+					width: 1,
+					height: 1
+				};
+			},
+			workspaceSlug: 'outer-ws'
+		});
+
+		// The discriminating artifact: the OUTER workspace's URL. If the inner
+		// call inherited the context it would have resolved the reference and
+		// emitted `/api/v1/workspaces/outer-ws/attachments/<uuid>` — a live link
+		// into a workspace the attached document knows nothing about.
+		expect(inner).not.toContain('outer-ws');
+		expect(inner).not.toContain('/api/v1/workspaces/');
+		// It rendered SOMETHING (the paragraph wrapper), so the assertion above
+		// is isolation rather than the call having failed outright.
+		expect(inner).toContain('<p>');
+	});
+
+	it('RESTORES the outer context afterwards', () => {
+		// Clearing without restoring would be the opposite bug: the outer
+		// document's remaining references would stop resolving mid-parse.
+		let sawInner = false;
+		const html = renderMarkedWithAttachments(
+			`${ATTACHMENT_MD}\n\n![second](pad-attachment:${UUID})`,
+			{
+				resolver: (id) => {
+					if (!sawInner) {
+						sawInner = true;
+						renderMarkdownDocument('# nested');
+					}
+					return {
+						id,
+						mime_type: 'image/png',
+						filename: 'outer.png',
+						size_bytes: 10,
+						width: 1,
+						height: 1
+					};
+				},
+				workspaceSlug: 'outer-ws'
+			}
+		);
+
+		expect(sawInner).toBe(true);
+		// BOTH outer references still resolved — the second one is the one a
+		// non-restoring implementation would strand.
+		const matches = html.match(/\/api\/v1\/workspaces\/outer-ws\//g) ?? [];
+		expect(matches.length).toBe(2);
+	});
+
+	it('drops an unresolvable pad-attachment reference rather than linking it', () => {
+		// The behaviour the doc comment now states, asserted instead of guessed:
+		// with no context, marked emits `<img src="pad-attachment:…">` and
+		// DOMPurify does not know that scheme, so the src is removed.
+		const html = renderMarkdownDocument(ATTACHMENT_MD);
+		expect(html).not.toContain('pad-attachment:');
+	});
+});

--- a/web/src/lib/utils/markdown.ts
+++ b/web/src/lib/utils/markdown.ts
@@ -497,6 +497,58 @@ export function renderMarkedWithAttachments(
 	}
 }
 
+/**
+ * Render a STANDALONE markdown document through the shared `marked` pipeline,
+ * sanitized (IDEA-2712 / GitHub #1169). The attachment-preview entry point.
+ *
+ * A third thin wrapper in FRONT of the one pipeline, for the same reason
+ * {@link renderMarkedWithAttachments} is the second: a surface with different
+ * needs gets a wrapper, never a second renderer. Two markdown pipelines
+ * disagreeing about one format is the failure this shape exists to prevent.
+ *
+ * WHAT IT DELIBERATELY OMITS, and why the omissions are the point:
+ *
+ *  - **No wiki-link resolution.** An attached `.md` was authored somewhere
+ *    else, so its `[[brackets]]` are not references into whatever workspace
+ *    happens to be showing it. Resolving them would silently retarget a
+ *    foreign document's links at local items — the same hazard BUG-2830
+ *    closed from the rename direction, entered through the front door. They
+ *    stay inert text, the posture the public share route already takes.
+ *  - **No attachment context.** A `pad-attachment:` href inside an attached
+ *    document is not ours to resolve either. The context is CLEARED for the
+ *    duration rather than merely left alone (codex R3): this module's context
+ *    is module-level state, so a call nested inside another render — an
+ *    attachment resolver or a `missing` hook that itself renders markdown —
+ *    would otherwise inherit the OUTER document's workspace and resolver, and
+ *    quietly resolve a foreign file's references against them. Save, clear,
+ *    restore, mirroring {@link renderMarkedWithAttachments}'s save/restore for
+ *    the same reason it does it.
+ *
+ *    With no context installed, a `pad-attachment:` image href falls through to
+ *    marked's default `<img src="pad-attachment:…">`, which `sanitizeMarkdownHtml`
+ *    then DROPS — DOMPurify's URL policy does not know that scheme. So the
+ *    reference disappears rather than rendering as a broken-image icon; either
+ *    way nothing resolves, but the earlier comment here said "broken image" and
+ *    that was a guess about the sanitizer's behaviour, not a reading of it.
+ *
+ * Sanitization is INHERITED, not re-derived: the same `sanitizeMarkdownHtml`
+ * pass every other `{@html}` source in the app goes through, so the tag and
+ * attribute allowlist for an attached document is by construction the one
+ * that governs item content.
+ */
+export function renderMarkdownDocument(content: string): string {
+	// Save/restore rather than assume none is installed — see the doc comment.
+	// Synchronous by contract, like the sibling wrapper: `marked` is not
+	// configured async here, so the `finally` cannot be outlived.
+	const prev = currentAttachmentCtx;
+	currentAttachmentCtx = null;
+	try {
+		return sanitizeMarkdownHtml(marked(content) as string);
+	} finally {
+		currentAttachmentCtx = prev;
+	}
+}
+
 export function wordCount(content: string): number {
 	return content.trim().split(/\s+/).filter(w => w.length > 0).length;
 }


### PR DESCRIPTION
Preview markdown and plain-text attachments in the viewer, and surface the repo link in the nav.

Closes #1169
Closes #1168

## #1169 — the gap was a missing predicate, not a wrong one

`web/src/lib/attachments/display.ts` already carried two preview predicates, each with a PLAN-2392 decision record, and **neither was wrong**:

- `canOpenInViewer` (DR-16) — may the in-app IMAGE viewer decode this? A five-MIME raster allowlist, deliberately not an `image/` prefix test.
- `canBrowserPreview` (DR-5) — may the BROWSER be handed this in a new tab? Its comment excludes markdown in as many words, and for `.md` that answer stays correct: browsers download it.

Widening DR-5 to reach this issue would have routed markdown to the Open-in-new-tab action (`actions.ts:182`) and reproduced the exact download-instead-of-render behaviour #1169 reports — a fix presenting as having done nothing. So this adds a THIRD predicate, `canPreviewAsText`, answering the only question the issue asks: do *we* fetch the bytes and render them ourselves.

**`canBrowserPreview` and its tests are untouched.** That is the evidence that nothing widened, rather than a claim that nothing did.

### Sanitization posture (stated rather than re-derived, per the reuse constraint)

Rendering goes through `renderMarkdownDocument`, a third thin wrapper in FRONT of the shared `marked` pipeline — following `renderMarkedWithAttachments`'s precedent (added for the share route), never a second renderer. It ends in the same `sanitizeMarkdownHtml` pass every other `{@html}` source in the app uses, so **the tag/attribute allowlist governing an attached document is by construction the one governing item content.** No new sanitizer, no new allowlist, no second policy to keep in sync.

Plain text does not go through the pipeline at all: a `.txt` renders in a `<pre>` as text, because interpreting a plain-text file's asterisks as formatting misrepresents it. Svelte escapes that interpolation, so the path emits no HTML.

### PLAN-2393 DR-6, and the trap next to it

DR-6 says never inline a `RenderForceDownload` type. Reading `internal/attachments/mime.go` rather than assuming where markdown lands:

- `text/markdown` is `RenderChip` + **`CategoryText`**.
- The force-download bucket is `text/html`, `text/javascript`, `application/javascript` — **also `CategoryText`**.

So **category is not a safe selector**: it contains the XSS bucket. `canPreviewAsText` is a MIME allowlist, excluding those three by construction rather than by anyone remembering. Tests assert all three stay on the fallback arm with no request issued.

Separately: `text/markdown` is served `Content-Disposition: attachment`, and that is fine. The disposition governs what a top-level navigation does; it does not impede `fetch()`, and it is not what makes this safe. Safety comes from the allowlist plus sanitization.

### The declared mirror, deliberately not joined

`inlineSafe`'s comment in `mime.go` declares itself the server mirror of the client's `VIEWER_MIMES` + `BROWSER_PREVIEW_MIMES`. `TEXT_PREVIEW_MIMES` is deliberately OUTSIDE that pair and says so at the site — we never ask the browser to inline these bytes. Keeping it out of the mirror is what lets markdown preview in-app while still being served as an attachment. **`internal/attachments/mime.go` is unchanged by this PR**, which is worth stating explicitly for a declared-lock-step pair where one half moved.

### Scope, with its boundary

`text/markdown` + `text/plain` only. `text/csv`, `text/tab-separated-values`, JSON, XML, YAML and TOML are all allowlisted uploads and all renderable as raw text — and all left out, because each has an obviously better rendering (a table; syntax highlighting) this PR does not build, and shipping them raw now would make that later rendering a REGRESSION. Tests pin the exclusions with that reason at the site.

### The size cap, with its receipt

`TEXT_PREVIEW_MAX_BYTES = 1 MiB`. No existing bound was available to reuse on the read path (`defaultAttachmentMaxBytes` is a 25 MiB UPLOAD bound), so this is the first, and the number is measured rather than picked:

| sample | n | p50 | p90 | max |
|---|---|---|---|---|
| `*.md` in this repo | 25 | 3.6 KB | 42 KB | 82 KB |
| `docs` item bodies, a real workspace | 63 | 5.0 KB | 12.6 KB | 23 KB |

~12x the largest document observed, comfortably under the 25 MiB upload bound so it has a live range to act in, and it errs toward RENDERING — the cap is for a log renamed `.md`, not for enforcing taste about length. The comment records what it does not cover (a small file that is expensive to render anyway) and says the fix for that would be a render-time budget, not a smaller byte cap.

**Two size gates, neither subsuming the other.** The metadata gate refuses before any request. The response gate bounds bytes actually read, and exists because `LightboxImage.size_bytes` is `number | null` **by declaration** — an emitter knows only what its own surface gave it — so the metadata gate passes vacuously for any entry that arrived without a size. Each has its own killing test naming the hole it covers.

### The change most likely to break something, called out

The fallback arm's condition was `shownRenderer !== 'raster-image'`. That was correct while the renderer union had one member, and would have drawn "No preview available" over every text document the moment it had two. It is now `shownRenderer === null` — the registry's actual "no renderer claims this" answer — which says what it means and stays correct when `'pdf'` lands. **A test asserts the fallback's ABSENCE for a markdown entry**, because asserting only the text arm's presence passes on the broken condition too (the arm still mounts; the fallback just paints over it).

## #1168 — a discoverability fix, not a new link

The repo link already existed, buried in the user-menu dropdown under Resources, which is why the reporter went to a search engine. This surfaces it in the sidebar footer beside the collapse / theme / bell controls. Icon-only, with an `aria-label` naming the destination and the new tab (the mark carries no accessible name) and `aria-hidden` on the SVG.

`$lib/brand/links.ts` exists because the URL was already written twice in `UserMenuResources` and this would have been the third copy.

## Verification

- `vitest`: **1965 passed, 114 files** (up from 1954 — 31 new).
- `svelte-check`: **0 errors** (6 warnings, all pre-existing, none in touched files).
- `vite build`: green.
- No Go files touched; the diff is `web/` only.

**Mutation matrices, both run against a committed tree:**

Loader — 10 mutants, all killed. One (`retry`'s `phase !== 'error'`) SURVIVED the first pass; checking faithfulness first showed the mutant was faithful and the guard untested for the `loading` case, where it is the only thing preventing two concurrent requests for one entry. Two tests added; it now dies.

Wiring — 6 mutants, all killed, including the fallback-condition revert above (1 failure), sanitization removed (1), markdown routed to the plain `<pre>` (2), and the text arm never mounted (6).


---

## Review round 1 (codex) — four findings, all real, plus one the review did not ask for

Codex read the diff and returned four defects. All four were confirmed by reading the sites rather than by trusting the report, and all four are fixed.

| # | finding | disposition |
|---|---|---|
| 1 | the metadata size gate was fed the SEED size, which most producers leave null | fixed — `resolvedSize` reaches the loader and joins `loadKey` |
| 2 | `readBounded`'s non-streaming fallback measures after buffering | prose fix — the claim was overstated, the code is right for its audience |
| 3 | the wheel handler consumed every wheel before its exclusions, so the card could never scroll | fixed — the exclusion returns BEFORE `preventDefault` |
| 4 | the full-bleed layer took `pointer-events: auto`, breaking backdrop-close for this arm | fixed — the layer is inert, the CARD is interactive |

#1's fix has an honest limit now written where the constant is declared: the cap always bounds what is RENDERED, but it saves the TRANSFER only when the size is known before the load. For a null seed it cannot, and the test says "cuts the transfer short" (asserting an ABORTED signal) rather than "never fetches", because the latter would be false.

#3 and #4 were both comments that were FALSE about the code — the arm claimed to be "scrollable and selectable" and claimed backdrop-click still worked, and neither was true. That is the class this repo's CONVE-23 exists for, arriving through my own new prose rather than someone else's old prose.

## And then the e2e found that the feature did not work at all

Three of the arm's guarantees are CSS mechanisms, and the jsdom unit environment does not inject component styles — `getComputedStyle` returns the engine default for every element, so two assertions written for #3/#4 could not fail and were deleted. Their guarantees moved to `web/e2e/attachment-text-preview.spec.ts`.

The first time that spec ran, the markdown rendered as **raw source**.

`attachments.ValidateUpload` sniffs uploaded bytes with `http.DetectContentType`, which answers `text/plain` for prose, and returns the SNIFFED entry. The filename extension is consulted only to REJECT a mismatch, and `.md` → `text/markdown` shares `CategoryText` with `text/plain`, so nothing rejects. Measured:

```
ValidateUpload([]byte("# Preview heading\n..."), "preview.md")
  -> mime="text/plain" category="text" code="" err=<nil>
```

**So `text/markdown` never appears in a row created by an upload**, and the md-vs-plain split — which tested `mime === 'text/markdown'` — was a branch that could not fire for the files this feature exists for. Every unit test passed because every fixture hand-set the MIME it expected.

Fixed on the client: `isMarkdownAttachment(mime, filename)` keeps the MIME check first (an explicitly-typed row is honoured whatever it is named) and falls back to the extension, GATED on the MIME already being in the text-preview set so a filename can never widen what previews. Tests pin that a `.md` name on an HTML, JS or PDF row stays false. A unit test with the real shape — `text/plain` bytes, `.md` filename — now exists and fails against the previous commit.

The server-side question is filed separately as **BUG-2841** rather than taken here: changing `ValidateUpload` to prefer the extension's type would alter the stored MIME for every future `.md`/`.csv`/`.json`/`.yaml` upload and flip `ServeInline`'s answer for them, which is wider than a frontend unit should decide alone. Existing rows keep the old value under any fix, so consumers need to be extension-aware regardless.

## Verification, re-measured at `b8d8c6e5`

- `vitest`: **1973 passed, 114 files**.
- `svelte-check`: **0 errors** (6 warnings, all pre-existing, none in touched files).
- `vite build`: green.
- **e2e `attachment-text-preview.spec.ts`: 4 passed** in desktop-chromium, against a binary built from this tree.
- The backdrop leg was mutation-checked end to end — layer reverted to `pointer-events: auto`, web and binary rebuilt, spec re-run, and it fails. It is an instrument, not a decoration.


---

## Rounds 2 and 3 (codex) — thirteen more findings

**R2, seven.** Three code defects: `resolvedSize` was in the SHARED load key under a comment calling it "inert for the raster arm, which does not read it" — the arm does not read it, the EFFECT does, so a late metadata fill restarted image loads and, on mobile, reset an already-triggered original; `touch-action` INTERSECTS down the ancestor chain, so the card's `pan-y` could never beat the stage's `none` and a phone could not scroll the document at all; and response-derived overflow echoed the DECLARED size, rendering "This file is 10 B — too large to preview" for an under-declaring row.

**The other four were tests of mine that could not fail** — a jsdom click dispatched on `root()` (which FORCES `event.target === root`, the very condition the handler tests, so it passed with the bug in place); a selection test using `Range` + `addRange`, which selects under `user-select: none`; a background-scroll assertion reading `window.scrollY` in an app that scrolls `.main-content`; and a test named "REAL .md upload" that was a fully synthetic row. All four rewritten or deleted, with the reason left where each stood.

**R3, six.** Two real interaction defects the diff introduced: the focus-handoff effect tracked `loader.phase` — the IMAGE loader, disposed on this arm — so a text reload unmounted a focused link inside the document and stranded focus outside the modal; and a parent RESTORE bumped `revalidateToken` without touching the text load key, so a preview that 404'd while the parent was archived stayed permanently errored after the restore that fixed it.

One contract defect: `renderMarkdownDocument` did not enforce the "no attachment context" its own doc comment claimed. The context is module-level, so a nested call — from a resolver or a `missing` hook that itself renders markdown — inherited the outer document's workspace and resolver. Now save/clear/restore. Its neighbouring claim that an unresolved reference "renders as a broken image" was also wrong: DOMPurify drops the unknown scheme, so the reference disappears. That was a guess about the sanitizer rather than a reading of it, and it is now asserted.

Three test-honesty findings: the streamed-response fixture also exposed the whole body through `text()`, so an implementation that ignored the stream and buffered everything passed the tests written to forbid exactly that (`text()` now throws, and the fixture reports read count and cancellation so a test can assert the read STOPPED); two assertions pass against `origin/main` as well and are labelled as regression guards rather than counted as evidence; and the sidebar test compared a rendered href to an imported constant, which passes identically for a component that hardcoded the same string — a question about SOURCE that a value comparison cannot decide, now covered by a narrow guard that reads the two consumers.

Also fixed, found by re-reading rather than by review: the scrollable card had no tab stop, so a keyboard-only user could open a document and never reach past its first screen (the viewer's arrow keys are its own navigation, so there was no fallback).

## Instruments

Every assertion that CAN be mutation-checked has been, and watched to fail:

- loader matrix 10/10, wiring matrix 6/6, R1 regressions 2/2
- R3 guards: sidebar re-hardcodes the URL → dies; stream drained-then-measured → dies; context not cleared → **survived**, which was a real gap rather than a weak assertion (nothing covered nested rendering), so isolation tests were added and the mutant now dies along with cleared-but-not-restored and sanitization-removed
- **e2e, end to end** (revert the property, rebuild web + binary, re-run): backdrop `pointer-events` → dies; stage `touch-action` → dies

## Verification at `eb582490`

- `vitest`: **1978 passed, 115 files**
- `svelte-check`: **0 errors**, 6 warnings — the repo's pre-existing count, in 4 files none of which this branch touches
- `vite build`: green
- **e2e `attachment-text-preview.spec.ts`: 4 passed**, desktop-chromium, against a binary built from this tree
- No Go files changed; the diff is `web/` plus one `.gitignore` line
