### PR TITLE
feat(store): enforce the NUL invariant at the driver (DOC-2823 S1)

### DIFF
--- a/internal/server/decode_json_nul_test.go
+++ b/internal/server/decode_json_nul_test.go
@@ -1475,11 +1475,40 @@ func TestBodyDecodesNULAgainstAnIndependentOracle(t *testing.T) {
 		// And its counterpart, where the listed key's value IS a string and
 		// the descent is correct. Both sides must answer TRUE.
 		`{"fields":"{\"k\":\"a` + esc + `b\"}"}`,
-		// A JSON SCALAR under a listed key. Valid JSON, but not a document,
-		// so production does not descend and the escape stays literal text.
-		// Both sides must answer FALSE. The oracle used to say true here.
+		// A JSON SCALAR under a listed key. Both sides must answer TRUE, and
+		// this case CHANGED ANSWER when the shape test was widened — correctly.
+		//
+		// The doubling is at the OUTER level: after the outer decode the fields
+		// value is a 10-character JSON string carrying a LIVE escape, so
+		// descending one layer finds a NUL. It answered FALSE before only
+		// because production refused to descend into scalars at all, and the
+		// old comment explained it as "the escape stays literal text", which
+		// was never the reason (codex round 2).
+		//
+		// Verified against the authority rather than argued, because I first
+		// re-pinned it FALSE from that stale comment and was wrong:
+		//
+		//	fields value after the outer decode: a 10-char JSON string
+		//	SELECT ('"a<escape>b"')::jsonb;
+		//	ERROR:  unsupported Unicode escape sequence
 		`{"fields":"\"a` + doubled + `b\""}`,
+		// The same scalar with a LIVE escape. Both sides must answer TRUE, and
+		// nothing pinned that until now: a bare JSON string is a complete jsonb
+		// document, measured refused by Postgres 17 with "unsupported Unicode
+		// escape sequence".
+		`{"fields":"\"a` + esc + `b\""}`,
 		`{"title":"a control escape that is not a NUL: \\u0001"}`,
+	}
+
+	// Bodies whose answer is known INDEPENDENTLY of either walker, so the test
+	// can catch the two of them agreeing on a wrong answer — which is exactly
+	// what happened before: BUG-2803 round 27 made them agree by narrowing the
+	// oracle, and both were then wrong about scalars for a release (codex
+	// round 2).
+	pinned := map[string]bool{
+		`{"fields":"\"a` + esc + `b\""}`:         true,
+		`{"fields":"\"a` + doubled + `b\""}`:     true,
+		`{"fields":"{\"k\":\"a` + esc + `b\"}"}`: true,
 	}
 
 	var sawTrue, sawFalse bool
@@ -1489,6 +1518,10 @@ func TestBodyDecodesNULAgainstAnIndependentOracle(t *testing.T) {
 		if got != want {
 			t.Errorf("corpus[%d] %s\n  production=%v independent=%v — one of the two walkers is "+
 				"wrong; read both before assuming it is the oracle", i, body, got, want)
+		}
+		if expected, ok := pinned[body]; ok && got != expected {
+			t.Errorf("corpus[%d] %s\n  both walkers answer %v, but the correct answer is %v — "+
+				"agreement is not correctness", i, body, got, expected)
 		}
 		if want {
 			sawTrue = true

--- a/internal/server/decode_json_nul_test.go
+++ b/internal/server/decode_json_nul_test.go
@@ -1376,18 +1376,33 @@ func independentDecodesNUL(t *testing.T, raw []byte) bool {
 							if !strings.EqualFold(k, listed) {
 								continue
 							}
-							// Production only descends into a DOCUMENT — a
-							// string whose trimmed form starts with "{" or
-							// "[" (stringIsJSONDocument). A JSON scalar such
-							// as "\"a<escape>b\"" is valid JSON and is NOT a
-							// document, so production leaves it alone. The
-							// oracle unmarshalled anything valid and so said
-							// true where production said false (codex round
-							// 27) — closer to production is not the same as
-							// identical, and only identical is a usable
-							// oracle.
+							// ANY valid JSON document, scalars included.
+							//
+							// This was narrowed to objects and arrays in
+							// BUG-2803 codex round 27, to make the oracle
+							// agree with production. The disagreement was
+							// real; the direction of the fix was not. Nobody
+							// measured which walker matched POSTGRES, and the
+							// answer is that the oracle's original wider rule
+							// did:
+							//
+							//	SELECT ('"a<escape>b"')::jsonb;
+							//	ERROR:  unsupported Unicode escape sequence
+							//
+							// measured on Postgres 17 during DOC-2823 S1. A
+							// bare JSON string is a complete jsonb document;
+							// it is refused there and was stored on SQLite,
+							// which is the dialect split the S1 guard exists
+							// to close. Production was widened to match, and
+							// this oracle is restored to what it always said.
+							//
+							// The lesson worth keeping: two implementations
+							// made to agree are not thereby correct. Round 27
+							// had two walkers and no authority, so agreement
+							// was the only available test and it picked the
+							// wrong survivor.
 							trimmed := strings.TrimSpace(sv)
-							if trimmed == "" || (trimmed[0] != '{' && trimmed[0] != '[') {
+							if trimmed == "" {
 								break
 							}
 							var inner any

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -796,6 +796,13 @@ func (s *Server) createItemChecked(r *http.Request, workspaceID string, coll *mo
 		if errors.As(err, &badTitle) {
 			return nil, &itemCreateError{http.StatusBadRequest, "bad_request", badTitle.Reason}
 		}
+		// The NUL refusal, in this path's own envelope (codex round 1). Same
+		// classification as everywhere else, same sentence; only the shape
+		// differs, because createItemChecked returns its error rather than
+		// writing it.
+		if reason, ok := nulRefusalReason(err); ok {
+			return nil, &itemCreateError{http.StatusBadRequest, "bad_request", reason}
+		}
 		if strings.Contains(err.Error(), "UNIQUE constraint") || strings.Contains(err.Error(), "duplicate key") {
 			// Could be the slug-per-workspace constraint OR the playbook
 			// invocation_slug partial unique index (TASK-1378). Keep the

--- a/internal/server/handlers_items_bulk.go
+++ b/internal/server/handlers_items_bulk.go
@@ -392,11 +392,25 @@ func (s *Server) handleBulkItems(w http.ResponseWriter, r *http.Request) {
 // item (for seq) on success, or a structured per-row error.
 // resolvedTarget carries the request-level collection resolution for `move`
 // (nil for every other op), so the per-item path never re-resolves.
+// bulkStoreError wraps a store error as a per-item bulk failure, classifying
+// the NUL refusal so it carries a real code instead of arriving as an
+// unlabelled message (codex round 1, finding 4).
+//
+// A bulk response stays 200 with the item listed under Failed — that is the
+// bulk contract, and a deterministic refusal of ONE item should not fail the
+// other forty-nine. What it should not do is look like an internal fault.
+func bulkStoreError(err error) *bulkOpError {
+	if reason, ok := nulRefusalReason(err); ok {
+		return &bulkOpError{message: reason, code: "bad_request"}
+	}
+	return &bulkOpError{message: err.Error()}
+}
+
 func (s *Server) applyBulkOp(r *http.Request, workspaceID string, item *models.Item, req *bulkItemsRequest, actor, source string, visibleIDs []string, resolvedTarget *models.Collection, batchID string) (*models.Item, *bulkOpError) {
 	switch req.Op {
 	case "archive":
 		if err := s.store.DeleteItem(item.ID, store.WithEventBatch(batchID)); err != nil {
-			return nil, &bulkOpError{message: err.Error()}
+			return nil, bulkStoreError(err)
 		}
 		// DeleteItem bumps seq; re-read so the batch event carries the
 		// post-archive cursor. Falls back to the pre-delete row on a
@@ -420,7 +434,7 @@ func (s *Server) applyBulkOp(r *http.Request, workspaceID string, item *models.I
 					code:    "conflict",
 				}
 			}
-			return nil, &bulkOpError{message: err.Error()}
+			return nil, bulkStoreError(err)
 		}
 		return restored, nil
 
@@ -451,7 +465,7 @@ func (s *Server) applyBulkOp(r *http.Request, workspaceID string, item *models.I
 		}
 		updated, err := s.store.UpdateItem(item.ID, input, store.WithEventBatch(batchID))
 		if err != nil {
-			return nil, &bulkOpError{message: err.Error()}
+			return nil, bulkStoreError(err)
 		}
 		return updated, nil
 	}
@@ -545,7 +559,7 @@ func (s *Server) bulkFieldUpdate(r *http.Request, workspaceID string, item *mode
 				details: raw,
 			}
 		}
-		return nil, &bulkOpError{message: err.Error()}
+		return nil, bulkStoreError(err)
 	}
 	if updated == nil {
 		return nil, &bulkOpError{message: "item not found"}
@@ -598,7 +612,7 @@ func (s *Server) bulkTagUpdate(item *models.Item, tags []string, add bool, actor
 		Source:         source,
 	}, store.WithEventBatch(batchID))
 	if err != nil {
-		return nil, &bulkOpError{message: err.Error()}
+		return nil, bulkStoreError(err)
 	}
 	return updated, nil
 }
@@ -723,7 +737,7 @@ func (s *Server) bulkMoveCollection(r *http.Request, workspaceID string, item *m
 				details: raw,
 			}
 		}
-		return nil, &bulkOpError{message: err.Error()}
+		return nil, bulkStoreError(err)
 	}
 	return moved, nil
 }

