### PR TITLE
fix(store,server): bound the event outbox's writes, claims and scrub (BUG-2827)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ dist/
 .pad-e2e-*/
 web/playwright-report/
 web/test-results/
+
+# Go build cache the codex review sandbox writes into the checkout (BUG-2827: 5,688 of them once reached a commit)
+.tmp-gocache/

--- a/internal/server/outbox_drain.go
+++ b/internal/server/outbox_drain.go
@@ -237,15 +237,18 @@ func (s *Server) runOutboxDrainTick() {
 	// tick would make a diagnostic the most expensive thing the drain does.
 	//
 	// A diagnostic is what it is, so latency is the cheap thing to spend: the
-	// rows it reports are permanently unclaimable and sit until the 7-day
-	// retention takes them, which makes a five-minute alarm delay
-	// irrelevant to any decision anyone makes about them.
+	// rows it reports are ones this binary will never claim, and they sit
+	// until the 7-day retention takes them, which makes a five-minute alarm
+	// delay irrelevant to any decision anyone makes about them. The log line
+	// says exactly that and no more — the query does not look at claimed_at,
+	// and during a rolling upgrade an older binary may well be holding one
+	// (codex round 6).
 	if s.shouldScanOversizedOutbox() {
 		if oversized, oerr := s.store.OversizedPendingOutbox(5); oerr != nil {
 			slog.Error("outbox drain: oversized scan failed", "error", oerr)
 		} else {
 			for _, row := range oversized {
-				slog.Error("outbox drain: payload over the size limit, not claimed",
+				slog.Error("outbox drain: payload over the claim ceiling; this instance will not claim it",
 					"event_id", row.ID, "event_type", row.EventType,
 					"bytes", row.Bytes, "limit", store.MaxOutboxClaimableBytes)
 			}

--- a/internal/server/outbox_drain.go
+++ b/internal/server/outbox_drain.go
@@ -208,6 +208,27 @@ func (s *Server) runOutboxDrainTick() {
 		slog.Error("outbox drain: claim failed", "error", err)
 		return
 	}
+	// Report what the claim REFUSED to read. The claim excludes rows over
+	// store.MaxOutboxClaimableBytes in its own predicate so they cannot occupy
+	// candidate slots (BUG-2827); without this they would then be invisible
+	// until retention silently reaped them. Only a binary older than that cap
+	// can have written one, so on most instances this logs nothing, ever.
+	//
+	// Logged rather than dead-lettered: stamping dispatched_at would record
+	// that an event went out when it did not, in the table that is the only
+	// durable answer to "did this mutation emit?". Leaving the row pending
+	// keeps that answer honest and hands its lifecycle to the undispatched
+	// retention bound, which already exists for events that can never be
+	// delivered.
+	if oversized, oerr := s.store.OversizedPendingOutbox(5); oerr != nil {
+		slog.Error("outbox drain: oversized scan failed", "error", oerr)
+	} else {
+		for _, row := range oversized {
+			slog.Error("outbox drain: payload over the size limit, not claimed",
+				"event_id", row.ID, "event_type", row.EventType,
+				"bytes", row.Bytes, "limit", store.MaxOutboxClaimableBytes)
+		}
+	}
 	for _, unit := range groupOutboxDeliveries(events) {
 		s.deliverOutboxUnit(unit)
 	}

--- a/internal/server/outbox_drain.go
+++ b/internal/server/outbox_drain.go
@@ -60,6 +60,9 @@ type outboxDrainConfig struct {
 	stop                chan struct{}
 	running             bool
 	drainerID           string
+	// lastOversizedScan throttles the oversized-row diagnostic; see
+	// shouldScanOversizedOutbox.
+	lastOversizedScan time.Time
 	// tick, when non-nil, replaces the interval ticker so a test can pin
 	// assertions to a SPECIFIC pass instead of racing a free-running loop —
 	// the same affordance server.go's other sweepers expose.
@@ -220,13 +223,26 @@ func (s *Server) runOutboxDrainTick() {
 	// keeps that answer honest and hands its lifecycle to the undispatched
 	// retention bound, which already exists for events that can never be
 	// delivered.
-	if oversized, oerr := s.store.OversizedPendingOutbox(5); oerr != nil {
-		slog.Error("outbox drain: oversized scan failed", "error", oerr)
-	} else {
-		for _, row := range oversized {
-			slog.Error("outbox drain: payload over the size limit, not claimed",
-				"event_id", row.ID, "event_type", row.EventType,
-				"bytes", row.Bytes, "limit", store.MaxOutboxClaimableBytes)
+	// THROTTLED, because the query is expensive precisely when it finds
+	// nothing (codex round 3). Its size predicate is non-sargable and there is
+	// no index on payload length, so with no oversized rows it must evaluate
+	// octet_length over every pending row — and on Postgres that means
+	// detoasting and serializing each JSONB payload. Running that every 5s
+	// tick would make a diagnostic the most expensive thing the drain does.
+	//
+	// A diagnostic is what it is, so latency is the cheap thing to spend: the
+	// rows it reports are permanently unclaimable and sit until the 7-day
+	// retention takes them, which makes a five-minute alarm delay
+	// irrelevant to any decision anyone makes about them.
+	if s.shouldScanOversizedOutbox() {
+		if oversized, oerr := s.store.OversizedPendingOutbox(5); oerr != nil {
+			slog.Error("outbox drain: oversized scan failed", "error", oerr)
+		} else {
+			for _, row := range oversized {
+				slog.Error("outbox drain: payload over the size limit, not claimed",
+					"event_id", row.ID, "event_type", row.EventType,
+					"bytes", row.Bytes, "limit", store.MaxOutboxClaimableBytes)
+			}
 		}
 	}
 	for _, unit := range groupOutboxDeliveries(events) {
@@ -236,6 +252,27 @@ func (s *Server) runOutboxDrainTick() {
 	if err := s.runOutboxRetention(settings.dispatchedRetention, settings.undispatchedMaxAge, settings.lease); err != nil {
 		slog.Error("outbox drain: retention pass failed", "error", err)
 	}
+}
+
+// oversizedOutboxScanInterval is how often the drain runs its oversized-row
+// diagnostic. See the call site for why this is not every tick.
+const oversizedOutboxScanInterval = 5 * time.Minute
+
+// shouldScanOversizedOutbox reports whether enough time has passed to run the
+// diagnostic again, and stamps the clock when it says yes.
+//
+// FIRST TICK ALWAYS SCANS: the zero time is far enough in the past, which is
+// what makes a restart report an existing oversized row promptly rather than
+// after the first interval.
+func (s *Server) shouldScanOversizedOutbox() bool {
+	s.outboxDrain.mu.Lock()
+	defer s.outboxDrain.mu.Unlock()
+	now := time.Now()
+	if now.Sub(s.outboxDrain.lastOversizedScan) < oversizedOutboxScanInterval {
+		return false
+	}
+	s.outboxDrain.lastOversizedScan = now
+	return true
 }
 
 // outboxDelivery is one WIRE event and the rows it acks.

--- a/internal/server/outbox_drain.go
+++ b/internal/server/outbox_drain.go
@@ -31,9 +31,15 @@ import (
 const (
 	defaultOutboxDrainInterval = 5 * time.Second
 
-	// How many pending rows one pass claims. Whole batches are claimed past
-	// this bound (see ClaimPendingOutboxEvents) — it is a throughput knob, not
-	// a statement about what a bulk operation was.
+	// How many pending rows one pass claims. A batch's siblings are collected
+	// past this bound where they fit (see ClaimPendingOutboxEvents) — it is a
+	// throughput knob, not a statement about what a bulk operation was.
+	//
+	// "Where they fit" since BUG-2827: the claim's byte budget and row cap can
+	// stop a sibling scan part-way, so a batch bigger than either is split.
+	// That is what keeps the memory bounds from being bypassable by a single
+	// large batch, and groupOutboxDeliveries below already defines what a
+	// consumer sees when it happens.
 	defaultOutboxDrainLimit = 100
 
 	// How long a claim is honored before another instance may take the row.

--- a/internal/server/outbox_payload_limit_test.go
+++ b/internal/server/outbox_payload_limit_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/PerpetualSoftware/pad/internal/store"
 )
@@ -26,6 +27,7 @@ func TestWriteInternalErrorMapsTheOutboxRowCapRefusal(t *testing.T) {
 		EventType: "item.bulk_updated",
 		Bytes:     200 << 20,
 		Limit:     store.MaxOutboxPayloadBytes,
+		Measured:  "the row as the database stored it",
 	}))
 
 	if rec.Code != http.StatusRequestEntityTooLarge {
@@ -56,6 +58,12 @@ func TestWriteInternalErrorMapsTheOutboxRowCapRefusal(t *testing.T) {
 	if !strings.Contains(body.Error.Message, fmt.Sprint(store.MaxOutboxPayloadBytes)) {
 		t.Errorf("message does not state the limit: %q", body.Error.Message)
 	}
+	// The store refuses on two different measurements against two different
+	// limits, so the message has to say which one this was or a caller cannot
+	// reconcile two numbers for one mutation.
+	if !strings.Contains(body.Error.Message, "the row as the database stored it") {
+		t.Errorf("message does not say what was measured: %q", body.Error.Message)
+	}
 }
 
 // TestWriteInternalErrorStillFallsThroughToFiveHundred is the negative control:
@@ -66,5 +74,58 @@ func TestWriteInternalErrorStillFallsThroughToFiveHundred(t *testing.T) {
 	writeInternalError(rec, fmt.Errorf("some unrelated failure"))
 	if rec.Code != http.StatusInternalServerError {
 		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+}
+
+// TestOversizedOutboxScanIsThrottled pins the diagnostic's cadence.
+//
+// The query it gates is expensive exactly when it finds nothing — a
+// non-sargable size predicate over every pending row, detoasting each JSONB
+// payload on Postgres — so running it per 5s tick would make the drain's
+// cheapest-value work its most expensive. Asserting "true then false" is the
+// whole contract: the first tick after a restart reports promptly, and the
+// interval keeps it off the hot path afterwards.
+func TestOversizedOutboxScanIsThrottled(t *testing.T) {
+	s := &Server{}
+	if !s.shouldScanOversizedOutbox() {
+		t.Fatal("the first call refused to scan; a restart must report an existing oversized row " +
+			"without waiting out an interval first")
+	}
+	if s.shouldScanOversizedOutbox() {
+		t.Fatal("a second call immediately after the first scanned again; the throttle is not applied")
+	}
+
+	// And it recovers once the interval has passed, or the diagnostic reports
+	// once per process and never again.
+	s.outboxDrain.lastOversizedScan = time.Now().Add(-2 * oversizedOutboxScanInterval)
+	if !s.shouldScanOversizedOutbox() {
+		t.Fatal("the scan never resumed after the interval elapsed")
+	}
+}
+
+// TestOutboxDrainTickConsultsTheThrottle covers the CALL SITE, which the test
+// above does not.
+//
+// Found by mutation: replacing `if s.shouldScanOversizedOutbox()` with `if
+// true` left the throttle test green, because that test drives the helper
+// directly and a helper nothing calls is still correct in isolation. The
+// observable that reaches the call site is the stamp — a tick that consulted
+// the throttle has set it, and one that skipped straight to the query has not.
+func TestOutboxDrainTickConsultsTheThrottle(t *testing.T) {
+	srv, _, _ := drainFixture(t)
+
+	if !srv.outboxDrain.lastOversizedScan.IsZero() {
+		t.Fatal("fixture started with the throttle already stamped")
+	}
+	srv.runOutboxDrainTick()
+	first := srv.outboxDrain.lastOversizedScan
+	if first.IsZero() {
+		t.Fatal("a drain tick left the throttle unstamped; the diagnostic is running unthrottled")
+	}
+
+	srv.runOutboxDrainTick()
+	if got := srv.outboxDrain.lastOversizedScan; !got.Equal(first) {
+		t.Fatalf("a second tick restamped the throttle (%v -> %v); the interval is not being honoured",
+			first, got)
 	}
 }

--- a/internal/server/outbox_payload_limit_test.go
+++ b/internal/server/outbox_payload_limit_test.go
@@ -27,7 +27,7 @@ func TestWriteInternalErrorMapsTheOutboxRowCapRefusal(t *testing.T) {
 		EventType: "item.bulk_updated",
 		Bytes:     200 << 20,
 		Limit:     store.MaxOutboxPayloadBytes,
-		Measured:  "the row as the database stored it",
+		Measured:  "the row as the database will hand it back",
 	}))
 
 	if rec.Code != http.StatusRequestEntityTooLarge {
@@ -61,7 +61,7 @@ func TestWriteInternalErrorMapsTheOutboxRowCapRefusal(t *testing.T) {
 	// The store refuses on two different measurements against two different
 	// limits, so the message has to say which one this was or a caller cannot
 	// reconcile two numbers for one mutation.
-	if !strings.Contains(body.Error.Message, "the row as the database stored it") {
+	if !strings.Contains(body.Error.Message, "the row as the database will hand it back") {
 		t.Errorf("message does not say what was measured: %q", body.Error.Message)
 	}
 }

--- a/internal/server/outbox_payload_limit_test.go
+++ b/internal/server/outbox_payload_limit_test.go
@@ -1,0 +1,70 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/store"
+)
+
+// TestWriteInternalErrorMapsTheOutboxRowCapRefusal pins the HTTP half of
+// BUG-2827.
+//
+// It drives writeInternalError directly rather than through a handler because
+// reaching the real refusal takes a payload over 128 MiB, and a test that
+// allocates that to observe a status code is measuring the wrong thing. What
+// has to be true here is the CLASSIFICATION — a stated refusal is not a 500 —
+// and that survives the substitution. The store-side tests own the question of
+// whether the refusal fires at the right size.
+func TestWriteInternalErrorMapsTheOutboxRowCapRefusal(t *testing.T) {
+	rec := httptest.NewRecorder()
+	writeInternalError(rec, fmt.Errorf("update item: %w", &store.OversizedOutboxPayloadError{
+		EventType: "item.bulk_updated",
+		Bytes:     200 << 20,
+		Limit:     store.MaxOutboxPayloadBytes,
+	}))
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d — a refusal under a stated rule must not surface as a server "+
+			"fault the caller cannot act on", rec.Code, http.StatusRequestEntityTooLarge)
+	}
+	var body struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body %q: %v", rec.Body.String(), err)
+	}
+	if body.Error.Code != "event_payload_too_large" {
+		t.Errorf("code = %q, want event_payload_too_large", body.Error.Code)
+	}
+	// The WRAPPER must not leak. The message is composed from the typed
+	// fields, so "update item:" — added by a caller on the way up — has no
+	// business in a client-facing string.
+	if strings.Contains(body.Error.Message, "update item") {
+		t.Errorf("message leaks the call path's wrapper: %q", body.Error.Message)
+	}
+	if !strings.Contains(body.Error.Message, "item.bulk_updated") {
+		t.Errorf("message does not name the event that was refused: %q", body.Error.Message)
+	}
+	if !strings.Contains(body.Error.Message, fmt.Sprint(store.MaxOutboxPayloadBytes)) {
+		t.Errorf("message does not state the limit: %q", body.Error.Message)
+	}
+}
+
+// TestWriteInternalErrorStillFallsThroughToFiveHundred is the negative control:
+// without it the test above passes just as well against a writeInternalError
+// that answers 413 to everything.
+func TestWriteInternalErrorStillFallsThroughToFiveHundred(t *testing.T) {
+	rec := httptest.NewRecorder()
+	writeInternalError(rec, fmt.Errorf("some unrelated failure"))
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2210,10 +2210,15 @@ func writeInternalError(w http.ResponseWriter, err error) {
 	if errors.As(err, &oversized) {
 		slog.Warn("write refused: outbox payload over the size limit",
 			"event_type", oversized.EventType, "bytes", oversized.Bytes, "limit", oversized.Limit)
+		// The message names WHAT was measured, because the store refuses on two
+		// different measurements — the member content before marshalling, and
+		// the row as stored — and a caller told only "%d bytes" for both
+		// cannot reconcile two different numbers for one mutation (codex
+		// round 3).
 		writeError(w, http.StatusRequestEntityTooLarge, "event_payload_too_large",
 			fmt.Sprintf("This change would record a %s event larger than the server will store in one "+
-				"row: %d bytes, and the limit is %d. Split the change into smaller ones and try again.",
-				oversized.EventType, oversized.Bytes, oversized.Limit))
+				"row: %s is %d bytes, and the limit is %d. Split the change into smaller ones and try again.",
+				oversized.EventType, oversized.Measured, oversized.Bytes, oversized.Limit))
 		return
 	}
 	slog.Error("internal server error", "error", err)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2191,6 +2191,31 @@ func writeInternalError(w http.ResponseWriter, err error) {
 		writeError(w, http.StatusBadRequest, "bad_request", reason)
 		return
 	}
+	// The outbox row cap is likewise a decision, not a fault, and is mapped in
+	// the same funnel for the same reason (BUG-2827). 413 with a *_too_large
+	// code follows the house precedent set by rename_cascade_too_large rather
+	// than inventing a second spelling for "this operation produces more than
+	// the server will process in one go".
+	//
+	// The literal reading of 413 is that the REQUEST entity is too large, and
+	// here the request is small while the event it derives is not. Taken
+	// alone that argues for 422. It loses to consistency: an operator watching
+	// for cascade refusals should not have to know which of two size bounds
+	// fired to know which status to grep for, and the message says plainly
+	// what was actually too big.
+	//
+	// Composed from the TYPED fields, never by splicing err.Error(), so no
+	// wrapper the call path added is published to the caller.
+	var oversized *store.OversizedOutboxPayloadError
+	if errors.As(err, &oversized) {
+		slog.Warn("write refused: outbox payload over the size limit",
+			"event_type", oversized.EventType, "bytes", oversized.Bytes, "limit", oversized.Limit)
+		writeError(w, http.StatusRequestEntityTooLarge, "event_payload_too_large",
+			fmt.Sprintf("This change would record a %s event larger than the server will store in one "+
+				"row: %d bytes, and the limit is %d. Split the change into smaller ones and try again.",
+				oversized.EventType, oversized.Bytes, oversized.Limit))
+		return
+	}
 	slog.Error("internal server error", "error", err)
 	writeError(w, http.StatusInternalServerError, "internal_error", "An internal error occurred")
 }

--- a/internal/store/dialect.go
+++ b/internal/store/dialect.go
@@ -63,6 +63,22 @@ type Dialect interface {
 	// PostgreSQL: STRING_AGG(DISTINCT expr, ',')
 	GroupConcat(expr string, distinct bool) string
 
+	// OctetLength returns SQL for the BYTE length of a text-ish column, as the
+	// driver will hand it to Scan.
+	//
+	// The distinction matters here rather than being pedantry: event_outbox
+	// payload is TEXT on SQLite and JSONB on Postgres, and JSONB is a parsed
+	// representation whose ::text rendering is normalized (whitespace stripped,
+	// object keys reordered, duplicate keys collapsed). So the stored byte count
+	// and the scanned byte count are not the same number on Postgres. This
+	// measures the SCANNED one on both dialects — octet_length of the TEXT for
+	// SQLite, octet_length of the ::text rendering for Postgres — because every
+	// caller of this is deciding whether it can afford to Scan the value, not
+	// how much disk it occupies.
+	//
+	// SQLite's octet_length() requires 3.43+; the bundled library is 3.53.3.
+	OctetLength(column string) string
+
 	// BoolToInt converts a Go bool to a query parameter value.
 	// SQLite: 0/1 (integers)
 	// PostgreSQL: true/false (native booleans)
@@ -168,6 +184,10 @@ func (d *sqliteDialect) GroupConcat(expr string, distinct bool) string {
 	return fmt.Sprintf("GROUP_CONCAT(%s)", expr)
 }
 
+func (d *sqliteDialect) OctetLength(column string) string {
+	return fmt.Sprintf("octet_length(%s)", column)
+}
+
 func (d *sqliteDialect) BoolToInt(b bool) interface{} {
 	if b {
 		return 1
@@ -249,6 +269,12 @@ func (d *postgresDialect) GroupConcat(expr string, distinct bool) string {
 		return fmt.Sprintf("STRING_AGG(DISTINCT %s, ',')", expr)
 	}
 	return fmt.Sprintf("STRING_AGG(%s, ',')", expr)
+}
+
+func (d *postgresDialect) OctetLength(column string) string {
+	// The ::text cast is load-bearing, not defensive: octet_length has no jsonb
+	// overload, so without it this is a type error rather than a wrong number.
+	return fmt.Sprintf("octet_length(%s::text)", column)
 }
 
 func (d *postgresDialect) BoolToInt(b bool) interface{} {

--- a/internal/store/event_outbox.go
+++ b/internal/store/event_outbox.go
@@ -223,9 +223,11 @@ const (
 // rule can reach retroactively.
 //
 // It is needed because the drain's row limit does not bound bytes and never
-// did: ClaimPendingOutboxEvents takes `limit` oldest rows AND every claimable
-// sibling of any batch they touch, then outboxEventsClaimedBy Scans every one
-// of those payloads into memory. At the default limit of 100 that is 100
+// did: ClaimPendingOutboxEvents took `limit` oldest rows AND every claimable
+// sibling of any batch they touched, then outboxEventsClaimedBy Scanned every
+// one of those payloads into memory. (The sibling half is now capped by this
+// budget and by maxOutboxClaimRows — that is this constant working, not a
+// second mechanism.) At the default limit of 100 that is 100
 // unbounded reads per tick, which is the crash loop BUG-2827 reports — and it
 // is self-sustaining, because runOutboxDrainTick runs retention AFTER the
 // claim, so a pass that dies claiming never reaches the prune that would have
@@ -250,10 +252,10 @@ const maxOutboxClaimBytes = 64 << 20
 // maxOutboxClaimRows bounds how many ROWS one pass claims, alongside the byte
 // budget, because a budget in bytes alone does not bound the per-row cost.
 //
-// The uncapped path is the batch scan: siblings are collected past the row
-// limit by design, so a batch of a million tiny rows fits the byte budget
-// comfortably while its ids, maps, OutboxEvent structs and folded delivery do
-// not (codex round 1). Roughly 200 bytes of overhead per row means the byte
+// The path that made it necessary is the batch scan: siblings are collected
+// past the row limit by design, so a batch of a million tiny rows fits the
+// byte budget comfortably while its ids, maps, OutboxEvent structs and folded
+// delivery do not (codex round 1). Roughly 200 bytes of overhead per row means the byte
 // budget alone admits hundreds of megabytes of it.
 //
 // 5,000 is chosen so it binds only on that pathological shape: at the measured
@@ -407,6 +409,27 @@ func writeOutboxTx(tx *sql.Tx, s *Store, ev OutboxEvent) error {
 	if !json.Valid(ev.Payload) {
 		return fmt.Errorf("outbox: event %s has a malformed JSON payload", ev.EventType)
 	}
+	if ev.Hop > maxOutboxHop {
+		// Cascade bound reached: drop the event, keep the mutation. No
+		// production caller can reach this today (see maxOutboxHop — nothing
+		// propagates a hop yet); it is here so the bound exists before the
+		// thing that needs it.
+		//
+		// When it does become reachable, a silent drop would make a runaway
+		// binding indistinguishable from one that never fired, so surfacing it
+		// is owed then — via the dispatcher's quota accounting, which is also
+		// still unimplemented. Recorded as an obligation rather than described
+		// as if it were already in place.
+		return nil
+	}
+
+	// AFTER THE HOP DROP, deliberately. An event past the cascade bound is not
+	// written at all, so refusing it for size would fail a mutation over a row
+	// that was never going to exist — and the hop bound's whole disposition is
+	// that the mutation stands. Unreachable today, since nothing propagates a
+	// hop yet, which is exactly why the ordering is worth getting right before
+	// something does (codex round 5).
+	//
 	// SIZE IS CHECKED HERE, at the one choke point every outbox row passes
 	// through, rather than at the bulk emitter that motivated it. The bulk
 	// emitter is the only caller that can currently build a payload this
@@ -428,19 +451,6 @@ func writeOutboxTx(tx *sql.Tx, s *Store, ev OutboxEvent) error {
 			Limit:     s.outboxRowCap(),
 			Measured:  measuredGoPayload,
 		}
-	}
-	if ev.Hop > maxOutboxHop {
-		// Cascade bound reached: drop the event, keep the mutation. No
-		// production caller can reach this today (see maxOutboxHop — nothing
-		// propagates a hop yet); it is here so the bound exists before the
-		// thing that needs it.
-		//
-		// When it does become reachable, a silent drop would make a runaway
-		// binding indistinguishable from one that never fired, so surfacing it
-		// is owed then — via the dispatcher's quota accounting, which is also
-		// still unimplemented. Recorded as an obligation rather than described
-		// as if it were already in place.
-		return nil
 	}
 
 	if ev.ID == "" {
@@ -1832,8 +1842,8 @@ func (s *Store) claimOutboxIDs(token string, ids []string, leaseCutoff string) e
 }
 
 // pendingClaimCandidates returns the ids a claim pass should attempt: the
-// oldest claimable pending rows, plus every claimable sibling of any batch
-// they belong to.
+// oldest claimable pending rows, plus as many claimable siblings of any batch
+// they belong to as the byte budget and row cap still allow.
 func (s *Store) pendingClaimCandidates(limit int, leaseCutoff string) ([]string, error) {
 	size := s.dialect.OctetLength("payload")
 	// OVERSIZED ROWS ARE EXCLUDED IN SQL, not filtered in Go, and that is the
@@ -1950,17 +1960,23 @@ type OversizedOutboxRow struct {
 	Bytes     int
 }
 
-// OversizedPendingOutbox lists pending rows over MaxOutboxPayloadBytes.
+// OversizedPendingOutbox lists pending rows over MaxOutboxClaimableBytes.
+//
+// THE CLAIM'S CEILING, not the write cap, because the question this answers is
+// "what will the claim refuse to read" rather than "what would the write have
+// rejected". The two differ on purpose; see MaxOutboxClaimableBytes.
 //
 // EXISTS SO THE EXCLUSION IS NOT SILENT. pendingClaimCandidates drops these in
 // the predicate, which is what stops them jamming the queue — but a row that
 // is never claimed, never logged, and eventually reaped by retention is an
-// event that vanishes with nobody told. Only rows written by a binary older
-// than MaxOutboxPayloadBytes can be here at all, so this is expected to return
-// nothing forever on an instance that never ran one.
+// event that vanishes with nobody told. Since writeOutboxTx refuses on the
+// STORED size against this same ceiling, only a row left by a binary older
+// than that check can be here at all, so this is expected to return nothing
+// forever on an instance that never ran one.
 //
-// Bounded by `limit` because this runs every drain tick and its purpose is to
-// raise an alarm, not to enumerate a backlog.
+// Bounded by `limit` because its purpose is to raise an alarm, not to
+// enumerate a backlog. The caller additionally throttles how often it runs;
+// see the drain, where the reason lives.
 func (s *Store) OversizedPendingOutbox(limit int) ([]OversizedOutboxRow, error) {
 	if limit <= 0 {
 		limit = 5

--- a/internal/store/event_outbox.go
+++ b/internal/store/event_outbox.go
@@ -242,23 +242,22 @@ const maxOutboxClaimRows = 5000
 //
 // The write cap measures the Go bytes json.Marshal produced. The claim
 // measures what the driver will hand to Scan, which on Postgres is the JSONB
-// — text rendering, and that rendering inserts one space after every colon
-// and comma. So a payload written at EXACTLY the cap comes back over it, and a
-// claim thresholded at the same number would write the row through the guard
-// and then never claim it: delivered to nobody, reported as nothing, reaped by
-// retention seven days later. Found by running the suite against real
-// Postgres, where a 40,000-byte payload read back as 40,001.
+// — text rendering of a reparsed document. Those two numbers differ, and they
+// differ WITHOUT BOUND: whitespace after colons and commas is the small part,
+// while numeric normalization is unbounded (measured on Postgres 16,
+// {"a":1e-3000} is 13 bytes stored as 3009, and the exponent can grow). See
+// writeOutboxTx, which is where that gap is actually closed.
 //
-// 2x, because the expansion is bounded well under that. Every inserted byte
-// follows a colon or comma, so the worst case is a document of single-character
-// keys and values (`{"a":1,"b":2}`) at about 1.4x; our payloads are long string
-// values and expand by a small fraction of a percent. Normalization can also
-// SHRINK a document (existing whitespace stripped, duplicate keys collapsed),
-// so the correction is one-directional only for the compact output
-// encoding/json actually produces.
+// So this constant is NOT a proof that everything writable is claimable — no
+// multiplier could be. That property is established at the write instead:
+// writeOutboxTx measures the row AS STORED, via RETURNING, and refuses against
+// THIS number. The multiplier's only job is to leave ordinary payloads
+// comfortable room above the write cap so the two rules do not fight over
+// rounding; the real payloads measured for this unit expand by well under a
+// percent.
 //
-// What it still excludes is what it is for: rows left by a binary older than
-// the write cap, which can be hundreds of megabytes.
+// What it excludes is what it is for: rows left by a binary older than any of
+// this, which can be hundreds of megabytes.
 const MaxOutboxClaimableBytes = 2 * MaxOutboxPayloadBytes
 
 // outboxRowCap and outboxClaimBudget read the bounds THROUGH the test seams,
@@ -464,12 +463,53 @@ func writeOutboxTx(tx *sql.Tx, s *Store, ev OutboxEvent) error {
 	}
 	ev.SubjectKind = kind
 
-	_, err := tx.Exec(s.q(`
+	// RETURNING THE STORED SIZE, and then refusing on it, is what makes "a row
+	// this binary wrote is a row this binary can read back" true rather than
+	// hoped for.
+	//
+	// The check above measures the bytes json.Marshal produced. On Postgres
+	// that is NOT what gets stored: payload is JSONB, a parsed representation,
+	// and its text rendering is what the drain will later Scan. The two differ
+	// without limit. Whitespace after colons and commas is the small part;
+	// NUMERIC NORMALIZATION is the unbounded one, because Postgres reparses
+	// JSON numbers as `numeric` and prints them in positional notation.
+	// Measured against Postgres 16:
+	//
+	//	{"a":1,"b":2}     13 bytes ->    16   (whitespace only, ~1.2x)
+	//	{"a":1e-100}      12 bytes ->   109   (~9x)
+	//	{"a":1e-3000}     13 bytes ->  3009   (~231x, and the exponent is free
+	//	                                       to grow, so this has no ceiling)
+	//
+	// A Go-side cap therefore bounds the stored size not at all, and no
+	// multiple of it is a safe claim ceiling either. Reachable rather than
+	// theoretical: item payloads carry `fields` as a JSON *string*, whose
+	// contents are escaped text and immune to this, but a bulk delta is a
+	// map[string]any and a numeric field value decoded from a request body
+	// arrives as a float64 that re-marshals in exponent form.
+	//
+	// So the size that governs is measured where it is true, by the database,
+	// on the row as stored. Refusing here rolls the caller's transaction back
+	// exactly as the pre-marshal check does, and the mutation fails with the
+	// same named error instead of committing an event the drain would then
+	// refuse to read for the rest of its retention window.
+	//
+	// Charged against the CLAIM ceiling, not the write cap: this number is
+	// about what the drain can read, and the drain's predicate is the thing it
+	// has to agree with.
+	var stored int
+	if err := tx.QueryRow(s.q(`
 		INSERT INTO event_outbox (id, workspace_id, event_type, subject_kind, subject_id, payload, hop, occurred_at, batch_id)
 		VALUES (?, ?, ?, ?, NULLIF(?, ''), ?, ?, ?, NULLIF(?, ''))
-	`), ev.ID, ev.WorkspaceID, ev.EventType, ev.SubjectKind, ev.SubjectID, string(ev.Payload), ev.Hop, ev.OccurredAt, ev.BatchID)
-	if err != nil {
+		RETURNING `+s.dialect.OctetLength("payload")+`
+	`), ev.ID, ev.WorkspaceID, ev.EventType, ev.SubjectKind, ev.SubjectID, string(ev.Payload), ev.Hop, ev.OccurredAt, ev.BatchID).Scan(&stored); err != nil {
 		return fmt.Errorf("outbox: write %s: %w", ev.EventType, err)
+	}
+	if stored > s.outboxClaimableRowCap() {
+		return &OversizedOutboxPayloadError{
+			EventType: ev.EventType,
+			Bytes:     stored,
+			Limit:     s.outboxClaimableRowCap(),
+		}
 	}
 	return nil
 }
@@ -809,6 +849,9 @@ func (s *Store) ScrubOutboxUserRefsTx(tx *sql.Tx, userID string) error {
 		// Advance past the last row READ, not the last row rewritten. A
 		// candidate the Go rewrite left untouched (a LIKE false positive) is
 		// still consumed, so the cursor always moves and the loop terminates.
+		if s.afterOutboxScrubBatch != nil {
+			s.afterOutboxScrubBatch(len(candidates))
+		}
 		cursor = candidates[len(candidates)-1].id
 	}
 

--- a/internal/store/event_outbox.go
+++ b/internal/store/event_outbox.go
@@ -181,12 +181,33 @@ type OversizedOutboxPayloadError struct {
 	EventType string
 	Bytes     int
 	Limit     int
+	// Measured names WHAT Bytes counted, because the two refusal sites count
+	// different things against different limits and saying "a %d-byte
+	// payload" for both was untrue of one of them (codex round 3).
+	//
+	// The early-out charges the members' own bytes, which is a LOWER BOUND on
+	// the payload, against the write cap. The post-insert check charges the
+	// row exactly as the database stored it, against the claim ceiling. A
+	// caller comparing two refusals without this cannot tell why the same
+	// mutation reports different numbers on retry.
+	Measured string
 }
 
 func (e *OversizedOutboxPayloadError) Error() string {
-	return fmt.Sprintf("outbox: event %s has a %d-byte payload, over the %d-byte limit",
-		e.EventType, e.Bytes, e.Limit)
+	measured := e.Measured
+	if measured == "" {
+		measured = "payload"
+	}
+	return fmt.Sprintf("outbox: event %s exceeds the %d-byte limit: %s is %d bytes",
+		e.EventType, e.Limit, measured, e.Bytes)
 }
+
+// The two things OversizedOutboxPayloadError.Measured can name.
+const (
+	measuredMemberBodies = "the member content, a lower bound on the payload it would marshal to"
+	measuredStoredRow    = "the row as the database stored it"
+	measuredGoPayload    = "the marshalled payload"
+)
 
 // maxOutboxClaimBytes is how many payload bytes ONE claim pass may take.
 //
@@ -400,6 +421,7 @@ func writeOutboxTx(tx *sql.Tx, s *Store, ev OutboxEvent) error {
 			EventType: ev.EventType,
 			Bytes:     len(ev.Payload),
 			Limit:     s.outboxRowCap(),
+			Measured:  measuredGoPayload,
 		}
 	}
 	if ev.Hop > maxOutboxHop {
@@ -509,6 +531,7 @@ func writeOutboxTx(tx *sql.Tx, s *Store, ev OutboxEvent) error {
 			EventType: ev.EventType,
 			Bytes:     stored,
 			Limit:     s.outboxClaimableRowCap(),
+			Measured:  measuredStoredRow,
 		}
 	}
 	return nil
@@ -871,6 +894,17 @@ func (s *Store) ScrubOutboxUserRefsTx(tx *sql.Tx, userID string) error {
 // scrubOutboxRowTx rewrites one candidate row, retrying against concurrent
 // writers.
 //
+// A REWRITE ONLY EVER SHRINKS A ROW, and the claim path depends on it. Sizes
+// are measured when candidates are selected and the claim UPDATE that follows
+// rechecks only lease and dispatch state, so a writer that GREW a payload in
+// between could push a row past the ceiling after it had been judged under it
+// (codex round 3). No such writer exists: this is the only UPDATE of payload in
+// the tree, and it removes keys and re-marshals compactly, so the result is
+// strictly smaller. Shrinking is harmless — a row already judged claimable
+// stays claimable. Stated here rather than left implicit because it is the
+// reason the claim needs no size revalidation, and pinned by
+// TestScrubOnlyEverShrinksAPayload.
+//
 // THE UPDATE IS A COMPARE-AND-SWAP, not a blind write, because two account
 // deletions can hold one payload at once: a bulk payload naming users A and B
 // is a candidate for both, and on Postgres READ COMMITTED both transactions
@@ -1162,6 +1196,7 @@ func (s *Store) emitBulkItemEventTx(tx *sql.Tx, workspaceID string, members []*m
 				EventType: kernelevents.ItemBulkUpdated,
 				Bytes:     n,
 				Limit:     s.outboxRowCap(),
+				Measured:  measuredMemberBodies,
 			}
 		}
 		payload, err := marshalEventPayload(bulkItemEventPayload{

--- a/internal/store/event_outbox.go
+++ b/internal/store/event_outbox.go
@@ -145,10 +145,10 @@ const maxOutboxHop = 4
 // constant is set by the DIALECT CEILING: SQLite refuses a value over 1 GB
 // with SQLITE_TOOBIG, and Postgres somewhere in (512 MB, 1 GB] with an error
 // that poisons the enclosing transaction (25P02) so the failure surfaces as an
-// unrelated "current transaction is aborted". 64 MiB is ~5.8x the largest
-// legitimate payload the measured instance can produce and two orders below
-// both ceilings, so what a caller hits is always the named refusal below and
-// never the opaque one.
+// unrelated "current transaction is aborted". 64 MiB would already be ~5.8x
+// the largest legitimate payload the measured instance can produce; 128 MiB
+// is ~11.6x it and still 4x under the lowest ceiling, so what a caller hits
+// is always the named refusal below and never the opaque one.
 //
 // IT MUST ALSO CLEAR MaxItemRenameCascadeBytes, which is why it is not simply
 // 64 MiB. That constant (wiki_links.go, BUG-2804) bounds the wiki-title rename
@@ -241,12 +241,12 @@ const (
 // alone costs one pass its batching, once.
 //
 // So a pass retains ~64 MiB in the normal case and at most one row's payload
-// above that in the worst. Two transients sit on top of that, both bounded by
-// it rather than open-ended: outboxEventsClaimedBy scans each payload into a
-// string and then copies it to []byte, and FoldBulkHeader builds one wire
-// payload out of a batch's header plus its members while still holding them.
-// Peak is therefore a small multiple of this number, not a multiple of the
-// queue depth, which is the property that was missing.
+// above that in the worst. One transient sits on top of that, bounded by it
+// rather than open-ended: FoldBulkHeader builds one wire payload out of a
+// batch's header plus its members while still holding them. (The scan itself
+// adds nothing — outboxEventsClaimedBy reads each payload straight into
+// []byte.) Peak is therefore a small multiple of this number, not a multiple
+// of the queue depth, which is the property that was missing.
 const maxOutboxClaimBytes = 64 << 20
 
 // maxOutboxClaimRows bounds how many ROWS one pass claims, alongside the byte
@@ -259,7 +259,7 @@ const maxOutboxClaimBytes = 64 << 20
 // budget alone admits hundreds of megabytes of it.
 //
 // 5,000 is chosen so it binds only on that pathological shape: at the measured
-// payload mean of ~2.4 KB, 5,000 rows is ~12 MiB, well inside the byte budget,
+// payload mean of ~3.5 KB, 5,000 rows is ~17 MiB, well inside the byte budget,
 // which stays the operative bound for real traffic. It is also ~1,000 events
 // per second against the 5s tick, orders above anything measured.
 const maxOutboxClaimRows = 5000
@@ -1204,8 +1204,10 @@ func (s *Store) emitBulkItemEventTx(tx *sql.Tx, workspaceID string, members []*m
 		// Charged on the members' own bytes, which the marshal can only GROW
 		// (JSON adds quoting, escaping and key names and removes nothing), so
 		// this never refuses a payload the real check would have accepted. It
-		// is an early-out, not a second rule — the authoritative refusal, and
-		// the numbers the caller is shown, still come from writeOutboxTx.
+		// is an early-out, not a second rule: when it fires, the error says
+		// it measured member bodies rather than a payload (Measured, below),
+		// and when it does not, writeOutboxTx's refusal against the marshalled
+		// and then the stored size is the authoritative one.
 		if n := projectedBulkPayloadBytes(group); n > s.outboxRowCap() {
 			return &OversizedOutboxPayloadError{
 				EventType: kernelevents.ItemBulkUpdated,
@@ -1960,16 +1962,18 @@ type OversizedOutboxRow struct {
 	Bytes     int
 }
 
-// OversizedPendingOutbox lists pending rows over MaxOutboxClaimableBytes.
+// OversizedPendingOutbox lists undispatched rows over MaxOutboxClaimableBytes.
 //
 // THE CLAIM'S CEILING, not the write cap, because the question this answers is
 // "what will the claim refuse to read" rather than "what would the write have
 // rejected". The two differ on purpose; see MaxOutboxClaimableBytes.
 //
 // EXISTS SO THE EXCLUSION IS NOT SILENT. pendingClaimCandidates drops these in
-// the predicate, which is what stops them jamming the queue — but a row that
-// is never claimed, never logged, and eventually reaped by retention is an
-// event that vanishes with nobody told. Since writeOutboxTx refuses on the
+// the predicate, which is what stops them jamming the queue — but a row this
+// binary never claims, never logs, and lets retention reap is an event that
+// vanishes with nobody told. It does not filter on claimed_at: a binary older
+// than the ceiling may hold a claim on such a row, and the alarm is about what
+// THIS binary will do with it, not about who else is touching it. Since writeOutboxTx refuses on the
 // STORED size against this same ceiling, only a row left by a binary older
 // than that check can be here at all, so this is expected to return nothing
 // forever on an instance that never ran one.

--- a/internal/store/event_outbox.go
+++ b/internal/store/event_outbox.go
@@ -170,7 +170,12 @@ const maxOutboxHop = 4
 // is a follow-up, not something to improvise inside a bound.
 const MaxOutboxPayloadBytes = 128 << 20
 
-// OversizedOutboxPayloadError reports a payload refused by MaxOutboxPayloadBytes.
+// OversizedOutboxPayloadError reports an outbox write refused for size.
+//
+// THREE SITES RAISE IT, against two different limits, which is why Measured
+// exists: the pre-marshal early-out charges member content against the write
+// cap, writeOutboxTx charges the marshalled payload against the same cap, and
+// the post-insert check charges the stored row against the CLAIM ceiling.
 //
 // A distinct type rather than a formatted error because the HTTP layer maps it
 // to a 4xx: the mutation was well-formed and the server is refusing it under a
@@ -202,10 +207,10 @@ func (e *OversizedOutboxPayloadError) Error() string {
 		e.EventType, e.Limit, measured, e.Bytes)
 }
 
-// The two things OversizedOutboxPayloadError.Measured can name.
+// The three things OversizedOutboxPayloadError.Measured can name.
 const (
 	measuredMemberBodies = "the member content, a lower bound on the payload it would marshal to"
-	measuredStoredRow    = "the row as the database stored it"
+	measuredStoredRow    = "the row as the database will hand it back"
 	measuredGoPayload    = "the marshalled payload"
 )
 
@@ -1758,7 +1763,14 @@ func (s *Store) PruneUndispatchedOutbox(before, leaseCutoff string) (int64, erro
 // strand its events. At-least-once is exactly the promise that makes
 // re-claiming safe.
 //
-// BATCHES ARE CLAIMED WHOLE, past the limit if necessary. A batch split across
+// BATCHES ARE CLAIMED WHOLE WHERE THEY FIT, past the row limit if necessary.
+// The qualifier is load-bearing since BUG-2827: the byte budget and the row
+// cap can both stop a sibling scan part-way, so a batch larger than either is
+// split deliberately. See pendingClaimCandidates for why a rule that cannot be
+// interrupted would make those bounds bypassable, and groupOutboxDeliveries
+// for what a consumer sees when it happens.
+//
+// The original reasoning, which still governs everything inside those bounds: A batch split across
 // two passes would be folded into two wire events each reporting a partial
 // member count — the limit is a throughput knob, and letting it decide what a
 // bulk operation "was" would make the wire event's truth depend on queue depth.
@@ -1945,9 +1957,7 @@ type OversizedOutboxRow struct {
 // is never claimed, never logged, and eventually reaped by retention is an
 // event that vanishes with nobody told. Only rows written by a binary older
 // than MaxOutboxPayloadBytes can be here at all, so this is expected to return
-// nothing forever on an instance that never ran one. The threshold is
-// MaxOutboxClaimableBytes, the claim's ceiling, not the write cap — those
-// differ on purpose (see that constant).
+// nothing forever on an instance that never ran one.
 //
 // Bounded by `limit` because this runs every drain tick and its purpose is to
 // raise an alarm, not to enumerate a backlog.

--- a/internal/store/event_outbox.go
+++ b/internal/store/event_outbox.go
@@ -221,6 +221,21 @@ func (e *OversizedOutboxPayloadError) Error() string {
 // queue depth, which is the property that was missing.
 const maxOutboxClaimBytes = 64 << 20
 
+// maxOutboxClaimRows bounds how many ROWS one pass claims, alongside the byte
+// budget, because a budget in bytes alone does not bound the per-row cost.
+//
+// The uncapped path is the batch scan: siblings are collected past the row
+// limit by design, so a batch of a million tiny rows fits the byte budget
+// comfortably while its ids, maps, OutboxEvent structs and folded delivery do
+// not (codex round 1). Roughly 200 bytes of overhead per row means the byte
+// budget alone admits hundreds of megabytes of it.
+//
+// 5,000 is chosen so it binds only on that pathological shape: at the measured
+// payload mean of ~2.4 KB, 5,000 rows is ~12 MiB, well inside the byte budget,
+// which stays the operative bound for real traffic. It is also ~1,000 events
+// per second against the 5s tick, orders above anything measured.
+const maxOutboxClaimRows = 5000
+
 // MaxOutboxClaimableBytes is the per-row size above which the claim refuses to
 // read a row at all. It is NOT MaxOutboxPayloadBytes, and the gap between them
 // is a dialect fact rather than slack.
@@ -260,6 +275,13 @@ func (s *Store) outboxRowCap() int {
 // multiple of the write cap under the test seam as it is in production so a
 // lowered seam cannot accidentally test a pairing production never has.
 func (s *Store) outboxClaimableRowCap() int { return 2 * s.outboxRowCap() }
+
+func (s *Store) outboxClaimRows() int {
+	if s.outboxClaimRowsOverride > 0 {
+		return s.outboxClaimRowsOverride
+	}
+	return maxOutboxClaimRows
+}
 
 func (s *Store) outboxClaimBudget() int {
 	if s.outboxClaimBudgetOverride > 0 {
@@ -649,8 +671,13 @@ func scrubUserRefsInNode(node any, userID string) bool {
 // memberEventPayload unmarshals an absent user_id to "", and the drain treats
 // payloads as opaque bytes.
 //
-// Candidate rows are found by `subject_id = ?` (indexed — catches every member
-// row, whose subject IS the user) OR a payload substring prefilter. The CAST
+// Candidate rows are found by `subject_id = ?` (catches every member row,
+// whose subject IS the user) OR a payload substring prefilter. NEITHER arm is
+// indexed — migrations 081/082/083 index (occurred_at,id), dispatched_at,
+// (workspace_id,occurred_at), batch_id and (claimed_at,occurred_at), and
+// nothing on subject_id — so this is a scan over the retention window either
+// way. An earlier version of this note called subject_id indexed; it is not
+// (codex round 1). The CAST
 // is load-bearing: payload is JSONB on Postgres and TEXT on SQLite, and LIKE
 // on jsonb is not a thing. A uuid carries no LIKE metacharacters and is
 // specific enough that false positives are rare — and harmless, because the Go
@@ -700,19 +727,35 @@ func (s *Store) ScrubOutboxUserRefsTx(tx *sql.Tx, userID string) error {
 	// locks in opposite orders. Scoped to those per-row updates: any bulk
 	// statement elsewhere in this transaction takes its own locks in its own
 	// order (codex round 6).
-	// BATCHED, because the collect below holds every matching payload in
-	// memory at once and nothing bounded how many that was. The scrub's own
-	// filter is a substring match over the whole retention window, so on an
-	// instance carrying large bulk payloads a single account deletion could
-	// allocate the matched set in one go — the same unbounded-read shape as
-	// the drain's claim (BUG-2827), reached by a different door.
+	// BATCHED, because the collect this replaces held every matching payload
+	// in memory at once and nothing bounded how many that was. The filter is a
+	// substring match over the whole retention window, so on an instance
+	// carrying large bulk payloads one account deletion could allocate the
+	// matched set in a single go — the unbounded-read shape of BUG-2827
+	// reached through a different door.
 	//
-	// The READ FULLY, THEN WRITE precondition is preserved PER BATCH rather
-	// than abandoned: each pass closes its cursor before issuing any Exec, so
-	// the BUG-2409 deadlock shape never appears. The keyset cursor keeps the
-	// per-row UPDATEs in ascending id order across batches too, which is the
-	// lock ordering the note above requires — batching would otherwise be a
-	// quiet way to reintroduce the deadlock it was written to prevent.
+	// WHAT BATCHING DOES TO THE RESIDUAL WINDOW, stated because a reviewer
+	// asked whether keyset paging over random uuids can miss a row (codex
+	// round 1). It cannot miss a row that EXISTED when the scan began: ids are
+	// fixed, the walk is ascending over every matching row above the cursor,
+	// and a row only stops matching once it has been scrubbed. What changes is
+	// concurrent commits, and it changes them in the SAFE direction — the
+	// single query missed every row committed after it, while this one still
+	// catches those that sort above the cursor. Coverage is a superset of what
+	// the unbatched version had, so the note above stays true and gets
+	// narrower rather than wider.
+	//
+	// A SNAPSHOT OF IDS FIRST would make the window describable without
+	// reference to uuid order, and was tried and rejected: it holds every
+	// matching id at once, which is an unbounded allocation of the same shape
+	// this change exists to remove — smaller per row, still O(matches).
+	//
+	// READ FULLY, THEN WRITE holds PER BATCH: each pass closes its cursor
+	// before issuing any Exec, so the BUG-2409 deadlock shape never appears.
+	// The keyset cursor also keeps the per-row UPDATEs in ascending id order
+	// across batches, which is the lock ordering the note above requires —
+	// batching must not become a quiet way to reintroduce the deadlock it was
+	// written to avoid.
 	type candidate struct {
 		id      string
 		payload string
@@ -973,6 +1016,25 @@ type bulkItemEventPayload struct {
 	Members     []*models.Item `json:"members"`
 }
 
+// projectedBulkPayloadBytes is a LOWER BOUND on what marshalling this member
+// set will produce: the bytes the members already carry.
+//
+// A lower bound is the only honest thing to compute without doing the marshal,
+// and it is the right direction: JSON only adds (quoting, escaping, key names,
+// the envelope) and never removes, so a set already over the cap is certainly
+// over it after rendering. A set under this is not necessarily under the cap,
+// which is why writeOutboxTx still checks the real thing.
+func projectedBulkPayloadBytes(members []*models.Item) int {
+	n := 0
+	for _, m := range members {
+		if m == nil {
+			continue
+		}
+		n += len(m.Content) + len(m.Fields) + len(m.Title) + len(m.Slug)
+	}
+	return n
+}
+
 // emitBulkItemEventTx writes one item.bulk_updated event covering every member
 // of a single-transaction bulk mutation.
 //
@@ -1041,6 +1103,24 @@ func (s *Store) emitBulkItemEventTx(tx *sql.Tx, workspaceID string, members []*m
 
 	for _, ws := range order {
 		group := byWorkspace[ws]
+		// REFUSE BEFORE MARSHALLING. writeOutboxTx enforces the same cap, but
+		// it can only see the payload once json.Marshal has already built it,
+		// and building it is the expensive allocation: a member set large
+		// enough to be refused is large enough that rendering it to be
+		// refused is its own memory event (codex round 1).
+		//
+		// Charged on the members' own bytes, which the marshal can only GROW
+		// (JSON adds quoting, escaping and key names and removes nothing), so
+		// this never refuses a payload the real check would have accepted. It
+		// is an early-out, not a second rule — the authoritative refusal, and
+		// the numbers the caller is shown, still come from writeOutboxTx.
+		if n := projectedBulkPayloadBytes(group); n > s.outboxRowCap() {
+			return &OversizedOutboxPayloadError{
+				EventType: kernelevents.ItemBulkUpdated,
+				Bytes:     n,
+				Limit:     s.outboxRowCap(),
+			}
+		}
 		payload, err := marshalEventPayload(bulkItemEventPayload{
 			Delta:       delta,
 			MemberCount: len(group),
@@ -1717,7 +1797,7 @@ func (s *Store) pendingClaimCandidates(limit int, leaseCutoff string) ([]string,
 		// than the per-row cap, so a legitimately written row can exceed a whole
 		// pass; refusing it here would starve it in every pass forever. Past the
 		// first, the budget is what stops a pass accumulating.
-		if len(ids) > 0 && bytes > budget {
+		if len(ids) > 0 && (bytes > budget || len(ids) >= s.outboxClaimRows()) {
 			break
 		}
 		budget -= bytes
@@ -1752,6 +1832,9 @@ func (s *Store) pendingClaimCandidates(limit int, leaseCutoff string) ([]string,
 		for _, sib := range siblings {
 			if seen[sib.id] {
 				continue
+			}
+			if len(ids) >= s.outboxClaimRows() {
+				break
 			}
 			if sib.bytes > budget {
 				continue
@@ -1831,7 +1914,8 @@ func (s *Store) claimableBatchSiblings(batchID, leaseCutoff string) ([]claimable
 		  AND (claimed_at IS NULL OR claimed_at < ?)
 		  AND `+size+` <= ?
 		ORDER BY occurred_at, id
-	`), batchID, leaseCutoff, s.outboxClaimableRowCap())
+		LIMIT ?
+	`), batchID, leaseCutoff, s.outboxClaimableRowCap(), s.outboxClaimRows())
 	if err != nil {
 		return nil, fmt.Errorf("list batch siblings: %w", err)
 	}
@@ -1865,12 +1949,14 @@ func (s *Store) outboxEventsClaimedBy(token string) ([]OutboxEvent, error) {
 	var out []OutboxEvent
 	for rows.Next() {
 		var ev OutboxEvent
-		var payload string
+		// STRAIGHT INTO []byte, not into a string that is then converted. The
+		// conversion doubled the transient cost of every row for no gain, and
+		// on the largest single row a pass may take that is the difference
+		// between one copy and two (codex round 1).
 		if err := rows.Scan(&ev.ID, &ev.WorkspaceID, &ev.EventType, &ev.SubjectKind, &ev.SubjectID,
-			&payload, &ev.Hop, &ev.OccurredAt, &ev.Attempts, &ev.LastError, &ev.BatchID); err != nil {
+			&ev.Payload, &ev.Hop, &ev.OccurredAt, &ev.Attempts, &ev.LastError, &ev.BatchID); err != nil {
 			return nil, fmt.Errorf("scan claimed outbox event: %w", err)
 		}
-		ev.Payload = []byte(payload)
 		ev.ClaimToken = token
 		out = append(out, ev)
 	}

--- a/internal/store/event_outbox.go
+++ b/internal/store/event_outbox.go
@@ -124,6 +124,180 @@ func newMutationOptions(opts []MutationOption) mutationOptions {
 // durable output rather than resting containment on the hop count alone.
 const maxOutboxHop = 4
 
+// MaxOutboxPayloadBytes is the largest payload a single outbox row may carry.
+//
+// A BACKSTOP, NOT THE MEMORY BOUND, and the distinction is the whole reason
+// this number is as large as it is. The measurement that set it (BUG-2827,
+// taken against an 8,434-item instance):
+//
+//   - The widest wiki-title cascade on that instance is 23 members / 175.6 KiB
+//     of member bodies; the widest wiki-ref cascade is 50 members / 365.5 KiB.
+//   - The collection-option arm is the big one, because its member set is
+//     every row carrying the renamed value: renaming the tasks.status option
+//     "done" covers 4,429 members / 7.34 MiB of bodies.
+//   - Marshalled payload runs ~1.46x the body sum (measured: item.updated
+//     payloads mean 3,518 B against an item body mean of 2,416 B), so that
+//     rename emits ~11 MiB in ONE row, today, from a user clicking rename in
+//     the collection editor.
+//
+// So a bound tight enough to bound the drain's memory would refuse routine
+// work. The drain protects itself instead (see maxOutboxClaimBytes), and this
+// constant is set by the DIALECT CEILING: SQLite refuses a value over 1 GB
+// with SQLITE_TOOBIG, and Postgres somewhere in (512 MB, 1 GB] with an error
+// that poisons the enclosing transaction (25P02) so the failure surfaces as an
+// unrelated "current transaction is aborted". 64 MiB is ~5.8x the largest
+// legitimate payload the measured instance can produce and two orders below
+// both ceilings, so what a caller hits is always the named refusal below and
+// never the opaque one.
+//
+// IT MUST ALSO CLEAR MaxItemRenameCascadeBytes, which is why it is not simply
+// 64 MiB. That constant (wiki_links.go, BUG-2804) bounds the wiki-title rename
+// cascade at 64 MiB of source bodies and answers a refusal with
+// rename_cascade_too_large — a message that names the actual operation and
+// tells the user what to do about it. Marshalling runs ~1.46x, so a cascade
+// that squeaks under that bound can produce a payload near 96 MiB. A 64 MiB
+// cap here would let the vaguer refusal fire FIRST on the very renames the
+// more specific bound was written to describe. At 128 MiB the specific bound
+// always wins, and this stays what it is meant to be: the backstop for the
+// arms that have no bound of their own — principally the collection-option
+// rename, whose member set is every row carrying the renamed value and which
+// is bounded by nothing today.
+//
+// RESIDUAL, said plainly because it has no fix here: a workspace that outgrows
+// this cannot shrink its own cascade, so the refusal leaves the user with no
+// recourse. The real answer is chunking one bulk event across rows sharing a
+// batch_id — the drain already folds those back into one wire event — and that
+// is a follow-up, not something to improvise inside a bound.
+const MaxOutboxPayloadBytes = 128 << 20
+
+// OversizedOutboxPayloadError reports a payload refused by MaxOutboxPayloadBytes.
+//
+// A distinct type rather than a formatted error because the HTTP layer maps it
+// to a 4xx: the mutation was well-formed and the server is refusing it under a
+// stated rule, which is not a 500. Carrying the two numbers lets the message
+// name the rule AND the distance from it, so an operator can tell "just over"
+// from "wildly over" without reading the row.
+type OversizedOutboxPayloadError struct {
+	EventType string
+	Bytes     int
+	Limit     int
+}
+
+func (e *OversizedOutboxPayloadError) Error() string {
+	return fmt.Sprintf("outbox: event %s has a %d-byte payload, over the %d-byte limit",
+		e.EventType, e.Bytes, e.Limit)
+}
+
+// maxOutboxClaimBytes is how many payload bytes ONE claim pass may take.
+//
+// THIS is the memory bound, not MaxOutboxPayloadBytes — and it has to exist
+// separately because the two protect against different things. The row cap
+// governs what a current binary may WRITE; this governs what any binary may
+// READ, including rows a pre-cap binary already wrote, which no write-side
+// rule can reach retroactively.
+//
+// It is needed because the drain's row limit does not bound bytes and never
+// did: ClaimPendingOutboxEvents takes `limit` oldest rows AND every claimable
+// sibling of any batch they touch, then outboxEventsClaimedBy Scans every one
+// of those payloads into memory. At the default limit of 100 that is 100
+// unbounded reads per tick, which is the crash loop BUG-2827 reports — and it
+// is self-sustaining, because runOutboxDrainTick runs retention AFTER the
+// claim, so a pass that dies claiming never reaches the prune that would have
+// cleared the row.
+//
+// SMALLER THAN MaxOutboxPayloadBytes, which means one row can legally exceed
+// a whole pass's budget. That is handled by always taking the first candidate
+// whatever it costs, and the alternative is worse: a row written legitimately
+// under the cap but too large for any pass would be claimed by no pass ever —
+// permanently starved by the bound meant to keep the drain alive. Taking it
+// alone costs one pass its batching, once.
+//
+// So a pass retains ~64 MiB in the normal case and at most one row's payload
+// above that in the worst. Two transients sit on top of that, both bounded by
+// it rather than open-ended: outboxEventsClaimedBy scans each payload into a
+// string and then copies it to []byte, and FoldBulkHeader builds one wire
+// payload out of a batch's header plus its members while still holding them.
+// Peak is therefore a small multiple of this number, not a multiple of the
+// queue depth, which is the property that was missing.
+const maxOutboxClaimBytes = 64 << 20
+
+// MaxOutboxClaimableBytes is the per-row size above which the claim refuses to
+// read a row at all. It is NOT MaxOutboxPayloadBytes, and the gap between them
+// is a dialect fact rather than slack.
+//
+// The write cap measures the Go bytes json.Marshal produced. The claim
+// measures what the driver will hand to Scan, which on Postgres is the JSONB
+// — text rendering, and that rendering inserts one space after every colon
+// and comma. So a payload written at EXACTLY the cap comes back over it, and a
+// claim thresholded at the same number would write the row through the guard
+// and then never claim it: delivered to nobody, reported as nothing, reaped by
+// retention seven days later. Found by running the suite against real
+// Postgres, where a 40,000-byte payload read back as 40,001.
+//
+// 2x, because the expansion is bounded well under that. Every inserted byte
+// follows a colon or comma, so the worst case is a document of single-character
+// keys and values (`{"a":1,"b":2}`) at about 1.4x; our payloads are long string
+// values and expand by a small fraction of a percent. Normalization can also
+// SHRINK a document (existing whitespace stripped, duplicate keys collapsed),
+// so the correction is one-directional only for the compact output
+// encoding/json actually produces.
+//
+// What it still excludes is what it is for: rows left by a binary older than
+// the write cap, which can be hundreds of megabytes.
+const MaxOutboxClaimableBytes = 2 * MaxOutboxPayloadBytes
+
+// outboxRowCap and outboxClaimBudget read the bounds THROUGH the test seams,
+// so every enforcement site gets the override and none can be missed by a test
+// that lowers one. Zero override means the production constant.
+func (s *Store) outboxRowCap() int {
+	if s.outboxRowCapOverride > 0 {
+		return s.outboxRowCapOverride
+	}
+	return MaxOutboxPayloadBytes
+}
+
+// outboxClaimableRowCap is the claim-side per-row ceiling, kept at the same
+// multiple of the write cap under the test seam as it is in production so a
+// lowered seam cannot accidentally test a pairing production never has.
+func (s *Store) outboxClaimableRowCap() int { return 2 * s.outboxRowCap() }
+
+func (s *Store) outboxClaimBudget() int {
+	if s.outboxClaimBudgetOverride > 0 {
+		return s.outboxClaimBudgetOverride
+	}
+	return maxOutboxClaimBytes
+}
+
+// Batch bounds for ScrubOutboxUserRefsTx's candidate read.
+//
+// Same byte figure as the claim path and for the same reason — it is the
+// answer to "how many payload bytes may one read pass hold", and the scrub is
+// a read pass. The row cap is the second half of the same question: a budget
+// in bytes alone still admits an unbounded number of tiny rows, whose per-row
+// struct and slice overhead is what would then dominate.
+const (
+	maxOutboxScrubBytes = maxOutboxClaimBytes
+	maxOutboxScrubRows  = 500
+)
+
+// outboxScrubBytes deliberately reads the CLAIM budget: maxOutboxScrubBytes is
+// defined as maxOutboxClaimBytes, so giving the scrub a second seam would let
+// a test move one without the other and assert against a pairing production
+// never has.
+func (s *Store) outboxScrubBytes() int {
+	if s.outboxClaimBudgetOverride > 0 {
+		return s.outboxClaimBudgetOverride
+	}
+	return maxOutboxScrubBytes
+}
+
+func (s *Store) outboxScrubRows() int {
+	if s.outboxScrubRowsOverride > 0 {
+		return s.outboxScrubRowsOverride
+	}
+	return maxOutboxScrubRows
+}
+
 // writeOutboxTx appends one canonical event to the outbox on the caller's
 // transaction.
 //
@@ -185,6 +359,27 @@ func writeOutboxTx(tx *sql.Tx, s *Store, ev OutboxEvent) error {
 	// identical on both.
 	if !json.Valid(ev.Payload) {
 		return fmt.Errorf("outbox: event %s has a malformed JSON payload", ev.EventType)
+	}
+	// SIZE IS CHECKED HERE, at the one choke point every outbox row passes
+	// through, rather than at the bulk emitter that motivated it. The bulk
+	// emitter is the only caller that can currently build a payload this
+	// large, but "currently" is a property of today's callers and the next one
+	// would inherit the ceiling silently (CONVE-18).
+	//
+	// REFUSING FAILS THE MUTATION, deliberately, and this is the fork worth
+	// naming: the hop bound above drops the event and keeps the mutation,
+	// which is right there because the cascade is what is illegitimate. Here
+	// the mutation and the event are the same fact. Dropping the event would
+	// let a rename cascade across thousands of items with no record that it
+	// happened, which is exactly the silent loss the outbox exists to prevent
+	// — and it is also what the v1 doc on emitBulkItemEventTx rejects when it
+	// refuses to cap the member list or omit content.
+	if len(ev.Payload) > s.outboxRowCap() {
+		return &OversizedOutboxPayloadError{
+			EventType: ev.EventType,
+			Bytes:     len(ev.Payload),
+			Limit:     s.outboxRowCap(),
+		}
 	}
 	if ev.Hop > maxOutboxHop {
 		// Cascade bound reached: drop the event, keep the mutation. No
@@ -505,37 +700,73 @@ func (s *Store) ScrubOutboxUserRefsTx(tx *sql.Tx, userID string) error {
 	// locks in opposite orders. Scoped to those per-row updates: any bulk
 	// statement elsewhere in this transaction takes its own locks in its own
 	// order (codex round 6).
-	rows, err := tx.Query(s.q(`
-		SELECT id, payload FROM event_outbox
-		WHERE subject_id = ? OR CAST(payload AS TEXT) LIKE ?
-		ORDER BY id
-	`), userID, "%"+userID+"%")
-	if err != nil {
-		return fmt.Errorf("outbox: scrub user refs: find rows: %w", err)
-	}
+	// BATCHED, because the collect below holds every matching payload in
+	// memory at once and nothing bounded how many that was. The scrub's own
+	// filter is a substring match over the whole retention window, so on an
+	// instance carrying large bulk payloads a single account deletion could
+	// allocate the matched set in one go — the same unbounded-read shape as
+	// the drain's claim (BUG-2827), reached by a different door.
+	//
+	// The READ FULLY, THEN WRITE precondition is preserved PER BATCH rather
+	// than abandoned: each pass closes its cursor before issuing any Exec, so
+	// the BUG-2409 deadlock shape never appears. The keyset cursor keeps the
+	// per-row UPDATEs in ascending id order across batches too, which is the
+	// lock ordering the note above requires — batching would otherwise be a
+	// quiet way to reintroduce the deadlock it was written to prevent.
 	type candidate struct {
 		id      string
 		payload string
 	}
-	var candidates []candidate
-	for rows.Next() {
-		var c candidate
-		if err := rows.Scan(&c.id, &c.payload); err != nil {
+	cursor := ""
+	for {
+		rows, err := tx.Query(s.q(`
+			SELECT id, payload FROM event_outbox
+			WHERE (subject_id = ? OR CAST(payload AS TEXT) LIKE ?)
+			  AND id > ?
+			ORDER BY id
+			LIMIT ?
+		`), userID, "%"+userID+"%", cursor, s.outboxScrubRows())
+		if err != nil {
+			return fmt.Errorf("outbox: scrub user refs: find rows: %w", err)
+		}
+		var candidates []candidate
+		held := 0
+		for rows.Next() {
+			var c candidate
+			if err := rows.Scan(&c.id, &c.payload); err != nil {
+				rows.Close()
+				return fmt.Errorf("outbox: scrub user refs: scan row: %w", err)
+			}
+			candidates = append(candidates, c)
+			held += len(c.payload)
+			// Checked AFTER appending, so a single payload larger than the
+			// whole budget is still processed rather than skipped forever.
+			// Erasure has no size exemption: a payload too big to batch with
+			// others is exactly as much of a privacy obligation as a small
+			// one, and the drain's cap does not apply here because these rows
+			// may predate it.
+			if held >= s.outboxScrubBytes() {
+				break
+			}
+		}
+		if err := rows.Err(); err != nil {
 			rows.Close()
-			return fmt.Errorf("outbox: scrub user refs: scan row: %w", err)
+			return fmt.Errorf("outbox: scrub user refs: iterate rows: %w", err)
 		}
-		candidates = append(candidates, c)
-	}
-	if err := rows.Err(); err != nil {
 		rows.Close()
-		return fmt.Errorf("outbox: scrub user refs: iterate rows: %w", err)
-	}
-	rows.Close()
 
-	for _, c := range candidates {
-		if err := s.scrubOutboxRowTx(tx, c.id, c.payload, userID); err != nil {
-			return err
+		if len(candidates) == 0 {
+			break
 		}
+		for _, c := range candidates {
+			if err := s.scrubOutboxRowTx(tx, c.id, c.payload, userID); err != nil {
+				return err
+			}
+		}
+		// Advance past the last row READ, not the last row rewritten. A
+		// candidate the Go rewrite left untouched (a LIKE false positive) is
+		// still consumed, so the cursor always moves and the loop terminates.
+		cursor = candidates[len(candidates)-1].id
 	}
 
 	// The COLUMN half: member rows carry the user id as their subject —
@@ -750,8 +981,14 @@ type bulkItemEventPayload struct {
 // a select option, renaming an item and cascading its backlinks) must not
 // arrive at a webhook consumer as hundreds of separate deliveries.
 //
-// PAYLOAD SIZE IS DELIBERATELY UNBOUNDED IN V1, and that is a decision rather
-// than an oversight. The alternatives both cost correctness: capping the
+// PAYLOAD SIZE WAS DELIBERATELY UNBOUNDED IN V1. SUPERSEDED by BUG-2827: the
+// follow-up condition this paragraph names below was met and acted on, and the
+// bound now lives at the outbox write itself (MaxOutboxPayloadBytes) rather
+// than here. The reasoning is kept verbatim because it still explains what the
+// bound does NOT do — it refuses the whole mutation rather than capping the
+// member list or dropping content, for exactly the reasons given here.
+//
+// The original decision, as written: The alternatives both cost correctness: capping the
 // member list silently drops binding evaluation for the tail, and omitting
 // `content` from the snapshots would break precisely the bindings that matter
 // for the wiki-title cascade, whose entire delta IS content. One large row is
@@ -760,6 +997,11 @@ type bulkItemEventPayload struct {
 // payload is bounded by data the mutation already touched. If a real workspace
 // shows this producing unreasonable rows, bounding it is a measured follow-up,
 // not a guess made here.
+//
+// (That follow-up: measurement against an 8,434-item instance found the
+// collection-option arm producing ~11 MiB in one row for a routine status
+// rename, and the drain reading up to 100 such rows per tick with no byte
+// bound at all. The row cap and the drain's claim budget came out of it.)
 //
 // A bulk mutation that touched nothing writes nothing: an empty member set is
 // not an event.
@@ -1423,14 +1665,32 @@ func (s *Store) claimOutboxIDs(token string, ids []string, leaseCutoff string) e
 // oldest claimable pending rows, plus every claimable sibling of any batch
 // they belong to.
 func (s *Store) pendingClaimCandidates(limit int, leaseCutoff string) ([]string, error) {
+	size := s.dialect.OctetLength("payload")
+	// OVERSIZED ROWS ARE EXCLUDED IN SQL, not filtered in Go, and that is the
+	// difference between a fix and a second jam. Candidates are the oldest
+	// `limit` claimable rows; a row skipped in Go would still have consumed
+	// its slot, so a hundred oversized rows at the head of the queue would
+	// return a hundred skips and drain nothing behind them until the 7-day
+	// undispatched reaper cleared them. Filtering in the predicate means they
+	// never occupy a slot at all.
+	//
+	// COST NOTE, on Postgres specifically: payload is JSONB there, and
+	// octet_length has no jsonb overload, so the ::text cast detoasts the
+	// value to measure it. For rows inside the cap that read is one the pass
+	// was about to do anyway. For an oversized legacy row it is a transient
+	// allocation in the Postgres backend proportional to the row — bounded by
+	// Postgres's own 1 GB field limit, and outside the Go heap, so the
+	// crash-looping drain this exists to protect stays up either way. Named
+	// rather than left for a reader to discover.
 	rows, err := s.db.Query(s.q(`
-		SELECT id, COALESCE(batch_id, '')
+		SELECT id, COALESCE(batch_id, ''), `+size+`
 		FROM event_outbox
 		WHERE dispatched_at IS NULL
 		  AND (claimed_at IS NULL OR claimed_at < ?)
+		  AND `+size+` <= ?
 		ORDER BY occurred_at, id
 		LIMIT ?
-	`), leaseCutoff, limit)
+	`), leaseCutoff, s.outboxClaimableRowCap(), limit)
 	if err != nil {
 		return nil, fmt.Errorf("list claimable outbox events: %w", err)
 	}
@@ -1438,6 +1698,7 @@ func (s *Store) pendingClaimCandidates(limit int, leaseCutoff string) ([]string,
 
 	seen := map[string]bool{}
 	var ids []string
+	budget := s.outboxClaimBudget()
 	// Batches are collected as a SET: a 100-row candidate slice drawn from one
 	// large batch would otherwise run the same sibling scan 100 times for the
 	// same answer (codex round 2).
@@ -1445,13 +1706,23 @@ func (s *Store) pendingClaimCandidates(limit int, leaseCutoff string) ([]string,
 	var batches []string
 	for rows.Next() {
 		var id, batch string
-		if err := rows.Scan(&id, &batch); err != nil {
+		var bytes int
+		if err := rows.Scan(&id, &batch, &bytes); err != nil {
 			return nil, fmt.Errorf("scan claimable outbox event: %w", err)
 		}
-		if !seen[id] {
-			seen[id] = true
-			ids = append(ids, id)
+		if seen[id] {
+			continue
 		}
+		// ALWAYS TAKE THE FIRST ROW, whatever it costs. The budget is smaller
+		// than the per-row cap, so a legitimately written row can exceed a whole
+		// pass; refusing it here would starve it in every pass forever. Past the
+		// first, the budget is what stops a pass accumulating.
+		if len(ids) > 0 && bytes > budget {
+			break
+		}
+		budget -= bytes
+		seen[id] = true
+		ids = append(ids, id)
 		if batch != "" && !seenBatch[batch] {
 			seenBatch[batch] = true
 			batches = append(batches, batch)
@@ -1461,45 +1732,122 @@ func (s *Store) pendingClaimCandidates(limit int, leaseCutoff string) ([]string,
 		return nil, fmt.Errorf("iterate claimable outbox events: %w", err)
 	}
 
+	// SIBLINGS ARE SPENT FROM THE SAME BUDGET, which knowingly relaxes the
+	// "batches are claimed whole" rule above. Taken literally that rule makes
+	// the budget bypassable by construction — one batch of ten thousand
+	// members is an unbounded read no row limit touches — and a memory bound
+	// with a documented way around it is not a bound.
+	//
+	// The wire consequence is already defined behaviour rather than new
+	// damage: groupOutboxDeliveries delivers members of a batch whose header
+	// is absent individually, correlated by the batch_id they all carry, and
+	// SPEC-3 v1.6 demotes one-wire-event-per-batch to the normal case for
+	// exactly this reason. The alternative is a batch that OOMs every pass
+	// forever, which delivers nothing at all.
 	for _, batch := range batches {
 		siblings, err := s.claimableBatchSiblings(batch, leaseCutoff)
 		if err != nil {
 			return nil, err
 		}
-		for _, id := range siblings {
-			if !seen[id] {
-				seen[id] = true
-				ids = append(ids, id)
+		for _, sib := range siblings {
+			if seen[sib.id] {
+				continue
 			}
+			if sib.bytes > budget {
+				continue
+			}
+			budget -= sib.bytes
+			seen[sib.id] = true
+			ids = append(ids, sib.id)
 		}
 	}
 	return ids, nil
 }
 
-func (s *Store) claimableBatchSiblings(batchID, leaseCutoff string) ([]string, error) {
+// claimableSibling is a batch member and the payload bytes claiming it costs.
+type claimableSibling struct {
+	id    string
+	bytes int
+}
+
+// OversizedOutboxRow is a pending row the claim path refuses to read.
+type OversizedOutboxRow struct {
+	ID        string
+	EventType string
+	Bytes     int
+}
+
+// OversizedPendingOutbox lists pending rows over MaxOutboxPayloadBytes.
+//
+// EXISTS SO THE EXCLUSION IS NOT SILENT. pendingClaimCandidates drops these in
+// the predicate, which is what stops them jamming the queue — but a row that
+// is never claimed, never logged, and eventually reaped by retention is an
+// event that vanishes with nobody told. Only rows written by a binary older
+// than MaxOutboxPayloadBytes can be here at all, so this is expected to return
+// nothing forever on an instance that never ran one. The threshold is
+// MaxOutboxClaimableBytes, the claim's ceiling, not the write cap — those
+// differ on purpose (see that constant).
+//
+// Bounded by `limit` because this runs every drain tick and its purpose is to
+// raise an alarm, not to enumerate a backlog.
+func (s *Store) OversizedPendingOutbox(limit int) ([]OversizedOutboxRow, error) {
+	if limit <= 0 {
+		limit = 5
+	}
+	size := s.dialect.OctetLength("payload")
 	rows, err := s.db.Query(s.q(`
-		SELECT id
+		SELECT id, event_type, `+size+`
+		FROM event_outbox
+		WHERE dispatched_at IS NULL
+		  AND `+size+` > ?
+		ORDER BY occurred_at, id
+		LIMIT ?
+	`), s.outboxClaimableRowCap(), limit)
+	if err != nil {
+		return nil, fmt.Errorf("list oversized outbox events: %w", err)
+	}
+	defer rows.Close()
+	var out []OversizedOutboxRow
+	for rows.Next() {
+		var r OversizedOutboxRow
+		if err := rows.Scan(&r.ID, &r.EventType, &r.Bytes); err != nil {
+			return nil, fmt.Errorf("scan oversized outbox event: %w", err)
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate oversized outbox events: %w", err)
+	}
+	return out, nil
+}
+
+func (s *Store) claimableBatchSiblings(batchID, leaseCutoff string) ([]claimableSibling, error) {
+	size := s.dialect.OctetLength("payload")
+	rows, err := s.db.Query(s.q(`
+		SELECT id, `+size+`
 		FROM event_outbox
 		WHERE batch_id = ?
 		  AND dispatched_at IS NULL
 		  AND (claimed_at IS NULL OR claimed_at < ?)
-	`), batchID, leaseCutoff)
+		  AND `+size+` <= ?
+		ORDER BY occurred_at, id
+	`), batchID, leaseCutoff, s.outboxClaimableRowCap())
 	if err != nil {
 		return nil, fmt.Errorf("list batch siblings: %w", err)
 	}
 	defer rows.Close()
-	var ids []string
+	var out []claimableSibling
 	for rows.Next() {
-		var id string
-		if err := rows.Scan(&id); err != nil {
+		var sib claimableSibling
+		if err := rows.Scan(&sib.id, &sib.bytes); err != nil {
 			return nil, fmt.Errorf("scan batch sibling: %w", err)
 		}
-		ids = append(ids, id)
+		out = append(out, sib)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterate batch siblings: %w", err)
 	}
-	return ids, nil
+	return out, nil
 }
 
 func (s *Store) outboxEventsClaimedBy(token string) ([]OutboxEvent, error) {

--- a/internal/store/event_outbox_bounds_test.go
+++ b/internal/store/event_outbox_bounds_test.go
@@ -694,3 +694,47 @@ func TestScrubSpendsItsByteBudgetNotJustItsRowLimit(t *testing.T) {
 		}
 	}
 }
+
+func TestScrubOnlyEverShrinksAPayload(t *testing.T) {
+	s := testStore(t)
+	deleted, _ := scrubTestUsers(t, s)
+	ws := createTestWorkspace(t, s, "ScrubShrinks")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	item := createTestItem(t, s, ws.ID, col.ID, "Commented", "")
+	clearOutbox(t, s)
+
+	// THE CLAIM PATH DEPENDS ON THIS. Sizes are measured when candidates are
+	// selected, and the claim UPDATE rechecks only lease and dispatch state,
+	// so a writer that GREW a payload in between could push a row past the
+	// ceiling after it was judged under it. The reason no revalidation is
+	// needed is that the only writer of payload shrinks it — an invariant
+	// worth a test rather than a sentence, since the next person to add a
+	// payload rewrite will not read the sentence.
+	c := &models.Comment{ID: newID(), ItemID: item.ID, WorkspaceID: ws.ID,
+		Author: "Scrub Me", UserID: deleted.ID, Body: strings.Repeat("y", 500)}
+	emitInTx(t, s, func(tx *sql.Tx) error {
+		return s.emitCommentEventTx(tx, kernelevents.CommentCreated, c)
+	})
+
+	size := func() int {
+		var n int
+		if err := s.db.QueryRow(s.q(`SELECT `+s.dialect.OctetLength("payload")+` FROM event_outbox WHERE subject_id = ?`), c.ID).Scan(&n); err != nil {
+			t.Fatalf("measure payload: %v", err)
+		}
+		return n
+	}
+	before := size()
+	scrubInTx(t, s, deleted.ID)
+	after := size()
+
+	if after > before {
+		t.Fatalf("the scrub grew a payload from %d to %d bytes; the claim measures size at candidate "+
+			"selection and never rechecks it, so a growing rewrite can push a row past the ceiling "+
+			"after it was judged under it", before, after)
+	}
+	// And it really did rewrite the row, or the assertion above is vacuous.
+	if after == before {
+		t.Fatalf("the payload is unchanged at %d bytes; this fixture must actually be scrubbed for "+
+			"the shrink assertion to mean anything", after)
+	}
+}

--- a/internal/store/event_outbox_bounds_test.go
+++ b/internal/store/event_outbox_bounds_test.go
@@ -1,0 +1,463 @@
+package store
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/kernelevents"
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// Tests for the outbox's two byte bounds (BUG-2827): the per-row cap the write
+// enforces, and the per-pass budget the claim enforces.
+//
+// WHY THE SEAMS EXIST AT ALL, since a test that lowers the limit it is testing
+// deserves the question. The production numbers are 128 MiB and 64 MiB, so
+// crossing them honestly costs hundreds of megabytes per case and several
+// cases here need to cross them more than once. The seams let each case cross
+// a small bound with the SAME code path, and
+// TestOutboxLimitSeamsDefaultToTheProductionConstants pins the production
+// values so a seam can never quietly become the real limit.
+
+// jsonPayloadOfSize returns a valid JSON document of exactly n bytes.
+func jsonPayloadOfSize(t *testing.T, n int) []byte {
+	t.Helper()
+	// {"p":"<pad>"} is 8 bytes of frame plus the padding.
+	const frame = 8
+	if n < frame+1 {
+		t.Fatalf("jsonPayloadOfSize: %d is below the %d-byte frame", n, frame+1)
+	}
+	b := []byte(`{"p":"` + strings.Repeat("x", n-frame) + `"}`)
+	if len(b) != n {
+		t.Fatalf("jsonPayloadOfSize built %d bytes, want %d", len(b), n)
+	}
+	return b
+}
+
+// insertRawOutboxRow writes a row STRAIGHT TO SQL, bypassing writeOutboxTx.
+//
+// That bypass is the point rather than a shortcut: rows over the row cap
+// cannot be written through the guarded path once the guard exists, and rows
+// left behind by a binary older than the guard are exactly the population the
+// claim-side defence is for. This is the only way to construct one.
+func insertRawOutboxRow(t *testing.T, s *Store, id, workspaceID, occurredAt string, payload []byte) {
+	t.Helper()
+	if _, err := s.db.Exec(s.q(`
+		INSERT INTO event_outbox (id, workspace_id, event_type, subject_kind, subject_id, payload, hop, occurred_at)
+		VALUES (?, ?, ?, ?, ?, ?, 0, ?)
+	`), id, workspaceID, kernelevents.ItemCreated, kernelevents.SubjectItem, id, string(payload), occurredAt); err != nil {
+		t.Fatalf("insert raw outbox row %s: %v", id, err)
+	}
+}
+
+func TestOutboxLimitSeamsDefaultToTheProductionConstants(t *testing.T) {
+	// A ZERO-VALUE Store, not just a constructed one. The seams are plain int
+	// fields, so the failure worth excluding is a Store that skipped the
+	// constructor and thereby enforced no bound at all — which is what a
+	// naive "override or zero" read would produce.
+	var zero Store
+	if got := zero.outboxRowCap(); got != MaxOutboxPayloadBytes {
+		t.Errorf("zero-value Store row cap = %d, want %d — an unset seam must mean the production "+
+			"constant, never no limit", got, MaxOutboxPayloadBytes)
+	}
+	if got := zero.outboxClaimBudget(); got != maxOutboxClaimBytes {
+		t.Errorf("zero-value Store claim budget = %d, want %d", got, maxOutboxClaimBytes)
+	}
+
+	s := testStore(t)
+	if got := s.outboxRowCap(); got != MaxOutboxPayloadBytes {
+		t.Errorf("row cap = %d, want %d", got, MaxOutboxPayloadBytes)
+	}
+	if got := s.outboxClaimBudget(); got != maxOutboxClaimBytes {
+		t.Errorf("claim budget = %d, want %d", got, maxOutboxClaimBytes)
+	}
+
+	// The row cap must sit ABOVE what MaxItemRenameCascadeBytes can marshal
+	// to, or the vaguer outbox refusal preempts the rename cascade's own,
+	// better-worded one on the very renames that bound describes. ~1.46x is
+	// the measured marshal ratio; 2x is the margin this asserts.
+	if MaxOutboxPayloadBytes < 2*MaxItemRenameCascadeBytes {
+		t.Errorf("MaxOutboxPayloadBytes = %d, must be at least 2x MaxItemRenameCascadeBytes (%d) so "+
+			"rename_cascade_too_large always fires first", MaxOutboxPayloadBytes, MaxItemRenameCascadeBytes)
+	}
+	// And the claim budget must be at or under the row cap, or the budget
+	// stops bounding anything.
+	if maxOutboxClaimBytes > MaxOutboxPayloadBytes {
+		t.Errorf("claim budget %d exceeds the row cap %d", maxOutboxClaimBytes, MaxOutboxPayloadBytes)
+	}
+}
+
+func TestOutboxRefusesAPayloadOverTheRowCap(t *testing.T) {
+	s := testStore(t)
+	s.outboxRowCapOverride = 4096
+	ws := createTestWorkspace(t, s, "OutboxRowCap")
+
+	write := func(t *testing.T, subject string, size int) error {
+		t.Helper()
+		tx, err := s.db.Begin()
+		if err != nil {
+			t.Fatalf("begin: %v", err)
+		}
+		defer tx.Rollback()
+		err = writeOutboxTx(tx, s, OutboxEvent{
+			WorkspaceID:   ws.ID,
+			EventType:     kernelevents.ItemCreated,
+			SubjectID:     subject,
+			Payload:       jsonPayloadOfSize(t, size),
+			PayloadFamily: kernelevents.PayloadItemSnapshot,
+		})
+		if err == nil {
+			if cerr := tx.Commit(); cerr != nil {
+				t.Fatalf("commit: %v", cerr)
+			}
+		}
+		return err
+	}
+
+	// BOTH SIDES OF THE BOUNDARY, so a > that becomes >= dies here rather
+	// than surviving as an off-by-one nobody can see.
+	if err := write(t, "at-cap", s.outboxRowCap()); err != nil {
+		t.Fatalf("a payload of exactly the cap was refused: %v", err)
+	}
+
+	err := write(t, "over-cap", s.outboxRowCap()+1)
+	var typed *OversizedOutboxPayloadError
+	if !errors.As(err, &typed) {
+		t.Fatalf("a payload one byte over the cap returned %v (%T), want *OversizedOutboxPayloadError", err, err)
+	}
+	if typed.Bytes != s.outboxRowCap()+1 {
+		t.Errorf("Bytes = %d, want %d", typed.Bytes, s.outboxRowCap()+1)
+	}
+	if typed.Limit != s.outboxRowCap() {
+		t.Errorf("Limit = %d, want %d", typed.Limit, s.outboxRowCap())
+	}
+	if typed.EventType != kernelevents.ItemCreated {
+		t.Errorf("EventType = %q, want %q — the caller needs to see which event was refused",
+			typed.EventType, kernelevents.ItemCreated)
+	}
+
+	// THE REFUSAL MUST FAIL THE MUTATION, not drop the event. The hop bound
+	// in the same function returns nil precisely so the mutation survives, so
+	// asserting the opposite disposition here is what keeps the two apart.
+	var n int
+	if err := s.db.QueryRow(s.q(`SELECT COUNT(*) FROM event_outbox WHERE subject_id = ?`), "over-cap").Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("over-cap rows = %d, want 0", n)
+	}
+}
+
+func TestOutboxClaimStopsAtTheByteBudget(t *testing.T) {
+	s := testStore(t)
+	s.outboxRowCapOverride = 8192
+	s.outboxClaimBudgetOverride = 10000
+	ws := createTestWorkspace(t, s, "OutboxClaimBudget")
+
+	// Five 4 KiB rows against a 10,000-byte budget: the third crosses it, so
+	// a correct pass takes two and leaves three.
+	const size = 4096
+	for i := 0; i < 5; i++ {
+		insertRawOutboxRow(t, s, fmt.Sprintf("row-%02d", i), ws.ID,
+			fmt.Sprintf("2026-01-01T00:00:%02dZ", i), jsonPayloadOfSize(t, size))
+	}
+
+	events, err := s.ClaimPendingOutboxEvents("drainer", 100, "2026-01-01T00:00:00Z")
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("claimed %d rows, want 2 — the budget admits two 4096-byte rows and the third "+
+			"crosses 10000", len(events))
+	}
+	total := 0
+	for _, ev := range events {
+		total += len(ev.Payload)
+	}
+	if total > s.outboxClaimBudget() {
+		t.Errorf("claimed %d payload bytes, over the %d budget", total, s.outboxClaimBudget())
+	}
+	// COUNTERFACTUAL: without the budget the pass takes all five, since the
+	// row limit is 100. Asserting "not all of them" is what distinguishes a
+	// working budget from a claim that happened to be short.
+	if len(events) == 5 {
+		t.Errorf("the pass claimed every row; the byte budget did nothing")
+	}
+
+	// The rows it left must still be claimable, or the budget converted a
+	// throughput bound into data loss.
+	rest, err := s.ClaimPendingOutboxEvents("drainer", 100, "2026-01-01T00:00:00Z")
+	if err != nil {
+		t.Fatalf("second claim: %v", err)
+	}
+	if len(rest) == 0 {
+		t.Errorf("the second pass claimed nothing; rows past the budget must still drain")
+	}
+}
+
+func TestOutboxClaimAlwaysTakesOneRowOverBudget(t *testing.T) {
+	s := testStore(t)
+	s.outboxRowCapOverride = 65536
+	s.outboxClaimBudgetOverride = 1024
+	ws := createTestWorkspace(t, s, "OutboxClaimStarvation")
+
+	// Under the row cap and so legitimately written, but larger than a whole
+	// pass's budget. Refusing it for cost would starve it in every pass
+	// forever — the failure this arm exists to prevent.
+	insertRawOutboxRow(t, s, "fat", ws.ID, "2026-01-01T00:00:00Z", jsonPayloadOfSize(t, 32768))
+	insertRawOutboxRow(t, s, "thin", ws.ID, "2026-01-01T00:00:01Z", jsonPayloadOfSize(t, 100))
+
+	events, err := s.ClaimPendingOutboxEvents("drainer", 100, "2026-01-01T00:00:00Z")
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	if len(events) != 1 || events[0].ID != "fat" {
+		t.Fatalf("claimed %d rows (%v), want exactly the one oversized-for-the-budget row: the first "+
+			"candidate is taken whatever it costs, and nothing after it fits", len(events), idsOf(events))
+	}
+}
+
+func TestOutboxClaimSkipsRowsOverTheRowCapWithoutJamming(t *testing.T) {
+	s := testStore(t)
+	s.outboxRowCapOverride = 4096 // claimable ceiling is 8192
+	ws := createTestWorkspace(t, s, "OutboxClaimJam")
+
+	// The oversized row is the OLDEST, so it is what the oldest-first
+	// candidate query reaches first. That ordering is the whole test: a
+	// version that filtered these in Go rather than in the predicate would
+	// let them consume candidate slots and starve everything behind them.
+	insertRawOutboxRow(t, s, "legacy-huge", ws.ID, "2026-01-01T00:00:00Z", jsonPayloadOfSize(t, 40000))
+	insertRawOutboxRow(t, s, "normal", ws.ID, "2026-01-01T00:00:01Z", jsonPayloadOfSize(t, 100))
+
+	// limit=1 makes the starvation observable. With the exclusion in SQL the
+	// single slot goes to "normal"; without it the slot goes to the oversized
+	// row and "normal" never drains.
+	events, err := s.ClaimPendingOutboxEvents("drainer", 1, "2026-01-01T00:00:00Z")
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	if len(events) != 1 || events[0].ID != "normal" {
+		t.Fatalf("claimed %v, want [normal] — an oversized row must not occupy a candidate slot", idsOf(events))
+	}
+
+	// And it must be REPORTED, or an event that will never be delivered
+	// disappears with nobody told.
+	rows, err := s.OversizedPendingOutbox(5)
+	if err != nil {
+		t.Fatalf("OversizedPendingOutbox: %v", err)
+	}
+	if len(rows) != 1 || rows[0].ID != "legacy-huge" {
+		t.Fatalf("OversizedPendingOutbox = %+v, want the one legacy row", rows)
+	}
+	// NOT an equality check. The reported size is what the driver will hand to
+	// Scan, and on Postgres that is the JSONB — text rendering, which inserts a
+	// space after every colon and comma: this 40,000-byte payload reads back as
+	// 40,001 there. Asserting the written size would be asserting a SQLite
+	// implementation detail on both dialects.
+	if rows[0].Bytes < 40000 {
+		t.Errorf("Bytes = %d, want at least the 40000 written", rows[0].Bytes)
+	}
+}
+
+func idsOf(events []OutboxEvent) []string {
+	out := make([]string, 0, len(events))
+	for _, ev := range events {
+		out = append(out, ev.ID)
+	}
+	return out
+}
+
+func TestOutboxClaimSpendsTheBudgetOnBatchSiblingsToo(t *testing.T) {
+	s := testStore(t)
+	s.outboxRowCapOverride = 8192
+	s.outboxClaimBudgetOverride = 10000
+	ws := createTestWorkspace(t, s, "OutboxSiblingBudget")
+
+	// One batch of five 4 KiB rows. The candidate query takes the oldest, and
+	// the sibling scan then pulls the rest of the batch — historically PAST
+	// the row limit and with no byte accounting at all, which is the door
+	// that made the budget bypassable: one large batch is an unbounded read
+	// no row limit touches.
+	const size = 4096
+	for i := 0; i < 5; i++ {
+		id := fmt.Sprintf("sib-%02d", i)
+		insertRawOutboxRow(t, s, id, ws.ID, fmt.Sprintf("2026-01-01T00:00:%02dZ", i), jsonPayloadOfSize(t, size))
+		if _, err := s.db.Exec(s.q(`UPDATE event_outbox SET batch_id = ? WHERE id = ?`), "batch-1", id); err != nil {
+			t.Fatalf("set batch_id: %v", err)
+		}
+	}
+
+	events, err := s.ClaimPendingOutboxEvents("drainer", 1, "2026-01-01T00:00:00Z")
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	total := 0
+	for _, ev := range events {
+		total += len(ev.Payload)
+	}
+	if total > s.outboxClaimBudget() {
+		t.Fatalf("claimed %d payload bytes across %d rows, over the %d budget — siblings are not "+
+			"spending it", total, len(events), s.outboxClaimBudget())
+	}
+	if len(events) == 5 {
+		t.Fatalf("the whole batch was claimed; the sibling scan bypassed the byte budget")
+	}
+	// Splitting the batch is defined behaviour, not loss: the rest must still
+	// be claimable on a later pass.
+	rest, err := s.ClaimPendingOutboxEvents("drainer", 1, "2026-01-01T00:00:00Z")
+	if err != nil {
+		t.Fatalf("second claim: %v", err)
+	}
+	if len(rest) == 0 {
+		t.Fatalf("siblings left behind by the budget never drained")
+	}
+}
+
+func TestScrubOutboxUserRefsBatchesWithoutLosingRows(t *testing.T) {
+	s := testStore(t)
+	// Force many small batches so the cursor, the lock ordering and the
+	// termination condition are all exercised rather than skipped by a single
+	// pass that happens to fit.
+	s.outboxScrubRowsOverride = 3
+	deleted, bystander := scrubTestUsers(t, s)
+	ws := createTestWorkspace(t, s, "ScrubBatching")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	item := createTestItem(t, s, ws.ID, col.ID, "Commented", "")
+	clearOutbox(t, s)
+
+	const n = 10
+	mine := make([]string, 0, n)
+	emitInTx(t, s, func(tx *sql.Tx) error {
+		for i := 0; i < n; i++ {
+			c := &models.Comment{ID: newID(), ItemID: item.ID, WorkspaceID: ws.ID,
+				Author: "Scrub Me", UserID: deleted.ID, Body: fmt.Sprintf("body %d", i)}
+			mine = append(mine, c.ID)
+			if err := s.emitCommentEventTx(tx, kernelevents.CommentCreated, c); err != nil {
+				return err
+			}
+		}
+		other := &models.Comment{ID: newID(), ItemID: item.ID, WorkspaceID: ws.ID,
+			Author: "Bystander", UserID: bystander.ID, Body: "untouched"}
+		return s.emitCommentEventTx(tx, kernelevents.CommentCreated, other)
+	})
+
+	scrubInTx(t, s, deleted.ID)
+
+	// EVERY row, not just the first batch. A cursor that failed to advance
+	// would loop forever; one that advanced too far would leave the tail
+	// carrying the deleted id, which is the silent half and the reason this
+	// counts rather than spot-checking.
+	for _, id := range mine {
+		got := outboxPayloadFor(t, s, id, kernelevents.CommentCreated)
+		if _, present := got["user_id"]; present {
+			t.Fatalf("comment %s kept user_id after a batched scrub: %v", id, got["user_id"])
+		}
+	}
+}
+
+func TestScrubOutboxUserRefsTerminatesOnLikeFalsePositives(t *testing.T) {
+	s := testStore(t)
+	s.outboxScrubRowsOverride = 3
+	deleted, _ := scrubTestUsers(t, s)
+	ws := createTestWorkspace(t, s, "ScrubCursor")
+	clearOutbox(t, s)
+
+	// LIKE FALSE POSITIVES: the id appears in `body`, which is not a user-ref
+	// key, so scrubUserRefsFromPayload rewrites nothing and the rows keep
+	// matching the candidate query on every pass. They are the population the
+	// cursor rule exists for — "advance past the last row READ, not the last
+	// row rewritten" — and without them a cursor bug is invisible, because
+	// every genuinely scrubbed row drops out of the candidate set by itself.
+	for i := 0; i < 7; i++ {
+		insertRawOutboxRow(t, s, fmt.Sprintf("fp-%02d", i), ws.ID,
+			fmt.Sprintf("2026-01-01T00:00:%02dZ", i),
+			[]byte(fmt.Sprintf(`{"body":"mentions %s in prose"}`, deleted.ID)))
+	}
+
+	// Bounded so a non-advancing cursor FAILS rather than hanging the package
+	// until the suite-wide timeout, which would report as an unrelated
+	// casualty in whatever test happened to be running.
+	done := make(chan error, 1)
+	go func() { done <- scrubInTxErr(s, deleted.ID) }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("scrub: %v", err)
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatalf("scrub did not terminate: rows that LIKE-match but are never rewritten must still " +
+			"advance the batch cursor")
+	}
+
+	// And the false positives are left byte-identical — consumed by the
+	// cursor, not damaged by it.
+	var body string
+	if err := s.db.QueryRow(s.q(`SELECT CAST(payload AS TEXT) FROM event_outbox WHERE id = ?`), "fp-00").Scan(&body); err != nil {
+		t.Fatalf("read payload: %v", err)
+	}
+	if !strings.Contains(body, deleted.ID) {
+		t.Errorf("a LIKE false positive was rewritten: %s", body)
+	}
+}
+
+// scrubInTxErr runs the scrub on its own transaction and RETURNS the error,
+// unlike the shared scrubInTx helper which fails the test from whatever
+// goroutine calls it — not safe from the watchdog goroutine above.
+func scrubInTxErr(s *Store, userID string) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	if err := s.ScrubOutboxUserRefsTx(tx, userID); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func TestARowWrittenAtTheCapIsStillClaimable(t *testing.T) {
+	s := testStore(t)
+	s.outboxRowCapOverride = 4096
+	ws := createTestWorkspace(t, s, "OutboxCapRoundTrip")
+
+	// THE POSTGRES ROUND TRIP, and the reason the claim's ceiling is not the
+	// write cap. A payload accepted at exactly the cap is stored as JSONB
+	// there and read back one byte larger, so a claim thresholded at the same
+	// number would exclude a row its own guard had just admitted: written,
+	// never delivered, never reported, reaped seven days later. This passes
+	// trivially on SQLite and is the whole point of running it on both.
+	tx, err := s.db.Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	if err := writeOutboxTx(tx, s, OutboxEvent{
+		WorkspaceID:   ws.ID,
+		EventType:     kernelevents.ItemCreated,
+		SubjectID:     "at-cap",
+		Payload:       jsonPayloadOfSize(t, s.outboxRowCap()),
+		PayloadFamily: kernelevents.PayloadItemSnapshot,
+	}); err != nil {
+		tx.Rollback()
+		t.Fatalf("write at the cap was refused: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	events, err := s.ClaimPendingOutboxEvents("drainer", 10, "2026-01-01T00:00:00Z")
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("claimed %d rows, want 1 — a row this binary wrote must always be claimable by it", len(events))
+	}
+	if skipped, err := s.OversizedPendingOutbox(5); err != nil {
+		t.Fatalf("OversizedPendingOutbox: %v", err)
+	} else if len(skipped) != 0 {
+		t.Fatalf("a row written at the cap was reported oversized: %+v", skipped)
+	}
+}

--- a/internal/store/event_outbox_bounds_test.go
+++ b/internal/store/event_outbox_bounds_test.go
@@ -149,6 +149,11 @@ func TestOutboxRefusesAPayloadOverTheRowCap(t *testing.T) {
 		t.Errorf("EventType = %q, want %q — the caller needs to see which event was refused",
 			typed.EventType, kernelevents.ItemCreated)
 	}
+	if typed.Measured != measuredGoPayload {
+		t.Errorf("Measured = %q, want %q — the three refusal sites count different things and the "+
+			"caller cannot reconcile two numbers for one mutation without being told which",
+			typed.Measured, measuredGoPayload)
+	}
 
 	// THE REFUSAL MUST FAIL THE MUTATION, not drop the event. The hop bound
 	// in the same function returns nil precisely so the mutation survives, so
@@ -551,6 +556,9 @@ func TestBulkEventIsRefusedBeforeItIsMarshalled(t *testing.T) {
 	// marshalled size is strictly larger (quoting, escaping, key names, the
 	// envelope), so equality with the projection can only come from the
 	// pre-marshal check.
+	if typed.Measured != measuredMemberBodies {
+		t.Errorf("Measured = %q, want %q", typed.Measured, measuredMemberBodies)
+	}
 	if want := projectedBulkPayloadBytes(members); typed.Bytes != want {
 		t.Errorf("Bytes = %d, want the projected %d — the refusal came from writeOutboxTx after "+
 			"marshalling, not from the early-out before it", typed.Bytes, want)
@@ -613,6 +621,18 @@ func TestEverythingWrittenIsClaimable(t *testing.T) {
 		if typed.Bytes <= len(payload) {
 			t.Errorf("refusal reported %d bytes, not more than the %d written — it was charged "+
 				"against the Go payload, not the stored row", typed.Bytes, len(payload))
+		}
+		if typed.Measured != measuredStoredRow {
+			t.Errorf("Measured = %q, want %q", typed.Measured, measuredStoredRow)
+		}
+		// The refusal branch must not be vacuously satisfied by a row that
+		// committed anyway: "refused" has to mean nothing is pending.
+		var n int
+		if err := s.db.QueryRow(s.q(`SELECT COUNT(*) FROM event_outbox WHERE subject_id = ?`), "numeric").Scan(&n); err != nil {
+			t.Fatalf("count: %v", err)
+		}
+		if n != 0 {
+			t.Errorf("the write was refused but %d row(s) are present; the refusal did not roll back", n)
 		}
 		return
 	}
@@ -710,8 +730,17 @@ func TestScrubOnlyEverShrinksAPayload(t *testing.T) {
 	// needed is that the only writer of payload shrinks it — an invariant
 	// worth a test rather than a sentence, since the next person to add a
 	// payload rewrite will not read the sentence.
+	// CONTENT CHOSEN TO EXERCISE THE ENCODERS, not just to be long. The
+	// growth path a reviewer proposed runs through the two encoders
+	// disagreeing: Go escapes <, > and & to \u003c and friends, while
+	// Postgres jsonb stores and prints them literally, so a value that costs 1
+	// byte stored costs 6 in Go's output. Non-ASCII and an exponent-form
+	// number cover the other two places the round trip could change length.
+	// A fixture of one repeated ASCII letter, which is what this test had
+	// first, cannot tell any of that apart (codex round 4).
 	c := &models.Comment{ID: newID(), ItemID: item.ID, WorkspaceID: ws.ID,
-		Author: "Scrub Me", UserID: deleted.ID, Body: strings.Repeat("y", 500)}
+		Author: "Scrub Me", UserID: deleted.ID,
+		Body: strings.Repeat("x<y>z&w é ", 50)}
 	emitInTx(t, s, func(tx *sql.Tx) error {
 		return s.emitCommentEventTx(tx, kernelevents.CommentCreated, c)
 	})

--- a/internal/store/event_outbox_bounds_test.go
+++ b/internal/store/event_outbox_bounds_test.go
@@ -76,6 +76,16 @@ func TestOutboxLimitSeamsDefaultToTheProductionConstants(t *testing.T) {
 		t.Errorf("claim budget = %d, want %d", got, maxOutboxClaimBytes)
 	}
 
+	// DIALECT-INDEPENDENT, and the reason it is here rather than only inside
+	// the Postgres round-trip test: the default suite runs on SQLite, where
+	// that test passes trivially, so a claim ceiling collapsed back to the
+	// write cap would go unnoticed in every run without PAD_TEST_POSTGRES_URL
+	// (codex round 2). This assertion fails on either dialect.
+	if MaxOutboxClaimableBytes <= MaxOutboxPayloadBytes {
+		t.Errorf("MaxOutboxClaimableBytes (%d) must exceed MaxOutboxPayloadBytes (%d)",
+			MaxOutboxClaimableBytes, MaxOutboxPayloadBytes)
+	}
+
 	// The row cap must sit ABOVE what MaxItemRenameCascadeBytes can marshal
 	// to, or the vaguer outbox refusal preempts the rename cascade's own,
 	// better-worded one on the very renames that bound describes. ~1.46x is
@@ -544,5 +554,143 @@ func TestBulkEventIsRefusedBeforeItIsMarshalled(t *testing.T) {
 	if want := projectedBulkPayloadBytes(members); typed.Bytes != want {
 		t.Errorf("Bytes = %d, want the projected %d — the refusal came from writeOutboxTx after "+
 			"marshalling, not from the early-out before it", typed.Bytes, want)
+	}
+}
+
+func TestEverythingWrittenIsClaimable(t *testing.T) {
+	s := testStore(t)
+	s.outboxRowCapOverride = 4096 // claimable ceiling 8192
+	ws := createTestWorkspace(t, s, "OutboxWriteReadAgreement")
+
+	// A PAYLOAD THAT IS SMALL IN GO AND HUGE AS STORED. Postgres reparses JSON
+	// numbers as numeric and prints them positionally, so 1e-3000 is 7 bytes
+	// on the way in and about 3,001 on the way out — measured, and unbounded
+	// as the exponent grows. SQLite stores the text verbatim and expands
+	// nothing.
+	//
+	// ASSERTED AS A PROPERTY, not as a dialect-specific outcome, because the
+	// two dialects legitimately differ on whether this is refused: what must
+	// hold on both is that a row the write accepted is a row the claim will
+	// read. Without the stored-size check in writeOutboxTx this row is
+	// accepted on Postgres and then excluded from every claim for the rest of
+	// its retention window — written, undeliverable, and reported only as an
+	// oversized-row log line.
+	var b strings.Builder
+	b.WriteString(`{"n":[`)
+	for i := 0; i < 100; i++ {
+		if i > 0 {
+			b.WriteString(",")
+		}
+		b.WriteString("1e-3000")
+	}
+	b.WriteString(`]}`)
+	payload := []byte(b.String())
+	if len(payload) > s.outboxRowCap() {
+		t.Fatalf("fixture is %d bytes, over the %d write cap — it must be refusable only by the "+
+			"STORED size, or it discriminates nothing", len(payload), s.outboxRowCap())
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	writeErr := writeOutboxTx(tx, s, OutboxEvent{
+		WorkspaceID:   ws.ID,
+		EventType:     kernelevents.ItemCreated,
+		SubjectID:     "numeric",
+		Payload:       payload,
+		PayloadFamily: kernelevents.PayloadItemSnapshot,
+	})
+	if writeErr != nil {
+		var typed *OversizedOutboxPayloadError
+		if !errors.As(writeErr, &typed) {
+			tx.Rollback()
+			t.Fatalf("write failed for an unexpected reason: %v", writeErr)
+		}
+		// Refused on the stored size. The mutation fails, nothing is
+		// committed, and the invariant holds vacuously.
+		tx.Rollback()
+		if typed.Bytes <= len(payload) {
+			t.Errorf("refusal reported %d bytes, not more than the %d written — it was charged "+
+				"against the Go payload, not the stored row", typed.Bytes, len(payload))
+		}
+		return
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	events, err := s.ClaimPendingOutboxEvents("drainer", 10, "2026-01-01T00:00:00Z")
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("the write was accepted but the claim returned %d rows: a row this binary wrote "+
+			"must be a row this binary can read back", len(events))
+	}
+}
+
+func TestBatchSiblingQueryIsBoundedInSQL(t *testing.T) {
+	s := testStore(t)
+	s.outboxRowCapOverride = 8192
+	s.outboxClaimRowsOverride = 3
+	ws := createTestWorkspace(t, s, "OutboxSiblingSQLBound")
+
+	for i := 0; i < 9; i++ {
+		id := fmt.Sprintf("sq-%02d", i)
+		insertRawOutboxRow(t, s, id, ws.ID, fmt.Sprintf("2026-01-01T00:00:%02dZ", i), jsonPayloadOfSize(t, 40))
+		if _, err := s.db.Exec(s.q(`UPDATE event_outbox SET batch_id = ? WHERE id = ?`), "batch-1", id); err != nil {
+			t.Fatalf("set batch_id: %v", err)
+		}
+	}
+
+	// DRIVEN DIRECTLY, because the caller's row cap would hide the defect this
+	// is about: a sibling query that materialised the whole batch and let the
+	// caller truncate afterwards passes every assertion on the claim's return
+	// value while keeping exactly the unbounded allocation the cap was added
+	// to remove (codex round 2).
+	siblings, err := s.claimableBatchSiblings("batch-1", "2026-01-01T00:00:00Z")
+	if err != nil {
+		t.Fatalf("claimableBatchSiblings: %v", err)
+	}
+	if len(siblings) > s.outboxClaimRows() {
+		t.Fatalf("the sibling query returned %d rows for a 9-row batch with a cap of %d; it is "+
+			"bounded by the caller, not by SQL", len(siblings), s.outboxClaimRows())
+	}
+}
+
+func TestScrubSpendsItsByteBudgetNotJustItsRowLimit(t *testing.T) {
+	s := testStore(t)
+	// Row limit high enough that only the BYTE budget can split the work.
+	s.outboxScrubRowsOverride = 100
+	s.outboxClaimBudgetOverride = 4096
+	deleted, _ := scrubTestUsers(t, s)
+	ws := createTestWorkspace(t, s, "ScrubByteBudget")
+	clearOutbox(t, s)
+
+	var batches []int
+	s.afterOutboxScrubBatch = func(rows int) { batches = append(batches, rows) }
+
+	// Eight rows of ~2 KiB each against a 4 KiB budget: a correct loop runs
+	// several batches, a byte-blind one runs exactly one.
+	const n = 8
+	for i := 0; i < n; i++ {
+		insertRawOutboxRow(t, s, fmt.Sprintf("big-%02d", i), ws.ID,
+			fmt.Sprintf("2026-01-01T00:00:%02dZ", i),
+			[]byte(fmt.Sprintf(`{"body":"%s mentions %s"}`, strings.Repeat("x", 2000), deleted.ID)))
+	}
+
+	if err := scrubInTxErr(s, deleted.ID); err != nil {
+		t.Fatalf("scrub: %v", err)
+	}
+	if len(batches) < 2 {
+		t.Fatalf("the scrub ran %d batch(es) over %d rows of ~2 KiB against a %d-byte budget; the "+
+			"byte budget is not being spent, so peak memory is still the whole match set",
+			len(batches), n, s.outboxScrubBytes())
+	}
+	for i, rows := range batches {
+		if rows > s.outboxScrubRows() {
+			t.Errorf("batch %d carried %d rows, over the %d row limit", i, rows, s.outboxScrubRows())
+		}
 	}
 }

--- a/internal/store/event_outbox_bounds_test.go
+++ b/internal/store/event_outbox_bounds_test.go
@@ -767,3 +767,48 @@ func TestScrubOnlyEverShrinksAPayload(t *testing.T) {
 			"the shrink assertion to mean anything", after)
 	}
 }
+
+func TestAnOversizedEventPastTheHopBoundIsDroppedNotRefused(t *testing.T) {
+	s := testStore(t)
+	s.outboxRowCapOverride = 4096
+	ws := createTestWorkspace(t, s, "OutboxHopVsSize")
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer tx.Rollback()
+
+	// TWO REFUSALS THAT DISAGREE ABOUT THE MUTATION. The hop bound drops the
+	// event and lets the mutation stand, because only the cascade it would
+	// extend is illegitimate. The size cap fails the mutation, because there
+	// the mutation and the event are the same fact. An event that trips BOTH
+	// must take the hop bound's disposition: it was never going to be written,
+	// so refusing it for its size fails a mutation over a row that would not
+	// have existed.
+	//
+	// Unreachable in production today — nothing propagates a hop — which is
+	// why the ordering is worth pinning now rather than after something does.
+	err = writeOutboxTx(tx, s, OutboxEvent{
+		WorkspaceID:   ws.ID,
+		EventType:     kernelevents.ItemCreated,
+		SubjectKind:   kernelevents.SubjectItem,
+		SubjectID:     "fat-and-deep",
+		Payload:       jsonPayloadOfSize(t, s.outboxRowCap()+1),
+		Hop:           maxOutboxHop + 1,
+		PayloadFamily: kernelevents.PayloadItemSnapshot,
+	})
+	if err != nil {
+		t.Fatalf("an oversized event past the cascade bound returned %v; the hop bound drops the "+
+			"event and keeps the mutation, and the size cap must not override that for a row that "+
+			"was never going to be written", err)
+	}
+
+	var n int
+	if err := tx.QueryRow(s.q(`SELECT COUNT(*) FROM event_outbox WHERE subject_id = ?`), "fat-and-deep").Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("rows = %d, want 0 — the event was dropped, not stored", n)
+	}
+}

--- a/internal/store/event_outbox_bounds_test.go
+++ b/internal/store/event_outbox_bounds_test.go
@@ -306,6 +306,13 @@ func TestOutboxClaimSpendsTheBudgetOnBatchSiblingsToo(t *testing.T) {
 	if len(events) == 5 {
 		t.Fatalf("the whole batch was claimed; the sibling scan bypassed the byte budget")
 	}
+	// BOTH BOUNDS, because "fewer than five" alone is satisfied by an
+	// implementation that never claims siblings at all (codex round 1). The
+	// limit passed above is 1, so anything past the first row IS a sibling.
+	if len(events) < 2 {
+		t.Fatalf("claimed %d rows with limit=1; siblings are not being claimed at all, which is a "+
+			"different bug wearing this test's passing result", len(events))
+	}
 	// Splitting the batch is defined behaviour, not loss: the rest must still
 	// be claimable on a later pass.
 	rest, err := s.ClaimPendingOutboxEvents("drainer", 1, "2026-01-01T00:00:00Z")
@@ -459,5 +466,83 @@ func TestARowWrittenAtTheCapIsStillClaimable(t *testing.T) {
 		t.Fatalf("OversizedPendingOutbox: %v", err)
 	} else if len(skipped) != 0 {
 		t.Fatalf("a row written at the cap was reported oversized: %+v", skipped)
+	}
+}
+
+func TestOutboxClaimStopsAtTheRowCap(t *testing.T) {
+	s := testStore(t)
+	s.outboxRowCapOverride = 8192
+	s.outboxClaimRowsOverride = 3
+	ws := createTestWorkspace(t, s, "OutboxClaimRows")
+
+	// Tiny payloads, so the BYTE budget is nowhere near spent and only the row
+	// cap can stop the pass. All in one batch, because the sibling scan is the
+	// path that collects past the row limit by design and is therefore the one
+	// a byte-only budget leaves unbounded.
+	for i := 0; i < 8; i++ {
+		id := fmt.Sprintf("tiny-%02d", i)
+		insertRawOutboxRow(t, s, id, ws.ID, fmt.Sprintf("2026-01-01T00:00:%02dZ", i), jsonPayloadOfSize(t, 40))
+		if _, err := s.db.Exec(s.q(`UPDATE event_outbox SET batch_id = ? WHERE id = ?`), "batch-1", id); err != nil {
+			t.Fatalf("set batch_id: %v", err)
+		}
+	}
+
+	events, err := s.ClaimPendingOutboxEvents("drainer", 1, "2026-01-01T00:00:00Z")
+	if err != nil {
+		t.Fatalf("claim: %v", err)
+	}
+	if len(events) > s.outboxClaimRows() {
+		t.Fatalf("claimed %d rows, over the %d row cap — a byte budget alone does not bound the "+
+			"per-row overhead of a large batch", len(events), s.outboxClaimRows())
+	}
+	if len(events) == 0 {
+		t.Fatalf("claimed nothing")
+	}
+}
+
+func TestBulkEventIsRefusedBeforeItIsMarshalled(t *testing.T) {
+	s := testStore(t)
+	s.outboxRowCapOverride = 4096
+	ws := createTestWorkspace(t, s, "BulkPreMarshal")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	// Member bodies alone exceed the cap, so the refusal is owed before
+	// json.Marshal builds the payload — building a payload only to reject it
+	// is the allocation the cap exists to avoid.
+	members := []*models.Item{}
+	for i := 0; i < 4; i++ {
+		members = append(members, &models.Item{
+			ID:           newID(),
+			WorkspaceID:  ws.ID,
+			CollectionID: col.ID,
+			Title:        fmt.Sprintf("Member %d", i),
+			Content:      strings.Repeat("x", 2000),
+		})
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer tx.Rollback()
+
+	err = s.emitBulkItemEventTx(tx, ws.ID, members, map[string]any{"kind": "field_option_renamed"})
+	var typed *OversizedOutboxPayloadError
+	if !errors.As(err, &typed) {
+		t.Fatalf("emitBulkItemEventTx returned %v (%T), want *OversizedOutboxPayloadError", err, err)
+	}
+	if typed.Limit != s.outboxRowCap() {
+		t.Errorf("Limit = %d, want %d", typed.Limit, s.outboxRowCap())
+	}
+	// EXACTLY the projection, which is what makes this test discriminate.
+	// Without the early-out the mutation still fails — writeOutboxTx refuses
+	// the marshalled payload with the same error type — so any assertion that
+	// only checks the type passes against the code this exists to guard. The
+	// marshalled size is strictly larger (quoting, escaping, key names, the
+	// envelope), so equality with the projection can only come from the
+	// pre-marshal check.
+	if want := projectedBulkPayloadBytes(members); typed.Bytes != want {
+		t.Errorf("Bytes = %d, want the projected %d — the refusal came from writeOutboxTx after "+
+			"marshalling, not from the early-out before it", typed.Bytes, want)
 	}
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -84,6 +84,16 @@ type Store struct {
 	// outboxClaimRowsOverride lowers maxOutboxClaimRows the same way.
 	outboxClaimRowsOverride int
 
+	// afterOutboxScrubBatch is a TEST-ONLY seam, nil in production. When set,
+	// ScrubOutboxUserRefsTx calls it once per candidate batch with the number
+	// of rows that batch carried.
+	//
+	// It exists because the scrub's BYTE budget is otherwise unobservable: it
+	// changes peak memory and nothing else, so removing it leaves every
+	// outcome assertion green (codex round 2). Counting batches is the one
+	// visible consequence of the budget doing its job.
+	afterOutboxScrubBatch func(rows int)
+
 	// afterItemPreLockRead is a TEST-ONLY seam, nil in production. When set,
 	// updateItemWithParentLinkOnce calls it after its pre-lock GetItem and
 	// before it opens the transaction — the window in which a concurrent

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -81,6 +81,8 @@ type Store struct {
 	// scrub's BYTE budget has no seam of its own because maxOutboxScrubBytes
 	// is defined as maxOutboxClaimBytes — one number, so one seam.
 	outboxScrubRowsOverride int
+	// outboxClaimRowsOverride lowers maxOutboxClaimRows the same way.
+	outboxClaimRowsOverride int
 
 	// afterItemPreLockRead is a TEST-ONLY seam, nil in production. When set,
 	// updateItemWithParentLinkOnce calls it after its pre-lock GetItem and

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -61,6 +61,27 @@ type Store struct {
 	// every test that sets it does so synchronously and none is parallel).
 	afterDebounceRead func()
 
+	// outboxRowCapOverride and outboxClaimBudgetOverride are TEST-ONLY seams,
+	// zero in production. They lower MaxOutboxPayloadBytes and
+	// maxOutboxClaimBytes so a test can cross those bounds with kilobytes
+	// instead of hundreds of megabytes.
+	//
+	// ZERO MEANS THE PRODUCTION CONSTANT, never "no limit" — read through
+	// outboxRowCap() / outboxClaimBudget(), never directly. A Store built
+	// without the constructor therefore enforces the real bounds rather than
+	// silently enforcing none, which is the failure mode a plain int field
+	// would have had.
+	//
+	// Store fields rather than package vars so parallel tests cannot write
+	// each other's seam, same reasoning as afterDebounceRead above. Set them
+	// only while no request is in flight against this Store.
+	outboxRowCapOverride      int
+	outboxClaimBudgetOverride int
+	// outboxScrubRowsOverride lowers maxOutboxScrubRows the same way. The
+	// scrub's BYTE budget has no seam of its own because maxOutboxScrubBytes
+	// is defined as maxOutboxClaimBytes — one number, so one seam.
+	outboxScrubRowsOverride int
+
 	// afterItemPreLockRead is a TEST-ONLY seam, nil in production. When set,
 	// updateItemWithParentLinkOnce calls it after its pre-lock GetItem and
 	// before it opens the transaction — the window in which a concurrent

--- a/internal/store/wiki_links.go
+++ b/internal/store/wiki_links.go
@@ -1773,9 +1773,12 @@ func newItemRenameCascadeTooLargeError(newTitle string, processed int64) error {
 // Peak residency is bounded by it in both, since each phase refuses before
 // allocating past it.
 //
-// Still NOT bounded here, and genuinely a separate vector: the outbox member
-// snapshots re-read every cascaded body after this function's work is done
-// (BUG-2827).
+// Still not bounded HERE, and genuinely a separate vector: the outbox member
+// snapshots re-read every cascaded body after this function's work is done.
+// That vector now has its own bound rather than none (BUG-2827) — see
+// store.MaxOutboxPayloadBytes, which is deliberately set ABOVE what this
+// constant can marshal to, so a rename large enough to refuse is refused by
+// the message above and never by the outbox's vaguer one.
 // cascadeRowOverheadBytes and cascadeSourceOverheadBytes are the per-entry
 // costs the scan charges on top of the strings it retains.
 //


### PR DESCRIPTION
Closes BUG-2827.

`item.bulk_updated` marshalled every cascaded member body into ONE `event_outbox` row and nothing bounded the row, the drain's reading of it, or the account-deletion scrub's collect. Measured on an 8,434-item instance, renaming one status option emits ~11 MiB in a single row today; the drain then Scans every claimed payload unbounded, oldest-first, before retention runs, so an oversized row is an OOM crash loop across restarts (TASK-2828 correction).

## What this does

- **Write cap** (128 MiB, `MaxOutboxPayloadBytes`) in `writeOutboxTx`, the single `INSERT INTO event_outbox`, so all seven emit paths inherit it. Refusal FAILS the mutation (413 `event_payload_too_large`), because the mutation and the event are the same fact. Bulk emitters charge member bytes before marshalling so a refusal is not itself a memory event.
- **Stored-size refusal**: the INSERT `RETURNING octet_length(payload)` and refuses against the claim ceiling. Postgres JSONB re-renders numbers positionally (`{"a":1e-3000}` stores at ~231x), so no multiple of the Go-side size is a safe ceiling; "a row this binary wrote is a row it can read back" is now true by construction on both dialects.
- **Drain claim** bounded by bytes (64 MiB per pass) and rows (5,000), spent on batch siblings too. Rows over the claim ceiling are excluded in the SQL predicate (not filtered in Go, which would jam the queue behind them), logged by a throttled diagnostic, and left for the existing 7-day retention. The first candidate is always taken so no row is starved.
- **Scrub** (`ScrubOutboxUserRefsTx`) batched by keyset cursor, bounded by bytes and rows; READ-FULLY-THEN-WRITE preserved per batch so the BUG-2409 deadlock stays fixed.
- **Hop drop precedes the size refusal** so an event past the cascade bound is dropped with the mutation standing.
- New `Dialect.OctetLength` — the byte length as the driver hands it to Scan (JSONB needs `::text`).

## Review

Seven codex rounds (round 7 CLEAN), all recorded in the commit bodies: unbounded sibling count, post-marshal cap, redundant copy, false index comment, JSONB numeric normalization, refusal figures, throttle, drifted comments, ordering. Two findings rejected with Postgres 16 measurements (keyset paging is a superset of the single query; the scrub cannot grow a payload). Mutation matrices per commit; one survivor recorded as unfaithful (CONVE-28).

## Not addressed, named

A workspace that outgrows the write cap has no recourse — it cannot shrink its own cascade. The answer is chunking one bulk event across rows sharing a `batch_id`, which the drain's fold already supports. Filed as IDEA-2845.