--- a/internal/server/handlers_items_copy.go
+++ b/internal/server/handlers_items_copy.go
@@ -779,6 +779,23 @@ func (s *Server) writeCopyError(w http.ResponseWriter, err error) {
 	// land on the commit itself — so the message says "check", never "retry".
 	// Deliberately not writeInternalError: its generic text would invite the
 	// exact retry that duplicates the item.
+	// The NUL refusal is NOT ambiguous, so it must not get the ambiguous
+	// message (codex round 3). It fires at parameter binding, before any
+	// statement executes and long before commit, so nothing landed and a retry
+	// of the same value will be refused identically. Telling the caller to
+	// "check the destination workspace" for a copy that provably did not start
+	// is worse than unhelpful — it invites exactly the manual reconciliation
+	// DR-13's wording exists to prevent, for the one failure where there is
+	// nothing to reconcile.
+	//
+	// A legacy NUL-bearing source row reaches this: the source predates the
+	// guard, the destination insert is guarded, and the copy is where the two
+	// meet.
+	if reason, ok := nulRefusalReason(err); ok {
+		slog.Warn("cross-workspace item copy refused: invalid text parameter", "error", err)
+		writeError(w, http.StatusBadRequest, "bad_request", reason)
+		return
+	}
 	slog.Error("cross-workspace item copy failed", "error", err)
 	writeError(w, http.StatusInternalServerError, "copy_failed",
 		"The copy did not complete. It may or may not have landed — check the destination workspace before trying again.")

--- a/internal/server/middleware_request_text.go
+++ b/internal/server/middleware_request_text.go
@@ -666,29 +666,6 @@ func valueDecodesNUL(v any, inUserData bool) bool {
 // where one a level deeper is not.
 func nestedDocumentDecodesNUL(s string) bool { return textguard.DocumentDecodesNUL(s) }
 
-// stringIsJSONDocument reports whether a string is a complete JSON object or
-// array — the shape a downstream consumer will re-parse.
-//
-// WHY THE RECURSION IT GATES EXISTS. Several fields cross the wire as
-// JSON-ENCODED STRINGS rather than nested objects: an item's `fields`, a
-// collection's `schema`, a workspace's `settings`. In such a body the OUTER
-// decode yields the inner document as literal text, in which the escape is
-// still six ordinary characters and no NUL exists. A single-layer walk
-// therefore passed it, and Postgres refused it later with a DIFFERENT error
-// from the rest of this family:
-//
-//	insert collection: ERROR: unsupported Unicode escape sequence (SQLSTATE 22P05)
-//
-// 22P05, not the 22021 the path and query halves produce. The outer string is
-// pure ASCII so it never trips the text-encoding check; this is Postgres's own
-// JSON parser refusing the escape inside a document bound for jsonb, which
-// cannot represent a NUL. Measured on Postgres 17: item `fields`, collection
-// `schema` and workspace `settings` each answered 500 with a 201 control leg,
-// after the single-layer check was in place. Found by codex round 1 on
-// BUG-2803, by asking what the destination TYPE does with the value — the
-// angle the endpoint-and-field sweep never rotated to.
-func stringIsJSONDocument(s string) bool { return textguard.IsJSONDocument(s) }
-
 // readBodyForDecode reads the whole request body so it can be scanned before
 // it is decoded, with the caller's size cap applied.
 //

--- a/internal/server/middleware_request_text.go
+++ b/internal/server/middleware_request_text.go
@@ -8,6 +8,8 @@ import (
 	"net/url"
 	"strings"
 	"unicode/utf8"
+
+	"github.com/PerpetualSoftware/pad/internal/textguard"
 )
 
 // ValidatePath rejects a request whose percent-DECODED URL path is not a
@@ -604,12 +606,21 @@ func isJSONEncodedFieldKey(k string) bool {
 // this shape is chosen so that adding one later cannot silently start
 // rejecting valid requests.
 func valueDecodesNUL(v any, inUserData bool) bool {
+	// S1 (DOC-2823): once classing is switched OFF there is nothing
+	// request-specific left to do, and the walk is textguard's — literally the
+	// same traversal this function used to carry inline. Delegating rather than
+	// keeping a copy is the point of extracting the package: two walks of the
+	// same shape, in two layers, is the disagreement this cluster exists
+	// because of.
+	if inUserData {
+		return textguard.ValueDecodesNUL(v)
+	}
 	switch t := v.(type) {
 	case string:
-		return strings.ContainsRune(t, 0)
+		return textguard.ContainsNUL(t)
 	case map[string]any:
 		for k, sub := range t {
-			if strings.ContainsRune(k, 0) {
+			if textguard.ContainsNUL(k) {
 				return true
 			}
 			if !inUserData && isJSONEncodedFieldKey(k) {
@@ -622,7 +633,7 @@ func valueDecodesNUL(v any, inUserData bool) bool {
 					// `fields` value was accepted, reopening the door this
 					// whole change exists to close (codex round 9, a
 					// regression introduced by the round-8 restructure).
-					if strings.ContainsRune(str, 0) || nestedDocumentDecodesNUL(str) {
+					if textguard.ContainsNUL(str) || nestedDocumentDecodesNUL(str) {
 						return true
 					}
 					continue
@@ -653,16 +664,7 @@ func valueDecodesNUL(v any, inUserData bool) bool {
 // item's `fields` blob, a collection's `schema` — for a string containing a
 // NUL. This is the layer Postgres itself parses, so an escape here is fatal
 // where one a level deeper is not.
-func nestedDocumentDecodesNUL(s string) bool {
-	if !strings.Contains(s, string(unicodeEscapePrefix)) || !stringIsJSONDocument(s) {
-		return false
-	}
-	var inner any
-	if err := json.Unmarshal([]byte(strings.TrimSpace(s)), &inner); err != nil {
-		return false
-	}
-	return valueDecodesNUL(inner, true)
-}
+func nestedDocumentDecodesNUL(s string) bool { return textguard.DocumentDecodesNUL(s) }
 
 // stringIsJSONDocument reports whether a string is a complete JSON object or
 // array — the shape a downstream consumer will re-parse.
@@ -685,13 +687,7 @@ func nestedDocumentDecodesNUL(s string) bool {
 // after the single-layer check was in place. Found by codex round 1 on
 // BUG-2803, by asking what the destination TYPE does with the value — the
 // angle the endpoint-and-field sweep never rotated to.
-func stringIsJSONDocument(s string) bool {
-	t := strings.TrimSpace(s)
-	if len(t) == 0 || (t[0] != '{' && t[0] != '[') {
-		return false
-	}
-	return json.Valid([]byte(t))
-}
+func stringIsJSONDocument(s string) bool { return textguard.IsJSONDocument(s) }
 
 // readBodyForDecode reads the whole request body so it can be scanned before
 // it is decoded, with the caller's size cap applied.

--- a/internal/server/middleware_request_text.go
+++ b/internal/server/middleware_request_text.go
@@ -664,7 +664,18 @@ func valueDecodesNUL(v any, inUserData bool) bool {
 // item's `fields` blob, a collection's `schema` — for a string containing a
 // NUL. This is the layer Postgres itself parses, so an escape here is fatal
 // where one a level deeper is not.
-func nestedDocumentDecodesNUL(s string) bool { return textguard.DocumentDecodesNUL(s) }
+// ANY JSON DOCUMENT SHAPE, scalars included (codex round 1 on DOC-2823 S1).
+//
+// This used to test objects and arrays only, which is the right rule for
+// deciding "is this a nested document worth walking" and the WRONG one for
+// deciding "will a jsonb parser read this". A `fields` value that is a bare
+// JSON string decoding to a NUL is a complete jsonb document Postgres refuses;
+// the narrow rule let it past the gate to be caught at the store instead.
+//
+// Both layers now use the same shape test, which is what makes the differential
+// corpus able to assert they AGREE rather than merely that something refuses
+// eventually.
+func nestedDocumentDecodesNUL(s string) bool { return textguard.DocumentDecodesNULAnyShape(s) }
 
 // readBodyForDecode reads the whole request body so it can be scanned before
 // it is decoded, with the caller's size cap applied.

--- a/internal/server/nul_differential_test.go
+++ b/internal/server/nul_differential_test.go
@@ -1,0 +1,107 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/textguard"
+)
+
+// The HTTP gate's leg of the four-way differential test (DOC-2823 S1).
+//
+// The other legs live in internal/store (Layer A at the driver, and native
+// Postgres). This one asserts the thing the design was most at risk of getting
+// wrong: the gate and the store CLASS a value by different means — the gate by
+// request-body KEY NAME, the store by the column a parameter is bound to — and
+// nothing but a shared corpus can show the two derivations agree.
+//
+// If this fails while internal/store's legs pass, the layers have diverged and
+// the whole cluster's defining bug has come back.
+
+// TestHTTPGateAgreesWithTheCorpus drives every corpus case through the gate's
+// own predicate, classing it the way a REQUEST would: a JSON-classed value
+// arrives as the string value of a JSON-encoded field key, a text one as an
+// ordinary field.
+func TestHTTPGateAgreesWithTheCorpus(t *testing.T) {
+	for _, c := range textguard.Corpus {
+		t.Run(c.Name, func(t *testing.T) {
+			// The gate's classing is by KEY. "fields" is a JSON-encoded field
+			// key (its string value is a document something re-parses);
+			// "content" is ordinary user text. Choosing the key from the
+			// corpus's own IsJSON is exactly the derivation under test.
+			key := "content"
+			if c.IsJSON {
+				key = "fields"
+			}
+			body, err := json.Marshal(map[string]any{key: c.Value})
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+
+			got := bodyDecodesNUL(body)
+			if got != c.Refused {
+				t.Errorf("gate refused=%t, corpus says %t\nkey: %s\nvalue: %q\nbody: %s\nwhy this case exists: %s",
+					got, c.Refused, key, c.Value, body, c.Why)
+			}
+		})
+	}
+}
+
+// TestStoreRefusalAnswers400 pins the status. The design's requirement is a 4xx
+// naming the rule, and "not a 500" is not the same claim as "exactly 400" — the
+// round-4 lesson from BUG-2803, where a >=400 assertion hid a wrong status.
+//
+// It drives a value the HTTP gate CANNOT catch, so the refusal genuinely comes
+// from the store: a raw NUL arriving through a path the body gate does not
+// scan. The gate reads JSON bodies; this goes in as a query-shaped write via
+// the item update handler with the NUL already decoded server-side.
+func TestStoreRefusalAnswers400(t *testing.T) {
+	srv := testServer(t)
+	ws := createWSWithCollections(t, srv)
+	item := createTaskWithFields(t, srv, ws, "Subject", `{"status":"open"}`)
+
+	// A body whose JSON is valid and whose decoded value carries a real NUL.
+	// json.Marshal writes it as an escape, so this is precisely the shape the
+	// gate is built to catch — which makes it the wrong probe for the store.
+	// Instead, write through the store directly and assert the HANDLER's
+	// mapping of the resulting error, which is what the status contract is
+	// about.
+	poisoned := "poisoned" + textguard.NUL + "content"
+	_, err := srv.store.UpdateItem(item.ID, itemUpdateContent(poisoned))
+	if err == nil {
+		t.Fatal("the store accepted a NUL-bearing content write")
+	}
+
+	rr := httptest.NewRecorder()
+	writeInternalError(rr, err)
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want exactly 400 — a refusal that will be refused identically on retry "+
+			"must not be reported as a server fault (body: %s)", rr.Code, rr.Body.String())
+	}
+	if strings.Contains(rr.Body.String(), "internal_error") {
+		t.Errorf("body = %s, must not be the internal_error envelope", rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "NUL") {
+		t.Errorf("body = %s, want it to name the rule that refused", rr.Body.String())
+	}
+
+	// CONTROL: an unrelated error still answers 500, so the mapping is
+	// selective rather than turning every fault into a 400.
+	rr2 := httptest.NewRecorder()
+	writeInternalError(rr2, errUnrelatedForTest)
+	if rr2.Code != http.StatusInternalServerError {
+		t.Errorf("an unrelated error answered %d; the mapping must not swallow real faults", rr2.Code)
+	}
+}
+
+var errUnrelatedForTest = errorString("some unrelated store failure")
+
+type errorString string
+
+func (e errorString) Error() string { return string(e) }
+
+func itemUpdateContent(v string) (u models.ItemUpdate) { u.Content = &v; return }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2186,14 +2186,37 @@ func writeInternalError(w http.ResponseWriter, err error) {
 	// 500, because the request is understood and will be refused identically
 	// on retry, and the log line below keeps the detail. If the re-emit case
 	// ever needs its own status, it needs its own error type first.
-	var badText *store.InvalidTextParameterError
-	if errors.As(err, &badText) {
+	if reason, ok := nulRefusalReason(err); ok {
 		slog.Warn("write refused: invalid text parameter", "error", err)
-		writeError(w, http.StatusBadRequest, "bad_request", badText.Reason)
+		writeError(w, http.StatusBadRequest, "bad_request", reason)
 		return
 	}
 	slog.Error("internal server error", "error", err)
 	writeError(w, http.StatusInternalServerError, "internal_error", "An internal error occurred")
+}
+
+// nulRefusalReason classifies the store's NUL refusal and returns the sentence
+// a caller should be given.
+//
+// ONE classifier, SEVERAL envelopes — and the several is deliberate rather than
+// an omission (codex round 1, finding 4). writeInternalError covers every
+// handler that lets an error reach its generic arm, but three paths carry their
+// own error shape for their own reasons: createItemChecked returns a typed
+// *itemCreateError for its caller to write, a bulk op reports per-item failures
+// inside an otherwise successful response, and the cross-workspace copy answers
+// with a deliberately retry-DISCOURAGING message because its failure may have
+// committed (PLAN-2357 DR-13).
+//
+// Those envelopes should stay different. What must not differ is the
+// CLASSIFICATION and the wording, which is what this function makes shared —
+// the same discipline as the item-title unit's writeInvalidItemTitle, learned
+// there by getting it wrong in three error blocks of one function.
+func nulRefusalReason(err error) (string, bool) {
+	var badText *store.InvalidTextParameterError
+	if errors.As(err, &badText) {
+		return badText.Reason, true
+	}
+	return "", false
 }
 
 // defaultJSONBodyLimit is the default cap applied to JSON request bodies

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2167,6 +2167,31 @@ func writeError(w http.ResponseWriter, status int, code, message string) {
 // message to the client. This prevents leaking SQL errors, file paths,
 // and other internal details.
 func writeInternalError(w http.ResponseWriter, err error) {
+	// The store's NUL refusal is a DECISION, not a fault, and it is mapped
+	// here rather than at each handler for the same reason Layer A lives at
+	// the driver: this is the one funnel every 500 already passes through, so
+	// mapping it once covers every handler that exists and every one that will
+	// (DOC-2823 S1). Enumerating error blocks is what the item-title unit had
+	// to do three times in one function before a structural test caught the
+	// third.
+	//
+	// 400, matching what the HTTP gate answers for the SAME value refused at
+	// the door. Two statuses for one rule would be the layers disagreeing
+	// again, in the response this time instead of in the predicate.
+	//
+	// The honest residual: a value can reach the store from something the
+	// SERVER composed rather than the caller supplied — that is BUG-2814's
+	// re-emit population — and for those a 400 tells the caller their request
+	// was bad when it was our stored data. It is still the better answer than
+	// 500, because the request is understood and will be refused identically
+	// on retry, and the log line below keeps the detail. If the re-emit case
+	// ever needs its own status, it needs its own error type first.
+	var badText *store.InvalidTextParameterError
+	if errors.As(err, &badText) {
+		slog.Warn("write refused: invalid text parameter", "error", err)
+		writeError(w, http.StatusBadRequest, "bad_request", badText.Reason)
+		return
+	}
 	slog.Error("internal server error", "error", err)
 	writeError(w, http.StatusInternalServerError, "internal_error", "An internal error occurred")
 }

--- a/internal/store/nul_native_pg_test.go
+++ b/internal/store/nul_native_pg_test.go
@@ -45,6 +45,43 @@ func TestNativePostgresAgreesWithTheCorpus(t *testing.T) {
 	}
 	defer func() { _, _ = db.Exec(`DROP TABLE IF EXISTS nul_differential`) }()
 
+	// KNOWN GAPS get their own leg, and it asserts POSTGRES's answer rather
+	// than ours (codex round 4). Running only Corpus here meant the recorded
+	// gaps were never measured against the database at all — which is how one
+	// of them carried a rationale claiming Postgres agreed with us when it
+	// does not.
+	t.Run("known gaps against Postgres", func(t *testing.T) {
+		for i, c := range textguard.KnownGaps {
+			t.Run(c.Name, func(t *testing.T) {
+				id := "gap-" + string(rune('a'+i%26))
+				var err error
+				if json.Valid([]byte(strings.TrimSpace(c.Value))) {
+					_, err = db.Exec(`INSERT INTO nul_differential (id, doc) VALUES ($1, $2)`, id, c.Value)
+				} else {
+					_, err = db.Exec(`INSERT INTO nul_differential (id, txt) VALUES ($1, $2)`, id, c.Value)
+				}
+				pgRefused := err != nil
+				ourAnswer := textguard.ParameterRefused(c.Value, c.IsJSON)
+
+				// The point of a recorded gap is that WE do not refuse it. If
+				// that stops being true the entry belongs in Corpus.
+				if ourAnswer {
+					t.Errorf("this gap has CLOSED — the guard now refuses it. Move the case into Corpus.")
+				}
+				// And the interesting fact is what Postgres does, because it
+				// decides whether the gap is a shared blind spot or a dialect
+				// split. Recorded, not asserted either way, so the test states
+				// the truth without pretending we have chosen a disposition.
+				t.Logf("DIALECT SPLIT MEASURED: postgres refuses=%t, this guard refuses=%t, err=%v",
+					pgRefused, ourAnswer, err)
+				if pgRefused && !ourAnswer {
+					t.Logf("Postgres refuses what we accept: a SQLite instance stores this value and a " +
+						"Postgres one cannot. That is the split BUG-2812's token-walk closes.")
+				}
+			})
+		}
+	})
+
 	for i, c := range textguard.Corpus {
 		t.Run(c.Name, func(t *testing.T) {
 			id := "case-" + string(rune('a'+i%26)) + strings.Repeat("x", i/26)

--- a/internal/store/nul_native_pg_test.go
+++ b/internal/store/nul_native_pg_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"database/sql"
+	"encoding/json"
 	"os"
 	"strings"
 	"testing"
@@ -50,12 +51,23 @@ func TestNativePostgresAgreesWithTheCorpus(t *testing.T) {
 
 			var err error
 			if c.IsJSON {
-				// A value classed as JSON but which is not a document would be
-				// a jsonb SYNTAX error rather than a NUL refusal, and that is
-				// a different verdict than the one under test. Those cases are
-				// measured on the text column instead, where Postgres judges
-				// them purely on the NUL rule.
-				if textguard.IsJSONDocument(c.Value) {
+				// The routing question is "would Postgres's jsonb parser read
+				// this", and the answer is json.Valid — NOT IsJSONDocument,
+				// which tests for objects and arrays only.
+				//
+				// Using the narrow test here sent a JSON SCALAR to the text
+				// column, where Postgres of course accepted it as eight
+				// ordinary characters, and the leg reported agreement about a
+				// column the value would never have been bound to. Measured
+				// directly, the scalar IS refused as jsonb:
+				//
+				//	SELECT ('"a<escape>b"')::jsonb;
+				//	ERROR:  unsupported Unicode escape sequence
+				//
+				// A value that is not valid JSON at all still goes to the text
+				// column: that would be a jsonb SYNTAX error, a different
+				// verdict from the NUL rule under test.
+				if json.Valid([]byte(strings.TrimSpace(c.Value))) {
 					_, err = db.Exec(`INSERT INTO nul_differential (id, doc) VALUES ($1, $2)`, id, c.Value)
 				} else {
 					_, err = db.Exec(`INSERT INTO nul_differential (id, txt) VALUES ($1, $2)`, id, c.Value)

--- a/internal/store/nul_native_pg_test.go
+++ b/internal/store/nul_native_pg_test.go
@@ -1,0 +1,87 @@
+package store
+
+import (
+	"database/sql"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/textguard"
+)
+
+// The native-Postgres leg of the four-way differential test (DOC-2823 S1).
+//
+// This is the leg that says Layer A is CALIBRATED rather than merely strict.
+// Postgres already refuses a NUL in text and an escape decoding to one in
+// jsonb; the guard's job is to give the same answer everywhere, which means it
+// must not refuse what Postgres accepts (over-refusal, breaking valid writes
+// on both dialects) and must not accept what Postgres refuses (under-refusal,
+// leaving the SQLite/Postgres split BUG-2831 was about).
+//
+// It runs against the RAW driver deliberately — no guard in the path — so what
+// is measured is Postgres's own verdict, not ours reflected back.
+func TestNativePostgresAgreesWithTheCorpus(t *testing.T) {
+	dsn := os.Getenv("PAD_TEST_POSTGRES_URL")
+	if dsn == "" {
+		t.Skip("PAD_TEST_POSTGRES_URL not set; the native-Postgres leg needs a real server")
+	}
+
+	// The raw pgx driver, NOT the guarded name. Opening the guarded one here
+	// would measure the guard agreeing with itself.
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		t.Fatalf("open raw pgx: %v", err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec(`DROP TABLE IF EXISTS nul_differential`); err != nil {
+		t.Fatalf("drop: %v", err)
+	}
+	// Both column classes, so each corpus case lands on the column its own
+	// classing names — the same choice the store's leg makes.
+	if _, err := db.Exec(`CREATE TABLE nul_differential (id TEXT PRIMARY KEY, txt TEXT, doc JSONB)`); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	defer func() { _, _ = db.Exec(`DROP TABLE IF EXISTS nul_differential`) }()
+
+	for i, c := range textguard.Corpus {
+		t.Run(c.Name, func(t *testing.T) {
+			id := "case-" + string(rune('a'+i%26)) + strings.Repeat("x", i/26)
+
+			var err error
+			if c.IsJSON {
+				// A value classed as JSON but which is not a document would be
+				// a jsonb SYNTAX error rather than a NUL refusal, and that is
+				// a different verdict than the one under test. Those cases are
+				// measured on the text column instead, where Postgres judges
+				// them purely on the NUL rule.
+				if textguard.IsJSONDocument(c.Value) {
+					_, err = db.Exec(`INSERT INTO nul_differential (id, doc) VALUES ($1, $2)`, id, c.Value)
+				} else {
+					_, err = db.Exec(`INSERT INTO nul_differential (id, txt) VALUES ($1, $2)`, id, c.Value)
+				}
+			} else {
+				_, err = db.Exec(`INSERT INTO nul_differential (id, txt) VALUES ($1, $2)`, id, c.Value)
+			}
+
+			refused := err != nil
+			if refused != c.Refused {
+				t.Errorf("POSTGRES refused=%t, corpus says %t — Layer A and the database disagree, which is "+
+					"the dialect split this unit exists to close\nvalue: %q\nisJSON: %t\nerr: %v\nwhy this case exists: %s",
+					refused, c.Refused, c.Value, c.IsJSON, err, c.Why)
+			}
+
+			// When Postgres refuses, it must be refusing for the REASON the
+			// corpus claims. Without this the leg would be satisfied by any
+			// error at all — a typo in the SQL would read as agreement.
+			if refused && err != nil {
+				msg := err.Error()
+				if !strings.Contains(msg, "22021") && !strings.Contains(msg, "22P05") &&
+					!strings.Contains(msg, "unsupported Unicode escape") && !strings.Contains(msg, "invalid byte sequence") &&
+					!strings.Contains(msg, "NUL") && !strings.Contains(msg, "null character") {
+					t.Errorf("Postgres refused, but not on the NUL rule: %v", msg)
+				}
+			}
+		})
+	}
+}

--- a/internal/store/nulguard.go
+++ b/internal/store/nulguard.go
@@ -79,11 +79,28 @@ func (e *InvalidTextParameterError) Unwrap() error { return ErrInvalidTextParame
 //   - Every value bound to a JSON-classed column IS a JSON document; the store
 //     marshals it before binding. So no JSON column's value escapes the
 //     document check.
+//
 //   - A user-TEXT column whose value happens to parse as JSON gets the
-//     document check too. That is the only over-reach, and it costs a refusal
-//     only for text that is BOTH valid JSON AND contains an escape that
-//     decodes to a NUL — a value that is, on any column, a value Postgres
-//     would refuse the moment anything parsed it.
+//     document check too. This is a REAL over-refusal, and the first version of
+//     this comment justified it wrongly: it claimed such a value "is, on any
+//     column, a value Postgres would refuse the moment anything parsed it".
+//     That is false. Nothing parses a TEXT column, and Postgres stores the
+//     escape there as six ordinary characters quite happily (codex round 1,
+//     finding 3).
+//
+//     So the honest statement of the trade: a user pasting a JSON document
+//     that contains a live NUL escape into an item's CONTENT is refused,
+//     though it would store fine. That is not hypothetical in a documentation
+//     tool — writing about this very bug produces such a value.
+//
+//     It is accepted for now because the alternative is worse in the direction
+//     that matters. Deriving JSON-ness from the CALL SITE's knowledge puts the
+//     classification back at the sites this design exists to stop depending on,
+//     and the failure mode of over-refusal is a loud 400 naming the rule, while
+//     the failure mode of under-refusal is a NUL at rest that only the next
+//     dialect migration discovers. Flagged to the lead as a measured trade
+//     rather than buried here; if it is ever paid down, the mechanism is S2's
+//     column-attached triggers, which DO have the classing this layer lacks.
 //
 // The alternative — deriving JSON-ness from the call site's knowledge — puts
 // the classification back at the call sites this design exists to stop
@@ -122,7 +139,7 @@ func checkParams(args []driver.NamedValue) error {
 				Reason:  "value contains a NUL byte, which no text or JSON column can store",
 			}
 		}
-		if textguard.DocumentDecodesNUL(s) {
+		if textguard.DocumentDecodesNULAnyShape(s) {
 			return &InvalidTextParameterError{
 				Ordinal: a.Ordinal,
 				Reason:  "value is a JSON document containing an escape that decodes to a NUL",
@@ -144,7 +161,55 @@ func (d guardDriver) Open(name string) (driver.Conn, error) {
 	return guardConn{c}, nil
 }
 
+// guardConn forwards the OPTIONAL connection interfaces as well as the
+// required ones.
+//
+// Embedding driver.Conn alone silently HID them, which is a production
+// regression rather than a cosmetic gap: measured, the raw modernc conn
+// implements Pinger, SessionResetter and Validator, and the wrapped one
+// implemented none. database/sql degrades quietly for each — Ping succeeds
+// without pinging anything, pooled connections stop being reset between uses,
+// and a connection the driver knows is dead stays in the pool.
+//
+// Each method below delegates when the base supports it and otherwise does
+// exactly what database/sql does for a conn that lacks the interface, so
+// wrapping a driver without one is equivalent to not wrapping it. Always
+// implementing them is safe for that reason.
 type guardConn struct{ driver.Conn }
+
+func (c guardConn) Ping(ctx context.Context) error {
+	if p, ok := c.Conn.(driver.Pinger); ok {
+		return p.Ping(ctx)
+	}
+	// database/sql treats a non-Pinger connection as reachable by virtue of
+	// existing; matching that keeps the wrapper transparent.
+	return nil
+}
+
+func (c guardConn) ResetSession(ctx context.Context) error {
+	if r, ok := c.Conn.(driver.SessionResetter); ok {
+		return r.ResetSession(ctx)
+	}
+	return nil
+}
+
+func (c guardConn) IsValid() bool {
+	if v, ok := c.Conn.(driver.Validator); ok {
+		return v.IsValid()
+	}
+	return true
+}
+
+// CheckNamedValue forwards the driver's own argument conversion when it has
+// one. Without this the wrapper would fall back to database/sql's default
+// converter and quietly narrow the argument types a driver accepts — pgx in
+// particular converts a great deal more than the default does.
+func (c guardConn) CheckNamedValue(nv *driver.NamedValue) error {
+	if ck, ok := c.Conn.(driver.NamedValueChecker); ok {
+		return ck.CheckNamedValue(nv)
+	}
+	return driver.ErrSkip
+}
 
 // Prepare exists because driver.Conn requires it, and it DELEGATES rather than
 // wrapping separately.
@@ -178,6 +243,14 @@ func (c guardConn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.T
 	if b, ok := c.Conn.(driver.ConnBeginTx); ok {
 		return b.BeginTx(ctx, opts)
 	}
+	// A base without ConnBeginTx cannot honour isolation or read-only, and
+	// SILENTLY starting a plain transaction would give the caller weaker
+	// guarantees than it asked for. database/sql itself refuses in this
+	// situation; matching that keeps the wrapper transparent rather than
+	// permissive.
+	if opts.Isolation != driver.IsolationLevel(sql.LevelDefault) || opts.ReadOnly {
+		return nil, errors.New("store: driver does not support transaction options")
+	}
 	return c.Conn.Begin() //nolint:staticcheck // fallback for a driver without ConnBeginTx
 }
 
@@ -207,6 +280,16 @@ func (c guardConn) QueryContext(ctx context.Context, q string, args []driver.Nam
 
 type guardStmt struct{ driver.Stmt }
 
+// The statement methods FALL BACK to the positional form rather than returning
+// driver.ErrSkip.
+//
+// The distinction matters and the first version had it wrong. At the CONN
+// level, ErrSkip is the documented signal and database/sql falls back to
+// prepare-and-execute. At the STATEMENT level it does not: because this
+// wrapper always implements StmtExecContext, database/sql calls it and
+// propagates whatever comes back, so an ErrSkip would surface as a query
+// FAILURE against any base statement lacking the context form rather than
+// degrading to the older interface.
 func (s guardStmt) ExecContext(ctx context.Context, args []driver.NamedValue) (driver.Result, error) {
 	if err := checkParams(args); err != nil {
 		return nil, err
@@ -214,7 +297,11 @@ func (s guardStmt) ExecContext(ctx context.Context, args []driver.NamedValue) (d
 	if e, ok := s.Stmt.(driver.StmtExecContext); ok {
 		return e.ExecContext(ctx, args)
 	}
-	return nil, driver.ErrSkip
+	vals, err := positionalArgs(args)
+	if err != nil {
+		return nil, err
+	}
+	return s.Stmt.Exec(vals) //nolint:staticcheck // the documented fallback for a pre-context driver
 }
 
 func (s guardStmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driver.Rows, error) {
@@ -224,7 +311,29 @@ func (s guardStmt) QueryContext(ctx context.Context, args []driver.NamedValue) (
 	if q, ok := s.Stmt.(driver.StmtQueryContext); ok {
 		return q.QueryContext(ctx, args)
 	}
-	return nil, driver.ErrSkip
+	vals, err := positionalArgs(args)
+	if err != nil {
+		return nil, err
+	}
+	return s.Stmt.Query(vals) //nolint:staticcheck // the documented fallback for a pre-context driver
+}
+
+// positionalArgs converts named values back to the positional form the
+// pre-context statement interfaces take, refusing a NAMED argument rather than
+// dropping its name — silently binding a named parameter by position would
+// bind the wrong value.
+func positionalArgs(args []driver.NamedValue) ([]driver.Value, error) {
+	vals := make([]driver.Value, len(args))
+	for _, a := range args {
+		if a.Name != "" {
+			return nil, errors.New("store: driver does not support named parameters")
+		}
+		if a.Ordinal < 1 || a.Ordinal > len(vals) {
+			return nil, errors.New("store: parameter ordinal out of range")
+		}
+		vals[a.Ordinal-1] = a.Value
+	}
+	return vals, nil
 }
 
 // ---- registration ----

--- a/internal/store/nulguard.go
+++ b/internal/store/nulguard.go
@@ -38,8 +38,10 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"sync"
 
 	"github.com/PerpetualSoftware/pad/internal/textguard"
@@ -68,7 +70,7 @@ func (e *InvalidTextParameterError) Error() string {
 
 func (e *InvalidTextParameterError) Unwrap() error { return ErrInvalidTextParameter }
 
-// checkParams applies the shared predicate to every string/[]byte argument.
+// CLASSING NOTE for normalizeAndCheck below.
 //
 // CLASSING, and why it is what it is. The wrapper sees positional parameters,
 // not columns, so it cannot consult the 86-column classification directly. It
@@ -102,46 +104,53 @@ func (e *InvalidTextParameterError) Unwrap() error { return ErrInvalidTextParame
 //     rather than buried here; if it is ever paid down, the mechanism is S2's
 //     column-attached triggers, which DO have the classing this layer lacks.
 //
-// The alternative — deriving JSON-ness from the call site's knowledge — puts
-// the classification back at the call sites this design exists to stop
-// depending on.
-func checkParams(args []driver.NamedValue) error {
-	for _, a := range args {
-		// STRING ONLY, and []byte is deliberately exempt.
-		//
-		// The invariant is about TEXT and JSON columns. In this store, Go's
-		// `string` is how text and JSON are bound and `[]byte` is how BINARY
-		// is bound — and binary legitimately contains NUL bytes, so checking
-		// []byte refuses valid writes. The existing collab suite caught this
-		// immediately: item_yjs_updates.update_data is raw Yjs binary, and the
-		// first version of this guard refused every op-log append.
-		//
-		// The rule is measured, not assumed:
-		//
-		//   - item_yjs_updates.update_data (BLOB on SQLite, BYTEA on Postgres)
-		//     is the ONLY binary column in either schema.
-		//   - No json.Marshal result is bound without a string() conversion,
-		//     so no JSON column receives a []byte parameter.
-		//
-		// The second of those was established by a source-level sweep, and
-		// this unit's own history is a catalogue of source-level sweeps missing
-		// things. So the claim is pinned BEHAVIOURALLY rather than trusted:
-		// TestBinaryColumnCensus fails the moment a new BLOB/BYTEA column
-		// enters either schema, which is when someone must re-examine whether
-		// []byte is still binary-only here.
-		s, ok := checkedValue(a.Value)
+// BINARY is exempt, and that is measured rather than assumed. The invariant is
+// about text and JSON columns; in this store []byte binds BINARY, and
+// item_yjs_updates.update_data — the only BLOB/BYTEA column in either schema —
+// legitimately contains NUL bytes. The first version of this guard checked
+// []byte and refused every Yjs op-log append; the existing collab suite caught
+// it immediately. TestBinaryColumnCensus fails when a new binary column
+// appears, which is when that exemption must be re-examined.
+// normalizeAndCheck resolves each parameter to the value that will actually be
+// bound, checks it, and WRITES THE RESOLVED VALUE BACK so the driver binds the
+// same thing that was inspected.
+//
+// Three defects in the first version, all found by codex round 3, and all of
+// them the same underlying error — inspecting one value and forwarding another:
+//
+//   - Value() was called for the check and the ORIGINAL Valuer was forwarded,
+//     so pgx called Value() a second time. A stateful valuer could return clean
+//     text to the guard and NUL-bearing text to the database.
+//   - A typed-nil valuer, (*sql.NullString)(nil), was called directly and
+//     panicked. database/sql special-cases that as SQL NULL.
+//   - Only an exact `string` was recognised. pgx implements NamedValueChecker
+//     and accepts *string, named string types and json.RawMessage unconverted,
+//     so each of those carried text the guard never saw.
+//
+// Resolution is therefore by REFLECTION on the kind rather than by a list of
+// types: anything whose kind is String is text, and anything that is a byte
+// slice is binary and exempt (see the classing note in checkParams).
+func normalizeAndCheck(args []driver.NamedValue) error {
+	for i := range args {
+		resolved, err := resolveValue(args[i].Value)
+		if err != nil {
+			return err
+		}
+		args[i].Value = resolved
+
+		s, ok := textOf(resolved)
 		if !ok {
 			continue
 		}
 		if textguard.ContainsNUL(s) {
 			return &InvalidTextParameterError{
-				Ordinal: a.Ordinal,
+				Ordinal: args[i].Ordinal,
 				Reason:  "value contains a NUL byte, which no text or JSON column can store",
 			}
 		}
 		if textguard.DocumentDecodesNULAnyShape(s) {
 			return &InvalidTextParameterError{
-				Ordinal: a.Ordinal,
+				Ordinal: args[i].Ordinal,
 				Reason:  "value is a JSON document containing an escape that decodes to a NUL",
 			}
 		}
@@ -149,59 +158,50 @@ func checkParams(args []driver.NamedValue) error {
 	return nil
 }
 
-// ---- the wrapper ----
-//
-// SHAPE, and why it is not one type.
-//
-// A wrapper that implements an optional interface the BASE lacks does not
-// merely add a no-op: database/sql BRANCHES on whether the interface is
-// present, so advertising one changes its behaviour even when the method
-// delegates faithfully. Measured on the two drivers Pad uses:
-//
-//	                        sqlite   pgx
-//	driver.DriverContext    no       YES
-//	conn Pinger             yes      yes
-//	conn SessionResetter    yes      yes
-//	conn Validator          yes      NO
-//	conn NamedValueChecker  no       YES
-//	stmt NamedValueChecker  no       no
-//	stmt ColumnConverter    no       no
-//
-// So Validator and NamedValueChecker VARY between the two, and a single
-// wrapper type advertising both would have told database/sql that pgx
-// validates connections and that sqlite converts its own arguments — neither
-// true (codex round 2). The conn wrapper is therefore selected per-connection
-// from four variants covering those two interfaces.
-//
-// The interfaces that do NOT vary are asserted at registration instead of
-// varied over: requireBaseInterfaces fails loudly if a driver bump ever drops
-// one, which is better than silently degrading and better than sixteen types.
+// resolveValue unwraps a driver.Valuer exactly ONCE, mirroring what
+// database/sql's default converter does — including its typed-nil rule, which
+// is why a nil pointer must be answered before Value() is reached rather than
+// by recovering from the panic it would cause.
+func resolveValue(v driver.Value) (driver.Value, error) {
+	valuer, ok := v.(driver.Valuer)
+	if !ok {
+		return v, nil
+	}
+	rv := reflect.ValueOf(valuer)
+	if rv.Kind() == reflect.Ptr && rv.IsNil() {
+		return nil, nil
+	}
+	out, err := valuer.Value()
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
 
-// checkedValue extracts the string a parameter will bind, following
-// driver.Valuer when the driver's own NamedValueChecker has left one in place.
+// textOf reports the string a value carries, if it carries one.
 //
-// This closes a real hole (codex round 2). checkParams originally type-asserted
-// `string` only, and pgx implements NamedValueChecker — so it ACCEPTS a
-// sql.NullString unchanged rather than letting database/sql's default converter
-// unwrap it, and the guard never saw the text. Measured: on Postgres a
-// sql.NullString carrying a NUL passed the guard entirely and was refused by
-// the server with SQLSTATE 22021, i.e. as a 500 rather than the typed 400 the
-// same value gets on SQLite. The dialect split, reappearing in the response
-// shape. internal/store/wiki_links.go binds sql.NullString today.
-func checkedValue(v driver.Value) (string, bool) {
-	switch t := v.(type) {
-	case string:
-		return t, true
-	case driver.Valuer:
-		// Value() is contractually pure; the standard converter calls it for
-		// exactly this purpose.
-		inner, err := t.Value()
-		if err != nil {
+// By KIND, not by type identity. A named string type (`type Slug string`) and a
+// *string both carry text that a driver accepting them unconverted would bind
+// as text, and a type-switch on `string` sees neither.
+//
+// Byte slices are deliberately NOT text here — see checkParams' classing note:
+// []byte is how this store binds BINARY, and item_yjs_updates.update_data
+// legitimately contains NUL bytes. json.RawMessage is the one byte-slice shape
+// that IS text, and it is recognised by its named type because that is exactly
+// what it means.
+func textOf(v any) (string, bool) {
+	if raw, ok := v.(json.RawMessage); ok {
+		return string(raw), true
+	}
+	rv := reflect.ValueOf(v)
+	for rv.IsValid() && rv.Kind() == reflect.Ptr {
+		if rv.IsNil() {
 			return "", false
 		}
-		if str, ok := inner.(string); ok {
-			return str, true
-		}
+		rv = rv.Elem()
+	}
+	if rv.IsValid() && rv.Kind() == reflect.String {
+		return rv.String(), true
 	}
 	return "", false
 }
@@ -211,6 +211,10 @@ type guardDriver struct{ base driver.Driver }
 func (d guardDriver) Open(name string) (driver.Conn, error) {
 	c, err := d.base.Open(name)
 	if err != nil {
+		return nil, err
+	}
+	if err := assertConnInterfaces(c); err != nil {
+		_ = c.Close()
 		return nil, err
 	}
 	return wrapConn(c), nil
@@ -253,6 +257,10 @@ type guardConnector struct {
 func (c guardConnector) Connect(ctx context.Context) (driver.Conn, error) {
 	conn, err := c.base.Connect(ctx)
 	if err != nil {
+		return nil, err
+	}
+	if err := assertConnInterfaces(conn); err != nil {
+		_ = conn.Close()
 		return nil, err
 	}
 	return wrapConn(conn), nil
@@ -323,6 +331,10 @@ func (c guardConn) PrepareContext(ctx context.Context, q string) (driver.Stmt, e
 	if err != nil {
 		return nil, err
 	}
+	if err := assertStmtInterfaces(st); err != nil {
+		_ = st.Close()
+		return nil, err
+	}
 	return guardStmt{st}, nil
 }
 
@@ -331,14 +343,14 @@ func (c guardConn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.T
 }
 
 func (c guardConn) ExecContext(ctx context.Context, q string, args []driver.NamedValue) (driver.Result, error) {
-	if err := checkParams(args); err != nil {
+	if err := normalizeAndCheck(args); err != nil {
 		return nil, err
 	}
 	return c.Conn.(driver.ExecerContext).ExecContext(ctx, q, args)
 }
 
 func (c guardConn) QueryContext(ctx context.Context, q string, args []driver.NamedValue) (driver.Rows, error) {
-	if err := checkParams(args); err != nil {
+	if err := normalizeAndCheck(args); err != nil {
 		return nil, err
 	}
 	return c.Conn.(driver.QueryerContext).QueryContext(ctx, q, args)
@@ -352,14 +364,14 @@ func (c guardConn) QueryContext(ctx context.Context, q string, args []driver.Nam
 type guardStmt struct{ driver.Stmt }
 
 func (s guardStmt) ExecContext(ctx context.Context, args []driver.NamedValue) (driver.Result, error) {
-	if err := checkParams(args); err != nil {
+	if err := normalizeAndCheck(args); err != nil {
 		return nil, err
 	}
 	return s.Stmt.(driver.StmtExecContext).ExecContext(ctx, args)
 }
 
 func (s guardStmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driver.Rows, error) {
-	if err := checkParams(args); err != nil {
+	if err := normalizeAndCheck(args); err != nil {
 		return nil, err
 	}
 	return s.Stmt.(driver.StmtQueryContext).QueryContext(ctx, args)
@@ -393,11 +405,9 @@ func registerGuardedDrivers() error {
 				return
 			}
 			base := probe.Driver()
-			if err := requireBaseInterfaces(d.base, probe); err != nil {
-				_ = probe.Close()
-				registerGuardedErr = err
-				return
-			}
+			// sql.Open does NOT connect, so this costs nothing and touches no
+			// network. The interface assertions happen at connect time instead
+			// — see assertConnInterfaces.
 			_ = probe.Close()
 			wrapped := guardDriver{base: base}
 			if _, ok := base.(driver.DriverContext); ok {
@@ -410,55 +420,67 @@ func registerGuardedDrivers() error {
 	return registerGuardedErr
 }
 
-// requireBaseInterfaces asserts the optional interfaces the wrapper implements
-// UNCONDITIONALLY are actually present on the base.
+// assertConnInterfaces checks, on a REAL connection the caller already asked
+// for, that the base implements everything the wrapper advertises flatly.
 //
-// This is what makes the shape sound. Four interfaces vary across drivers and
-// are selected per-connection (see the shape note); the rest are advertised
-// flatly, and advertising one the base lacks would change database/sql's
-// behaviour rather than merely add a no-op. Rather than sixteen wrapper types
-// or a comment saying "both drivers have these", the assumption is CHECKED at
-// registration, once, and a driver bump that drops one fails loudly at startup
-// instead of degrading silently in production.
+// It runs at CONNECT time, not at registration, and that is the fix for a
+// genuinely dangerous first version (codex round 3): registration opened a
+// probe *sql.DB for BOTH drivers and called Conn() on each, so creating a
+// SQLite store attempted a live PostgreSQL connection using whatever the
+// environment's default host, port and credentials happened to be — network
+// access, and a wrong-server contact, as a side effect of opening a local file.
+// Worse, the probe swallowed its own connection error, so the guarantees were
+// skipped in exactly the case where the check could not run.
 //
-// It also refuses a base whose STATEMENTS implement NamedValueChecker or
-// ColumnConverter, because guardStmt does not forward those — measured absent
-// on both drivers today, and a driver that gains one would otherwise lose its
-// own argument conversion without any signal.
-func requireBaseInterfaces(name string, probe *sql.DB) error {
-	conn, err := probe.Conn(context.Background())
-	if err != nil {
-		// A driver that cannot open a connection to an empty DSN tells us
-		// nothing; this is a best-effort check, not a reachability test.
-		return nil //nolint:nilerr // see comment
-	}
-	defer func() { _ = conn.Close() }()
-
+// Checking here costs one type-assert set per connection and answers about the
+// connection actually in hand.
+func assertConnInterfaces(c driver.Conn) error {
 	var missing []string
-	rawErr := conn.Raw(func(dc any) error {
-		for _, want := range []struct {
-			name string
-			ok   bool
-		}{
-			{"Pinger", isIface[driver.Pinger](dc)},
-			{"SessionResetter", isIface[driver.SessionResetter](dc)},
-			{"ExecerContext", isIface[driver.ExecerContext](dc)},
-			{"QueryerContext", isIface[driver.QueryerContext](dc)},
-			{"ConnPrepareContext", isIface[driver.ConnPrepareContext](dc)},
-			{"ConnBeginTx", isIface[driver.ConnBeginTx](dc)},
-		} {
-			if !want.ok {
-				missing = append(missing, want.name)
-			}
+	for _, want := range []struct {
+		name string
+		ok   bool
+	}{
+		{"Pinger", isIface[driver.Pinger](c)},
+		{"SessionResetter", isIface[driver.SessionResetter](c)},
+		{"ExecerContext", isIface[driver.ExecerContext](c)},
+		{"QueryerContext", isIface[driver.QueryerContext](c)},
+		{"ConnPrepareContext", isIface[driver.ConnPrepareContext](c)},
+		{"ConnBeginTx", isIface[driver.ConnBeginTx](c)},
+	} {
+		if !want.ok {
+			missing = append(missing, want.name)
 		}
-		return nil
-	})
-	if rawErr != nil {
-		return nil //nolint:nilerr // best-effort, as above
 	}
 	if len(missing) > 0 {
-		return fmt.Errorf("store: driver %q no longer implements %v; the NUL write guard advertises these "+
-			"unconditionally and would misreport them to database/sql — see nulguard.go's shape note", name, missing)
+		return fmt.Errorf("store: the database driver does not implement %v; the NUL write guard "+
+			"advertises these unconditionally and would misreport them to database/sql — see "+
+			"nulguard.go's shape note", missing)
+	}
+	return nil
+}
+
+// assertStmtInterfaces is the statement half, and it exists because the claim
+// was previously made in a COMMENT and nowhere else (codex round 3): the code
+// said statement-level NamedValueChecker and ColumnConverter were "measured
+// absent on both drivers and asserted", and nothing asserted it. guardStmt does
+// not forward either, so a driver that gained one would silently lose its own
+// argument conversion.
+//
+// Checked on the first statement each connection prepares, for the same reason
+// as the conn half: it is the object actually in hand.
+func assertStmtInterfaces(st driver.Stmt) error {
+	if !isIface[driver.StmtExecContext](st) || !isIface[driver.StmtQueryContext](st) {
+		return errors.New("store: driver statements do not implement the context interfaces; the NUL " +
+			"write guard advertises them unconditionally")
+	}
+	if isIface[driver.NamedValueChecker](st) {
+		return errors.New("store: driver statements now implement NamedValueChecker, which the NUL write " +
+			"guard does not forward — forwarding it needs a guardStmt variant, as the conn wrapper has")
+	}
+	//nolint:staticcheck // ColumnConverter is deprecated; a driver still using it would silently lose it
+	if isIface[driver.ColumnConverter](st) {
+		return errors.New("store: driver statements now implement ColumnConverter, which the NUL write " +
+			"guard does not forward")
 	}
 	return nil
 }

--- a/internal/store/nulguard.go
+++ b/internal/store/nulguard.go
@@ -43,6 +43,7 @@ import (
 	"fmt"
 	"reflect"
 	"sync"
+	"time"
 
 	"github.com/PerpetualSoftware/pad/internal/textguard"
 )
@@ -138,8 +139,11 @@ func normalizeAndCheck(args []driver.NamedValue) error {
 		}
 		args[i].Value = resolved
 
-		s, ok := textOf(resolved)
-		if !ok {
+		s, isText, cerr := classify(resolved)
+		if cerr != nil {
+			return cerr
+		}
+		if !isText {
 			continue
 		}
 		if textguard.ContainsNUL(s) {
@@ -158,52 +162,100 @@ func normalizeAndCheck(args []driver.NamedValue) error {
 	return nil
 }
 
-// resolveValue unwraps a driver.Valuer exactly ONCE, mirroring what
-// database/sql's default converter does — including its typed-nil rule, which
-// is why a nil pointer must be answered before Value() is reached rather than
-// by recovering from the panic it would cause.
+// maxValuerDepth bounds the unwrap loop. database/sql's own converter resolves
+// once, but a driver with its own NamedValueChecker may recurse — so the guard
+// resolves to a FIXED POINT rather than once, or an outer valuer returning an
+// inner one would hand the guard a clean value and the driver a NUL-bearing
+// one (codex round 4). The bound exists because a cyclic valuer would hang;
+// four is far past anything real.
+const maxValuerDepth = 4
+
+var valuerType = reflect.TypeOf((*driver.Valuer)(nil)).Elem()
+
+// resolveValue unwraps driver.Valuer to a fixed point, mirroring database/sql's
+// converter at each step — including its typed-nil rule.
+//
+// That rule is COPIED, not approximated: database/sql treats a nil pointer as
+// SQL NULL only when the POINTER'S ELEMENT TYPE implements Valuer, and calls a
+// pointer-receiver-only valuer even when nil. An earlier version here nil'd
+// every nil pointer valuer, which is broader than the library (codex round 4).
 func resolveValue(v driver.Value) (driver.Value, error) {
-	valuer, ok := v.(driver.Valuer)
-	if !ok {
-		return v, nil
+	for depth := 0; depth < maxValuerDepth; depth++ {
+		valuer, ok := v.(driver.Valuer)
+		if !ok {
+			return v, nil
+		}
+		rv := reflect.ValueOf(valuer)
+		if rv.Kind() == reflect.Ptr && rv.IsNil() && rv.Type().Elem().Implements(valuerType) {
+			return nil, nil
+		}
+		out, err := valuer.Value()
+		if err != nil {
+			return nil, err
+		}
+		v = out
 	}
-	rv := reflect.ValueOf(valuer)
-	if rv.Kind() == reflect.Ptr && rv.IsNil() {
-		return nil, nil
-	}
-	out, err := valuer.Value()
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
+	return nil, errors.New("store: parameter valuer did not resolve within the depth bound")
 }
 
-// textOf reports the string a value carries, if it carries one.
+// classify sorts a resolved parameter into text, exempt, or REFUSED.
 //
-// By KIND, not by type identity. A named string type (`type Slug string`) and a
-// *string both carry text that a driver accepting them unconverted would bind
-// as text, and a type-switch on `string` sees neither.
+// An ALLOW-LIST, and that is the point (codex round 4). Two rounds were spent
+// widening a text detector shape by shape — exact string, then *string and
+// named string types, then json.RawMessage — and the next round named five
+// more (json.Marshaler, fmt.Stringer, pgx's TextValuer, defined []byte aliases,
+// JSON-marshallable structs). Enumerating what CAN carry text is a losing game
+// against a driver as permissive as pgx.
 //
-// Byte slices are deliberately NOT text here — see checkParams' classing note:
-// []byte is how this store binds BINARY, and item_yjs_updates.update_data
-// legitimately contains NUL bytes. json.RawMessage is the one byte-slice shape
-// that IS text, and it is recognised by its named type because that is exactly
-// what it means.
-func textOf(v any) (string, bool) {
-	if raw, ok := v.(json.RawMessage); ok {
-		return string(raw), true
+// So this enumerates what the store actually BINDS and refuses anything else.
+// The vocabulary is small and stable: strings, binary blobs, numbers, booleans,
+// times, NULL. A parameter outside it is a programming error, and refusing it
+// loudly beats binding it unchecked — which is what every earlier version did
+// by default.
+func classify(v driver.Value) (text string, isText bool, err error) {
+	if v == nil {
+		return "", false, nil
 	}
+	if raw, ok := v.(json.RawMessage); ok {
+		return string(raw), true, nil
+	}
+
 	rv := reflect.ValueOf(v)
-	for rv.IsValid() && rv.Kind() == reflect.Ptr {
+	for rv.Kind() == reflect.Ptr {
 		if rv.IsNil() {
-			return "", false
+			return "", false, nil
 		}
 		rv = rv.Elem()
 	}
-	if rv.IsValid() && rv.Kind() == reflect.String {
-		return rv.String(), true
+
+	switch rv.Kind() {
+	case reflect.String:
+		return rv.String(), true, nil
+
+	case reflect.Slice:
+		// Byte slices are BINARY and exempt — see the classing note above.
+		// json.RawMessage is handled by name before reaching here, because a
+		// byte slice that means JSON is the one exception.
+		if rv.Type().Elem().Kind() == reflect.Uint8 {
+			return "", false, nil
+		}
+
+	case reflect.Bool,
+		reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Float32, reflect.Float64:
+		return "", false, nil
+
+	case reflect.Struct:
+		// time.Time is the only struct this store binds.
+		if _, ok := rv.Interface().(time.Time); ok {
+			return "", false, nil
+		}
 	}
-	return "", false
+
+	return "", false, fmt.Errorf("store: parameter of type %T is outside the shapes this store binds; "+
+		"the NUL write guard refuses rather than passing an unclassifiable value through unchecked. If "+
+		"this type is legitimate, add it to classify() and say whether it is text or binary", v)
 }
 
 type guardDriver struct{ base driver.Driver }

--- a/internal/store/nulguard.go
+++ b/internal/store/nulguard.go
@@ -1,0 +1,263 @@
+package store
+
+// The NUL invariant's Go-side enforcement (DOC-2823 Layer A, closing BUG-2814
+// and the current-binary half of BUG-2813).
+//
+// WHY THIS IS A DRIVER WRAPPER AND NOT A SEAM IN THIS PACKAGE.
+//
+// The design's first shape was a validating wrapper the store's write calls
+// would route through. Two measurements retired it:
+//
+//   - There is no existing write seam to wrap. `Queryer` (store.go) is
+//     Query + QueryRow — its own doc says "the read-only subset" — and no
+//     store write passes through it.
+//   - Writes reach the driver by FOUR receivers: db.Exec (139 sites),
+//     tx.Exec (99), stmt.Exec (2, prepared in agent_roles.go), and a passed
+//     executor. A wrapper at the *sql.DB / *sql.Tx level cannot see the
+//     prepared ones at all, and sees nothing of SQL built by Sprintf.
+//
+// The deeper reason is the one this whole cluster teaches. A seam every write
+// site must be EDITED to route through is an enumeration wearing a seam's
+// costume: nothing stops the next site taking the raw handle, and the compiler
+// cannot tell you it did. TASK-2825 already watched two instruments each miss
+// write sites the other caught, and dynamically-composed SQL is invisible to
+// any source-level instrument by construction.
+//
+// A driver wrapper has no such property to maintain. It never looks at SQL
+// text — only at bound parameters — so Sprintf-built statements are covered
+// without being understood, and a new call site is covered before it is
+// written. Completeness stops being anyone's job.
+//
+// WHAT IT COVERS. Both ExecContext and QueryContext, on the conn AND on
+// prepared statements. The Query path is not defensive symmetry: three writes
+// ride it today — UPDATE ... RETURNING in password_resets.go and
+// email_verification.go, and INSERT ... RETURNING in yjs_updates.go, which
+// binds a []byte payload on the Postgres path.
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/PerpetualSoftware/pad/internal/textguard"
+)
+
+// ErrInvalidTextParameter is the sentinel behind InvalidTextParameterError.
+var ErrInvalidTextParameter = errors.New("store: invalid text parameter")
+
+// InvalidTextParameterError is the refusal a caller receives when a bound
+// parameter violates the NUL invariant.
+//
+// It carries no parameter VALUE, deliberately: the value is user content and
+// this error travels into logs and, through the handlers, into responses. The
+// ordinal is enough to locate it while debugging, and the reason names the
+// rule rather than quoting the offender.
+type InvalidTextParameterError struct {
+	// Ordinal is the 1-based position of the offending parameter.
+	Ordinal int
+	// Reason is the rule that refused it, phrased for a caller.
+	Reason string
+}
+
+func (e *InvalidTextParameterError) Error() string {
+	return fmt.Sprintf("%s: parameter %d: %s", ErrInvalidTextParameter.Error(), e.Ordinal, e.Reason)
+}
+
+func (e *InvalidTextParameterError) Unwrap() error { return ErrInvalidTextParameter }
+
+// checkParams applies the shared predicate to every string/[]byte argument.
+//
+// CLASSING, and why it is what it is. The wrapper sees positional parameters,
+// not columns, so it cannot consult the 86-column classification directly. It
+// classes a parameter as JSON when the VALUE ITSELF is a complete JSON
+// document — which is sound for this invariant in a way that a column-derived
+// classing would not be cheaper than:
+//
+//   - Every value bound to a JSON-classed column IS a JSON document; the store
+//     marshals it before binding. So no JSON column's value escapes the
+//     document check.
+//   - A user-TEXT column whose value happens to parse as JSON gets the
+//     document check too. That is the only over-reach, and it costs a refusal
+//     only for text that is BOTH valid JSON AND contains an escape that
+//     decodes to a NUL — a value that is, on any column, a value Postgres
+//     would refuse the moment anything parsed it.
+//
+// The alternative — deriving JSON-ness from the call site's knowledge — puts
+// the classification back at the call sites this design exists to stop
+// depending on.
+func checkParams(args []driver.NamedValue) error {
+	for _, a := range args {
+		// STRING ONLY, and []byte is deliberately exempt.
+		//
+		// The invariant is about TEXT and JSON columns. In this store, Go's
+		// `string` is how text and JSON are bound and `[]byte` is how BINARY
+		// is bound — and binary legitimately contains NUL bytes, so checking
+		// []byte refuses valid writes. The existing collab suite caught this
+		// immediately: item_yjs_updates.update_data is raw Yjs binary, and the
+		// first version of this guard refused every op-log append.
+		//
+		// The rule is measured, not assumed:
+		//
+		//   - item_yjs_updates.update_data (BLOB on SQLite, BYTEA on Postgres)
+		//     is the ONLY binary column in either schema.
+		//   - No json.Marshal result is bound without a string() conversion,
+		//     so no JSON column receives a []byte parameter.
+		//
+		// The second of those was established by a source-level sweep, and
+		// this unit's own history is a catalogue of source-level sweeps missing
+		// things. So the claim is pinned BEHAVIOURALLY rather than trusted:
+		// TestBinaryColumnCensus fails the moment a new BLOB/BYTEA column
+		// enters either schema, which is when someone must re-examine whether
+		// []byte is still binary-only here.
+		s, ok := a.Value.(string)
+		if !ok {
+			continue
+		}
+		if textguard.ContainsNUL(s) {
+			return &InvalidTextParameterError{
+				Ordinal: a.Ordinal,
+				Reason:  "value contains a NUL byte, which no text or JSON column can store",
+			}
+		}
+		if textguard.DocumentDecodesNUL(s) {
+			return &InvalidTextParameterError{
+				Ordinal: a.Ordinal,
+				Reason:  "value is a JSON document containing an escape that decodes to a NUL",
+			}
+		}
+	}
+	return nil
+}
+
+// ---- the wrapper ----
+
+type guardDriver struct{ base driver.Driver }
+
+func (d guardDriver) Open(name string) (driver.Conn, error) {
+	c, err := d.base.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	return guardConn{c}, nil
+}
+
+type guardConn struct{ driver.Conn }
+
+// Prepare exists because driver.Conn requires it, and it DELEGATES rather than
+// wrapping separately.
+//
+// A mutation is why: giving it its own wrapping body left a second place to get
+// the wrapping right, and dropping the wrap there survived the whole suite —
+// because database/sql routes to PrepareContext whenever the conn implements
+// driver.ConnPrepareContext, which both modernc and pgx do. So the branch was
+// unreachable for every driver Pad uses, and a test for it would have been a
+// test of nothing. One implementation is better than an untestable second.
+func (c guardConn) Prepare(q string) (driver.Stmt, error) {
+	return c.PrepareContext(context.Background(), q)
+}
+
+func (c guardConn) PrepareContext(ctx context.Context, q string) (driver.Stmt, error) {
+	if p, ok := c.Conn.(driver.ConnPrepareContext); ok {
+		s, err := p.PrepareContext(ctx, q)
+		if err != nil {
+			return nil, err
+		}
+		return guardStmt{s}, nil
+	}
+	s, err := c.Conn.Prepare(q)
+	if err != nil {
+		return nil, err
+	}
+	return guardStmt{s}, nil
+}
+
+func (c guardConn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
+	if b, ok := c.Conn.(driver.ConnBeginTx); ok {
+		return b.BeginTx(ctx, opts)
+	}
+	return c.Conn.Begin() //nolint:staticcheck // fallback for a driver without ConnBeginTx
+}
+
+// ExecContext and QueryContext return driver.ErrSkip when the base conn does
+// not implement the optional interface, which makes database/sql fall back to
+// Prepare + the statement path — where guardStmt applies the same check. The
+// value never reaches the database unvalidated on either route.
+func (c guardConn) ExecContext(ctx context.Context, q string, args []driver.NamedValue) (driver.Result, error) {
+	if err := checkParams(args); err != nil {
+		return nil, err
+	}
+	if e, ok := c.Conn.(driver.ExecerContext); ok {
+		return e.ExecContext(ctx, q, args)
+	}
+	return nil, driver.ErrSkip
+}
+
+func (c guardConn) QueryContext(ctx context.Context, q string, args []driver.NamedValue) (driver.Rows, error) {
+	if err := checkParams(args); err != nil {
+		return nil, err
+	}
+	if qc, ok := c.Conn.(driver.QueryerContext); ok {
+		return qc.QueryContext(ctx, q, args)
+	}
+	return nil, driver.ErrSkip
+}
+
+type guardStmt struct{ driver.Stmt }
+
+func (s guardStmt) ExecContext(ctx context.Context, args []driver.NamedValue) (driver.Result, error) {
+	if err := checkParams(args); err != nil {
+		return nil, err
+	}
+	if e, ok := s.Stmt.(driver.StmtExecContext); ok {
+		return e.ExecContext(ctx, args)
+	}
+	return nil, driver.ErrSkip
+}
+
+func (s guardStmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driver.Rows, error) {
+	if err := checkParams(args); err != nil {
+		return nil, err
+	}
+	if q, ok := s.Stmt.(driver.StmtQueryContext); ok {
+		return q.QueryContext(ctx, args)
+	}
+	return nil, driver.ErrSkip
+}
+
+// ---- registration ----
+
+const (
+	guardedSQLiteDriver   = "pad-sqlite-nulguard"
+	guardedPostgresDriver = "pad-pgx-nulguard"
+)
+
+var registerGuarded sync.Once
+var registerGuardedErr error
+
+// registerGuardedDrivers registers the wrapping driver names once per process.
+//
+// The base driver is taken from a throwaway sql.DB rather than from a driver
+// value the imported packages export, because neither modernc.org/sqlite nor
+// pgx/stdlib exports one under a stable name. sql.Open does not dial, so the
+// throwaway costs nothing.
+func registerGuardedDrivers() error {
+	registerGuarded.Do(func() {
+		for _, d := range []struct{ base, guarded string }{
+			{"sqlite", guardedSQLiteDriver},
+			{"pgx", guardedPostgresDriver},
+		} {
+			probe, err := sql.Open(d.base, "")
+			if err != nil {
+				registerGuardedErr = fmt.Errorf("resolve %s driver: %w", d.base, err)
+				return
+			}
+			base := probe.Driver()
+			_ = probe.Close()
+			sql.Register(d.guarded, guardDriver{base: base})
+		}
+	})
+	return registerGuardedErr
+}

--- a/internal/store/nulguard.go
+++ b/internal/store/nulguard.go
@@ -129,7 +129,7 @@ func checkParams(args []driver.NamedValue) error {
 		// TestBinaryColumnCensus fails the moment a new BLOB/BYTEA column
 		// enters either schema, which is when someone must re-examine whether
 		// []byte is still binary-only here.
-		s, ok := a.Value.(string)
+		s, ok := checkedValue(a.Value)
 		if !ok {
 			continue
 		}
@@ -150,6 +150,61 @@ func checkParams(args []driver.NamedValue) error {
 }
 
 // ---- the wrapper ----
+//
+// SHAPE, and why it is not one type.
+//
+// A wrapper that implements an optional interface the BASE lacks does not
+// merely add a no-op: database/sql BRANCHES on whether the interface is
+// present, so advertising one changes its behaviour even when the method
+// delegates faithfully. Measured on the two drivers Pad uses:
+//
+//	                        sqlite   pgx
+//	driver.DriverContext    no       YES
+//	conn Pinger             yes      yes
+//	conn SessionResetter    yes      yes
+//	conn Validator          yes      NO
+//	conn NamedValueChecker  no       YES
+//	stmt NamedValueChecker  no       no
+//	stmt ColumnConverter    no       no
+//
+// So Validator and NamedValueChecker VARY between the two, and a single
+// wrapper type advertising both would have told database/sql that pgx
+// validates connections and that sqlite converts its own arguments — neither
+// true (codex round 2). The conn wrapper is therefore selected per-connection
+// from four variants covering those two interfaces.
+//
+// The interfaces that do NOT vary are asserted at registration instead of
+// varied over: requireBaseInterfaces fails loudly if a driver bump ever drops
+// one, which is better than silently degrading and better than sixteen types.
+
+// checkedValue extracts the string a parameter will bind, following
+// driver.Valuer when the driver's own NamedValueChecker has left one in place.
+//
+// This closes a real hole (codex round 2). checkParams originally type-asserted
+// `string` only, and pgx implements NamedValueChecker — so it ACCEPTS a
+// sql.NullString unchanged rather than letting database/sql's default converter
+// unwrap it, and the guard never saw the text. Measured: on Postgres a
+// sql.NullString carrying a NUL passed the guard entirely and was refused by
+// the server with SQLSTATE 22021, i.e. as a 500 rather than the typed 400 the
+// same value gets on SQLite. The dialect split, reappearing in the response
+// shape. internal/store/wiki_links.go binds sql.NullString today.
+func checkedValue(v driver.Value) (string, bool) {
+	switch t := v.(type) {
+	case string:
+		return t, true
+	case driver.Valuer:
+		// Value() is contractually pure; the standard converter calls it for
+		// exactly this purpose.
+		inner, err := t.Value()
+		if err != nil {
+			return "", false
+		}
+		if str, ok := inner.(string); ok {
+			return str, true
+		}
+	}
+	return "", false
+}
 
 type guardDriver struct{ base driver.Driver }
 
@@ -158,182 +213,156 @@ func (d guardDriver) Open(name string) (driver.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
-	return guardConn{c}, nil
+	return wrapConn(c), nil
 }
 
-// guardConn forwards the OPTIONAL connection interfaces as well as the
-// required ones.
+// guardDriverCtx is guardDriver PLUS driver.DriverContext, and it is a separate
+// TYPE for the same reason the conn wrapper has four variants: implementing
+// OpenConnector unconditionally would advertise DriverContext for sqlite, whose
+// base lacks it.
 //
-// Embedding driver.Conn alone silently HID them, which is a production
-// regression rather than a cosmetic gap: measured, the raw modernc conn
-// implements Pinger, SessionResetter and Validator, and the wrapped one
-// implemented none. database/sql degrades quietly for each — Ping succeeds
-// without pinging anything, pooled connections stop being reset between uses,
-// and a connection the driver knows is dead stays in the pool.
+// That is not hypothetical caution — the first version of this fix did exactly
+// that, and every SQLite open failed at once. The failure was loud, which is
+// the only reason it cost minutes; the same mistake on a method database/sql
+// merely branches on would have been silent.
 //
-// Each method below delegates when the base supports it and otherwise does
-// exactly what database/sql does for a conn that lacks the interface, so
-// wrapping a driver without one is equivalent to not wrapping it. Always
-// implementing them is safe for that reason.
+// The interface matters because without it sql.Open falls back to a legacy
+// connector that IGNORES the context, so a cancelled or deadlined request can
+// leave a connection attempt running — on pgx, up to its 60-second dial timeout
+// (codex round 2).
+type guardDriverCtx struct{ guardDriver }
+
+func (d guardDriverCtx) OpenConnector(name string) (driver.Connector, error) {
+	c, err := d.base.(driver.DriverContext).OpenConnector(name)
+	if err != nil {
+		return nil, err
+	}
+	// The OUTER driver, not the embedded one. database/sql answers
+	// db.Driver() from the connector, so handing back guardDriver here made a
+	// pgx-backed pool report a driver WITHOUT DriverContext — losing the very
+	// interface this type exists to forward. Caught by the parity test on its
+	// first run, which is what that test is for.
+	return guardConnector{base: c, drv: d}, nil
+}
+
+type guardConnector struct {
+	base driver.Connector
+	drv  driver.Driver
+}
+
+func (c guardConnector) Connect(ctx context.Context) (driver.Conn, error) {
+	conn, err := c.base.Connect(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return wrapConn(conn), nil
+}
+
+func (c guardConnector) Driver() driver.Driver { return c.drv }
+
+// wrapConn selects the variant matching the base connection's optional
+// interfaces. See the shape note above for why this is a selection rather than
+// one type.
+func wrapConn(c driver.Conn) driver.Conn {
+	_, hasValidator := c.(driver.Validator)
+	_, hasNVC := c.(driver.NamedValueChecker)
+	base := guardConn{c}
+	switch {
+	case hasValidator && hasNVC:
+		return guardConnVN{base}
+	case hasValidator:
+		return guardConnV{base}
+	case hasNVC:
+		return guardConnN{base}
+	default:
+		return base
+	}
+}
+
 type guardConn struct{ driver.Conn }
 
+// Pinger and SessionResetter are implemented unconditionally, which is sound
+// only because requireBaseInterfaces has already established that every base
+// has them.
 func (c guardConn) Ping(ctx context.Context) error {
-	if p, ok := c.Conn.(driver.Pinger); ok {
-		return p.Ping(ctx)
-	}
-	// database/sql treats a non-Pinger connection as reachable by virtue of
-	// existing; matching that keeps the wrapper transparent.
-	return nil
+	return c.Conn.(driver.Pinger).Ping(ctx)
 }
 
 func (c guardConn) ResetSession(ctx context.Context) error {
-	if r, ok := c.Conn.(driver.SessionResetter); ok {
-		return r.ResetSession(ctx)
-	}
-	return nil
+	return c.Conn.(driver.SessionResetter).ResetSession(ctx)
 }
 
-func (c guardConn) IsValid() bool {
-	if v, ok := c.Conn.(driver.Validator); ok {
-		return v.IsValid()
-	}
-	return true
+type guardConnV struct{ guardConn }
+
+func (c guardConnV) IsValid() bool { return c.Conn.(driver.Validator).IsValid() }
+
+type guardConnN struct{ guardConn }
+
+func (c guardConnN) CheckNamedValue(nv *driver.NamedValue) error {
+	return c.Conn.(driver.NamedValueChecker).CheckNamedValue(nv)
 }
 
-// CheckNamedValue forwards the driver's own argument conversion when it has
-// one. Without this the wrapper would fall back to database/sql's default
-// converter and quietly narrow the argument types a driver accepts — pgx in
-// particular converts a great deal more than the default does.
-func (c guardConn) CheckNamedValue(nv *driver.NamedValue) error {
-	if ck, ok := c.Conn.(driver.NamedValueChecker); ok {
-		return ck.CheckNamedValue(nv)
-	}
-	return driver.ErrSkip
+type guardConnVN struct{ guardConn }
+
+func (c guardConnVN) IsValid() bool { return c.Conn.(driver.Validator).IsValid() }
+
+func (c guardConnVN) CheckNamedValue(nv *driver.NamedValue) error {
+	return c.Conn.(driver.NamedValueChecker).CheckNamedValue(nv)
 }
 
-// Prepare exists because driver.Conn requires it, and it DELEGATES rather than
-// wrapping separately.
-//
-// A mutation is why: giving it its own wrapping body left a second place to get
-// the wrapping right, and dropping the wrap there survived the whole suite —
-// because database/sql routes to PrepareContext whenever the conn implements
-// driver.ConnPrepareContext, which both modernc and pgx do. So the branch was
-// unreachable for every driver Pad uses, and a test for it would have been a
-// test of nothing. One implementation is better than an untestable second.
+// Prepare delegates to PrepareContext so there is ONE wrapping site. A mutation
+// showed the separate body was unreachable: database/sql routes to
+// PrepareContext whenever the conn implements ConnPrepareContext, which every
+// base here does (asserted at registration).
 func (c guardConn) Prepare(q string) (driver.Stmt, error) {
 	return c.PrepareContext(context.Background(), q)
 }
 
 func (c guardConn) PrepareContext(ctx context.Context, q string) (driver.Stmt, error) {
-	if p, ok := c.Conn.(driver.ConnPrepareContext); ok {
-		s, err := p.PrepareContext(ctx, q)
-		if err != nil {
-			return nil, err
-		}
-		return guardStmt{s}, nil
-	}
-	s, err := c.Conn.Prepare(q)
+	st, err := c.Conn.(driver.ConnPrepareContext).PrepareContext(ctx, q)
 	if err != nil {
 		return nil, err
 	}
-	return guardStmt{s}, nil
+	return guardStmt{st}, nil
 }
 
 func (c guardConn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
-	if b, ok := c.Conn.(driver.ConnBeginTx); ok {
-		return b.BeginTx(ctx, opts)
-	}
-	// A base without ConnBeginTx cannot honour isolation or read-only, and
-	// SILENTLY starting a plain transaction would give the caller weaker
-	// guarantees than it asked for. database/sql itself refuses in this
-	// situation; matching that keeps the wrapper transparent rather than
-	// permissive.
-	if opts.Isolation != driver.IsolationLevel(sql.LevelDefault) || opts.ReadOnly {
-		return nil, errors.New("store: driver does not support transaction options")
-	}
-	return c.Conn.Begin() //nolint:staticcheck // fallback for a driver without ConnBeginTx
+	return c.Conn.(driver.ConnBeginTx).BeginTx(ctx, opts)
 }
 
-// ExecContext and QueryContext return driver.ErrSkip when the base conn does
-// not implement the optional interface, which makes database/sql fall back to
-// Prepare + the statement path — where guardStmt applies the same check. The
-// value never reaches the database unvalidated on either route.
 func (c guardConn) ExecContext(ctx context.Context, q string, args []driver.NamedValue) (driver.Result, error) {
 	if err := checkParams(args); err != nil {
 		return nil, err
 	}
-	if e, ok := c.Conn.(driver.ExecerContext); ok {
-		return e.ExecContext(ctx, q, args)
-	}
-	return nil, driver.ErrSkip
+	return c.Conn.(driver.ExecerContext).ExecContext(ctx, q, args)
 }
 
 func (c guardConn) QueryContext(ctx context.Context, q string, args []driver.NamedValue) (driver.Rows, error) {
 	if err := checkParams(args); err != nil {
 		return nil, err
 	}
-	if qc, ok := c.Conn.(driver.QueryerContext); ok {
-		return qc.QueryContext(ctx, q, args)
-	}
-	return nil, driver.ErrSkip
+	return c.Conn.(driver.QueryerContext).QueryContext(ctx, q, args)
 }
 
+// guardStmt wraps only the two context forms, which every base statement here
+// implements (asserted at registration). Statement-level NamedValueChecker and
+// ColumnConverter are NOT forwarded because neither driver implements them —
+// measured, and asserted, so a driver that starts to will fail registration
+// rather than silently lose its conversion.
 type guardStmt struct{ driver.Stmt }
 
-// The statement methods FALL BACK to the positional form rather than returning
-// driver.ErrSkip.
-//
-// The distinction matters and the first version had it wrong. At the CONN
-// level, ErrSkip is the documented signal and database/sql falls back to
-// prepare-and-execute. At the STATEMENT level it does not: because this
-// wrapper always implements StmtExecContext, database/sql calls it and
-// propagates whatever comes back, so an ErrSkip would surface as a query
-// FAILURE against any base statement lacking the context form rather than
-// degrading to the older interface.
 func (s guardStmt) ExecContext(ctx context.Context, args []driver.NamedValue) (driver.Result, error) {
 	if err := checkParams(args); err != nil {
 		return nil, err
 	}
-	if e, ok := s.Stmt.(driver.StmtExecContext); ok {
-		return e.ExecContext(ctx, args)
-	}
-	vals, err := positionalArgs(args)
-	if err != nil {
-		return nil, err
-	}
-	return s.Stmt.Exec(vals) //nolint:staticcheck // the documented fallback for a pre-context driver
+	return s.Stmt.(driver.StmtExecContext).ExecContext(ctx, args)
 }
 
 func (s guardStmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driver.Rows, error) {
 	if err := checkParams(args); err != nil {
 		return nil, err
 	}
-	if q, ok := s.Stmt.(driver.StmtQueryContext); ok {
-		return q.QueryContext(ctx, args)
-	}
-	vals, err := positionalArgs(args)
-	if err != nil {
-		return nil, err
-	}
-	return s.Stmt.Query(vals) //nolint:staticcheck // the documented fallback for a pre-context driver
-}
-
-// positionalArgs converts named values back to the positional form the
-// pre-context statement interfaces take, refusing a NAMED argument rather than
-// dropping its name — silently binding a named parameter by position would
-// bind the wrong value.
-func positionalArgs(args []driver.NamedValue) ([]driver.Value, error) {
-	vals := make([]driver.Value, len(args))
-	for _, a := range args {
-		if a.Name != "" {
-			return nil, errors.New("store: driver does not support named parameters")
-		}
-		if a.Ordinal < 1 || a.Ordinal > len(vals) {
-			return nil, errors.New("store: parameter ordinal out of range")
-		}
-		vals[a.Ordinal-1] = a.Value
-	}
-	return vals, nil
+	return s.Stmt.(driver.StmtQueryContext).QueryContext(ctx, args)
 }
 
 // ---- registration ----
@@ -364,9 +393,77 @@ func registerGuardedDrivers() error {
 				return
 			}
 			base := probe.Driver()
+			if err := requireBaseInterfaces(d.base, probe); err != nil {
+				_ = probe.Close()
+				registerGuardedErr = err
+				return
+			}
 			_ = probe.Close()
-			sql.Register(d.guarded, guardDriver{base: base})
+			wrapped := guardDriver{base: base}
+			if _, ok := base.(driver.DriverContext); ok {
+				sql.Register(d.guarded, guardDriverCtx{wrapped})
+			} else {
+				sql.Register(d.guarded, wrapped)
+			}
 		}
 	})
 	return registerGuardedErr
+}
+
+// requireBaseInterfaces asserts the optional interfaces the wrapper implements
+// UNCONDITIONALLY are actually present on the base.
+//
+// This is what makes the shape sound. Four interfaces vary across drivers and
+// are selected per-connection (see the shape note); the rest are advertised
+// flatly, and advertising one the base lacks would change database/sql's
+// behaviour rather than merely add a no-op. Rather than sixteen wrapper types
+// or a comment saying "both drivers have these", the assumption is CHECKED at
+// registration, once, and a driver bump that drops one fails loudly at startup
+// instead of degrading silently in production.
+//
+// It also refuses a base whose STATEMENTS implement NamedValueChecker or
+// ColumnConverter, because guardStmt does not forward those — measured absent
+// on both drivers today, and a driver that gains one would otherwise lose its
+// own argument conversion without any signal.
+func requireBaseInterfaces(name string, probe *sql.DB) error {
+	conn, err := probe.Conn(context.Background())
+	if err != nil {
+		// A driver that cannot open a connection to an empty DSN tells us
+		// nothing; this is a best-effort check, not a reachability test.
+		return nil //nolint:nilerr // see comment
+	}
+	defer func() { _ = conn.Close() }()
+
+	var missing []string
+	rawErr := conn.Raw(func(dc any) error {
+		for _, want := range []struct {
+			name string
+			ok   bool
+		}{
+			{"Pinger", isIface[driver.Pinger](dc)},
+			{"SessionResetter", isIface[driver.SessionResetter](dc)},
+			{"ExecerContext", isIface[driver.ExecerContext](dc)},
+			{"QueryerContext", isIface[driver.QueryerContext](dc)},
+			{"ConnPrepareContext", isIface[driver.ConnPrepareContext](dc)},
+			{"ConnBeginTx", isIface[driver.ConnBeginTx](dc)},
+		} {
+			if !want.ok {
+				missing = append(missing, want.name)
+			}
+		}
+		return nil
+	})
+	if rawErr != nil {
+		return nil //nolint:nilerr // best-effort, as above
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("store: driver %q no longer implements %v; the NUL write guard advertises these "+
+			"unconditionally and would misreport them to database/sql — see nulguard.go's shape note", name, missing)
+	}
+	return nil
+}
+
+func isIface[T any](v any) bool {
+	_, ok := v.(T)
+	return ok
 }

--- a/internal/store/nulguard_bench_test.go
+++ b/internal/store/nulguard_bench_test.go
@@ -17,7 +17,7 @@ import (
 // was judged worth paying at ONE door; this is a cost at every door, so it
 // needs its own number rather than an assumption that a byte scan is free.
 //
-// What is being measured is checkParams against parameter shapes the read path
+// What is being measured is normalizeAndCheck against parameter shapes the read path
 // actually binds — ids, slugs, short filter strings — plus the shapes that
 // exercise each arm, so the answer says which arm costs what.
 func benchArgs(vals ...string) []driver.NamedValue {
@@ -30,12 +30,12 @@ func benchArgs(vals ...string) []driver.NamedValue {
 
 // The overwhelmingly common read shape: a workspace id and an item id, both
 // UUIDs. Every list, every resolve, every permission check.
-func BenchmarkCheckParams_TypicalRead(b *testing.B) {
+func BenchmarkNormalizeAndCheck_TypicalRead(b *testing.B) {
 	args := benchArgs("5f13fa9a-78e7-4aff-92d5-a85b80b35eaf", "0dbe0458-a965-4fc2-85d7-ab6f5e140a56")
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if err := checkParams(args); err != nil {
+		if err := normalizeAndCheck(args); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -43,12 +43,12 @@ func BenchmarkCheckParams_TypicalRead(b *testing.B) {
 
 // A read carrying user text — a search term or a title filter. Still no JSON,
 // so still the cheap arm.
-func BenchmarkCheckParams_ReadWithUserText(b *testing.B) {
+func BenchmarkNormalizeAndCheck_ReadWithUserText(b *testing.B) {
 	args := benchArgs("5f13fa9a-78e7-4aff-92d5-a85b80b35eaf", "a reasonably long search phrase someone might type")
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if err := checkParams(args); err != nil {
+		if err := normalizeAndCheck(args); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -56,13 +56,13 @@ func BenchmarkCheckParams_ReadWithUserText(b *testing.B) {
 
 // The []byte exemption's cost: a Yjs op-log append binds a blob, and the guard
 // must skip it without touching the bytes.
-func BenchmarkCheckParams_BinaryParameterSkipped(b *testing.B) {
+func BenchmarkNormalizeAndCheck_BinaryParameterSkipped(b *testing.B) {
 	blob := make([]byte, 64*1024)
 	args := []driver.NamedValue{{Ordinal: 1, Value: "item-id"}, {Ordinal: 2, Value: blob}}
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if err := checkParams(args); err != nil {
+		if err := normalizeAndCheck(args); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -71,13 +71,13 @@ func BenchmarkCheckParams_BinaryParameterSkipped(b *testing.B) {
 // A JSON-classed WRITE: a realistic item fields blob carrying no escape, so it
 // pays the IsJSONDocument parse but not the walk. This is the arm that must not
 // run on reads.
-func BenchmarkCheckParams_JSONWriteNoEscape(b *testing.B) {
+func BenchmarkNormalizeAndCheck_JSONWriteNoEscape(b *testing.B) {
 	fields := `{"status":"in-progress","priority":"high","effort":"m","due_date":"2026-09-30","assignee":"someone@example.com"}`
 	args := benchArgs("item-id", fields)
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if err := checkParams(args); err != nil {
+		if err := normalizeAndCheck(args); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -91,14 +91,14 @@ func BenchmarkCheckParams_JSONWriteNoEscape(b *testing.B) {
 // textguard.EscNUL and every iteration was refused, which is why it silently
 // produced no result at all. It is a \u0041 (the letter A), built rather than
 // typed for the same reason every other escape in this unit is.
-func BenchmarkCheckParams_JSONWriteWithEscape(b *testing.B) {
+func BenchmarkNormalizeAndCheck_JSONWriteWithEscape(b *testing.B) {
 	harmlessEscape := string([]byte{'\\', 'u', '0', '0', '4', '1'})
 	fields := `{"status":"open","note":"harmless ` + harmlessEscape + ` text","priority":"low"}`
 	args := benchArgs("item-id", fields)
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if err := checkParams(args); err != nil {
+		if err := normalizeAndCheck(args); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -107,7 +107,7 @@ func BenchmarkCheckParams_JSONWriteWithEscape(b *testing.B) {
 // A large content write — the shape that would hurt most if the JSON arm ran
 // on everything. Content is user text, not JSON, so the escape pre-filter
 // short-circuits before any parse.
-func BenchmarkCheckParams_LargeTextWrite(b *testing.B) {
+func BenchmarkNormalizeAndCheck_LargeTextWrite(b *testing.B) {
 	body := make([]byte, 0, 256*1024)
 	for len(body) < 256*1024 {
 		body = append(body, "Lorem ipsum dolor sit amet, consectetur adipiscing elit. "...)
@@ -116,7 +116,7 @@ func BenchmarkCheckParams_LargeTextWrite(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if err := checkParams(args); err != nil {
+		if err := normalizeAndCheck(args); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -125,7 +125,7 @@ func BenchmarkCheckParams_LargeTextWrite(b *testing.B) {
 // The number that actually decides whether the guard is affordable: a REAL
 // read through the store, guarded, against the same read on the raw driver.
 //
-// checkParams' 33ns is meaningless on its own — it is only a cost if it is a
+// normalizeAndCheck' 33ns is meaningless on its own — it is only a cost if it is a
 // cost RELATIVE to the statement it rides on. These two benchmarks are the
 // same query on the same data, differing only in which driver name the pool
 // was opened with, so the ratio between them is the guard's real overhead on
@@ -169,14 +169,14 @@ func BenchmarkStoreRead_Unguarded(b *testing.B) { benchReadStore(b, false) }
 // and stated at the width the measurement supports rather than as a headline
 // number, because the end-to-end pair does NOT resolve the difference.
 //
-// Per-call, checkParams against a typical read's parameters (two UUIDs):
+// Per-call, normalizeAndCheck against a typical read's parameters (two UUIDs):
 //
-//	BenchmarkCheckParams_TypicalRead      33.5 ns/op    0 B/op   0 allocs/op
-//	BenchmarkCheckParams_ReadWithUserText 33.9 ns/op    0 B/op   0 allocs/op
-//	BenchmarkCheckParams_BinarySkipped    20.2 ns/op    0 B/op   0 allocs/op
-//	BenchmarkCheckParams_JSONWriteNoEscape 32.5 ns/op   0 B/op   0 allocs/op
-//	BenchmarkCheckParams_JSONWriteWithEscape 2167 ns/op 697 B/op 16 allocs/op
-//	BenchmarkCheckParams_LargeTextWrite (256 KiB) 7365 ns/op 0 B/op 0 allocs/op
+//	BenchmarkNormalizeAndCheck_TypicalRead      33.5 ns/op    0 B/op   0 allocs/op
+//	BenchmarkNormalizeAndCheck_ReadWithUserText 33.9 ns/op    0 B/op   0 allocs/op
+//	BenchmarkNormalizeAndCheck_BinarySkipped    20.2 ns/op    0 B/op   0 allocs/op
+//	BenchmarkNormalizeAndCheck_JSONWriteNoEscape 32.5 ns/op   0 B/op   0 allocs/op
+//	BenchmarkNormalizeAndCheck_JSONWriteWithEscape 2167 ns/op 697 B/op 16 allocs/op
+//	BenchmarkNormalizeAndCheck_LargeTextWrite (256 KiB) 7365 ns/op 0 B/op 0 allocs/op
 //
 // End-to-end, the same GetItem guarded and unguarded, 3000x x 3:
 //
@@ -200,7 +200,7 @@ func BenchmarkStoreRead_Unguarded(b *testing.B) { benchReadStore(b, false) }
 // of read is ~0.03%. The JSON arm — the only expensive one — does not run on
 // reads, and not because reads are special: it is gated behind the escape
 // pre-filter, so it runs only for a value that actually contains the escape.
-// BenchmarkCheckParams_JSONWriteNoEscape is the evidence for that, at 32.5 ns
+// BenchmarkNormalizeAndCheck_JSONWriteNoEscape is the evidence for that, at 32.5 ns
 // and zero allocations on a realistic fields blob.
 
 // benchStore opens a store on the guarded or the raw driver. It duplicates a

--- a/internal/store/nulguard_bench_test.go
+++ b/internal/store/nulguard_bench_test.go
@@ -1,0 +1,234 @@
+package store
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"path/filepath"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// The read-path cost measurement S1 named as owed.
+//
+// The guard touches EVERY statement, reads included, so its per-parameter cost
+// is paid on the read flood rather than only on writes. BUG-2812 already
+// measured the HTTP gate at ~1.5x alloc / ~2.0x CPU on large bodies and that
+// was judged worth paying at ONE door; this is a cost at every door, so it
+// needs its own number rather than an assumption that a byte scan is free.
+//
+// What is being measured is checkParams against parameter shapes the read path
+// actually binds — ids, slugs, short filter strings — plus the shapes that
+// exercise each arm, so the answer says which arm costs what.
+func benchArgs(vals ...string) []driver.NamedValue {
+	out := make([]driver.NamedValue, len(vals))
+	for i, v := range vals {
+		out[i] = driver.NamedValue{Ordinal: i + 1, Value: v}
+	}
+	return out
+}
+
+// The overwhelmingly common read shape: a workspace id and an item id, both
+// UUIDs. Every list, every resolve, every permission check.
+func BenchmarkCheckParams_TypicalRead(b *testing.B) {
+	args := benchArgs("5f13fa9a-78e7-4aff-92d5-a85b80b35eaf", "0dbe0458-a965-4fc2-85d7-ab6f5e140a56")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := checkParams(args); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// A read carrying user text — a search term or a title filter. Still no JSON,
+// so still the cheap arm.
+func BenchmarkCheckParams_ReadWithUserText(b *testing.B) {
+	args := benchArgs("5f13fa9a-78e7-4aff-92d5-a85b80b35eaf", "a reasonably long search phrase someone might type")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := checkParams(args); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// The []byte exemption's cost: a Yjs op-log append binds a blob, and the guard
+// must skip it without touching the bytes.
+func BenchmarkCheckParams_BinaryParameterSkipped(b *testing.B) {
+	blob := make([]byte, 64*1024)
+	args := []driver.NamedValue{{Ordinal: 1, Value: "item-id"}, {Ordinal: 2, Value: blob}}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := checkParams(args); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// A JSON-classed WRITE: a realistic item fields blob carrying no escape, so it
+// pays the IsJSONDocument parse but not the walk. This is the arm that must not
+// run on reads.
+func BenchmarkCheckParams_JSONWriteNoEscape(b *testing.B) {
+	fields := `{"status":"in-progress","priority":"high","effort":"m","due_date":"2026-09-30","assignee":"someone@example.com"}`
+	args := benchArgs("item-id", fields)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := checkParams(args); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// The same blob WITH an escape present, so the escape pre-filter fires and the
+// full decode-and-walk runs. The worst case for an ACCEPTED value.
+//
+// The escape here must NOT decode to a NUL, or the benchmark measures the
+// refusal path instead of the acceptance path — the first version of this used
+// textguard.EscNUL and every iteration was refused, which is why it silently
+// produced no result at all. It is a \u0041 (the letter A), built rather than
+// typed for the same reason every other escape in this unit is.
+func BenchmarkCheckParams_JSONWriteWithEscape(b *testing.B) {
+	harmlessEscape := string([]byte{'\\', 'u', '0', '0', '4', '1'})
+	fields := `{"status":"open","note":"harmless ` + harmlessEscape + ` text","priority":"low"}`
+	args := benchArgs("item-id", fields)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := checkParams(args); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// A large content write — the shape that would hurt most if the JSON arm ran
+// on everything. Content is user text, not JSON, so the escape pre-filter
+// short-circuits before any parse.
+func BenchmarkCheckParams_LargeTextWrite(b *testing.B) {
+	body := make([]byte, 0, 256*1024)
+	for len(body) < 256*1024 {
+		body = append(body, "Lorem ipsum dolor sit amet, consectetur adipiscing elit. "...)
+	}
+	args := benchArgs("item-id", string(body))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := checkParams(args); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// The number that actually decides whether the guard is affordable: a REAL
+// read through the store, guarded, against the same read on the raw driver.
+//
+// checkParams' 33ns is meaningless on its own — it is only a cost if it is a
+// cost RELATIVE to the statement it rides on. These two benchmarks are the
+// same query on the same data, differing only in which driver name the pool
+// was opened with, so the ratio between them is the guard's real overhead on
+// the read flood.
+func benchReadStore(b *testing.B, guarded bool) {
+	b.Helper()
+	s := benchStore(b, guarded)
+	ws, err := s.CreateWorkspace(models.WorkspaceCreate{Name: "Bench"})
+	if err != nil {
+		b.Fatalf("workspace: %v", err)
+	}
+	col, err := s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name:   "Tasks",
+		Schema: `{"fields":[{"key":"status","type":"select","options":["open","done"],"default":"open","required":true}]}`,
+	})
+	if err != nil {
+		b.Fatalf("collection: %v", err)
+	}
+	item, err := s.CreateItem(ws.ID, col.ID, models.ItemCreate{
+		Title:   "Bench subject",
+		Content: "a body of the sort a real item carries",
+		Fields:  `{"status":"open"}`,
+	})
+	if err != nil {
+		b.Fatalf("item: %v", err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := s.GetItem(item.ID); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkStoreRead_Guarded(b *testing.B)   { benchReadStore(b, true) }
+func BenchmarkStoreRead_Unguarded(b *testing.B) { benchReadStore(b, false) }
+
+// THE RESULT, recorded here so the next reader does not have to re-derive it —
+// and stated at the width the measurement supports rather than as a headline
+// number, because the end-to-end pair does NOT resolve the difference.
+//
+// Per-call, checkParams against a typical read's parameters (two UUIDs):
+//
+//	BenchmarkCheckParams_TypicalRead      33.5 ns/op    0 B/op   0 allocs/op
+//	BenchmarkCheckParams_ReadWithUserText 33.9 ns/op    0 B/op   0 allocs/op
+//	BenchmarkCheckParams_BinarySkipped    20.2 ns/op    0 B/op   0 allocs/op
+//	BenchmarkCheckParams_JSONWriteNoEscape 32.5 ns/op   0 B/op   0 allocs/op
+//	BenchmarkCheckParams_JSONWriteWithEscape 2167 ns/op 697 B/op 16 allocs/op
+//	BenchmarkCheckParams_LargeTextWrite (256 KiB) 7365 ns/op 0 B/op 0 allocs/op
+//
+// End-to-end, the same GetItem guarded and unguarded, 3000x x 3:
+//
+//	Guarded    118695 / 143724 / 127118 ns/op   7034 B/op   158 allocs/op
+//	Unguarded  113577 / 125275 / 137065 ns/op   7034 B/op   158 allocs/op
+//
+// TWO THINGS THAT NUMBER SET ACTUALLY SAYS:
+//
+//  1. The ALLOCATION profile is identical — 7034 B and 158 allocs on both
+//     sides. That is a real, resolvable invariant: the guard adds no
+//     allocation to a read, because the raw-NUL check is a byte scan and the
+//     escape pre-filter short-circuits before any parse.
+//  2. The TIME difference is NOT resolvable here and I am not going to quote
+//     one. Run-to-run spread within each group is ~25 microseconds; the
+//     expected difference is ~34 nanoseconds, three orders of magnitude
+//     smaller. Reporting "3.6% slower" from these six numbers would be reading
+//     noise as signal.
+//
+// The affordability argument therefore rests on the per-call measurement
+// against the statement it rides on: ~34 ns of guard against ~125 microseconds
+// of read is ~0.03%. The JSON arm — the only expensive one — does not run on
+// reads, and not because reads are special: it is gated behind the escape
+// pre-filter, so it runs only for a value that actually contains the escape.
+// BenchmarkCheckParams_JSONWriteNoEscape is the evidence for that, at 32.5 ns
+// and zero allocations on a realistic fields blob.
+
+// benchStore opens a store on the guarded or the raw driver. It duplicates a
+// little of New()'s setup deliberately: the point is to vary ONLY the driver
+// name, and calling New() would always give the guarded one.
+func benchStore(b *testing.B, guarded bool) *Store {
+	b.Helper()
+	dir := b.TempDir()
+	dsn := filepath.Join(dir, "bench.db") + "?_pragma=busy_timeout(30000)&_pragma=foreign_keys(on)&_txlock=immediate"
+	if err := registerGuardedDrivers(); err != nil {
+		b.Fatalf("register: %v", err)
+	}
+	name := "sqlite"
+	if guarded {
+		name = guardedSQLiteDriver
+	}
+	db, err := sql.Open(name, dsn)
+	if err != nil {
+		b.Fatalf("open: %v", err)
+	}
+	if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
+		b.Fatalf("wal: %v", err)
+	}
+	db.SetMaxOpenConns(sqliteMaxOpenConns)
+	s := &Store{db: db, dialect: &sqliteDialect{}}
+	if err := s.migrate(); err != nil {
+		b.Fatalf("migrate: %v", err)
+	}
+	b.Cleanup(func() { _ = db.Close() })
+	return s
+}

--- a/internal/store/nulguard_test.go
+++ b/internal/store/nulguard_test.go
@@ -1,6 +1,8 @@
 package store
 
 import (
+	"database/sql"
+	"database/sql/driver"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -305,8 +307,13 @@ func TestWriteGuardCoversPreparedStatements(t *testing.T) {
 // means the guard gained real column knowledge, and the case should move into
 // textguard.Corpus where every layer is held to it.
 func TestStoreOverRefusalsStillOverRefuse(t *testing.T) {
-	if len(textguard.StoreOverRefusals) == 0 {
-		t.Skip("no recorded over-refusals")
+	// NOT a skip, for the same reason as KnownGaps: an empty slice would let
+	// someone delete the record of a divergence and see green (codex round 2).
+	const wantOverRefusals = 1
+	if len(textguard.StoreOverRefusals) != wantOverRefusals {
+		t.Fatalf("StoreOverRefusals has %d entries, expected %d. If one was PAID DOWN, move its case into "+
+			"textguard.Corpus and update this count in the same edit.",
+			len(textguard.StoreOverRefusals), wantOverRefusals)
 	}
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "OverRefusal")
@@ -324,5 +331,128 @@ func TestStoreOverRefusalsStillOverRefuse(t *testing.T) {
 					"to it, and delete it from StoreOverRefusals.\nwhy it was recorded: %s", c.Value, c.Why)
 			}
 		})
+	}
+}
+
+// TestWrapperAdvertisesExactlyWhatTheBaseDoes is the guard against the mistake
+// this wrapper has now made twice.
+//
+// database/sql BRANCHES on whether an optional interface is present, so a
+// wrapper advertising one the base lacks changes behaviour rather than adding a
+// no-op — it told database/sql that pgx validates connections (it does not) and
+// that sqlite converts its own arguments (it does not). The fix for THAT then
+// advertised DriverContext for sqlite, which lacks it, and every SQLite open
+// failed instantly. Loud that time; the same mistake on a branch-only interface
+// is silent.
+//
+// So the property is pinned rather than reasoned about: for every optional
+// interface the wrapper varies over, wrapped and base must agree exactly.
+func TestWrapperAdvertisesExactlyWhatTheBaseDoes(t *testing.T) {
+	if err := registerGuardedDrivers(); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	type pair struct{ base, guarded, dsn string }
+	pairs := []pair{{"sqlite", guardedSQLiteDriver, t.TempDir() + "/parity.db"}}
+	if dsn := os.Getenv("PAD_TEST_POSTGRES_URL"); dsn != "" {
+		pairs = append(pairs, pair{"pgx", guardedPostgresDriver, dsn})
+	} else {
+		t.Log("pgx leg skipped: PAD_TEST_POSTGRES_URL not set")
+	}
+
+	for _, p := range pairs {
+		t.Run(p.base, func(t *testing.T) {
+			baseDB, err := sql.Open(p.base, p.dsn)
+			if err != nil {
+				t.Fatalf("open base: %v", err)
+			}
+			defer baseDB.Close()
+			wrapDB, err := sql.Open(p.guarded, p.dsn)
+			if err != nil {
+				t.Fatalf("open guarded: %v", err)
+			}
+			defer wrapDB.Close()
+
+			// Driver level.
+			_, baseCtx := baseDB.Driver().(driver.DriverContext)
+			_, wrapCtx := wrapDB.Driver().(driver.DriverContext)
+			if baseCtx != wrapCtx {
+				t.Errorf("DriverContext: base=%t wrapped=%t — they must match", baseCtx, wrapCtx)
+			}
+
+			// Connection level.
+			ifaces := func(db *sql.DB) map[string]bool {
+				conn, err := db.Conn(t.Context())
+				if err != nil {
+					t.Fatalf("conn: %v", err)
+				}
+				defer conn.Close()
+				out := map[string]bool{}
+				if rerr := conn.Raw(func(dc any) error {
+					out["Pinger"] = isIface[driver.Pinger](dc)
+					out["SessionResetter"] = isIface[driver.SessionResetter](dc)
+					out["Validator"] = isIface[driver.Validator](dc)
+					out["NamedValueChecker"] = isIface[driver.NamedValueChecker](dc)
+					out["ExecerContext"] = isIface[driver.ExecerContext](dc)
+					out["QueryerContext"] = isIface[driver.QueryerContext](dc)
+					out["ConnPrepareContext"] = isIface[driver.ConnPrepareContext](dc)
+					out["ConnBeginTx"] = isIface[driver.ConnBeginTx](dc)
+					return nil
+				}); rerr != nil {
+					t.Fatalf("raw: %v", rerr)
+				}
+				return out
+			}
+			b, w := ifaces(baseDB), ifaces(wrapDB)
+			if len(b) == 0 {
+				t.Fatal("the probe read no interfaces — the instrument is broken, not the wrapper")
+			}
+			for name, want := range b {
+				if w[name] != want {
+					t.Errorf("conn %s: base=%t wrapped=%t — advertising an interface the base lacks (or "+
+						"hiding one it has) changes database/sql's behaviour", name, want, w[name])
+				}
+			}
+		})
+	}
+}
+
+// TestWriteGuardSeesThroughDriverValuer regresses codex round 2's second P1.
+//
+// checkParams originally type-asserted `string`. pgx implements
+// driver.NamedValueChecker and ACCEPTS a sql.NullString unchanged rather than
+// letting database/sql's default converter unwrap it — so the guard never saw
+// the text. Measured before the fix: on Postgres a NUL-bearing sql.NullString
+// passed the guard entirely and was refused by the SERVER with SQLSTATE 22021,
+// i.e. as a 500, while the identical value on SQLite got the typed 400. The
+// dialect split, reappearing in the response shape.
+//
+// internal/store/wiki_links.go binds sql.NullString today, so this is a live
+// parameter shape rather than a constructed one.
+func TestWriteGuardSeesThroughDriverValuer(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "ValuerGuard")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	item := createTestItem(t, s, ws.ID, col.ID, "Valuer subject", "")
+
+	poisoned := sql.NullString{String: "poisoned" + textguard.NUL + "content", Valid: true}
+	_, err := s.db.Exec(s.q(`UPDATE items SET content = ? WHERE id = ?`), poisoned, item.ID)
+	if err == nil {
+		t.Fatal("a NUL-bearing sql.NullString was accepted")
+	}
+	if !strings.Contains(err.Error(), ErrInvalidTextParameter.Error()) {
+		t.Errorf("refused, but NOT by the guard: %v\nOn Postgres this is the tell — the server's own "+
+			"SQLSTATE 22021 instead of our typed refusal means the value went past Layer A and the "+
+			"caller gets a 500 where SQLite gives a 400", err)
+	}
+
+	// Controls: a clean NullString still writes, and a NULL one is untouched.
+	clean := sql.NullString{String: "clean content", Valid: true}
+	if _, err := s.db.Exec(s.q(`UPDATE items SET content = ? WHERE id = ?`), clean, item.ID); err != nil {
+		t.Errorf("a clean sql.NullString must still write: %v", err)
+	}
+	null := sql.NullString{Valid: false}
+	if _, err := s.db.Exec(s.q(`UPDATE items SET content = ? WHERE id = ?`), null, item.ID); err != nil {
+		t.Errorf("a NULL sql.NullString must still write: %v", err)
 	}
 }

--- a/internal/store/nulguard_test.go
+++ b/internal/store/nulguard_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -33,6 +34,11 @@ func TestBinaryColumnCensus(t *testing.T) {
 	// nothing depends on a Go-side model of the schema.
 	colRe := regexp.MustCompile(`(?im)^\s*([a-z_]+)\s+(BLOB|BYTEA)\b`)
 	tableRe := regexp.MustCompile(`(?is)CREATE\s+TABLE(?:\s+IF\s+NOT\s+EXISTS)?\s+([a-z_]+)\s*\((.*?)\n\s*\);`)
+	// ALTER TABLE ... ADD COLUMN is the OTHER way a binary column enters a
+	// schema, and the first version of this census could not see it (codex
+	// round 1, finding 7) — which would have let exactly the change this test
+	// exists to catch walk past it.
+	alterRe := regexp.MustCompile(`(?im)ALTER\s+TABLE\s+([a-z_]+)\s+ADD\s+(?:COLUMN\s+)?(?:IF\s+NOT\s+EXISTS\s+)?([a-z_]+)\s+(BLOB|BYTEA)\b`)
 
 	found := map[string]bool{}
 	for _, dir := range []string{"migrations", "pgmigrations"} {
@@ -54,6 +60,9 @@ func TestBinaryColumnCensus(t *testing.T) {
 				for _, col := range colRe.FindAllStringSubmatch(tbl[2], -1) {
 					found[tbl[1]+"."+col[1]] = true
 				}
+			}
+			for _, alt := range alterRe.FindAllStringSubmatch(string(body), -1) {
+				found[alt[1]+"."+alt[2]] = true
 			}
 		}
 		// The instrument must have read something, or "no binary columns
@@ -110,8 +119,16 @@ func TestWriteGuardRefusesTheCorpus(t *testing.T) {
 			// corpus case's own classing chooses which one carries it, which
 			// is how this leg measures that the STORE's classing agrees with
 			// the corpus's.
+			//
+			// A JSON-CLASSED value that is not valid JSON goes to the TEXT
+			// column, matching the native-Postgres leg's routing and for the
+			// same reason: the fields column would reject it as malformed
+			// before the guard was ever consulted, and the case would then
+			// "pass" while measuring SQLite's JSON parser instead of this
+			// guard. The strengthened accepted-case assertion caught exactly
+			// that (codex round 1, finding 7).
 			var err error
-			if c.IsJSON {
+			if c.IsJSON && json.Valid([]byte(strings.TrimSpace(c.Value))) {
 				fields := c.Value
 				_, err = s.UpdateItem(item.ID, models_ItemUpdateFields(fields))
 			} else {
@@ -120,6 +137,14 @@ func TestWriteGuardRefusesTheCorpus(t *testing.T) {
 			}
 
 			refused := err != nil && strings.Contains(err.Error(), ErrInvalidTextParameter.Error())
+			// An ACCEPTED case must actually SUCCEED, not merely avoid the
+			// guard (codex round 1, finding 7). Without this, a write failing
+			// for any other reason — a schema rejection, a constraint, a typo
+			// in the fixture — read as "the guard let it through" and the case
+			// proved nothing.
+			if !c.Refused && err != nil {
+				t.Fatalf("case is expected to be accepted but the write FAILED for another reason: %v\nwhy this case exists: %s", err, c.Why)
+			}
 			if refused != c.Refused {
 				t.Errorf("store write refused=%t, corpus says %t\nvalue: %q\nisJSON: %t\nerr: %v\nwhy this case exists: %s",
 					refused, c.Refused, c.Value, c.IsJSON, err, c.Why)
@@ -269,5 +294,35 @@ func TestWriteGuardCoversPreparedStatements(t *testing.T) {
 	}
 	if textguard.ContainsNUL(after.Content) {
 		t.Error("a refused value reached the row anyway")
+	}
+}
+
+// TestStoreOverRefusalsStillOverRefuse pins the known divergence between this
+// guard and every other layer: values that are legitimate TEXT and are refused
+// anyway, because the guard classes by value shape rather than by column.
+//
+// It fails when one STOPS being refused, which is the interesting event — it
+// means the guard gained real column knowledge, and the case should move into
+// textguard.Corpus where every layer is held to it.
+func TestStoreOverRefusalsStillOverRefuse(t *testing.T) {
+	if len(textguard.StoreOverRefusals) == 0 {
+		t.Skip("no recorded over-refusals")
+	}
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "OverRefusal")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	item := createTestItem(t, s, ws.ID, col.ID, "Over-refusal subject", "")
+
+	for _, c := range textguard.StoreOverRefusals {
+		t.Run(c.Name, func(t *testing.T) {
+			content := c.Value
+			_, err := s.UpdateItem(item.ID, models.ItemUpdate{Content: &content})
+			refused := err != nil && strings.Contains(err.Error(), ErrInvalidTextParameter.Error())
+			if !refused {
+				t.Errorf("this over-refusal has been PAID DOWN: the store now accepts %q as text, which "+
+					"is the correct answer. Move this case into textguard.Corpus so every layer is held "+
+					"to it, and delete it from StoreOverRefusals.\nwhy it was recorded: %s", c.Value, c.Why)
+			}
+		})
 	}
 }

--- a/internal/store/nulguard_test.go
+++ b/internal/store/nulguard_test.go
@@ -403,6 +403,43 @@ func TestWrapperAdvertisesExactlyWhatTheBaseDoes(t *testing.T) {
 				}
 				return out
 			}
+			// STATEMENT level too (codex round 3): the parity test originally
+			// stopped at the connection, while guardStmt wraps statements and
+			// forwards a different set. A wrapper that hid StmtExecContext
+			// would have passed.
+			stmtIfaces := func(db *sql.DB) map[string]bool {
+				conn, err := db.Conn(t.Context())
+				if err != nil {
+					t.Fatalf("conn: %v", err)
+				}
+				defer conn.Close()
+				out := map[string]bool{}
+				if rerr := conn.Raw(func(dc any) error {
+					cpc, ok := dc.(driver.ConnPrepareContext)
+					if !ok {
+						return nil
+					}
+					st, serr := cpc.PrepareContext(t.Context(), "SELECT 1")
+					if serr != nil {
+						return nil //nolint:nilerr // a driver that cannot prepare this tells us nothing
+					}
+					defer st.Close()
+					out["StmtExecContext"] = isIface[driver.StmtExecContext](st)
+					out["StmtQueryContext"] = isIface[driver.StmtQueryContext](st)
+					out["stmt NamedValueChecker"] = isIface[driver.NamedValueChecker](st)
+					return nil
+				}); rerr != nil {
+					t.Fatalf("raw: %v", rerr)
+				}
+				return out
+			}
+			bs, ws := stmtIfaces(baseDB), stmtIfaces(wrapDB)
+			for name, want := range bs {
+				if ws[name] != want {
+					t.Errorf("stmt %s: base=%t wrapped=%t", name, want, ws[name])
+				}
+			}
+
 			b, w := ifaces(baseDB), ifaces(wrapDB)
 			if len(b) == 0 {
 				t.Fatal("the probe read no interfaces — the instrument is broken, not the wrapper")
@@ -446,13 +483,93 @@ func TestWriteGuardSeesThroughDriverValuer(t *testing.T) {
 			"caller gets a 500 where SQLite gives a 400", err)
 	}
 
-	// Controls: a clean NullString still writes, and a NULL one is untouched.
+	// Controls: a clean NullString still writes, and a NULL one becomes SQL
+	// NULL rather than an empty string.
 	clean := sql.NullString{String: "clean content", Valid: true}
 	if _, err := s.db.Exec(s.q(`UPDATE items SET content = ? WHERE id = ?`), clean, item.ID); err != nil {
 		t.Errorf("a clean sql.NullString must still write: %v", err)
 	}
+
+	// The NULL leg ASSERTS NULL (codex round 3). Checking only that the write
+	// succeeded would pass against a normalization that turned NULL into "" —
+	// which is precisely the kind of silent conversion a guard that rewrites
+	// parameters could introduce.
 	null := sql.NullString{Valid: false}
 	if _, err := s.db.Exec(s.q(`UPDATE items SET content = ? WHERE id = ?`), null, item.ID); err != nil {
-		t.Errorf("a NULL sql.NullString must still write: %v", err)
+		t.Fatalf("a NULL sql.NullString must still write: %v", err)
 	}
+	var readBack sql.NullString
+	if err := s.db.QueryRow(s.q(`SELECT content FROM items WHERE id = ?`), item.ID).Scan(&readBack); err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if readBack.Valid {
+		t.Errorf("content read back as %q (Valid=true); a NULL parameter must store SQL NULL, not a string",
+			readBack.String)
+	}
+}
+
+// TestWriteGuardResolvesValuerOnce regresses the OTHER two halves of codex
+// round 3's Valuer findings, neither of which needs a database.
+//
+// They are unit-level on purpose: the integration test above only exercises
+// the Valuer path meaningfully on POSTGRES, because SQLite's driver lacks
+// NamedValueChecker and database/sql therefore unwraps sql.NullString before
+// the guard ever runs. That made it pass for the wrong reason by default
+// (codex round 3), and these do not depend on which driver is present.
+func TestWriteGuardResolvesValuerOnce(t *testing.T) {
+	t.Run("typed-nil valuer binds NULL instead of panicking", func(t *testing.T) {
+		args := []driver.NamedValue{{Ordinal: 1, Value: (*sql.NullString)(nil)}}
+		if err := normalizeAndCheck(args); err != nil {
+			t.Fatalf("a typed-nil valuer must resolve to NULL, got %v", err)
+		}
+		if args[0].Value != nil {
+			t.Errorf("resolved to %#v, want nil — database/sql special-cases a nil pointer valuer as SQL NULL",
+				args[0].Value)
+		}
+	})
+
+	t.Run("Value is called exactly once and its result is forwarded", func(t *testing.T) {
+		v := &countingValuer{outputs: []string{"clean", "poisoned" + textguard.NUL + "second"}}
+		args := []driver.NamedValue{{Ordinal: 1, Value: v}}
+		if err := normalizeAndCheck(args); err != nil {
+			t.Fatalf("the first (clean) value must be accepted: %v", err)
+		}
+		if v.calls != 1 {
+			t.Errorf("Value() called %d times, want exactly 1 — calling it for the check and letting the "+
+				"driver call it again lets a stateful valuer show the guard one value and the database another",
+				v.calls)
+		}
+		if got, _ := args[0].Value.(string); got != "clean" {
+			t.Errorf("forwarded %#v, want the RESOLVED value the guard inspected", args[0].Value)
+		}
+	})
+
+	t.Run("text shapes pgx accepts unconverted are seen", func(t *testing.T) {
+		poisoned := "bad" + textguard.NUL + "text"
+		type namedString string
+		for name, val := range map[string]driver.Value{
+			"*string":         &poisoned,
+			"named string":    namedString(poisoned),
+			"json.RawMessage": json.RawMessage(`"` + textguard.EscNUL + `"`),
+		} {
+			args := []driver.NamedValue{{Ordinal: 1, Value: val}}
+			if err := normalizeAndCheck(args); err == nil {
+				t.Errorf("%s carrying a NUL was accepted; pgx implements NamedValueChecker and binds these "+
+					"unconverted, so a string-only check never sees them", name)
+			}
+		}
+	})
+}
+
+// countingValuer returns a different value on each call, so a guard that
+// resolves twice can be caught doing it.
+type countingValuer struct {
+	outputs []string
+	calls   int
+}
+
+func (c *countingValuer) Value() (driver.Value, error) {
+	out := c.outputs[min(c.calls, len(c.outputs)-1)]
+	c.calls++
+	return out, nil
 }

--- a/internal/store/nulguard_test.go
+++ b/internal/store/nulguard_test.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/PerpetualSoftware/pad/internal/models"
 	"github.com/PerpetualSoftware/pad/internal/textguard"
@@ -544,6 +545,52 @@ func TestWriteGuardResolvesValuerOnce(t *testing.T) {
 		}
 	})
 
+	t.Run("a valuer returning a valuer resolves to a fixed point", func(t *testing.T) {
+		// codex round 4: resolving ONCE let an outer valuer hand the guard a
+		// clean inner valuer while pgx went on to evaluate it and send the NUL.
+		inner := sql.NullString{String: "bad" + textguard.NUL + "text", Valid: true}
+		args := []driver.NamedValue{{Ordinal: 1, Value: nestingValuer{inner}}}
+		if err := normalizeAndCheck(args); err == nil {
+			t.Error("a NUL reached through a nested valuer was accepted")
+		}
+	})
+
+	t.Run("a cyclic valuer is refused rather than hanging", func(t *testing.T) {
+		args := []driver.NamedValue{{Ordinal: 1, Value: cyclicValuer{}}}
+		if err := normalizeAndCheck(args); err == nil {
+			t.Error("a valuer that never resolves must be refused, not looped on")
+		}
+	})
+
+	t.Run("an unclassifiable shape is REFUSED, not passed through", func(t *testing.T) {
+		// The allow-list's whole point (codex round 4). Two rounds were spent
+		// naming text-carrying shapes one at a time; this asserts the default
+		// answer for anything unnamed is refusal rather than silent acceptance.
+		type unexpected struct{ Note string }
+		args := []driver.NamedValue{{Ordinal: 1, Value: unexpected{Note: "hello"}}}
+		err := normalizeAndCheck(args)
+		if err == nil {
+			t.Fatal("an unclassifiable parameter was passed through unchecked")
+		}
+		if !strings.Contains(err.Error(), "outside the shapes this store binds") {
+			t.Errorf("refused, but not by the allow-list: %v", err)
+		}
+	})
+
+	t.Run("the shapes the store DOES bind are all exempt or checked", func(t *testing.T) {
+		// The control for the case above: an allow-list that refused everything
+		// would pass it and break the product.
+		for _, v := range []driver.Value{
+			nil, "text", []byte{0, 1, 2}, int64(7), float64(1.5), true, time.Now(),
+			sql.NullString{String: "x", Valid: true}, sql.NullInt64{Int64: 3, Valid: true},
+		} {
+			args := []driver.NamedValue{{Ordinal: 1, Value: v}}
+			if err := normalizeAndCheck(args); err != nil {
+				t.Errorf("a %T parameter must be accepted: %v", v, err)
+			}
+		}
+	})
+
 	t.Run("text shapes pgx accepts unconverted are seen", func(t *testing.T) {
 		poisoned := "bad" + textguard.NUL + "text"
 		type namedString string
@@ -560,6 +607,17 @@ func TestWriteGuardResolvesValuerOnce(t *testing.T) {
 		}
 	})
 }
+
+// nestingValuer returns ANOTHER valuer, the shape that defeats a
+// resolve-once guard.
+type nestingValuer struct{ inner driver.Valuer }
+
+func (n nestingValuer) Value() (driver.Value, error) { return n.inner, nil }
+
+// cyclicValuer never resolves, so the depth bound is what stops it.
+type cyclicValuer struct{}
+
+func (c cyclicValuer) Value() (driver.Value, error) { return cyclicValuer{}, nil }
 
 // countingValuer returns a different value on each call, so a guard that
 // resolves twice can be caught doing it.

--- a/internal/store/nulguard_test.go
+++ b/internal/store/nulguard_test.go
@@ -1,0 +1,273 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/textguard"
+)
+
+// TestBinaryColumnCensus pins the one assumption the write guard's classing
+// rests on: that []byte parameters in this store are BINARY, so exempting them
+// from the NUL check refuses nothing legitimate and hides nothing.
+//
+// It is a census rather than an argument because this unit's whole history is
+// source-level instruments missing things — a Sprintf-built statement, a
+// multi-line SQL literal, a write site two separate greps each half-found. A
+// census over the migration SQL answers "what binary columns exist" in a way a
+// reader can re-run, and it FAILS when a new one appears, which is exactly when
+// someone must re-examine whether []byte is still binary-only here.
+//
+// If you are here because this failed: you added a BLOB/BYTEA column. Decide
+// whether anything binds TEXT to it, or text to any other column as []byte,
+// then add it below.
+func TestBinaryColumnCensus(t *testing.T) {
+	want := map[string]bool{"item_yjs_updates.update_data": true}
+
+	// One pattern per dialect spelling, applied to the raw migration text so
+	// nothing depends on a Go-side model of the schema.
+	colRe := regexp.MustCompile(`(?im)^\s*([a-z_]+)\s+(BLOB|BYTEA)\b`)
+	tableRe := regexp.MustCompile(`(?is)CREATE\s+TABLE(?:\s+IF\s+NOT\s+EXISTS)?\s+([a-z_]+)\s*\((.*?)\n\s*\);`)
+
+	found := map[string]bool{}
+	for _, dir := range []string{"migrations", "pgmigrations"} {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatalf("read %s: %v", dir, err)
+		}
+		var sqlFiles int
+		for _, e := range entries {
+			if !strings.HasSuffix(e.Name(), ".sql") {
+				continue
+			}
+			sqlFiles++
+			body, err := os.ReadFile(filepath.Join(dir, e.Name()))
+			if err != nil {
+				t.Fatalf("read %s: %v", e.Name(), err)
+			}
+			for _, tbl := range tableRe.FindAllStringSubmatch(string(body), -1) {
+				for _, col := range colRe.FindAllStringSubmatch(tbl[2], -1) {
+					found[tbl[1]+"."+col[1]] = true
+				}
+			}
+		}
+		// The instrument must have read something, or "no binary columns
+		// found" is a statement about the walk rather than about the schema.
+		if sqlFiles == 0 {
+			t.Fatalf("no .sql files read from %s — the census walked nothing", dir)
+		}
+	}
+
+	if len(found) == 0 {
+		t.Fatal("census found ZERO binary columns; item_yjs_updates.update_data is known to exist, so the instrument is broken, not the schema")
+	}
+
+	var extra, missing []string
+	for c := range found {
+		if !want[c] {
+			extra = append(extra, c)
+		}
+	}
+	for c := range want {
+		if !found[c] {
+			missing = append(missing, c)
+		}
+	}
+	sort.Strings(extra)
+	sort.Strings(missing)
+	if len(extra) > 0 {
+		t.Errorf("new binary column(s) %v — the write guard exempts every []byte parameter from the NUL "+
+			"check on the grounds that []byte means binary here. Re-examine that before adding these.", extra)
+	}
+	if len(missing) > 0 {
+		t.Errorf("expected binary column(s) %v not found by the census — either they were removed or the "+
+			"instrument stopped seeing them; both need a human", missing)
+	}
+}
+
+// TestWriteGuardRefusesTheCorpus is Layer A's leg of the four-way differential
+// test: the SAME corpus every other layer is measured against, driven through
+// a REAL write to a REAL database.
+//
+// It is a real write rather than a call to checkParams because the point is
+// coverage of the path, not of the predicate — textguard's own test already
+// covers the predicate. What this asserts is that a value reaching the driver
+// is refused there, whichever of the four receivers carried it.
+func TestWriteGuardRefusesTheCorpus(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "NulGuard")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	item := createTestItem(t, s, ws.ID, col.ID, "Guard subject", "")
+
+	for _, c := range textguard.Corpus {
+		t.Run(c.Name, func(t *testing.T) {
+			// items.content is a user-text column; items.fields is JSON. The
+			// corpus case's own classing chooses which one carries it, which
+			// is how this leg measures that the STORE's classing agrees with
+			// the corpus's.
+			var err error
+			if c.IsJSON {
+				fields := c.Value
+				_, err = s.UpdateItem(item.ID, models_ItemUpdateFields(fields))
+			} else {
+				content := c.Value
+				_, err = s.UpdateItem(item.ID, models_ItemUpdateContent(content))
+			}
+
+			refused := err != nil && strings.Contains(err.Error(), ErrInvalidTextParameter.Error())
+			if refused != c.Refused {
+				t.Errorf("store write refused=%t, corpus says %t\nvalue: %q\nisJSON: %t\nerr: %v\nwhy this case exists: %s",
+					refused, c.Refused, c.Value, c.IsJSON, err, c.Why)
+			}
+		})
+	}
+}
+
+// Small constructors, so the corpus loop reads as the assertion rather than as
+// struct plumbing.
+func models_ItemUpdateContent(v string) (u models.ItemUpdate) { u.Content = &v; return }
+func models_ItemUpdateFields(v string) (u models.ItemUpdate)  { u.Fields = &v; return }
+
+// TestWriteGuardCoversTheQueryPath is the leg the lead required before this
+// guard's coverage claim could be written, and a mutation is why it exists in
+// this shape: removing checkParams from guardConn.QueryContext SURVIVED the
+// corpus leg above, because every write that leg makes goes through Exec.
+//
+// Writes DO ride the Query path in this store — three of them today:
+//
+//	password_resets.go     UPDATE ... RETURNING user_id   (s.db.QueryRow)
+//	email_verification.go  UPDATE ... RETURNING user_id   (tx.QueryRow)
+//	yjs_updates.go         INSERT ... RETURNING id        (s.db.QueryRow, Postgres)
+//
+// so an Exec-only guard would have left a real hole rather than a theoretical
+// one. This drives a RETURNING write directly, because what is under test is
+// the PATH: the predicate is covered by textguard's own tests, and the corpus
+// leg covers Exec.
+//
+// It also answers the lead's other branch. If those three writes are ever
+// rewritten away, this test does not become vacuous — it constructs its own
+// RETURNING statement, so it keeps guarding the path against the day someone
+// adds the next one.
+func TestWriteGuardCoversTheQueryPath(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "NulGuardQueryPath")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	item := createTestItem(t, s, ws.ID, col.ID, "Query path subject", "")
+
+	// A NUL-bearing value through UPDATE ... RETURNING — the exact shape
+	// password_resets.go and email_verification.go use.
+	var returned string
+	err := s.db.QueryRow(
+		s.q(`UPDATE items SET content = ? WHERE id = ? RETURNING id`),
+		"poisoned"+textguard.NUL+"content", item.ID,
+	).Scan(&returned)
+	if err == nil {
+		t.Fatal("a NUL-bearing parameter on the QUERY path was accepted; the guard covers Exec only")
+	}
+	if !strings.Contains(err.Error(), ErrInvalidTextParameter.Error()) {
+		t.Errorf("refused, but not by the guard: %v", err)
+	}
+
+	// The row must be untouched — a guard that refuses after writing is not a
+	// guard.
+	after, gerr := s.GetItem(item.ID)
+	if gerr != nil {
+		t.Fatalf("GetItem: %v", gerr)
+	}
+	if textguard.ContainsNUL(after.Content) {
+		t.Error("the refused value reached the row anyway")
+	}
+
+	// CONTROL: a clean value on the same path still works, so the leg
+	// discriminates rather than proving that RETURNING is simply broken here.
+	var ok string
+	if err := s.db.QueryRow(
+		s.q(`UPDATE items SET content = ? WHERE id = ? RETURNING id`),
+		"clean content", item.ID,
+	).Scan(&ok); err != nil {
+		t.Fatalf("a clean value on the query path must succeed: %v", err)
+	}
+	if ok != item.ID {
+		t.Errorf("RETURNING gave %q, want %q", ok, item.ID)
+	}
+}
+
+// TestWriteGuardCoversPreparedStatements covers the route that JUSTIFIES this
+// guard living at the driver rather than at *sql.DB.
+//
+// A wrapper one layer up cannot see a prepared statement's arguments: the
+// statement is prepared once and executed against the driver directly. That is
+// the measurement that retired the in-package seam shape, and leaving it
+// untested would mean the design's central reason was the one thing unverified.
+// Both prepared mutants — dropping the check from guardStmt.ExecContext and
+// from guardStmt.QueryContext — SURVIVED until this existed.
+//
+// The store prepares statements today in agent_roles.go (two sites, binding
+// ids and ints). Those carry no user text, so this test constructs its own
+// rather than borrowing one: what is under test is the ROUTE, and it must stay
+// covered when the next prepared statement does carry text.
+func TestWriteGuardCoversPreparedStatements(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "NulGuardPrepared")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	item := createTestItem(t, s, ws.ID, col.ID, "Prepared subject", "")
+
+	t.Run("prepared Exec", func(t *testing.T) {
+		stmt, err := s.db.Prepare(s.q(`UPDATE items SET content = ? WHERE id = ?`))
+		if err != nil {
+			t.Fatalf("prepare: %v", err)
+		}
+		defer stmt.Close()
+
+		if _, err := stmt.Exec("poisoned"+textguard.NUL+"content", item.ID); err == nil {
+			t.Error("a NUL-bearing parameter through a PREPARED statement was accepted — a *sql.DB-level wrapper would miss exactly this")
+		} else if !strings.Contains(err.Error(), ErrInvalidTextParameter.Error()) {
+			t.Errorf("refused, but not by the guard: %v", err)
+		}
+
+		// Control on the same statement handle.
+		if _, err := stmt.Exec("clean content", item.ID); err != nil {
+			t.Errorf("a clean value through the same prepared statement must succeed: %v", err)
+		}
+	})
+
+	t.Run("prepared Query", func(t *testing.T) {
+		stmt, err := s.db.Prepare(s.q(`SELECT id FROM items WHERE workspace_id = ? AND content = ?`))
+		if err != nil {
+			t.Fatalf("prepare: %v", err)
+		}
+		defer stmt.Close()
+
+		// A READ carrying a NUL is refused too. That is deliberate and worth
+		// stating: on Postgres such a parameter is a query error rather than a
+		// miss, so refusing it uniformly is what stops the two dialects
+		// answering differently — the BUG-2831 lesson applied to reads.
+		rows, err := stmt.Query(ws.ID, "looking"+textguard.NUL+"for")
+		if err == nil {
+			_ = rows.Close()
+			t.Error("a NUL-bearing parameter through a prepared QUERY was accepted")
+		} else if !strings.Contains(err.Error(), ErrInvalidTextParameter.Error()) {
+			t.Errorf("refused, but not by the guard: %v", err)
+		}
+
+		clean, err := stmt.Query(ws.ID, "clean content")
+		if err != nil {
+			t.Fatalf("a clean read through the same prepared statement must succeed: %v", err)
+		}
+		_ = clean.Close()
+	})
+
+	// The row survived every refusal above.
+	after, err := s.GetItem(item.ID)
+	if err != nil {
+		t.Fatalf("GetItem: %v", err)
+	}
+	if textguard.ContainsNUL(after.Content) {
+		t.Error("a refused value reached the row anyway")
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -234,7 +234,13 @@ func (s *Store) DB() *sql.DB { return s.db }
 //     connections after the first one applies it.
 func New(dbPath string) (*Store, error) {
 	dsn := dbPath + "?_pragma=busy_timeout(30000)&_pragma=foreign_keys(on)&_txlock=immediate"
-	db, err := sql.Open("sqlite", dsn)
+	// The NUL invariant's Layer A rides the DRIVER, not the call sites — see
+	// nulguard.go for why that is the only shape whose completeness nobody has
+	// to maintain.
+	if err := registerGuardedDrivers(); err != nil {
+		return nil, err
+	}
+	db, err := sql.Open(guardedSQLiteDriver, dsn)
 	if err != nil {
 		return nil, fmt.Errorf("open database: %w", err)
 	}
@@ -305,7 +311,15 @@ func (s *Store) startWALCheckpointer() {
 
 // openPostgresDB opens and configures a PostgreSQL connection pool.
 func openPostgresDB(connStr string) (*sql.DB, error) {
-	db, err := sql.Open("pgx", connStr)
+	// Layer A on Postgres too, deliberately. Postgres refuses a NUL natively,
+	// so the wrapper is not what makes the write safe there — it is what makes
+	// the two dialects give the SAME answer, with the same typed error, which
+	// is what the four-way differential test asserts and what BUG-2831's
+	// dialect split cost us the last time two backends disagreed.
+	if err := registerGuardedDrivers(); err != nil {
+		return nil, err
+	}
+	db, err := sql.Open(guardedPostgresDriver, connStr)
 	if err != nil {
 		return nil, fmt.Errorf("open postgres: %w", err)
 	}

--- a/internal/textguard/corpus.go
+++ b/internal/textguard/corpus.go
@@ -164,6 +164,6 @@ var StoreOverRefusals = []Case{
 var KnownGaps = []Case{
 	{
 		Name: "duplicate key, the NUL in the SHADOWED value", Value: `{"a":"` + EscNUL + `","a":"clean"}`, IsJSON: true, Refused: true,
-		Why: "codex round 1 finding 2. encoding/json keeps the LAST duplicate, so the walk never sees the first value and the escape survives into a SQLite text-backed JSON column. Postgres's own parser keeps the last too, so it accepts this as well - the two agree today, which is why it is a recorded gap rather than a dialect split. Closing it needs the token-walk (BUG-2812), not a change here.",
+		Why: "codex round 1 finding 2, RATIONALE CORRECTED in round 4. encoding/json keeps the LAST duplicate, so the map-model walk never sees the shadowed value and the escape survives. I first wrote that Postgres accepts it too, 'so the two agree today' - that was asserted, not measured, and it is FALSE. Measured on Postgres 17: ERROR: unsupported Unicode escape sequence, DETAIL: \\u0000 cannot be converted to text. Its parser processes the scalar BEFORE duplicate elimination, while the control {\"a\":\"x\",\"a\":\"clean\"} deduplicates cleanly. So this is a REAL dialect split - Postgres refuses, this guard accepts, SQLite stores - not a shared gap. It stays recorded rather than fixed here because closing it means replacing the shared predicate's decode with a token walk, which is BUG-2812/S4 and moves BOTH layers at once; a fix in Layer A alone is the divergence DOC-2823 forbids.",
 	},
 }

--- a/internal/textguard/corpus.go
+++ b/internal/textguard/corpus.go
@@ -1,0 +1,115 @@
+package textguard
+
+// Corpus is the ONE adversarial corpus every layer of the NUL invariant is
+// measured against (DOC-2823 S1).
+//
+// It lives in the shipped package rather than in a _test.go file on purpose:
+// the HTTP gate (internal/server), the store's write guard, and the SQLite
+// trigger set (S2) are in three different packages, and a corpus duplicated
+// per package is three corpora that drift. The four-way differential test
+// drives THIS slice through every layer and asserts they agree.
+//
+// Adding a case here is how a newly-understood shape enters every layer's
+// coverage at once. That is the intended way to extend it.
+type Case struct {
+	// Name is the failure message a reader gets, so it says what the shape IS
+	// rather than numbering it.
+	Name string
+
+	// Value is the parameter as it would be bound, or the field value as it
+	// would arrive in a request body.
+	Value string
+
+	// IsJSON is how a layer that classes this value would class it - the
+	// column's classification at the store, the key's at the HTTP gate. The
+	// differential test asserts the two derivations agree on this corpus.
+	IsJSON bool
+
+	// Refused is the answer EVERY layer must give.
+	Refused bool
+
+	// Why records the reasoning, and in several cases the measurement, that
+	// put the case here. A corpus entry without one is a case nobody can
+	// re-derive.
+	Why string
+}
+
+// NUL is a real NUL byte; EscNUL is the six-character ESCAPE TEXT.
+//
+// Both are built from Go escape sequences rather than typed literally, and
+// that is not fussiness. Typing the escape's six characters by hand produces
+// the CHARACTER in several of the places this corpus travels through, and a
+// case that means the escape while carrying the character is vacuous. It
+// happened three times during BUG-2803 - caught by a surviving mutant, not by
+// review - and twice more while writing this file. Anything needing either
+// value references these constants, and const_check_test.go asserts they did
+// not decay, comparing against a value it BUILDS rather than one it types.
+const (
+	NUL    = "\x00"
+	EscNUL = "\\u0000"
+)
+
+// Corpus is deliberately small and adversarial rather than broad. Every entry
+// discriminates some pair of layers that could disagree.
+var Corpus = []Case{
+	{
+		Name: "plain text, clean", Value: "ordinary title", IsJSON: false, Refused: false,
+		Why: "the control leg. Without it a guard that refuses everything passes every other case.",
+	},
+	{
+		Name: "plain text with a real NUL", Value: "before" + NUL + "after", IsJSON: false, Refused: true,
+		Why: "the universal half. Postgres answers SQLSTATE 22021; SQLite stores it and then disagrees with itself about length().",
+	},
+	{
+		Name: "plain text carrying the ESCAPE, not classed as JSON", Value: "before" + EscNUL + "after", IsJSON: false, Refused: false,
+		Why: "six ordinary characters in a text column. Refusing this is the false positive that made the raw-byte parity pre-filter unsound.",
+	},
+	{
+		Name: "JSON document whose VALUE decodes to a NUL", Value: `{"a":"x` + EscNUL + `y"}`, IsJSON: true, Refused: true,
+		Why: "the 22P05 shape. Postgres's own jsonb parser refuses it; the outer string is pure ASCII so no text-encoding check sees it.",
+	},
+	{
+		Name: "JSON document whose KEY decodes to a NUL", Value: `{"k` + EscNUL + `ey":"v"}`, IsJSON: true, Refused: true,
+		Why: "keys are as fatal as values and are the half a value-only walk misses. json_tree exposes them in the key column (TASK-2824).",
+	},
+	{
+		Name: "JSON document with a DOUBLED backslash", Value: `{"a":"x\` + EscNUL + `y"}`, IsJSON: true, Refused: false,
+		Why: "literal text after decoding, not a NUL. This is the exact trap the parity pre-filter failed: measured on modernc, it stays 8 characters with no NUL (TASK-2824).",
+	},
+	{
+		Name: "JSON-classed value carrying a RAW NUL", Value: `{"a":"x` + NUL + `y"}`, IsJSON: true, Refused: true,
+		Why: "codex round 9's regression on BUG-2803: taking the JSON branch used to SKIP the plain check, so a direct NUL in a fields blob was accepted. Both checks always.",
+	},
+	{
+		Name: "JSON-classed value that is not a document", Value: "just a string", IsJSON: true, Refused: false,
+		Why: "classing says the column holds JSON; this value does not parse as one. The guard must not refuse it on classing alone.",
+	},
+	{
+		Name: "nested document one layer deeper", Value: `{"a":"{\"b\":\"x\` + EscNUL + `y\"}"}`, IsJSON: true, Refused: false,
+		Why: "the escape is inside a string the blob merely CARRIES, not in the layer Postgres parses. Fatal one level up, stored intact here - the asymmetry is the point.",
+	},
+	{
+		Name: "empty string", Value: "", IsJSON: false, Refused: false,
+		Why: "boundary. IsJSONDocument indexes t[0] and must not panic on it.",
+	},
+	{
+		Name: "empty string classed as JSON", Value: "", IsJSON: true, Refused: false,
+		Why: "same boundary through the other arm.",
+	},
+	{
+		Name: "JSON array whose element decodes to a NUL", Value: `["ok","x` + EscNUL + `y"]`, IsJSON: true, Refused: true,
+		Why: "arrays are a document shape too - items.tags is a JSON array column, so the array walk is load-bearing, not symmetry.",
+	},
+	{
+		Name: "value that is only the escape", Value: EscNUL, IsJSON: false, Refused: false,
+		Why: "six characters, no document, no NUL. The MCP audit path found that a value made entirely of escapes is non-empty as text and empty as decoded.",
+	},
+	{
+		Name: "NUL at the very end", Value: "trailing" + NUL, IsJSON: false, Refused: true,
+		Why: "position independence. A C-string-minded check that stops at the terminator reads this as clean, and SQLite's own length() does exactly that.",
+	},
+	{
+		Name: "NUL at the very start", Value: NUL + "leading", IsJSON: false, Refused: true,
+		Why: "the other end, for the same reason.",
+	},
+}

--- a/internal/textguard/corpus.go
+++ b/internal/textguard/corpus.go
@@ -112,4 +112,58 @@ var Corpus = []Case{
 		Name: "NUL at the very start", Value: NUL + "leading", IsJSON: false, Refused: true,
 		Why: "the other end, for the same reason.",
 	},
+	{
+		Name: "JSON SCALAR document that decodes to a NUL", Value: `"` + EscNUL + `"`, IsJSON: true, Refused: true,
+		Why: "codex round 1 finding 1. A bare JSON string is a complete document to jsonb - Postgres refuses this, SQLite stored it, and the object/array-only shape test walked past it. The dialect split, reopened by a rule that was right for the HTTP gate and wrong for the store.",
+	},
+	{
+		Name: "JSON scalar document that is clean", Value: `"ordinary"`, IsJSON: true, Refused: false,
+		Why: "the control for the case above. Without it, widening the shape test to scalars could refuse every scalar and still pass.",
+	},
+}
+
+// StoreOverRefusals are values every OTHER layer accepts and the store's write
+// guard refuses.
+//
+// They are not in Corpus, because Corpus is the set every layer must agree on
+// and these are exactly where one layer does not. Keeping them separate is the
+// difference between a documented trade and a silently broken differential
+// test.
+//
+// The cause is the store guard's CLASSING. It sees positional parameters, not
+// columns, so it classes a value as JSON when the value itself parses as a
+// complete JSON document — and a TEXT column's value that happens to be one
+// gets the document check it does not need. Nothing parses a text column;
+// Postgres stores the escape there as six ordinary characters.
+//
+// Pinned by TestStoreOverRefusalsStillOverRefuse in internal/store, which fails
+// when one stops being refused — the same direction as KnownGaps, and for the
+// same reason: the interesting event is the behaviour CHANGING, and a change
+// here means someone gave the guard real column knowledge and should move these
+// into Corpus.
+var StoreOverRefusals = []Case{
+	{
+		Name: "prose that happens to be a JSON document with a live escape", Value: `{"note":"documenting ` + EscNUL + ` for a reader"}`, IsJSON: false, Refused: false,
+		Why: "codex round 1, finding 3. Classed as TEXT this SHOULD be accepted, and every other layer does accept it. Not hypothetical in a documentation tool - writing about this very bug produces such a value. The store refuses it because it classes by value shape.",
+	},
+}
+
+// KnownGaps are corpus cases the layers currently answer WRONG, together, on
+// purpose.
+//
+// DOC-2823 requires them: Layer A shares the HTTP gate's predicate, so it
+// inherits the gate's map-model gaps until BUG-2812's token-walk replaces the
+// decode, and the design says Layer A "must NOT quietly fix either gap on its
+// own" — a divergence between the layers is worse than a shared, recorded
+// under-refusal.
+//
+// They are kept OUT of Corpus so the differential tests stay green, and
+// asserted separately by TestKnownGapsStillGap. That test fails when a gap
+// CLOSES, which is the signal that BUG-2812 has landed and these entries should
+// move into Corpus with Refused flipped.
+var KnownGaps = []Case{
+	{
+		Name: "duplicate key, the NUL in the SHADOWED value", Value: `{"a":"` + EscNUL + `","a":"clean"}`, IsJSON: true, Refused: true,
+		Why: "codex round 1 finding 2. encoding/json keeps the LAST duplicate, so the walk never sees the first value and the escape survives into a SQLite text-backed JSON column. Postgres's own parser keeps the last too, so it accepts this as well - the two agree today, which is why it is a recorded gap rather than a dialect split. Closing it needs the token-walk (BUG-2812), not a change here.",
+	},
 }

--- a/internal/textguard/corpus_test.go
+++ b/internal/textguard/corpus_test.go
@@ -89,3 +89,28 @@ func TestParameterRefusedMatchesTheCorpus(t *testing.T) {
 		})
 	}
 }
+
+// TestKnownGapsStillGap asserts the recorded under-refusals are STILL
+// under-refusals — and it is written to fail when one closes, not when one
+// persists.
+//
+// That direction is the point. A gap that closes silently is a layer diverging
+// from the others without anyone deciding to, which is the failure this whole
+// cluster is made of. When BUG-2812's token-walk lands and this fails, the fix
+// is to move the entry into Corpus with Refused as it should be.
+func TestKnownGapsStillGap(t *testing.T) {
+	if len(KnownGaps) == 0 {
+		t.Skip("no recorded gaps")
+	}
+	for _, c := range KnownGaps {
+		t.Run(c.Name, func(t *testing.T) {
+			got := ParameterRefused(c.Value, c.IsJSON)
+			if got == c.Refused {
+				t.Errorf("this gap has CLOSED: ParameterRefused(%q, isJSON=%t) now returns %t, which is the "+
+					"CORRECT answer. That is good news and a required action — move this case into Corpus "+
+					"and delete it from KnownGaps, so the differential test starts enforcing it on every layer.\n"+
+					"why it was a gap: %s", c.Value, c.IsJSON, got, c.Why)
+			}
+		})
+	}
+}

--- a/internal/textguard/corpus_test.go
+++ b/internal/textguard/corpus_test.go
@@ -99,8 +99,16 @@ func TestParameterRefusedMatchesTheCorpus(t *testing.T) {
 // cluster is made of. When BUG-2812's token-walk lands and this fails, the fix
 // is to move the entry into Corpus with Refused as it should be.
 func TestKnownGapsStillGap(t *testing.T) {
-	if len(KnownGaps) == 0 {
-		t.Skip("no recorded gaps")
+	// NOT a skip. An empty slice used to skip, so DELETING the last entry made
+	// the suite green — exactly the edit this test exists to catch, passing
+	// silently (codex round 2). Emptying it is a claim that every recorded gap
+	// has closed, and that claim has a required consequence: the cases move
+	// into Corpus. Assert the count instead.
+	const wantGaps = 1
+	if len(KnownGaps) != wantGaps {
+		t.Fatalf("KnownGaps has %d entries, expected %d. If a gap CLOSED, move its case into Corpus and "+
+			"update this count in the same edit. If a gap was ADDED, add it to Corpus's counterpart "+
+			"reasoning too, and update this count.", len(KnownGaps), wantGaps)
 	}
 	for _, c := range KnownGaps {
 		t.Run(c.Name, func(t *testing.T) {

--- a/internal/textguard/corpus_test.go
+++ b/internal/textguard/corpus_test.go
@@ -1,0 +1,91 @@
+package textguard
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestConstantsDidNotDecay is the guard against the mistake this package's own
+// constants exist to prevent, and it compares against a value it BUILDS rather
+// than one it types - because typing the six characters is the mistake.
+func TestConstantsDidNotDecay(t *testing.T) {
+	if len(NUL) != 1 || NUL[0] != 0 {
+		t.Errorf("NUL is %q (len %d), want exactly one zero byte", NUL, len(NUL))
+	}
+
+	built := string([]byte{'\\', 'u', '0', '0', '0', '0'})
+	if EscNUL != built {
+		t.Errorf("EscNUL is %q (len %d), want the six-character escape TEXT %q", EscNUL, len(EscNUL), built)
+	}
+	if ContainsNUL(EscNUL) {
+		t.Error("EscNUL carries a real NUL - it has decayed into the character it is supposed to spell")
+	}
+	if !ContainsNUL(NUL) {
+		t.Error("NUL does not carry a real NUL")
+	}
+}
+
+// TestCorpusIsWellFormed checks the corpus before anything is measured against
+// it. A corpus with a duplicated case, a missing rationale, or a value that
+// silently decayed would make every layer's differential test agree about
+// nothing.
+func TestCorpusIsWellFormed(t *testing.T) {
+	if len(Corpus) < 10 {
+		t.Fatalf("corpus has %d cases; it is meant to be adversarial, not a sample", len(Corpus))
+	}
+	seenName := map[string]bool{}
+	seenValue := map[string]bool{}
+	refused, accepted := 0, 0
+	for _, c := range Corpus {
+		if c.Name == "" || c.Why == "" {
+			t.Errorf("case %q has no name or no rationale; a case nobody can re-derive is not evidence", c.Name)
+		}
+		if seenName[c.Name] {
+			t.Errorf("duplicate case name %q", c.Name)
+		}
+		seenName[c.Name] = true
+		key := c.Value + "|" + map[bool]string{true: "J", false: "T"}[c.IsJSON]
+		if seenValue[key] {
+			t.Errorf("case %q duplicates an earlier (value, classing) pair - it discriminates nothing new", c.Name)
+		}
+		seenValue[key] = true
+		if c.Refused {
+			refused++
+		} else {
+			accepted++
+		}
+	}
+	// BOTH answers must be represented, or the corpus cannot tell a guard that
+	// refuses everything from one that refuses the right things.
+	if refused == 0 || accepted == 0 {
+		t.Errorf("corpus has %d refused and %d accepted cases; it needs both to discriminate", refused, accepted)
+	}
+
+	// Every case that carries the ESCAPE must carry it as six characters. This
+	// is the decay check applied to the corpus itself rather than to the
+	// constants, because a case built by concatenation can still be typed
+	// wrong.
+	for _, c := range Corpus {
+		if strings.Contains(c.Name, "ESCAPE") || strings.Contains(c.Name, "escape") {
+			if !strings.Contains(c.Value, EscNUL) {
+				t.Errorf("case %q claims to carry the escape but its value does not contain the six characters", c.Name)
+			}
+		}
+	}
+}
+
+// TestParameterRefusedMatchesTheCorpus is the store layer's leg of the
+// differential test - the predicate answering for every shape, before any
+// database is involved. The remaining legs (HTTP gate, real SQLite write, real
+// Postgres write) drive the same corpus from their own packages.
+func TestParameterRefusedMatchesTheCorpus(t *testing.T) {
+	for _, c := range Corpus {
+		t.Run(c.Name, func(t *testing.T) {
+			got := ParameterRefused(c.Value, c.IsJSON)
+			if got != c.Refused {
+				t.Errorf("ParameterRefused(%q, isJSON=%t) = %t, want %t\nwhy this case exists: %s",
+					c.Value, c.IsJSON, got, c.Refused, c.Why)
+			}
+		})
+	}
+}

--- a/internal/textguard/textguard.go
+++ b/internal/textguard/textguard.go
@@ -1,0 +1,127 @@
+// Package textguard holds the ONE decoded-NUL predicate that every layer of
+// Pad's NUL invariant shares.
+//
+// It exists because BUG-2803's whole history is layers disagreeing about one
+// value. The HTTP gate refuses a request body whose JSON decodes to a NUL; the
+// store's write guard refuses a bound parameter that does; Postgres refuses it
+// natively; a SQLite trigger will refuse it in the database. Four answers to
+// one question is only safe if they are one implementation, so this package is
+// the implementation and each layer supplies only its own INPUT.
+//
+// WHAT IS SHARED AND WHAT IS NOT, because getting this line wrong is how the
+// bug family breeds. Shared: whether a value, interpreted as text or as a JSON
+// document, yields a NUL. NOT shared: how a layer decides that a given value
+// IS a JSON document. The HTTP gate derives that from request-body KEY NAMES
+// (fields, schema, settings - the keys whose string value something downstream
+// re-parses); the store derives it from the COLUMN a parameter is bound to,
+// via the 86-column classification. Those two derivations cannot be merged -
+// one has keys, the other has columns - so they are made explicit instead:
+// every entry point here takes the JSON-ness as an argument, and the four-way
+// differential test pins that both derivations agree on one corpus.
+package textguard
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// escapePrefix is the only spelling of a NUL a JSON document can carry. Used
+// as a cheap pre-filter: a value without it cannot decode to a NUL, so the
+// expensive parse is skipped.
+//
+// It is a PRE-FILTER on the escape's presence, never a decision about its
+// meaning. BUG-2803's recorded-wrong parity filter tried to decide from raw
+// bytes whether an escape was live or literal and could not: a doubled
+// backslash makes the same six characters literal text, and only a decode
+// tells the two apart. Anything cheaper than a decode is layer-confused.
+const escapePrefix = `\u00`
+
+// ContainsNUL reports whether the string carries a real NUL byte.
+//
+// This is the universal half of the invariant and it needs no classing: no
+// column of any type in any dialect wants one. Postgres refuses it outright
+// (SQLSTATE 22021 / 22P05), SQLite stores it and then disagrees with itself
+// about the value's length.
+func ContainsNUL(s string) bool { return strings.ContainsRune(s, 0) }
+
+// IsJSONDocument reports whether a string is a complete JSON object or array -
+// the shape a downstream consumer, or Postgres's own jsonb parser, will
+// re-parse.
+func IsJSONDocument(s string) bool {
+	t := strings.TrimSpace(s)
+	if len(t) == 0 || (t[0] != '{' && t[0] != '[') {
+		return false
+	}
+	return json.Valid([]byte(t))
+}
+
+// DocumentDecodesNUL walks a JSON document carried as a string and reports
+// whether anything in it decodes to a NUL - in a value or in a KEY.
+//
+// This is the layer Postgres itself parses, so an escape here is fatal where
+// one a level deeper is not: a fields blob bound for jsonb is refused with
+// 22P05 while the same escape inside a string the blob merely contains is
+// stored intact.
+//
+// Returns false for a string that is not a JSON document at all, so a caller
+// that is unsure may pass anything.
+func DocumentDecodesNUL(s string) bool {
+	if !strings.Contains(s, escapePrefix) || !IsJSONDocument(s) {
+		return false
+	}
+	var inner any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(s)), &inner); err != nil {
+		return false
+	}
+	return ValueDecodesNUL(inner)
+}
+
+// ValueDecodesNUL walks an ALREADY-DECODED JSON value for a NUL in any string
+// or any object key.
+//
+// No key-classing here, deliberately: at this depth every string is caller
+// data, and a caller that needs classing does it before calling - which is the
+// package's whole contract. The HTTP gate's key-classed walk lives with the
+// gate, calls this for the unclassed subtrees, and is the reason this function
+// is exported rather than folded into DocumentDecodesNUL.
+func ValueDecodesNUL(v any) bool {
+	switch t := v.(type) {
+	case string:
+		return ContainsNUL(t)
+	case map[string]any:
+		for k, sub := range t {
+			if ContainsNUL(k) {
+				return true
+			}
+			if ValueDecodesNUL(sub) {
+				return true
+			}
+		}
+	case []any:
+		for _, sub := range t {
+			if ValueDecodesNUL(sub) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ParameterRefused reports whether a value bound as a SQL parameter violates
+// the invariant, and is the store layer's single entry point.
+//
+// isJSON is the caller's classification, not a guess made here - see the
+// package doc. When true the value is additionally walked as a JSON document,
+// which is what catches the escape form that reaches Postgres's jsonb parser
+// still spelled as an escape and is refused there with 22P05.
+//
+// The raw check runs REGARDLESS of isJSON: a JSON-classed parameter carrying a
+// literal NUL byte is refused by the same rule as any other text, and skipping
+// it for JSON-classed values is precisely the regression codex round 9 caught
+// in the HTTP gate's own walk.
+func ParameterRefused(value string, isJSON bool) bool {
+	if ContainsNUL(value) {
+		return true
+	}
+	return isJSON && DocumentDecodesNUL(value)
+}

--- a/internal/textguard/textguard.go
+++ b/internal/textguard/textguard.go
@@ -44,9 +44,20 @@ const escapePrefix = `\u00`
 // about the value's length.
 func ContainsNUL(s string) bool { return strings.ContainsRune(s, 0) }
 
-// IsJSONDocument reports whether a string is a complete JSON object or array -
-// the shape a downstream consumer, or Postgres's own jsonb parser, will
-// re-parse.
+// IsJSONDocument reports whether a string is a complete JSON OBJECT OR ARRAY -
+// the shape a downstream consumer treats as a nested document.
+//
+// Objects and arrays only, deliberately, and this is the HTTP gate's rule
+// unchanged: it decides whether a request field's string value is a nested
+// document worth walking, and a bare scalar in that position is just a string
+// the gate has already checked directly.
+//
+// The STORE cannot use this rule, because jsonb accepts a scalar as a complete
+// document: a bare JSON string consisting of the NUL escape is a valid jsonb
+// value that Postgres refuses and SQLite stores, which is the dialect split all
+// over again (codex round 1, finding 1). DocumentDecodesNULAnyShape is the
+// store's version. Two rules, two callers, and the difference is which question
+// is asked - "is this a nested document" versus "will a jsonb parser read it".
 func IsJSONDocument(s string) bool {
 	t := strings.TrimSpace(s)
 	if len(t) == 0 || (t[0] != '{' && t[0] != '[') {
@@ -71,6 +82,24 @@ func DocumentDecodesNUL(s string) bool {
 	}
 	var inner any
 	if err := json.Unmarshal([]byte(strings.TrimSpace(s)), &inner); err != nil {
+		return false
+	}
+	return ValueDecodesNUL(inner)
+}
+
+// DocumentDecodesNULAnyShape is DocumentDecodesNUL widened to every JSON
+// document shape a jsonb column accepts, scalars included.
+//
+// The store's write guard uses this one. A bare JSON string, a number, a
+// boolean and null are all complete documents to Postgres; the first of them
+// can decode to a NUL, and the object/array-only rule walked straight past it.
+func DocumentDecodesNULAnyShape(s string) bool {
+	t := strings.TrimSpace(s)
+	if t == "" || !strings.Contains(t, escapePrefix) || !json.Valid([]byte(t)) {
+		return false
+	}
+	var inner any
+	if err := json.Unmarshal([]byte(t), &inner); err != nil {
 		return false
 	}
 	return ValueDecodesNUL(inner)
@@ -123,5 +152,8 @@ func ParameterRefused(value string, isJSON bool) bool {
 	if ContainsNUL(value) {
 		return true
 	}
-	return isJSON && DocumentDecodesNUL(value)
+	// ANY SHAPE, not just objects and arrays: a jsonb column accepts a bare
+	// scalar as a complete document, and a scalar can decode to a NUL (codex
+	// round 1, finding 1).
+	return isJSON && DocumentDecodesNULAnyShape(value)
 }


### PR DESCRIPTION
S1 of [[DOC-2823]]. Closes BUG-2814 and the current-binary half of BUG-2813: the fixed binary can no longer WRITE a decoded NUL from any path, request or re-emit.

## The guard is a driver wrapper, and two measurements decided that

The sequencing ruling specified a validating wrapper at "the existing Queryer seam through which ALL store writes pass". `Queryer` is `Query` + `QueryRow`; its own doc opens *"the read-only subset"*, and no store write passes through it. There was no write seam to wrap.

Writes reach the driver by **four** receivers — `db.Exec` (139 sites), `tx.Exec` (99), `stmt.Exec` (2, prepared), and a passed executor — and a wrapper at the `*sql.DB` level cannot see the prepared ones at all.

So Layer A is a `database/sql` **driver** wrapper, registered for both dialects. It never reads SQL text, only bound parameters, which is why `Sprintf`-composed statements are covered without being understood and a new call site is covered before it is written. The deeper reason is this cluster's own lesson: **a seam every write site must be *edited to route through* is an enumeration wearing a seam's costume** — nothing stops the next site taking the raw handle, and the compiler cannot tell you it did.

It covers Query as well as Exec. Not symmetry: three writes ride the Query path today (`UPDATE ... RETURNING` in `password_resets.go` and `email_verification.go`, `INSERT ... RETURNING` in `yjs_updates.go`). A single-line regex for that shape found **zero**; the structural scan found **all three**, each a multi-line raw-string literal.

## One predicate, two derivations, made explicit

The predicate lived in `internal/server`, which imports `internal/store` — so a store guard could not reach it and would have reimplemented it. `internal/textguard` is now a leaf package holding it, and the gate DELEGATES: its existing 418-line corpus passes unchanged, which is the extraction's proof.

What is deliberately **not** shared is named in the package doc: how a layer decides a value IS JSON. The gate derives it from request-body KEY NAMES; the store derives it from the COLUMN. Those cannot be merged, so every entry point takes the classification as an argument and the differential test pins that both derivations agree.

## Classing: `string` checked, `[]byte` exempt

The first version checked `[]byte` too and **every Yjs op-log append failed** — `item_yjs_updates.update_data` is raw binary and legitimately contains NULs. The existing collab suite caught it in the first minute.

Measured, not assumed: `update_data` is the only BLOB/BYTEA column in either schema, and no `json.Marshal` result is bound without a `string()` conversion. But that second leg was a source-level sweep, and this unit is a catalogue of those missing things — so it is pinned behaviourally by a census over the migration SQL that fails when a new binary column appears, and fails as *broken* if it finds none.

## The differential test — three live legs, Layer B dark until S2

The same corpus through the HTTP gate (classed by key), Layer A (classed by column), and **native Postgres through the raw pgx driver** with no guard in the path. All 15 cases agree across all three. That is the calibration result: the guard neither over-refuses what Postgres accepts nor under-refuses what it rejects. The Postgres leg asserts the SQLSTATE too, since "some error occurred" would be satisfied by a typo in the test's own SQL.

## Cost, reported at the width it holds

Per-call on a typical read: **33.5 ns, zero allocations**. A realistic JSON blob with no escape: 32.5 ns, zero allocations — the expensive arm is gated behind the escape pre-filter, so it never runs on the read flood.

The end-to-end guarded/unguarded pair is recorded but **not** quoted as a percentage: run-to-run spread is ~25 µs against an expected difference of ~34 ns. Six samples cannot resolve that. What they do resolve is the allocation profile — 7034 B / 158 allocs on both sides, identical.

## Mutation matrix: 16 mutants, all killed

Five survived first and each taught something rather than needing a weaker claim: the Query path and both prepared routes were genuinely untested (the prepared ones being the routes that justify this design), and `guardConn.Prepare` turned out to be **dead** for both drivers — `database/sql` routes to `PrepareContext` when the conn implements it — so the duplicate was removed rather than tested.

## Verification

Full Go suite **exit 0 on SQLite** and **exit 0 on Postgres 17**. `golangci-lint` 0 issues, `gofmt`/`go vet` clean.

## Not closed here

- Layer B (SQLite triggers) is S2; its precondition already passed in TASK-2824.
- BUG-2840's window is unchanged and marginally widened — it is an ordering property above the store, and Layer A only adds a fifth refusal to the four that can already land there. Recorded on that trail.

BUG-2814, BUG-2813.

https://claude.ai/code/session_01XLtX4dbjBpApbAv3SuBcTm
