### PR TITLE
feat(web): comment on a selection, with comments back under the item content (IDEA-2843)

### DIFF
--- a/web/e2e/attachment-lifecycle.spec.ts
+++ b/web/e2e/attachment-lifecycle.spec.ts
@@ -346,15 +346,17 @@ test.describe('attachment lifecycle completeness — 3c-iii browser proof (TASK-
 
 		await page.goto(itemUrl(fixture, doc.slug));
 
-		// The timeline lives under the Activity tab. Open it and confirm the comment
-		// thumbnail resolved to a LIVE image first — the baseline the reconciliation
-		// flips away from. (The tab-panels are CSS-hidden, not `{#if}`-gated, so both
-		// the strip and the timeline stay MOUNTED across a switch — the timeline
-		// instance never remounts, which is what makes the reconciliation "live".)
-		const tlImg = `.timeline img[data-attachment-id="${att}"]`;
-		const tlMissing = `.timeline .attachment-missing[data-attachment-id="${att}"]`;
-		await page.getByRole('tab', { name: 'Activity' }).click();
-		await expect(page.locator('.timeline')).toBeVisible();
+		// Comments live under the item CONTENT on the Details tab (IDEA-2843);
+		// they used to be behind the Activity tab and this opened it. Confirm the
+		// comment thumbnail resolved to a LIVE image first — the baseline the
+		// reconciliation flips away from. (The tab-panels are CSS-hidden, not
+		// `{#if}`-gated, so the strip and the timeline stay MOUNTED across a
+		// switch — the timeline instance never remounts, which is what makes the
+		// reconciliation "live". That property is exercised at the end of the
+		// test, which still round-trips through another tab.)
+		const tlImg = `#item-comments img[data-attachment-id="${att}"]`;
+		const tlMissing = `#item-comments .attachment-missing[data-attachment-id="${att}"]`;
+		await expect(page.locator('#item-comments .timeline')).toBeVisible();
 		await expect(page.locator(tlImg)).toBeVisible();
 		await expect(page.locator(tlMissing)).toHaveCount(0);
 
@@ -368,10 +370,11 @@ test.describe('attachment lifecycle completeness — 3c-iii browser proof (TASK-
 			if (el) el.__tl = 2;
 		});
 
-		// Delete the attachment through the STRIP UI. Switch to the Details tab where
-		// the strip is visible (its `.att-delete` is display:none while Activity is
-		// shown, so unclickable there), open the confirm drill-down, and confirm — this
-		// is the same-page path that runs `announceAttachmentDeleted`.
+		// Delete the attachment through the STRIP UI. The strip and the comments
+		// now share the Details tab (IDEA-2843), so this click is a no-op where it
+		// used to be a switch away from Activity; kept because the test must be
+		// ON Details for the strip's `.att-delete` to be clickable, whatever tab
+		// a future edit leaves us on.
 		await page.getByRole('tab', { name: 'Details' }).click();
 		// The delete control is CSS-revealed on hover / focus-within and sits over the
 		// tile, so focus it first (keyboard-reachable by contract) before clicking —
@@ -400,8 +403,12 @@ test.describe('attachment lifecycle completeness — 3c-iii browser proof (TASK-
 			'the reconciliation is the live bus reaching the mounted timeline — not a reload or a remount'
 		).toBe(true);
 
-		// And it renders correctly when the tab is shown again.
+		// And it renders correctly after a tab round-trip. Comments are on
+		// Details now, so the switch that proves the panel is CSS-hidden rather
+		// than unmounted has to go OUT and BACK — leaving on Activity would
+		// assert against a hidden panel and pass for the wrong reason.
 		await page.getByRole('tab', { name: 'Activity' }).click();
+		await page.getByRole('tab', { name: 'Details' }).click();
 		await expect(page.locator(tlMissing)).toBeVisible();
 	});
 });

--- a/web/e2e/attachment-surface-chrome.spec.ts
+++ b/web/e2e/attachment-surface-chrome.spec.ts
@@ -49,10 +49,14 @@ import {
 
 const INLINE_IMG = '.editor-content .ProseMirror img[data-attachment-id]';
 
-/** The timeline (and its comment images) live under the item's Activity tab. */
-async function openActivityTab(page: Page): Promise<void> {
-	await page.getByRole('tab', { name: 'Activity' }).click();
-	await expect(page.locator('.timeline')).toBeVisible();
+/**
+ * Comments (and their inline images) live under the item CONTENT on the
+ * Details tab — IDEA-2843 moved them out of the Activity tab, which now
+ * carries changes and versions only. Details is the tab a pane opens on, so
+ * there is nothing to click; the wait is what the tab click used to provide.
+ */
+async function openCommentsSurface(page: Page): Promise<void> {
+	await expect(page.locator('#item-comments .timeline')).toBeVisible();
 }
 
 test.describe('attachment viewer — 3c-i surface chrome (TASK-2484)', () => {
@@ -105,7 +109,7 @@ test.describe('attachment viewer — 3c-i surface chrome (TASK-2484)', () => {
 		const one = await uploadAttachment(fixture, request, doc.id, 'tl-tool.png');
 		await postComment(fixture, request, doc.slug, `shot\n\n![first](pad-attachment:${one})\n`);
 		await page.goto(itemUrl(fixture, doc.slug));
-		await openActivityTab(page);
+		await openCommentsSurface(page);
 		await page.locator('.timeline img[data-attachment-id]').first().click();
 		await expect(page.locator(VIEWER_IMAGE)).toBeVisible();
 		await expect(page.locator(VIEWER_TOOLBAR)).toBeVisible();

--- a/web/e2e/attachment-viewer-parity.spec.ts
+++ b/web/e2e/attachment-viewer-parity.spec.ts
@@ -60,14 +60,14 @@ const INLINE_IMG = '.editor-content .ProseMirror img[data-attachment-id]';
 const COMMENT_EDITOR = '.comment-editor .ProseMirror';
 
 /**
- * The timeline (and with it the comment composer) lives under the item's
- * ACTIVITY tab; on the Details tab it is mounted but has no box at all, so
- * every locator inside it is "not visible". Two of the four surfaces live
- * here, which is itself part of what makes them different code paths.
+ * The comment composer lives under the item CONTENT on the Details tab since
+ * IDEA-2843; before that it was on the Activity tab and this helper clicked
+ * there. Two of the four surfaces live here, which is itself part of what
+ * makes them different code paths. Details is the default tab, so the wait is
+ * all that remains of the old prelude.
  */
-async function openActivityTab(page: Page): Promise<void> {
-	await page.getByRole('tab', { name: 'Activity' }).click();
-	await expect(page.locator('.timeline')).toBeVisible();
+async function openCommentsSurface(page: Page): Promise<void> {
+	await expect(page.locator('#item-comments .timeline')).toBeVisible();
 }
 
 /** open → ←/→ → Escape → reopen → backdrop click → reopen → Close button. */
@@ -162,7 +162,7 @@ test.describe('attachment viewer — four-surface parity (TASK-2436)', () => {
 			`two shots\n\n![first](pad-attachment:${one})\n\n![second](pad-attachment:${two})\n`
 		);
 		await page.goto(itemUrl(fixture, doc.slug));
-		await openActivityTab(page);
+		await openCommentsSurface(page);
 
 		const thumbs = page.locator('.timeline img[data-attachment-id]');
 		await expect(thumbs).toHaveCount(2);
@@ -205,7 +205,7 @@ test.describe('attachment viewer — four-surface parity (TASK-2436)', () => {
 		await browserLogin(page);
 		const doc = await seedDoc(fixture, request, 'Parity comment editor');
 		await page.goto(itemUrl(fixture, doc.slug));
-		await openActivityTab(page);
+		await openCommentsSurface(page);
 
 		await page.locator(COMMENT_EDITOR).first().click();
 		await dropFileIntoEditor(page, 'draft-a.png', REAL_PNG.toString('base64'), 'image/png', COMMENT_EDITOR);
@@ -343,7 +343,7 @@ test.describe('attachment viewer — four-surface parity (TASK-2436)', () => {
 		await expect(page.locator(VIEWER)).toHaveCount(0);
 
 		// ── The modified-key case, in the surface that owns the shortcut ──
-		await openActivityTab(page);
+		await openCommentsSurface(page);
 		await page.locator(COMMENT_EDITOR).first().click();
 		await dropFileIntoEditor(
 			page,

--- a/web/e2e/pane-full-page-capstone.spec.ts
+++ b/web/e2e/pane-full-page-capstone.spec.ts
@@ -329,11 +329,13 @@ test.describe('full-page pane host CAPSTONE (PLAN-2154 Phase 2 / TASK-2175)', ()
 		await col.getByRole('tab', { name: 'Relationships' }).click();
 		await expect(col.locator('button.link-delete-btn')).toHaveCount(1);
 		await expect(col.locator('button.add-relationship-btn')).toBeVisible();
-		// Activity tab: the comment composer.
-		await col.getByRole('tab', { name: 'Activity' }).click();
-		await expect(col.locator('.compose')).toBeVisible();
-		// Return to Details so the peek-era editor checks read the right tab.
+		// Details tab: the comment composer, under the content (IDEA-2843 —
+		// it used to be behind the Activity tab, which now carries changes and
+		// versions only). Return to Details first, since the Relationships
+		// click above left us elsewhere; the peek-era editor checks below need
+		// this tab anyway.
 		await col.getByRole('tab', { name: 'Details' }).click();
+		await expect(col.locator('#item-comments .compose')).toBeVisible();
 
 		// ── Open the pane → focus-follows-editing (PLAN-2179 DR-2 / TASK-2181) keeps
 		//    the MASTER editable (the pane opens as a read-only PREVIEW). Then click

--- a/web/e2e/selection-comment-peek.spec.ts
+++ b/web/e2e/selection-comment-peek.spec.ts
@@ -140,8 +140,22 @@ test.describe('selection toolbar — Comment (IDEA-2843)', () => {
 		await expect(masterMain).toHaveAttribute('contenteditable', 'true');
 
 		// And with the master active again, both actions are available.
-		await expect(page.getByRole('button', { name: 'Comment on selection' })).toBeVisible();
-		await expect(page.getByRole('button', { name: 'Extract', exact: true })).toBeVisible();
+		const comment = page.getByRole('button', { name: 'Comment on selection' });
+		const extract = page.getByRole('button', { name: 'Extract', exact: true });
+		await expect(comment).toBeVisible();
+		await expect(extract).toBeVisible();
+
+		// Side by side, not stacked. The menu's buttons are themselves flex, so
+		// without a row layout on the container they stack — which also
+		// falsifies the width the positioner clamps against, drifting the menu
+		// over the text it points at (codex round 7). Layout is not observable
+		// in jsdom, so this is the only place the claim can be made.
+		const commentBox = await comment.boundingBox();
+		const extractBox = await extract.boundingBox();
+		expect(commentBox).not.toBeNull();
+		expect(extractBox).not.toBeNull();
+		expect(Math.abs(commentBox!.y - extractBox!.y)).toBeLessThan(4);
+		expect(extractBox!.x).toBeGreaterThan(commentBox!.x);
 	});
 
 	test('Comment quotes the selection into the composer under the content, keeping a draft', async ({

--- a/web/e2e/selection-comment-peek.spec.ts
+++ b/web/e2e/selection-comment-peek.spec.ts
@@ -1,0 +1,180 @@
+// The selection toolbar's Comment action, end to end (IDEA-2843 / GitHub #1228).
+//
+// Why these cannot be unit tests. A jsdom test drives selection with
+// `editor.commands.setTextSelection(...)` — a programmatic transaction that
+// emits `selectionUpdate` whether or not a browser would, and that never
+// touches focus. Both questions here are about what a REAL mouse drag does:
+// whether it raises the toolbar, and what it does to a peeking master's
+// editable state. Only a browser can answer either, so these drag with the
+// mouse and never call the editor's command API.
+//
+// The second test is a NEGATIVE result kept deliberately. The Comment action
+// was briefly gated peek-independently on the theory that a peeking master can
+// comment but cannot act on a selection; this measured that state and found it
+// unreachable, and the gate was simplified because of it. The test stays so
+// that a future change making selections survive the freeze turns red here
+// instead of silently reopening a question everyone has forgotten.
+import { test, expect } from './fixtures';
+import { browserLogin, seedDoc } from './lib/collab-helpers';
+import type { APIRequestContext, Page } from '@playwright/test';
+import type { SuiteFixture } from './fixtures';
+
+const DESKTOP = { width: 1200, height: 900 };
+
+function authHeaders(fixture: SuiteFixture) {
+	return { Authorization: `Bearer ${fixture.apiToken}`, 'Content-Type': 'application/json' };
+}
+
+function openItemParam(page: Page): string | null {
+	return new URL(page.url()).searchParams.get('item');
+}
+
+async function seedDocWithContent(
+	fixture: SuiteFixture,
+	request: APIRequestContext,
+	titlePrefix: string,
+	content: string,
+): Promise<{ id: string; slug: string }> {
+	const resp = await request.post(
+		`/api/v1/workspaces/${fixture.workspaceSlug}/collections/docs/items`,
+		{ headers: authHeaders(fixture), data: { title: `${titlePrefix} ${Date.now()}`, fields: '{}', content } },
+	);
+	if (!resp.ok()) throw new Error(`doc create failed (${resp.status()}): ${await resp.text()}`);
+	return (await resp.json()) as { id: string; slug: string };
+}
+
+async function seedRelatedLink(
+	fixture: SuiteFixture,
+	request: APIRequestContext,
+	sourceSlug: string,
+	targetId: string,
+): Promise<void> {
+	const resp = await request.post(
+		`/api/v1/workspaces/${fixture.workspaceSlug}/items/${sourceSlug}/links`,
+		{ headers: authHeaders(fixture), data: { target_id: targetId, link_type: 'related' } },
+	);
+	if (!resp.ok()) throw new Error(`link create failed (${resp.status()}): ${await resp.text()}`);
+}
+
+async function itemRef(fixture: SuiteFixture, request: APIRequestContext, slug: string): Promise<string> {
+	const resp = await request.get(`/api/v1/workspaces/${fixture.workspaceSlug}/items/${slug}`, {
+		headers: authHeaders(fixture),
+	});
+	if (!resp.ok()) throw new Error(`item get failed (${resp.status()}): ${await resp.text()}`);
+	const item = (await resp.json()) as { collection_prefix?: string; item_number?: number };
+	if (!item.collection_prefix || !item.item_number) throw new Error('item has no ref');
+	return `${item.collection_prefix}-${item.item_number}`;
+}
+
+function fullPageUrl(fixture: SuiteFixture, slug: string): string {
+	return `/${fixture.adminUsername}/${fixture.workspaceSlug}/docs/${slug}`;
+}
+
+/** Drag-select a paragraph with the MOUSE — the browser path, not the API. */
+async function dragSelect(page: Page, paragraph: ReturnType<Page['locator']>) {
+	const box = await paragraph.boundingBox();
+	if (!box) throw new Error('paragraph has no box');
+	await page.mouse.move(box.x + 2, box.y + box.height / 2);
+	await page.mouse.down();
+	await page.mouse.move(box.x + box.width - 2, box.y + box.height / 2, { steps: 12 });
+	await page.mouse.up();
+}
+
+test.describe('selection toolbar — Comment (IDEA-2843)', () => {
+	test.beforeEach(({}, testInfo) => {
+		test.skip(testInfo.project.name !== 'desktop-chromium', 'desktop-split concern');
+	});
+
+	test('a drag-selection in a PEEKING master re-activates it — so there is no frozen-selection case', async ({
+		page,
+		fixture,
+		request,
+	}) => {
+		await page.setViewportSize(DESKTOP);
+		await browserLogin(page);
+
+		const master = await seedDocWithContent(
+			fixture,
+			request,
+			'Peek comment master',
+			'Alpha paragraph here\n\nBravo paragraph here',
+		);
+		const related = await seedDoc(fixture, request, 'Peek comment related');
+		await seedRelatedLink(fixture, request, master.slug, related.id);
+		const relatedRef = await itemRef(fixture, request, related.slug);
+
+		await page.goto(fullPageUrl(fixture, master.slug));
+		const masterPage = page.locator('.item-page-host > .item-page');
+		const masterMain = masterPage.locator('.editor-wrapper .ProseMirror');
+		await expect(masterMain).toHaveAttribute('contenteditable', 'true');
+		const firstPara = masterMain.locator('p').first();
+		await expect(firstPara).toContainText('Alpha paragraph');
+
+		// PEEK: open the pane, click into it so the master freezes, put the
+		// master's Details tab back on screen (which re-activates it), then
+		// re-peek — the master is frozen WITH its editor visible.
+		const pane = page.locator('.item-pane');
+		await masterPage.getByRole('tab', { name: 'Relationships' }).click();
+		await page
+			.locator('.relationship-group', { hasText: 'Related' })
+			.locator('a.link-target', { hasText: 'Peek comment related' })
+			.click();
+		await expect(pane).toBeVisible();
+		await expect.poll(() => openItemParam(page)).toBe(relatedRef);
+		await pane.locator('.editor-wrapper .ProseMirror').click();
+		await masterPage.getByRole('tab', { name: 'Details' }).click();
+		await pane.locator('.editor-wrapper .ProseMirror').click();
+		await expect(masterMain).toHaveAttribute('contenteditable', 'false');
+
+		// THE MEASUREMENT. The Comment action was briefly given a
+		// peek-INdependent gate, reasoning that a peeking master keeps a live
+		// composer (BUG-2263) and so should be able to act on a selection. This
+		// asserts the state that argument assumed, and it does not exist: the
+		// drag itself re-activates the master (focus-follows-editing,
+		// PLAN-2179 DR-2), so a selection and a frozen master never coexist.
+		//
+		// The gate was collapsed back onto `mutationsEnabled` because of this.
+		// If a future change makes a selection survivable in a frozen master,
+		// THIS test goes red and the gate question reopens with evidence.
+		await dragSelect(page, firstPara);
+		await expect(masterMain).toHaveAttribute('contenteditable', 'true');
+
+		// And with the master active again, both actions are available.
+		await expect(page.getByRole('button', { name: 'Comment on selection' })).toBeVisible();
+		await expect(page.getByRole('button', { name: 'Extract', exact: true })).toBeVisible();
+	});
+
+	test('Comment quotes the selection into the composer under the content, keeping a draft', async ({
+		page,
+		fixture,
+		request,
+	}) => {
+		await page.setViewportSize(DESKTOP);
+		await browserLogin(page);
+
+		const doc = await seedDocWithContent(
+			fixture,
+			request,
+			'Quote into composer',
+			'Alpha paragraph here\n\nBravo paragraph here',
+		);
+		await page.goto(fullPageUrl(fixture, doc.slug));
+
+		const masterPage = page.locator('.item-page-host > .item-page');
+		const composer = masterPage.locator('#item-comments .compose .ProseMirror');
+		// The composer is on the Details tab now, with no tab click needed —
+		// that relocation is half of this unit.
+		await expect(composer).toBeVisible();
+
+		// A draft the user already typed. The quote must not eat it.
+		await composer.click();
+		await page.keyboard.type('my own remark');
+
+		const firstPara = masterPage.locator('.editor-wrapper .ProseMirror p').first();
+		await dragSelect(page, firstPara);
+		await page.getByRole('button', { name: 'Comment on selection' }).click();
+
+		await expect(composer.locator('blockquote')).toContainText('Alpha paragraph here');
+		await expect(composer).toContainText('my own remark');
+	});
+});

--- a/web/src/lib/components/CommentEditor.svelte
+++ b/web/src/lib/components/CommentEditor.svelte
@@ -169,7 +169,21 @@
 			await onSubmit(md);
 			// Composer behaviour: clear on success. In edit/reply mode the host
 			// unmounts this component, so the clear is harmless there.
-			if (editor && !editor.isDestroyed && reqWs === wsSlug && reqItem === itemId) {
+			//
+			// ...but only if the composer still holds what was SENT. Anything
+			// added during the round trip is not part of the submitted comment,
+			// and clearing it destroys it: a quote pushed in through
+			// `appendMarkdown` while the submit was in flight (IDEA-2843, codex
+			// round 5), and — pre-existing, same mechanism — anything the user
+			// typed. This is the same class as the item-identity capture above,
+			// applied to the CONTENT rather than to which item it belongs to.
+			if (
+				editor &&
+				!editor.isDestroyed &&
+				reqWs === wsSlug &&
+				reqItem === itemId &&
+				currentMarkdown() === md
+			) {
 				editor.commands.clearContent();
 			}
 		} catch {

--- a/web/src/lib/components/CommentEditor.svelte
+++ b/web/src/lib/components/CommentEditor.svelte
@@ -123,24 +123,32 @@
 		if (addition === '') return false;
 		const existing = currentMarkdown();
 		const next = existing === '' ? addition : `${existing}\n\n${addition}`;
-		// setContent (not insertContentAt): tiptap-markdown overrides
-		// insertContentAt to parse with `{ inline: true }`, which runs the
-		// parser's inline normalization over the addition. A blockquote
-		// survives that today only incidentally — normalizeInline unwraps the
-		// first child only when it is a <p> — and depending on a library
-		// internal to preserve block structure is how the quote would one day
-		// flatten to a paragraph with nothing failing. setContent parses in
-		// block mode, which is the documented path.
+		// setContent (block parse) rather than insertContentAt, and the reason
+		// is a PREFERENCE, not a defect avoided: both routes preserve the
+		// blockquote today. That was measured — swapping this line for
+		// insertContentAt leaves the whole suite green. What separates them is
+		// what they depend on. tiptap-markdown overrides insertContentAt to
+		// parse with `{ inline: true }`, and the block structure survives that
+		// only because normalizeInline unwraps the first child when it is a
+		// <p> and a blockquote is not one. setContent parses in block mode and
+		// depends on nothing of the sort.
+		//
+		// Nothing enforces this choice — a source guard for it would be a
+		// scanner with an unbounded tail, which is not worth it here. If a
+		// future edit moves to insertContentAt, the suite will stay green and
+		// this comment is the only warning that the quote's block structure
+		// then rides on a library internal.
 		//
 		// The round trip through markdown is not new loss: the composer already
 		// parses markdown at mount and serializes it on every submit, so both
 		// directions are the component's existing contract.
+		// `empty` (which gates the submit button) is maintained by the editor's
+		// own onUpdate: setContent's `emitUpdate` defaults true in
+		// @tiptap/core 3.30.2. An explicit `empty = editor.isEmpty` here was
+		// removed after a mutation showed it inert — the suite asserts the
+		// button becomes enabled, so if a future bump flips that default the
+		// test goes red and says so, which a defensive line would have hidden.
 		editor.chain().setContent(next).focus('end').run();
-		// Kept explicit rather than left to onUpdate: setContent's `emitUpdate`
-		// defaults true in @tiptap/core 3.30.2, but the submit button is gated
-		// on `empty`, and a silently-disabled submit is exactly the class of
-		// failure above.
-		empty = editor.isEmpty;
 		return true;
 	}
 

--- a/web/src/lib/components/CommentEditor.svelte
+++ b/web/src/lib/components/CommentEditor.svelte
@@ -95,6 +95,55 @@
 		return unescapeDocLinks((editor.storage as any).markdown?.getMarkdown?.() ?? '').trim();
 	}
 
+	/**
+	 * Appends markdown to the composer from OUTSIDE the component, without
+	 * remounting it (IDEA-2843). The selection toolbar's "Comment" action uses
+	 * this to drop a blockquote of the reader's selection into the live
+	 * composer; the blockquote grammar is the CALLER's, so this stays a
+	 * general append.
+	 *
+	 * Why an imperative handle and not the `content` prop: `content` is read
+	 * ONCE, inside `new Editor({...})` in `onMount` below, and this component
+	 * has no `$effect` syncing it afterwards. Writing the prop on a mounted
+	 * composer is a SILENT no-op — no error, no warning, the text is simply
+	 * dropped. A `{#key}` remount would work but would destroy an in-progress
+	 * draft, which is the thing `doSubmit`'s identity capture (PLAN-2105 /
+	 * TASK-2112) exists to protect.
+	 *
+	 * Append, never replace: a draft the user has already typed is kept and the
+	 * addition goes after a blank line, so quoting a second passage into the
+	 * same comment works without losing the first. Returns false when there was
+	 * nothing to insert or no live editor, so a caller can tell the difference
+	 * between "inserted" and "silently did nothing" — the failure mode this
+	 * handle exists to remove.
+	 */
+	export function appendMarkdown(markdown: string): boolean {
+		if (!editor || editor.isDestroyed) return false;
+		const addition = markdown.trim();
+		if (addition === '') return false;
+		const existing = currentMarkdown();
+		const next = existing === '' ? addition : `${existing}\n\n${addition}`;
+		// setContent (not insertContentAt): tiptap-markdown overrides
+		// insertContentAt to parse with `{ inline: true }`, which runs the
+		// parser's inline normalization over the addition. A blockquote
+		// survives that today only incidentally — normalizeInline unwraps the
+		// first child only when it is a <p> — and depending on a library
+		// internal to preserve block structure is how the quote would one day
+		// flatten to a paragraph with nothing failing. setContent parses in
+		// block mode, which is the documented path.
+		//
+		// The round trip through markdown is not new loss: the composer already
+		// parses markdown at mount and serializes it on every submit, so both
+		// directions are the component's existing contract.
+		editor.chain().setContent(next).focus('end').run();
+		// Kept explicit rather than left to onUpdate: setContent's `emitUpdate`
+		// defaults true in @tiptap/core 3.30.2, but the submit button is gated
+		// on `empty`, and a silently-disabled submit is exactly the class of
+		// failure above.
+		empty = editor.isEmpty;
+		return true;
+	}
+
 	async function doSubmit() {
 		if (busy || !editor) return;
 		const md = currentMarkdown();

--- a/web/src/lib/components/commentEditorAppendMarkdown.svelte.test.ts
+++ b/web/src/lib/components/commentEditorAppendMarkdown.svelte.test.ts
@@ -151,6 +151,44 @@ describe('CommentEditor.appendMarkdown', () => {
 		expect(quotes[1].textContent).toContain('Second passage');
 	});
 
+	it('survives a quote arriving while a submit is in flight', async () => {
+		// `doSubmit` clears on success. A quote pushed in during the round trip
+		// is not part of what was sent, and an unconditional clear destroys it
+		// (codex round 5). Same class as the item-identity capture that already
+		// guards this path, applied to the content rather than the item.
+		let release: (() => void) | null = null;
+		const inFlight = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+
+		target = document.body.appendChild(document.createElement('div'));
+		const handle = mount(CommentEditor, {
+			target,
+			props: {
+				wsSlug: 'ws',
+				itemId: 'item-A',
+				content: 'the comment being sent',
+				onSubmit: () => inFlight,
+			},
+		}) as unknown as Handle;
+		app = handle;
+		flushSync();
+
+		submitButton().click();
+		flushSync();
+
+		// The quote lands mid-submit.
+		expect(handle.appendMarkdown('> quoted while sending')).toBe(true);
+		flushSync();
+
+		release!();
+		await inFlight;
+		await Promise.resolve();
+		flushSync();
+
+		expect(surface().textContent).toContain('quoted while sending');
+	});
+
 	it('reports false and changes nothing when there is nothing to insert', () => {
 		const handle = mountComposer();
 

--- a/web/src/lib/components/commentEditorAppendMarkdown.svelte.test.ts
+++ b/web/src/lib/components/commentEditorAppendMarkdown.svelte.test.ts
@@ -1,0 +1,159 @@
+// The imperative append handle on `CommentEditor` (IDEA-2843, GitHub #1228).
+//
+// The selection toolbar's "Comment" action has to drop a blockquote of the
+// reader's selection into the composer that is ALREADY MOUNTED. The obvious
+// route — write the `content` prop — is a silent no-op: `content` is read once
+// inside `new Editor({...})` in `onMount`, and the component has no `$effect`
+// syncing it. Nothing throws, nothing warns, the text is simply gone.
+//
+// That failure mode is why none of these tests assert that the composer is
+// visible, or that a handler ran. They assert the QUOTE TEXT is in the
+// composer's document, because "the composer opened" is exactly what the
+// broken version also does.
+//
+// Two of the assertions are shaped by a mechanism rather than by taste:
+//
+//  - **`blockquote`, not text.** tiptap-markdown overrides `insertContentAt`
+//    to parse with `{ inline: true }`. An implementation that reached for it
+//    would run the addition through inline normalization, where block
+//    structure is preserved only incidentally. Asserting the tag means a
+//    quote that flattens into a paragraph is RED, and the visible text alone
+//    would not have caught it.
+//  - **Draft first, then quote.** An implementation that replaced the document
+//    instead of appending satisfies every "the quote is present" assertion
+//    ever written. The draft's survival, and its position, are the only things
+//    that separate append from replace.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount, unmount, flushSync } from 'svelte';
+
+vi.mock('$lib/api/client', () => ({
+	api: {
+		attachments: {
+			downloadUrl: (ws: string, id: string, variant?: string) =>
+				`/api/v1/workspaces/${ws}/attachments/${id}?variant=${variant ?? 'thumb-md'}`,
+			upload: vi.fn(),
+		},
+	},
+}));
+
+const CommentEditor = (await import('./CommentEditor.svelte')).default;
+
+type Handle = { appendMarkdown: (markdown: string) => boolean };
+
+const QUOTE = '> The passage the reviewer highlighted';
+const QUOTE_TEXT = 'The passage the reviewer highlighted';
+
+let target: HTMLDivElement;
+let app: Handle | null = null;
+
+function mountComposer(content = ''): Handle {
+	target = document.body.appendChild(document.createElement('div'));
+	app = mount(CommentEditor, {
+		target,
+		props: { wsSlug: 'ws', itemId: 'item-A', content, onSubmit: () => {} },
+	}) as unknown as Handle;
+	flushSync();
+	return app;
+}
+
+/** The ProseMirror surface — what the user would be looking at. */
+function surface(): HTMLElement {
+	const el = target.querySelector('.ce-surface');
+	if (!el) throw new Error('composer surface never rendered');
+	return el as HTMLElement;
+}
+
+function submitButton(): HTMLButtonElement {
+	return target.querySelector('.ce-submit') as HTMLButtonElement;
+}
+
+beforeEach(() => {
+	document.body.innerHTML = '';
+});
+
+afterEach(() => {
+	if (app) unmount(app as never);
+	app = null;
+	vi.restoreAllMocks();
+});
+
+describe('CommentEditor.appendMarkdown', () => {
+	it('puts the quote in the composer as a blockquote, on an empty composer', () => {
+		const handle = mountComposer();
+
+		// Precondition, asserted rather than assumed: the composer really is
+		// empty first, so the blockquote below cannot be left over from mount.
+		expect(surface().querySelector('blockquote')).toBeNull();
+
+		expect(handle.appendMarkdown(QUOTE)).toBe(true);
+		flushSync();
+
+		const quote = surface().querySelector('blockquote');
+		expect(quote).not.toBeNull();
+		expect(quote!.textContent).toContain(QUOTE_TEXT);
+	});
+
+	it('enables submit, because the composer gates the button on its own empty flag', () => {
+		const handle = mountComposer();
+		expect(submitButton().disabled).toBe(true);
+
+		handle.appendMarkdown(QUOTE);
+		flushSync();
+
+		// A quote that lands in a document whose `empty` flag stayed stale is a
+		// comment the user cannot post — the same silent shape as losing the
+		// text outright.
+		expect(submitButton().disabled).toBe(false);
+	});
+
+	it('appends after an existing draft instead of replacing it, draft first', () => {
+		const handle = mountComposer('Half a thought I already typed');
+
+		expect(handle.appendMarkdown(QUOTE)).toBe(true);
+		flushSync();
+
+		const root = surface();
+		expect(root.textContent).toContain('Half a thought I already typed');
+
+		const quote = root.querySelector('blockquote');
+		expect(quote).not.toBeNull();
+		expect(quote!.textContent).toContain(QUOTE_TEXT);
+
+		// Order, not just co-presence: a replace-then-restore implementation
+		// could satisfy both assertions above with the draft in the wrong place.
+		const draftNode = Array.from(root.querySelectorAll('p')).find((p) =>
+			p.textContent?.includes('Half a thought I already typed')
+		);
+		expect(draftNode).toBeDefined();
+		expect(
+			draftNode!.compareDocumentPosition(quote!) & Node.DOCUMENT_POSITION_FOLLOWING
+		).toBeTruthy();
+	});
+
+	it('quoting a second passage keeps the first', () => {
+		const handle = mountComposer();
+
+		handle.appendMarkdown('> First passage');
+		flushSync();
+		handle.appendMarkdown('> Second passage');
+		flushSync();
+
+		const quotes = surface().querySelectorAll('blockquote');
+		expect(quotes.length).toBe(2);
+		expect(quotes[0].textContent).toContain('First passage');
+		expect(quotes[1].textContent).toContain('Second passage');
+	});
+
+	it('reports false and changes nothing when there is nothing to insert', () => {
+		const handle = mountComposer();
+
+		// The negative control for the honest-failure contract: the handle
+		// exists to make "did nothing" distinguishable from "inserted", so a
+		// blank addition must SAY so rather than return true and no-op.
+		expect(handle.appendMarkdown('   \n  ')).toBe(false);
+		flushSync();
+
+		expect(surface().querySelector('blockquote')).toBeNull();
+		expect(submitButton().disabled).toBe(true);
+	});
+});

--- a/web/src/lib/components/commentEditorAppendMarkdown.svelte.test.ts
+++ b/web/src/lib/components/commentEditorAppendMarkdown.svelte.test.ts
@@ -13,12 +13,14 @@
 //
 // Two of the assertions are shaped by a mechanism rather than by taste:
 //
-//  - **`blockquote`, not text.** tiptap-markdown overrides `insertContentAt`
-//    to parse with `{ inline: true }`. An implementation that reached for it
-//    would run the addition through inline normalization, where block
-//    structure is preserved only incidentally. Asserting the tag means a
-//    quote that flattens into a paragraph is RED, and the visible text alone
-//    would not have caught it.
+//  - **`blockquote`, not text.** An implementation that inserts the selection
+//    as plain text, or otherwise loses the block, is RED here where an
+//    assertion on the visible text alone would stay green — verified by
+//    mutation. What this does NOT catch, also verified: swapping the
+//    implementation's `setContent` for tiptap-markdown's inline-parsing
+//    `insertContentAt` keeps the whole suite green, because a blockquote
+//    survives inline normalization today. The choice between those two is
+//    argued in the component and is deliberately not test-enforced.
 //  - **Draft first, then quote.** An implementation that replaced the document
 //    instead of appending satisfies every "the quote is present" assertion
 //    ever written. The draft's survival, and its position, are the only things
@@ -93,6 +95,11 @@ describe('CommentEditor.appendMarkdown', () => {
 		expect(quote!.textContent).toContain(QUOTE_TEXT);
 	});
 
+	// This one carries the `empty` flag, which no line in `appendMarkdown`
+	// sets — the editor's own onUpdate does, because setContent emits by
+	// default. That default is the thing under test: if a tiptap bump flips
+	// it, the quote still lands and the user still cannot post it, and this
+	// is what says so.
 	it('enables submit, because the composer gates the button on its own empty flag', () => {
 		const handle = mountComposer();
 		expect(submitButton().disabled).toBe(true);

--- a/web/src/lib/components/editor/EditorBubbleMenu.svelte
+++ b/web/src/lib/components/editor/EditorBubbleMenu.svelte
@@ -5,17 +5,38 @@
 	import { api, isPlanLimitError, planLimitMessage } from '$lib/api/client';
 	import { toastStore } from '$lib/stores/toast.svelte';
 	import { localIndex } from '$lib/stores/localIndex.svelte';
+	import { toBlockquote } from '$lib/utils/markdown';
 
 	let {
 		editor,
 		wsSlug,
 		collections,
 		onItemCreated,
+		onComment,
 	}: {
 		editor: Editor | null;
 		wsSlug: string;
 		collections: Collection[];
 		onItemCreated?: (item: Item, ws: string, sinceEpoch?: number) => void;
+		/**
+		 * Quote the selection into the host's comment composer (IDEA-2843).
+		 *
+		 * Supplying this IS the capability — the Comment action renders when a
+		 * host has a composer to quote into and not otherwise. There is no
+		 * separate boolean, deliberately: this menu mounts in one place today,
+		 * and a flag whose value is always `true` beside a callback that is
+		 * always supplied is two ways to say one thing.
+		 *
+		 * It was briefly a peek-INdependent gate of its own, on the theory that
+		 * a peeking master can comment (BUG-2263) but could not act on a
+		 * selection. Measured end to end, that case does not exist: a
+		 * drag-selection in a peeking master RE-ACTIVATES it
+		 * (focus-follows-editing, PLAN-2179 DR-2), so by the time a selection
+		 * exists the master is editable again. See
+		 * `e2e/selection-comment-peek.spec.ts`, which asserts that rather than
+		 * leaving it as folklore.
+		 */
+		onComment?: (markdown: string) => boolean;
 	} = $props();
 
 	let visible = $state(false);
@@ -82,7 +103,9 @@
 		const topY = Math.min(coordsFrom.top, coordsTo.top);
 
 		// Estimate menu dimensions for clamping
-		const menuWidth = showForm ? 340 : 120;
+		// Two buttons when the host wired a composer — the clamp keeps the menu
+		// on screen, so an under-estimate lets it hang off the edge.
+		const menuWidth = showForm ? 340 : (onComment ? 210 : 120);
 		const menuHeight = 40;
 		const padding = 8;
 
@@ -104,6 +127,21 @@
 		title = '';
 		errorMsg = '';
 		creating = false;
+	}
+
+	/**
+	 * Quote the selection into the host's comment composer (IDEA-2843).
+	 *
+	 * The selection is NOT consumed — unlike Extract, which replaces it with a
+	 * wiki-link, quoting leaves the document untouched, so a reader can quote
+	 * the same passage into a second comment or keep reading from where they
+	 * were.
+	 */
+	function quoteSelection() {
+		const text = selectedText.trim();
+		if (!text || !onComment) return;
+		onComment(toBlockquote(text));
+		hide();
 	}
 
 	function openForm() {
@@ -262,6 +300,21 @@
 		<div class="bubble-arrow"></div>
 
 		{#if !showForm}
+			{#if onComment}
+				<!-- The visible label is "Comment" (a bubble menu has no room for
+				     more), but the ACCESSIBLE name says what it acts on: the comment
+				     composer's submit button is also named "Comment", and two
+				     identically-named buttons doing different things is a real
+				     ambiguity for anyone navigating by name rather than by sight. -->
+				<button class="comment-btn" aria-label="Comment on selection" onclick={quoteSelection}>
+					<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+						<path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z" />
+					</svg>
+					Comment
+				</button>
+			{/if}
+		{/if}
+		{#if !showForm}
 			<button class="extract-btn" onclick={openForm}>
 				<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
 					<circle cx="6" cy="6" r="3" />
@@ -344,6 +397,7 @@
 		border-bottom: 1px solid var(--border);
 	}
 
+	.comment-btn,
 	.extract-btn {
 		display: flex;
 		align-items: center;
@@ -357,6 +411,7 @@
 		cursor: pointer;
 	}
 
+	.comment-btn:hover,
 	.extract-btn:hover {
 		background: var(--bg-hover);
 		color: var(--accent-blue);

--- a/web/src/lib/components/editor/EditorBubbleMenu.svelte
+++ b/web/src/lib/components/editor/EditorBubbleMenu.svelte
@@ -148,7 +148,16 @@
 		// call site at all, which made that test true and unreachable.
 		const text = editor.state.doc.textBetween(selFrom, selTo, '\n\n').trim();
 		if (!text) return;
-		onComment(toBlockquote(text));
+		// The return value is the whole reason `appendMarkdown` has one: it
+		// says "inserted" or "did nothing", and discarding it here would put
+		// the silent no-op back exactly where the handle was built to remove it
+		// (codex round 3). A false means the composer is unreachable — the
+		// timeline is filtered away, or the user cannot comment — so keep the
+		// selection and the menu, and say so.
+		if (!onComment(toBlockquote(text))) {
+			toastStore.show("Couldn't add that quote — the comment box isn't available.", 'error');
+			return;
+		}
 		hide();
 	}
 

--- a/web/src/lib/components/editor/EditorBubbleMenu.svelte
+++ b/web/src/lib/components/editor/EditorBubbleMenu.svelte
@@ -138,8 +138,16 @@
 	 * were.
 	 */
 	function quoteSelection() {
-		const text = selectedText.trim();
-		if (!text || !onComment) return;
+		if (!editor || !onComment) return;
+		// Re-extract with a PARAGRAPH separator. `selectedText` is joined with a
+		// single space (line 77) because Extract uses it as an item TITLE, where
+		// newlines would be wrong — but that join silently flattens a
+		// multi-paragraph selection into one run-on line, and a quote has to
+		// keep the shape of what was quoted. Found by codex round 1; before it,
+		// `toBlockquote`'s blank-line handling could never be reached from this
+		// call site at all, which made that test true and unreachable.
+		const text = editor.state.doc.textBetween(selFrom, selTo, '\n\n').trim();
+		if (!text) return;
 		onComment(toBlockquote(text));
 		hide();
 	}

--- a/web/src/lib/components/editor/EditorBubbleMenu.svelte
+++ b/web/src/lib/components/editor/EditorBubbleMenu.svelte
@@ -379,6 +379,14 @@
 	.bubble-menu {
 		position: fixed;
 		z-index: 40;
+		/* A ROW. The action buttons are themselves `display: flex`, so without
+		   this they are block-level and stack vertically — invisible with one
+		   action, wrong the moment there were two, and it also falsified the
+		   width/height the positioner clamps against (codex round 7). The
+		   expanded state opts out below: the extract form lays itself out. */
+		display: flex;
+		align-items: center;
+		gap: var(--space-1);
 		background: var(--bg-secondary);
 		border: 1px solid var(--border);
 		border-radius: var(--radius);
@@ -388,6 +396,7 @@
 	}
 
 	.bubble-menu.expanded {
+		display: block;
 		padding: var(--space-2) var(--space-3);
 	}
 

--- a/web/src/lib/components/editor/bubbleMenuCommentAction.svelte.test.ts
+++ b/web/src/lib/components/editor/bubbleMenuCommentAction.svelte.test.ts
@@ -151,6 +151,28 @@ describe('selection toolbar — Comment action', () => {
 		expect(quoted).toEqual(['> First paragraph here.']);
 	});
 
+	it('keeps paragraph breaks in a multi-paragraph selection', () => {
+		const quoted: string[] = [];
+		mountMenu({
+			onComment: (md) => {
+				quoted.push(md);
+				return true;
+			},
+		});
+		editor.commands.selectAll();
+		flushSync();
+		button('Comment')!.click();
+		flushSync();
+
+		// The menu's own `selectedText` joins blocks with a SINGLE SPACE,
+		// because Extract uses it as an item title where newlines would be
+		// wrong. Quoting through that would flatten two paragraphs into one
+		// run-on line — and `toBlockquote`'s blank-line handling, which has its
+		// own test, could never be reached from production at all. Found by
+		// codex round 1; this is the assertion that makes the two agree.
+		expect(quoted).toEqual(['> First paragraph here.\n>\n> Second paragraph here.']);
+	});
+
 	it('leaves the document untouched — quoting is not Extract', () => {
 		const before = editor.getHTML();
 		mountMenu({ onComment: () => true });

--- a/web/src/lib/components/editor/bubbleMenuCommentAction.svelte.test.ts
+++ b/web/src/lib/components/editor/bubbleMenuCommentAction.svelte.test.ts
@@ -1,0 +1,166 @@
+// The selection toolbar's Comment action and its gate (IDEA-2843, GitHub #1228).
+//
+// The Comment action renders when the host supplies `onComment` — a composer
+// to quote into IS the capability, so there is no separate flag. Both actions
+// then sit behind the host's editor-mutation gate.
+//
+// It was briefly gated peek-independently, on the theory that a peeking master
+// can comment (BUG-2263) but could not act on a selection. That state does not
+// exist: a drag-selection in a peeking master re-activates it
+// (focus-follows-editing), which was MEASURED in
+// `e2e/selection-comment-peek.spec.ts` rather than argued. The tests below are
+// what is left once that unreachable case is dropped.
+//
+// Driven through a REAL Tiptap editor: the toolbar's visibility is a function
+// of `selectionUpdate`, and a hand-built stub would pin the assertions to my
+// idea of when that fires rather than to when it does.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount, unmount, flushSync } from 'svelte';
+import { Editor } from '@tiptap/core';
+import StarterKit from '@tiptap/starter-kit';
+
+vi.mock('$lib/api/client', () => ({
+	api: { items: { create: vi.fn() } },
+	isPlanLimitError: () => false,
+	planLimitMessage: () => '',
+}));
+vi.mock('$lib/stores/toast.svelte', () => ({ toastStore: { show: vi.fn() } }));
+vi.mock('$lib/stores/localIndex.svelte', () => ({
+	localIndex: { scopeEpochFor: () => 0, upsert: vi.fn() },
+}));
+
+const EditorBubbleMenu = (await import('./EditorBubbleMenu.svelte')).default;
+
+const DOC = '<p>First paragraph here.</p><p>Second paragraph here.</p>';
+
+let target: HTMLDivElement;
+let editorHost: HTMLDivElement;
+let editor: Editor;
+let app: Record<string, unknown> | null = null;
+
+function mountMenu(opts: { onComment?: (markdown: string) => boolean }) {
+	target = document.body.appendChild(document.createElement('div'));
+	app = mount(EditorBubbleMenu, {
+		target,
+		props: {
+			editor,
+			wsSlug: 'ws',
+			collections: [],
+			onComment: opts.onComment,
+		},
+	}) as Record<string, unknown>;
+	flushSync();
+}
+
+/** Select "First paragraph here." — a real transaction, so the menu reacts. */
+function selectFirstParagraph() {
+	editor.commands.setTextSelection({ from: 1, to: 22 });
+	flushSync();
+}
+
+function button(name: string): HTMLButtonElement | null {
+	return Array.from(target.querySelectorAll('button')).find((b) =>
+		b.textContent?.trim().startsWith(name)
+	) as HTMLButtonElement | undefined ?? null;
+}
+
+/** The toolbar's Comment button carries a distinguishing accessible name. */
+function commentButtonLabel(): string | null {
+	return target.querySelector('.comment-btn')?.getAttribute('aria-label') ?? null;
+}
+
+beforeEach(() => {
+	document.body.innerHTML = '';
+	editorHost = document.body.appendChild(document.createElement('div'));
+	editor = new Editor({ element: editorHost, content: DOC, extensions: [StarterKit] });
+	// jsdom has no layout: `coordsAtPos` walks to a text node and calls
+	// `getClientRects`, which does not exist there. Only the menu's POSITION
+	// depends on it, and position is not what these tests are about — the
+	// gate and the quote are. Stubbing it keeps the real selection plumbing
+	// (`selectionUpdate`, `state.doc.textBetween`) intact, which is the part
+	// the assertions actually rest on.
+	vi.spyOn(editor.view, 'coordsAtPos').mockReturnValue({
+		top: 10,
+		bottom: 20,
+		left: 10,
+		right: 20,
+	});
+});
+
+afterEach(() => {
+	if (app) unmount(app as never);
+	app = null;
+	editor.destroy();
+	vi.restoreAllMocks();
+});
+
+describe('selection toolbar — Comment action', () => {
+	it('offers no Comment action when the host has no composer to quote into', () => {
+		// The menu is a generic editor component; only a host that wires
+		// `onComment` has somewhere for a quote to go. Rendering the button
+		// without one would be a control that does nothing.
+		mountMenu({});
+		selectFirstParagraph();
+
+		expect(button('Comment')).toBeNull();
+		expect(button('Extract')).not.toBeNull();
+	});
+
+	it('names the Comment button for what it acts on, not just "Comment"', () => {
+		// The comment composer's submit button is also named "Comment". Two
+		// buttons with one name and different effects is an ambiguity for
+		// anyone navigating by name — and it is what made the first end-to-end
+		// run of this feature fail on a locator rather than on behaviour.
+		mountMenu({ onComment: () => true });
+		selectFirstParagraph();
+
+		expect(commentButtonLabel()).toBe('Comment on selection');
+	});
+
+	it('shows both actions when a composer is wired', () => {
+		mountMenu({ onComment: () => true });
+		selectFirstParagraph();
+
+		expect(button('Comment')).not.toBeNull();
+		expect(button('Extract')).not.toBeNull();
+	});
+
+	it('shows nothing at all without a selection', () => {
+		// The gate that actually hides both actions is the host's — this menu
+		// only ever renders while something is selected.
+		mountMenu({ onComment: () => true });
+
+		expect(button('Comment')).toBeNull();
+		expect(button('Extract')).toBeNull();
+	});
+
+	it('hands the host a blockquote of the selected text', () => {
+		const quoted: string[] = [];
+		mountMenu({
+			onComment: (md) => {
+				quoted.push(md);
+				return true;
+			},
+		});
+		selectFirstParagraph();
+		button('Comment')!.click();
+		flushSync();
+
+		// The quote, not the raw text: asserting only "contains the passage"
+		// would pass on an implementation that dropped the blockquote entirely.
+		expect(quoted).toEqual(['> First paragraph here.']);
+	});
+
+	it('leaves the document untouched — quoting is not Extract', () => {
+		const before = editor.getHTML();
+		mountMenu({ onComment: () => true });
+		selectFirstParagraph();
+		button('Comment')!.click();
+		flushSync();
+
+		// Extract REPLACES the selection with a wiki-link. Comment must not:
+		// the reader is reading, and a passage they quote has to still be there
+		// for them to quote again or keep reading from.
+		expect(editor.getHTML()).toBe(before);
+	});
+});

--- a/web/src/lib/components/editor/bubbleMenuCommentAction.svelte.test.ts
+++ b/web/src/lib/components/editor/bubbleMenuCommentAction.svelte.test.ts
@@ -173,6 +173,19 @@ describe('selection toolbar — Comment action', () => {
 		expect(quoted).toEqual(['> First paragraph here.\n>\n> Second paragraph here.']);
 	});
 
+	it('keeps the menu and the selection when the insert fails', () => {
+		// `appendMarkdown` returns false when there is no composer to reach.
+		// Discarding that and hiding the menu would restore the exact silent
+		// no-op the handle exists to remove — the quote vanishes and the reader
+		// has no way to tell (codex round 3).
+		mountMenu({ onComment: () => false });
+		selectFirstParagraph();
+		button('Comment')!.click();
+		flushSync();
+
+		expect(button('Comment')).not.toBeNull();
+	});
+
 	it('leaves the document untouched — quoting is not Extract', () => {
 		const before = editor.getHTML();
 		mountMenu({ onComment: () => true });

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -25,6 +25,13 @@
 	import FieldEditor from '$lib/components/fields/FieldEditor.svelte';
 	import TagInput from '$lib/components/fields/TagInput.svelte';
 	import ItemTimeline from '$lib/components/timeline/ItemTimeline.svelte';
+	import TimelineEntryList from '$lib/components/timeline/TimelineEntryList.svelte';
+	import {
+		COMMENT_KINDS,
+		CHANGE_KINDS,
+		VERSION_KINDS,
+		type TimelineFeed
+	} from '$lib/components/timeline/feed';
 	import ChildItems from '$lib/components/ChildItems.svelte';
 	import BacklinksPanel from '$lib/components/BacklinksPanel.svelte';
 	import { goto } from '$app/navigation';
@@ -700,6 +707,11 @@
 	let moving = $state(false);
 	let itemLinks = $state<ItemLink[]>([]);
 	let workspaceMembers = $state<{ user_id: string; user_name: string; user_email: string; role: string }[]>([]);
+	// Mirrored out of the ONE mounted <ItemTimeline> (IDEA-2843), which now
+	// lives under the content on Details rendering comments. The Activity and
+	// Versions panels render the SAME feed through a second
+	// <TimelineEntryList> — one subscription, one composer, two views.
+	let timelineFeed = $state<TimelineFeed | undefined>(undefined);
 	let shareDialogOpen = $state(false);
 	let editCollectionOpen = $state(false);
 
@@ -5761,6 +5773,49 @@
 				{/if}
 			</div>
 		</div>
+
+		<!-- Comments, under the content (IDEA-2843 / GitHub #1228). They were
+		     reachable only through the Activity tab, which Dave called a
+		     regression: reviewing an agent-written doc means many small
+		     comments, and every one cost a trip away from the passage being
+		     commented on. TASK-2294's own spec had an activity preview on this
+		     panel; it never shipped, and this is that half.
+
+		     This is THE mounted ItemTimeline — the single owner of the fetch,
+		     the SSE subscription, pagination and every mutation. The Activity
+		     and Versions panels render the same feed from `timelineFeed`.
+
+		     {#key itemSlug}: structural containment (PLAN-2105 / TASK-2112),
+		     the same remount the timeline had inside the panel block below —
+		     it cancels in-flight loads and resets the composer on an item
+		     switch. Moving out of that block without bringing the key would
+		     have dropped the guard silently. It wraps ONLY the timeline: the
+		     collab editor above must never be keyed.
+
+		     COMMENTS/REACTIONS are per-item / per-user REST entities,
+		     side-independent, so they are NOT frozen while peeking (BUG-2263) —
+		     composer + controls stay live on the passive side. -->
+		{#key itemSlug}
+			<div id="item-comments" class="timeline-section">
+				<ItemTimeline
+					bind:feed={timelineFeed}
+					{wsSlug}
+					{username}
+					{itemSlug}
+					currentContent={item.content ?? ''}
+					items={localIndex.getAll(wsSlug)}
+					onRestore={handleVersionRestore}
+					flushBeforeRestore={flushCollabBeforeRestore}
+					itemId={item.id}
+					hostToken={attachmentHostToken}
+					collectionId={item.collection_id}
+					frozen={false}
+					restoreFrozen={peeking}
+					parentArchived={itemMatchesRef && isArchived}
+					visibleKinds={[...COMMENT_KINDS]}
+				/>
+			</div>
+		{/key}
 		</div><!-- /tab-panel Details -->
 
 		<!-- {#key itemSlug}: structural containment (PLAN-2105 / TASK-2112).
@@ -5907,10 +5962,26 @@
 		{/if}
 		</div><!-- /tab-panel Relationships -->
 
-		<!-- Unified Timeline (comments + activity + versions). ONE mounted
-		     instance serves both the Activity and Versions tabs — the
-		     visibleKinds render-filter switches with the tab, the SSE
-		     subscription and merged feed survive (PLAN-2290 Phase 4). -->
+		<!-- Activity / Versions — a SECOND VIEW of the one feed (IDEA-2843).
+		     The owning <ItemTimeline> now lives under the content on Details;
+		     this renders the same entries through `timelineFeed`, so there is
+		     still exactly one subscription and one composer. The composer is
+		     deliberately absent here — comments are on Details now.
+
+		     VERSION RESTORE stays frozen while peeking: it REST-writes this
+		     item's `items.content` directly (not via the Y.Doc applier), so on
+		     a peeking side whose Y.Doc is retained-alive a later collab flush
+		     could overwrite it — a same-item collision (Codex P1, BUG-2263).
+
+		     `note` / `decision` in the Activity filter below are the structured
+		     entries `pad item note` / `pad item decide` write into the item's
+		     fields blob. They belong to Activity, not Versions — things that
+		     happened to the record, not restore points. That whitelist is the
+		     ONLY gate on them: omitting them renders them on NEITHER tab, which
+		     is exactly how the feature shipped invisible the first time
+		     (BUG-2301). `comment` appears in NEITHER filter here, which is the
+		     move itself — it is not an omission of the BUG-2301 kind, because
+		     comments render on Details. -->
 		<div
 			class="tab-panel"
 			class:tab-hidden={activeTab !== 'activity' && activeTab !== 'versions'}
@@ -5919,38 +5990,37 @@
 			aria-label={activeTab === 'versions' ? 'Versions' : 'Activity'}
 		>
 		<div id="item-timeline" class="timeline-section">
-			<!-- Timeline COMMENTS/REACTIONS are per-item / per-user REST entities,
-			     side-independent, so they are NOT frozen while peeking (BUG-2263) —
-			     composer + controls stay live on the passive side. VERSION RESTORE is
-			     different: it REST-writes this item's `items.content` directly (not via
-			     the Y.Doc applier), so on a peeking side whose Y.Doc is retained-alive a
-			     later collab flush could overwrite it — a same-item collision. So it
-			     stays frozen: `restoreFrozen={peeking}` (Codex P1).
-
-			     `note` / `decision` in visibleKinds below are the structured entries
-			     `pad item note` / `pad item decide` write into the item's fields blob.
-			     They belong to Activity, not Versions — things that happened to the
-			     record, not restore points. That whitelist is the ONLY gate on them:
-			     omitting them there renders them on NEITHER tab, which is exactly how
-			     the feature shipped invisible the first time (BUG-2301). -->
-			<ItemTimeline
-				{wsSlug}
-				{username}
-				{itemSlug}
-				currentContent={item.content ?? ''}
-				items={localIndex.getAll(wsSlug)}
-				onRestore={handleVersionRestore}
-				flushBeforeRestore={flushCollabBeforeRestore}
-				itemId={item.id}
-				hostToken={attachmentHostToken}
-				collectionId={item.collection_id}
-				frozen={false}
-				restoreFrozen={peeking}
-				parentArchived={itemMatchesRef && isArchived}
-				visibleKinds={activeTab === 'versions'
-					? ['version']
-					: ['comment', 'activity', 'note', 'decision']}
-			/>
+			{#if timelineFeed}
+				{@const kinds: readonly string[] =
+					activeTab === 'versions' ? VERSION_KINDS : CHANGE_KINDS}
+				{@const shown = timelineFeed.entries.filter((e) => kinds.includes(e.kind))}
+				<TimelineEntryList
+					entries={shown}
+					showEmpty={timelineFeed.entries.length === 0 && !timelineFeed.loading}
+					{wsSlug}
+					{username}
+					{itemSlug}
+					currentContent={item.content ?? ''}
+					items={localIndex.getAll(wsSlug)}
+					hostToken={attachmentHostToken}
+					onRestore={handleVersionRestore}
+					flushBeforeRestore={flushCollabBeforeRestore}
+					restoreFrozen={peeking}
+				/>
+				<!-- Pagination belongs to the ONE feed, so this asks the OWNER for
+				     the next page. Without it these tabs could show older entries
+				     only by visiting Details and paging there. -->
+				{#if timelineFeed.hasMore}
+					<button
+						class="load-more-btn"
+						type="button"
+						disabled={timelineFeed.loadingMore}
+						onclick={() => timelineFeed?.loadMore()}
+					>
+						{timelineFeed.loadingMore ? 'Loading...' : 'Load more'}
+					</button>
+				{/if}
+			{/if}
 		</div>
 		</div><!-- /tab-panel Activity/Versions -->
 		{/key}

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -5870,6 +5870,8 @@
 					restoreFrozen={peeking}
 					parentArchived={itemMatchesRef && isArchived}
 					visibleKinds={[...COMMENT_KINDS]}
+					title="Comments"
+					emptyLabel="No comments yet."
 				/>
 			</div>
 		{/key}
@@ -6068,9 +6070,8 @@
 				{@const shown = timelineFeed.entries.filter((e) => kinds.includes(e.kind))}
 				<TimelineEntryList
 					entries={shown}
-					showEmpty={timelineFeed.entries.length === 0 &&
-						!timelineFeed.loading &&
-						!timelineFeed.error}
+					showEmpty={shown.length === 0 && !timelineFeed.loading && !timelineFeed.error}
+					emptyLabel={activeTab === 'versions' ? 'No versions yet.' : 'No changes yet.'}
 					{wsSlug}
 					{username}
 					{itemSlug}

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -718,6 +718,36 @@
 	// composer after a switch.
 	let timelineRef = $state<{ quoteIntoComposer: (markdown: string) => boolean } | undefined>();
 
+	/**
+	 * "Load more" for a FILTERED view (IDEA-2843, codex round 1).
+	 *
+	 * The owner's hop loop stops as soon as a page adds any entry, of ANY kind.
+	 * On a view that renders only some kinds, a page of pure comments therefore
+	 * ends the loop having added nothing here — a button that visibly does
+	 * nothing. So page until THIS view's list actually grows, or the feed runs
+	 * out.
+	 *
+	 * Bounded, and the bound is the point: each call already walks up to
+	 * MAX_EMPTY_HOPS pages inside the owner, so an unbounded loop here could
+	 * walk the whole timeline on one click. Six rounds is a visible amount of
+	 * progress without becoming a "load everything" button by accident.
+	 *
+	 * Not fixed inside the owner deliberately: it would have to know what the
+	 * OTHER view is rendering, and the two disagree by construction.
+	 */
+	const MAX_FILTERED_PAGE_ROUNDS = 6;
+	async function loadMoreForThisView(shownBefore: number) {
+		const feed = timelineFeed;
+		if (!feed) return;
+		for (let round = 0; round < MAX_FILTERED_PAGE_ROUNDS; round++) {
+			await feed.loadMore();
+			const current = timelineFeed;
+			if (!current || !current.hasMore) return;
+			const kinds: readonly string[] = activeTab === 'versions' ? VERSION_KINDS : CHANGE_KINDS;
+			if (current.entries.filter((e) => kinds.includes(e.kind)).length > shownBefore) return;
+		}
+	}
+
 	let shareDialogOpen = $state(false);
 	let editCollectionOpen = $state(false);
 
@@ -6013,6 +6043,21 @@
 		>
 		<div id="item-timeline" class="timeline-section">
 			{#if timelineFeed}
+				<!-- Loading and error are the owner's states, mirrored so this view
+				     does not render a FAILED load as an empty timeline — "no entries
+				     yet" and "the server did not answer" look identical otherwise,
+				     and only one of them is the reader's problem (codex round 1).
+
+				     Text rather than the owner's spinner: that spinner carries its
+				     own @keyframes inside ItemTimeline's scoped styles, and copying
+				     an animation across components to say one word is not worth the
+				     second copy to keep in step. -->
+				{#if timelineFeed.loading && timelineFeed.entries.length === 0}
+					<div class="feed-loading">Loading timeline...</div>
+				{/if}
+				{#if timelineFeed.error}
+					<div class="feed-error">{timelineFeed.error}</div>
+				{/if}
 				{@const kinds: readonly string[] =
 					activeTab === 'versions' ? VERSION_KINDS : CHANGE_KINDS}
 				{@const shown = timelineFeed.entries.filter((e) => kinds.includes(e.kind))}
@@ -6037,7 +6082,7 @@
 						class="load-more-btn"
 						type="button"
 						disabled={timelineFeed.loadingMore}
-						onclick={() => timelineFeed?.loadMore()}
+						onclick={() => loadMoreForThisView(shown.length)}
 					>
 						{timelineFeed.loadingMore ? 'Loading...' : 'Load more'}
 					</button>
@@ -7261,6 +7306,20 @@
 		padding: var(--space-2);
 		color: var(--text-muted);
 		font-size: 0.8rem;
+	}
+
+	.feed-loading {
+		padding: var(--space-4);
+		color: var(--text-muted);
+		font-size: 0.9em;
+	}
+
+	.feed-error {
+		padding: var(--space-3);
+		background: color-mix(in srgb, var(--accent-red) 12%, transparent);
+		border-radius: var(--radius);
+		color: var(--accent-red);
+		font-size: 0.85em;
 	}
 
 	/* Timeline */

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -712,6 +712,12 @@
 	// Versions panels render the SAME feed through a second
 	// <TimelineEntryList> — one subscription, one composer, two views.
 	let timelineFeed = $state<TimelineFeed | undefined>(undefined);
+	// The owning <ItemTimeline>, so the selection toolbar can quote into its
+	// composer (IDEA-2843). Rebinds on the comments section's {#key itemSlug}
+	// remount, which is what keeps a quote from landing in the previous item's
+	// composer after a switch.
+	let timelineRef = $state<{ quoteIntoComposer: (markdown: string) => boolean } | undefined>();
+
 	let shareDialogOpen = $state(false);
 	let editCollectionOpen = $state(false);
 
@@ -5756,12 +5762,27 @@
 					{/if}
 					{#if mutationsEnabled}
 						<!-- Editor mutation UI — gated on the master-freeze predicate
-						     (TASK-2172): a peeking master shows no bubble/link popover. -->
+						     (TASK-2172): a peeking master shows no bubble/link popover.
+
+						     The Comment action (IDEA-2843) rides the SAME gate, though it
+						     writes nothing to the document. It was briefly gated
+						     peek-independently, on the theory that a peeking master can
+						     comment (BUG-2263) but could not act on a selection. That case
+						     does not exist: a drag-selection in a peeking master
+						     re-activates it (focus-follows-editing, PLAN-2179 DR-2), so
+						     there is no state where a selection exists in a frozen master.
+						     Measured, not reasoned — e2e/selection-comment-peek.spec.ts.
+
+						     Commenting also requires edit permission today, in
+						     ItemTimeline's composer gate and in the server's
+						     handleCreateComment (requireEditPermission), so this gate is
+						     not narrower than the composer's either. -->
 						<EditorBubbleMenu
 							editor={editorInstance}
 							{wsSlug}
 							collections={collectionStore.collections}
 							onItemCreated={(item, ws, epoch) => localIndex.upsert(ws, item, epoch)}
+							onComment={(markdown) => timelineRef?.quoteIntoComposer(markdown) ?? false}
 						/>
 						<EditorLinkPopover
 							editor={editorInstance}
@@ -5798,6 +5819,7 @@
 		{#key itemSlug}
 			<div id="item-comments" class="timeline-section">
 				<ItemTimeline
+					bind:this={timelineRef}
 					bind:feed={timelineFeed}
 					{wsSlug}
 					{username}

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -5817,6 +5817,20 @@
 		     side-independent, so they are NOT frozen while peeking (BUG-2263) —
 		     composer + controls stay live on the passive side. -->
 		{#key itemSlug}
+			<!-- ITEM IDENTITY PROPS ARE GATED ON itemMatchesRef (codex round 6).
+			     During an A→B navigation `item` still holds A while loadData
+			     fetches B, so itemId/collectionId would describe A while itemSlug
+			     describes B — and an attachment dropped in the composer during
+			     that window is associated with the WRONG item. Honest inputs
+			     rather than a new gate: with no itemId/collectionId,
+			     ItemTimeline's canEdit derives false and the composer hides until
+			     the identities agree.
+
+			     Pre-existing wiring, identical on main — the EXPOSURE is what
+			     changed. The composer used to sit behind the Activity tab, and
+			     tabs reset to Details on an item switch, so reaching it inside
+			     the load window took a deliberate click. It is now on the tab you
+			     land on. -->
 			<div id="item-comments" class="timeline-section">
 				<ItemTimeline
 					bind:this={timelineRef}
@@ -5828,9 +5842,9 @@
 					items={localIndex.getAll(wsSlug)}
 					onRestore={handleVersionRestore}
 					flushBeforeRestore={flushCollabBeforeRestore}
-					itemId={item.id}
+					itemId={itemMatchesRef ? item.id : undefined}
 					hostToken={attachmentHostToken}
-					collectionId={item.collection_id}
+					collectionId={itemMatchesRef ? item.collection_id : undefined}
 					frozen={false}
 					restoreFrozen={peeking}
 					parentArchived={itemMatchesRef && isArchived}

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -743,6 +743,11 @@
 			await feed.loadMore();
 			const current = timelineFeed;
 			if (!current || !current.hasMore) return;
+			// A failed page resolves rather than throwing — the owner catches and
+			// records `error` — and leaves `hasMore` true, so without this the
+			// loop would retry a dead server six times per click, silently
+			// (codex round 2).
+			if (current.error) return;
 			const kinds: readonly string[] = activeTab === 'versions' ? VERSION_KINDS : CHANGE_KINDS;
 			if (current.entries.filter((e) => kinds.includes(e.kind)).length > shownBefore) return;
 		}
@@ -6063,7 +6068,9 @@
 				{@const shown = timelineFeed.entries.filter((e) => kinds.includes(e.kind))}
 				<TimelineEntryList
 					entries={shown}
-					showEmpty={timelineFeed.entries.length === 0 && !timelineFeed.loading}
+					showEmpty={timelineFeed.entries.length === 0 &&
+						!timelineFeed.loading &&
+						!timelineFeed.error}
 					{wsSlug}
 					{username}
 					{itemSlug}

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -6035,7 +6035,10 @@
 				{@const shown = timelineFeed.entries.filter((e) => kinds.includes(e.kind))}
 				<TimelineEntryList
 					entries={shown}
-					showEmpty={shown.length === 0 && !timelineFeed.loading && !timelineFeed.error}
+					showEmpty={shown.length === 0 &&
+						!timelineFeed.loading &&
+						!timelineFeed.error &&
+						!timelineFeed.hasMore}
 					emptyLabel={activeTab === 'versions' ? 'No versions yet.' : 'No changes yet.'}
 					{wsSlug}
 					{username}

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -718,41 +718,6 @@
 	// composer after a switch.
 	let timelineRef = $state<{ quoteIntoComposer: (markdown: string) => boolean } | undefined>();
 
-	/**
-	 * "Load more" for a FILTERED view (IDEA-2843, codex round 1).
-	 *
-	 * The owner's hop loop stops as soon as a page adds any entry, of ANY kind.
-	 * On a view that renders only some kinds, a page of pure comments therefore
-	 * ends the loop having added nothing here — a button that visibly does
-	 * nothing. So page until THIS view's list actually grows, or the feed runs
-	 * out.
-	 *
-	 * Bounded, and the bound is the point: each call already walks up to
-	 * MAX_EMPTY_HOPS pages inside the owner, so an unbounded loop here could
-	 * walk the whole timeline on one click. Six rounds is a visible amount of
-	 * progress without becoming a "load everything" button by accident.
-	 *
-	 * Not fixed inside the owner deliberately: it would have to know what the
-	 * OTHER view is rendering, and the two disagree by construction.
-	 */
-	const MAX_FILTERED_PAGE_ROUNDS = 6;
-	async function loadMoreForThisView(shownBefore: number) {
-		const feed = timelineFeed;
-		if (!feed) return;
-		for (let round = 0; round < MAX_FILTERED_PAGE_ROUNDS; round++) {
-			await feed.loadMore();
-			const current = timelineFeed;
-			if (!current || !current.hasMore) return;
-			// A failed page resolves rather than throwing — the owner catches and
-			// records `error` — and leaves `hasMore` true, so without this the
-			// loop would retry a dead server six times per click, silently
-			// (codex round 2).
-			if (current.error) return;
-			const kinds: readonly string[] = activeTab === 'versions' ? VERSION_KINDS : CHANGE_KINDS;
-			if (current.entries.filter((e) => kinds.includes(e.kind)).length > shownBefore) return;
-		}
-	}
-
 	let shareDialogOpen = $state(false);
 	let editCollectionOpen = $state(false);
 
@@ -6090,7 +6055,7 @@
 						class="load-more-btn"
 						type="button"
 						disabled={timelineFeed.loadingMore}
-						onclick={() => loadMoreForThisView(shown.length)}
+						onclick={() => timelineFeed?.loadMore(kinds)}
 					>
 						{timelineFeed.loadingMore ? 'Loading...' : 'Load more'}
 					</button>
@@ -7314,6 +7279,35 @@
 		padding: var(--space-2);
 		color: var(--text-muted);
 		font-size: 0.8rem;
+	}
+
+	/* Copied from ItemTimeline, not shared: Svelte scopes styles per component,
+	   so reusing the class NAME across the boundary gets browser-default
+	   styling and nothing warns — the button just looks wrong (codex round 4).
+	   Kept as a copy rather than promoted to app.css because the button exists
+	   in exactly these two places; if a third appears, promote it. */
+	.load-more-btn {
+		display: block;
+		width: 100%;
+		padding: var(--space-2) var(--space-4);
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		color: var(--text-muted);
+		font-size: 0.85em;
+		font-weight: 500;
+		cursor: pointer;
+		text-align: center;
+	}
+
+	.load-more-btn:hover:not(:disabled) {
+		color: var(--text-primary);
+		border-color: var(--accent-blue);
+	}
+
+	.load-more-btn:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
 	}
 
 	.feed-loading {

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -5,10 +5,6 @@
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
 	import type { TimelineEntry, TimelineResponse, Item } from '$lib/types';
-	import TimelineCommentCard from './TimelineCommentCard.svelte';
-	import TimelineActivityCard from './TimelineActivityCard.svelte';
-	import TimelineVersionCard from './TimelineVersionCard.svelte';
-	import TimelineStructuredCard from './TimelineStructuredCard.svelte';
 	import { attachmentRefsIn } from '$lib/utils/commentAttachments';
 	import {
 		fetchAttachmentMetadata,
@@ -25,6 +21,7 @@
 		type LightboxImage
 	} from '$lib/attachments/events';
 	import { viewIdentity, createPaintFence } from '$lib/attachments/viewFence';
+	import TimelineEntryList from './TimelineEntryList.svelte';
 	import CommentEditor from '$lib/components/CommentEditor.svelte';
 
 	interface Props {
@@ -1168,13 +1165,6 @@
 		}
 	}
 
-	function dotClass(kind: TimelineEntry['kind']): string {
-		if (kind === 'comment') return 'dot-comment';
-		if (kind === 'version') return 'dot-version';
-		if (kind === 'note') return 'dot-note';
-		if (kind === 'decision') return 'dot-decision';
-		return 'dot-activity';
-	}
 </script>
 
 <section class="timeline">
@@ -1219,71 +1209,30 @@
 	{/if}
 
 	{#if !loading || entries.length > 0}
-		<div class="entry-list" bind:this={entryListEl}>
-			{#each visibleEntries as entry (entry.id)}
-				<div class="entry">
-					<div class="entry-rail">
-						<span class="dot {dotClass(entry.kind)}"></span>
-						<span class="line"></span>
-					</div>
-					<div class="entry-content">
-						{#if entry.kind === 'comment' && entry.comment}
-							<TimelineCommentCard
-								comment={entry.comment}
-								{wsSlug}
-								{username}
-								{items}
-								{currentUserId}
-								{canEdit}
-								{frozen}
-								{isAdmin}
-								{hostToken}
-								{attachmentResolver}
-								onDelete={handleDelete}
-								onReply={handleReply}
-								onEdit={handleEdit}
-								onReaction={handleReaction}
-								onRemoveReaction={handleRemoveReaction}
-							/>
-						{:else if entry.kind === 'activity' && entry.activity}
-							<TimelineActivityCard activity={entry.activity} />
-						{:else if entry.kind === 'version' && entry.version}
-							<TimelineVersionCard
-								version={entry.version}
-								{wsSlug}
-								{itemSlug}
-								{currentContent}
-								{onRestore}
-								{flushBeforeRestore}
-								frozen={frozen || restoreFrozen}
-							/>
-						<!-- No `&& entry.note` guard, unlike the kinds above: the card is
-						     null-safe, and a payload-less entry still occupies a rail. Requiring
-						     the payload turns a partial entry into a blank rail with no card at
-						     all, which reads as a rendering fault rather than as a thin entry. -->
-						{:else if entry.kind === 'note'}
-							<TimelineStructuredCard
-								kind="note"
-								note={entry.note}
-								actor={entry.actor}
-								createdAt={entry.created_at}
-							/>
-						{:else if entry.kind === 'decision'}
-							<TimelineStructuredCard
-								kind="decision"
-								decision={entry.decision}
-								actor={entry.actor}
-								createdAt={entry.created_at}
-							/>
-						{/if}
-					</div>
-				</div>
-			{/each}
-
-			{#if entries.length === 0 && !loading}
-				<div class="empty">No timeline entries yet.</div>
-			{/if}
-		</div>
+		<TimelineEntryList
+			bind:listEl={entryListEl}
+			entries={visibleEntries}
+			showEmpty={entries.length === 0 && !loading}
+			{wsSlug}
+			{username}
+			{items}
+			{hostToken}
+			{currentUserId}
+			{canEdit}
+			{frozen}
+			{isAdmin}
+			{attachmentResolver}
+			onDelete={handleDelete}
+			onReply={handleReply}
+			onEdit={handleEdit}
+			onReaction={handleReaction}
+			onRemoveReaction={handleRemoveReaction}
+			{itemSlug}
+			{currentContent}
+			{onRestore}
+			{flushBeforeRestore}
+			{restoreFrozen}
+		/>
 
 		{#if hasMore}
 			<button class="load-more-btn" type="button" disabled={loadingMore} onclick={loadMore}>
@@ -1380,78 +1329,6 @@
 		border-radius: var(--radius);
 		color: var(--accent-red);
 		font-size: 0.85em;
-	}
-
-	/* ── Timeline entries ─────────────────────────────────────────────────── */
-
-	.entry-list {
-		display: flex;
-		flex-direction: column;
-	}
-
-	.entry {
-		display: flex;
-		gap: var(--space-3);
-	}
-
-	.entry-rail {
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		flex-shrink: 0;
-		width: 16px;
-		padding-top: var(--space-2);
-	}
-
-	.dot {
-		width: 10px;
-		height: 10px;
-		border-radius: 50%;
-		flex-shrink: 0;
-		z-index: 1;
-	}
-
-	.dot-comment {
-		background: var(--accent-blue);
-	}
-
-	.dot-activity {
-		background: var(--text-muted);
-	}
-
-	.dot-version {
-		background: var(--accent-green);
-	}
-
-	.dot-note {
-		background: var(--accent-cyan);
-	}
-
-	.dot-decision {
-		background: var(--accent-orange);
-	}
-
-	.line {
-		width: 1px;
-		flex: 1;
-		background: var(--border);
-	}
-
-	.entry:last-child .line {
-		display: none;
-	}
-
-	.entry-content {
-		flex: 1;
-		min-width: 0;
-		padding-bottom: var(--space-3);
-	}
-
-	.empty {
-		text-align: center;
-		padding: var(--space-6);
-		color: var(--text-muted);
-		font-size: 0.9em;
 	}
 
 	.load-more-btn {

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -22,6 +22,7 @@
 	} from '$lib/attachments/events';
 	import { viewIdentity, createPaintFence } from '$lib/attachments/viewFence';
 	import TimelineEntryList from './TimelineEntryList.svelte';
+	import type { TimelineFeed } from './feed';
 	import CommentEditor from '$lib/components/CommentEditor.svelte';
 
 	interface Props {
@@ -105,9 +106,24 @@
 		 * no item_id). Defaults false → byte-identical for every existing caller.
 		 */
 		parentArchived?: boolean;
+		/**
+		 * Read-only mirror of the feed, for a SECOND view rendered elsewhere in
+		 * the DOM (IDEA-2843). Comments live under the item content while
+		 * changes and versions live in the pane's tabs, and one component
+		 * cannot be in two places — so this component stays the single owner of
+		 * fetching, SSE, pagination and mutations, and hands a host the values
+		 * a second `TimelineEntryList` needs to render from the SAME feed.
+		 *
+		 * Bound rather than fetched again: a second subscription would double
+		 * the SSE traffic and give the two views independently stale windows.
+		 * `loadMore` is included because pagination is a property of the ONE
+		 * feed — a view that can show older entries but not ask for them is a
+		 * dead end, and today both tabs page through the same cursor.
+		 */
+		feed?: TimelineFeed;
 	}
 
-	let { wsSlug, username = '', itemSlug, currentContent, items = [], onRestore, itemId, collectionId, frozen = false, restoreFrozen = false, flushBeforeRestore, visibleKinds, hostToken = '', parentArchived = false }: Props = $props();
+	let { wsSlug, username = '', itemSlug, currentContent, items = [], onRestore, itemId, collectionId, frozen = false, restoreFrozen = false, flushBeforeRestore, visibleKinds, hostToken = '', parentArchived = false, feed = $bindable() }: Props = $props();
 
 	// Resolve canEditItem reactively; falls to false if itemId/collectionId
 	// aren't supplied (e.g. an older caller). Folds in the master-freeze gate
@@ -694,6 +710,18 @@
 	 * appear rather than a spinner and nothing, and it is small so a
 	 * pathological item cannot turn one click into an unbounded request fan.
 	 */
+	// Mirror the feed out for a host-rendered second view (IDEA-2843).
+	//
+	// Writes `feed`, reads everything else — no self-write, so this cannot
+	// abort its own flush. A fresh object per change is deliberate: the host
+	// holds it in `$state`, and identity change is what tells it to re-render.
+	// `loadMore` rides along because pagination belongs to the ONE feed; a
+	// second view that can show older entries but not ask for them is a dead
+	// end, and both tabs page through the same cursor today.
+	$effect(() => {
+		feed = { entries, loading, hasMore, loadingMore, loadMore };
+	});
+
 	const MAX_EMPTY_HOPS = 5;
 
 	/**

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -1247,6 +1247,13 @@
 		     "Timeline 3" over an empty comments list — three activity entries,
 		     no comments — is a count of something the reader cannot see. -->
 		<h3 class="timeline-title">{title}</h3>
+		<!-- The `+` rides the feed-wide `hasMore`, so "Comments 1+" can appear
+		     when the only unfetched entries are activity or versions. Left as
+		     is deliberately (codex round 7): `+` reads as a LOWER BOUND, and a
+		     lower bound of 1 over exactly one comment is true. The alternative —
+		     dropping it unless more of THIS kind exist — cannot be known without
+		     fetching the rest of the feed, so it would trade a true imprecise
+		     count for a confident wrong one. -->
 		{#if visibleEntries.length > 0}
 			<span class="entry-count">{visibleEntries.length}{hasMore ? '+' : ''}</span>
 		{/if}

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -774,6 +774,11 @@
 		const reqSlug = itemSlug;
 		const reqWs = wsSlug;
 		loadingMore = true;
+		// A successful page clears a previous failure. Without this the banner
+		// outlives the problem and sits next to the entries it claims did not
+		// load — newly visible because the error is mirrored to the tabs now
+		// (codex round 6).
+		error = '';
 		try {
 			for (let hop = 0; hop < MAX_EMPTY_HOPS && nextCursor; hop++) {
 				const cursor = nextCursor;

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -754,7 +754,20 @@
 		});
 	}
 
-	async function loadMore() {
+	/**
+	 * `forKinds` is the CALLER's view filter (IDEA-2843, codex rounds 3-4).
+	 *
+	 * The hop loop below used to stop as soon as a page added any entry of any
+	 * kind. One feed now serves views that render different kinds, so a page of
+	 * pure comments ends the loop having added nothing to a changes view — a
+	 * button that visibly does nothing. Whoever pressed the button says what
+	 * counts as progress; it defaults to this component's own `visibleKinds`,
+	 * which is what its own button wants.
+	 *
+	 * MAX_EMPTY_HOPS still bounds the walk, so a filter that matches nothing
+	 * left in the feed costs a fixed number of pages, not the whole timeline.
+	 */
+	async function loadMore(forKinds?: readonly string[]) {
 		if (loadingMore || !nextCursor) return;
 		// Capture identity before the await so a switch mid-flight can't append
 		// A's older page onto B's entries (TASK-2112).
@@ -797,8 +810,14 @@
 				entries = byNewestFirst([...entries, ...newEntries]);
 				hasMore = resp.has_more;
 				nextCursor = cursorFrom(resp, entries);
-				// Stop as soon as the press produced something to look at.
-				if (newEntries.length > 0) break;
+				// Stop as soon as the press produced something THE CALLER can see.
+				// Counting every kind is what made this a dead button on a
+				// filtered view (codex rounds 3-4).
+				const wanted = forKinds ?? visibleKinds;
+				const newVisible = wanted
+					? newEntries.filter((e) => wanted.includes(e.kind))
+					: newEntries;
+				if (newVisible.length > 0) break;
 				// A cursor that did not move cannot make progress, so asking
 				// again would only repeat this request. Reachable against a
 				// server that predates next_before: the fallback re-derives
@@ -1290,7 +1309,7 @@
 		/>
 
 		{#if hasMore}
-			<button class="load-more-btn" type="button" disabled={loadingMore} onclick={loadMore}>
+			<button class="load-more-btn" type="button" disabled={loadingMore} onclick={() => loadMore()}>
 				{loadingMore ? 'Loading...' : 'Load more'}
 			</button>
 		{/if}

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -1258,7 +1258,7 @@
 		<TimelineEntryList
 			bind:listEl={entryListEl}
 			entries={visibleEntries}
-			showEmpty={entries.length === 0 && !loading}
+			showEmpty={entries.length === 0 && !loading && !error}
 			{wsSlug}
 			{username}
 			{items}

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -1285,7 +1285,7 @@
 		<TimelineEntryList
 			bind:listEl={entryListEl}
 			entries={visibleEntries}
-			showEmpty={visibleEntries.length === 0 && !loading && !error}
+			showEmpty={visibleEntries.length === 0 && !loading && !error && !hasMore}
 			{emptyLabel}
 			{wsSlug}
 			{username}

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -719,7 +719,7 @@
 	// second view that can show older entries but not ask for them is a dead
 	// end, and both tabs page through the same cursor today.
 	$effect(() => {
-		feed = { entries, loading, hasMore, loadingMore, loadMore };
+		feed = { entries, loading, error, hasMore, loadingMore, loadMore };
 	});
 
 	const MAX_EMPTY_HOPS = 5;

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -121,9 +121,13 @@
 		 * dead end, and today both tabs page through the same cursor.
 		 */
 		feed?: TimelineFeed;
+		/** Heading for this view — it renders a slice, not "the timeline". */
+		title?: string;
+		/** Empty-state line, phrased for the kinds this view renders. */
+		emptyLabel?: string;
 	}
 
-	let { wsSlug, username = '', itemSlug, currentContent, items = [], onRestore, itemId, collectionId, frozen = false, restoreFrozen = false, flushBeforeRestore, visibleKinds, hostToken = '', parentArchived = false, feed = $bindable() }: Props = $props();
+	let { wsSlug, username = '', itemSlug, currentContent, items = [], onRestore, itemId, collectionId, frozen = false, restoreFrozen = false, flushBeforeRestore, visibleKinds, hostToken = '', parentArchived = false, feed = $bindable(), title = 'Timeline', emptyLabel = 'No timeline entries yet.' }: Props = $props();
 
 	// Resolve canEditItem reactively; falls to false if itemId/collectionId
 	// aren't supplied (e.g. an older caller). Folds in the master-freeze gate
@@ -1214,9 +1218,13 @@
 
 <section class="timeline">
 	<header class="timeline-header">
-		<h3 class="timeline-title">Timeline</h3>
-		{#if entries.length > 0}
-			<span class="entry-count">{entries.length}{hasMore ? '+' : ''}</span>
+		<!-- Title and count describe what this view RENDERS, not the whole feed
+		     (IDEA-2843, codex round 3). The one feed is now split across views;
+		     "Timeline 3" over an empty comments list — three activity entries,
+		     no comments — is a count of something the reader cannot see. -->
+		<h3 class="timeline-title">{title}</h3>
+		{#if visibleEntries.length > 0}
+			<span class="entry-count">{visibleEntries.length}{hasMore ? '+' : ''}</span>
 		{/if}
 	</header>
 
@@ -1258,7 +1266,8 @@
 		<TimelineEntryList
 			bind:listEl={entryListEl}
 			entries={visibleEntries}
-			showEmpty={entries.length === 0 && !loading && !error}
+			showEmpty={visibleEntries.length === 0 && !loading && !error}
+			{emptyLabel}
 			{wsSlug}
 			{username}
 			{items}

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -1088,6 +1088,23 @@
 		clearTimeout(sseRefreshTimer);
 	});
 
+	let composerRef = $state<{ appendMarkdown: (markdown: string) => boolean } | undefined>();
+
+	/**
+	 * Push a quote into the live composer from the selection toolbar
+	 * (IDEA-2843). Forwards to `CommentEditor.appendMarkdown`, which appends
+	 * after a blank line rather than replacing an in-progress draft.
+	 *
+	 * Returns false when there is no composer to reach — the user cannot
+	 * comment, or the composer is filtered out of this view — so the caller can
+	 * report that instead of appearing to have quoted into nothing. The
+	 * toolbar's Comment action is gated on the same permission, so a false here
+	 * means the two gates have drifted apart.
+	 */
+	export function quoteIntoComposer(markdown: string): boolean {
+		return composerRef?.appendMarkdown(markdown) ?? false;
+	}
+
 	let submitting: boolean = $state(false);
 
 	// Posts a new comment. Throws on failure so CommentEditor preserves the
@@ -1214,6 +1231,7 @@
 	{#if canEdit && showComposer}
 		<div class="compose">
 			<CommentEditor
+				bind:this={composerRef}
 				{wsSlug}
 				{itemId}
 				{hostToken}

--- a/web/src/lib/components/timeline/TimelineEntryList.svelte
+++ b/web/src/lib/components/timeline/TimelineEntryList.svelte
@@ -39,6 +39,13 @@
 		 * an empty list rather than claiming the item has no history.
 		 */
 		showEmpty?: boolean;
+		/**
+		 * What to say when empty. Each view renders a different slice, so
+		 * "No timeline entries yet." is wrong on all but the whole feed — a
+		 * changes tab with no changes has not established anything about
+		 * comments (codex round 3).
+		 */
+		emptyLabel?: string;
 
 		wsSlug: string;
 		username?: string;
@@ -76,6 +83,7 @@
 		entries,
 		listEl = $bindable(),
 		showEmpty = false,
+		emptyLabel = 'No timeline entries yet.',
 		wsSlug,
 		username = '',
 		items = [],
@@ -168,7 +176,7 @@
 	{/each}
 
 	{#if showEmpty}
-		<div class="empty">No timeline entries yet.</div>
+		<div class="empty">{emptyLabel}</div>
 	{/if}
 </div>
 

--- a/web/src/lib/components/timeline/TimelineEntryList.svelte
+++ b/web/src/lib/components/timeline/TimelineEntryList.svelte
@@ -1,0 +1,245 @@
+<script lang="ts">
+	/**
+	 * The timeline's rendered entry list — rail chrome plus one card per entry
+	 * (IDEA-2843). Extracted from `ItemTimeline` unchanged, so that the SAME
+	 * list can render in two places: comments under the item content, and
+	 * changes/versions in the pane's Activity and Versions tabs.
+	 *
+	 * It is PRESENTATION ONLY. Fetching, the SSE subscription, pagination, the
+	 * attachment-metadata probe, the paint fence and every mutation stay in
+	 * `ItemTimeline`, which remains the single owner — the constraint on this
+	 * work is one subscription and one composer, and the way to keep that true
+	 * is for this component to have no data of its own.
+	 *
+	 * The comment-card callbacks are threaded rather than dispatched because
+	 * their handlers live with the data they mutate. A view that renders no
+	 * comments (the changes list) simply omits them.
+	 */
+	import type { TimelineEntry, Item } from '$lib/types';
+	import type { AttachmentMeta } from '$lib/markdown/attachments';
+	import TimelineCommentCard from './TimelineCommentCard.svelte';
+	import TimelineActivityCard from './TimelineActivityCard.svelte';
+	import TimelineVersionCard from './TimelineVersionCard.svelte';
+	import TimelineStructuredCard from './TimelineStructuredCard.svelte';
+
+	interface Props {
+		/** The entries to render — already kind-filtered by the owner. */
+		entries: TimelineEntry[];
+		/**
+		 * The list container. Bindable because the owner attaches the
+		 * delegated lightbox listeners and the imperative image-a11y pass to
+		 * it; both are about inline images in comment BODIES, so they stay
+		 * with the owner rather than moving here.
+		 */
+		listEl?: HTMLElement;
+		/**
+		 * Render the "no entries yet" line. Computed by the owner, and
+		 * deliberately NOT `entries.length === 0` here: the owner's condition
+		 * is over the WHOLE feed, so a tab that filters everything out renders
+		 * an empty list rather than claiming the item has no history.
+		 */
+		showEmpty?: boolean;
+
+		wsSlug: string;
+		username?: string;
+		items?: Item[];
+		hostToken?: string;
+
+		// Comment cards.
+		currentUserId?: string;
+		canEdit?: boolean;
+		frozen?: boolean;
+		isAdmin?: boolean;
+		attachmentResolver?: (uuid: string) => AttachmentMeta | null;
+		/**
+		 * Optional here, required by `TimelineCommentCard`. A list rendering no
+		 * comments — the changes/versions view — has nothing to hand it, so the
+		 * defaults below stand in and are never reached: a card that could call
+		 * one is a comment card, and a comment card only renders when the owner
+		 * supplied the real handlers.
+		 */
+		onDelete?: (commentId: string) => void;
+		onReply?: (commentId: string, body: string) => void | Promise<void>;
+		onEdit?: (commentId: string, body: string) => void | Promise<void>;
+		onReaction?: (commentId: string, emoji: string) => void;
+		onRemoveReaction?: (commentId: string, emoji: string) => void;
+
+		// Version cards.
+		itemSlug?: string;
+		currentContent?: string;
+		onRestore?: (item: Item) => void;
+		flushBeforeRestore?: () => Promise<void>;
+		restoreFrozen?: boolean;
+	}
+
+	let {
+		entries,
+		listEl = $bindable(),
+		showEmpty = false,
+		wsSlug,
+		username = '',
+		items = [],
+		hostToken = '',
+		currentUserId = '',
+		canEdit = false,
+		frozen = false,
+		isAdmin = false,
+		attachmentResolver,
+		onDelete = () => {},
+		onReply = () => {},
+		onEdit = () => {},
+		onReaction = () => {},
+		onRemoveReaction = () => {},
+		itemSlug = '',
+		currentContent = '',
+		onRestore,
+		flushBeforeRestore,
+		restoreFrozen = false
+	}: Props = $props();
+
+	function dotClass(kind: TimelineEntry['kind']): string {
+		if (kind === 'comment') return 'dot-comment';
+		if (kind === 'version') return 'dot-version';
+		if (kind === 'note') return 'dot-note';
+		if (kind === 'decision') return 'dot-decision';
+		return 'dot-activity';
+	}
+</script>
+
+<div class="entry-list" bind:this={listEl}>
+	{#each entries as entry (entry.id)}
+		<div class="entry">
+			<div class="entry-rail">
+				<span class="dot {dotClass(entry.kind)}"></span>
+				<span class="line"></span>
+			</div>
+			<div class="entry-content">
+				{#if entry.kind === 'comment' && entry.comment}
+					<TimelineCommentCard
+						comment={entry.comment}
+						{wsSlug}
+						{username}
+						{items}
+						{currentUserId}
+						{canEdit}
+						{frozen}
+						{isAdmin}
+						{hostToken}
+						{attachmentResolver}
+						{onDelete}
+						{onReply}
+						{onEdit}
+						{onReaction}
+						{onRemoveReaction}
+					/>
+				{:else if entry.kind === 'activity' && entry.activity}
+					<TimelineActivityCard activity={entry.activity} />
+				{:else if entry.kind === 'version' && entry.version}
+					<TimelineVersionCard
+						version={entry.version}
+						{wsSlug}
+						{itemSlug}
+						{currentContent}
+						{onRestore}
+						{flushBeforeRestore}
+						frozen={frozen || restoreFrozen}
+					/>
+				<!-- No `&& entry.note` guard, unlike the kinds above: the card is
+				     null-safe, and a payload-less entry still occupies a rail. Requiring
+				     the payload turns a partial entry into a blank rail with no card at
+				     all, which reads as a rendering fault rather than as a thin entry. -->
+				{:else if entry.kind === 'note'}
+					<TimelineStructuredCard
+						kind="note"
+						note={entry.note}
+						actor={entry.actor}
+						createdAt={entry.created_at}
+					/>
+				{:else if entry.kind === 'decision'}
+					<TimelineStructuredCard
+						kind="decision"
+						decision={entry.decision}
+						actor={entry.actor}
+						createdAt={entry.created_at}
+					/>
+				{/if}
+			</div>
+		</div>
+	{/each}
+
+	{#if showEmpty}
+		<div class="empty">No timeline entries yet.</div>
+	{/if}
+</div>
+
+<style>
+	.entry-list {
+		display: flex;
+		flex-direction: column;
+	}
+
+	.entry {
+		display: flex;
+		gap: var(--space-3);
+	}
+
+	.entry-rail {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		flex-shrink: 0;
+		width: 16px;
+		padding-top: var(--space-2);
+	}
+
+	.dot {
+		width: 10px;
+		height: 10px;
+		border-radius: 50%;
+		flex-shrink: 0;
+		z-index: 1;
+	}
+
+	.dot-comment {
+		background: var(--accent-blue);
+	}
+
+	.dot-activity {
+		background: var(--text-muted);
+	}
+
+	.dot-version {
+		background: var(--accent-green);
+	}
+
+	.dot-note {
+		background: var(--accent-cyan);
+	}
+
+	.dot-decision {
+		background: var(--accent-orange);
+	}
+
+	.line {
+		width: 1px;
+		flex: 1;
+		background: var(--border);
+	}
+
+	.entry:last-child .line {
+		display: none;
+	}
+
+	.entry-content {
+		flex: 1;
+		min-width: 0;
+		padding-bottom: var(--space-3);
+	}
+
+	.empty {
+		text-align: center;
+		padding: var(--space-6);
+		color: var(--text-muted);
+		font-size: 0.9em;
+	}
+</style>

--- a/web/src/lib/components/timeline/feed.ts
+++ b/web/src/lib/components/timeline/feed.ts
@@ -1,0 +1,56 @@
+import type { TimelineEntry } from '$lib/types';
+
+/**
+ * What a SECOND, host-rendered view of the item timeline needs (IDEA-2843).
+ *
+ * Comments render under the item content while changes and versions render in
+ * the pane's tabs, and one component cannot be in two DOM locations. So
+ * `ItemTimeline` stays the single owner of fetching, the SSE subscription,
+ * pagination and every mutation, and mirrors these values out for the host to
+ * pass to a second `TimelineEntryList`.
+ *
+ * It lives in its own module rather than being exported from the component's
+ * instance script so both sides can import the type without importing the
+ * component.
+ */
+export interface TimelineFeed {
+	entries: TimelineEntry[];
+	loading: boolean;
+	hasMore: boolean;
+	loadingMore: boolean;
+	loadMore: () => void;
+}
+
+/**
+ * Which entry kinds each view renders (IDEA-2843).
+ *
+ * These are constants rather than literals at the two mount sites because the
+ * partition carries an invariant that literals cannot state: EVERY kind must
+ * appear in at least one view. A kind omitted from all of them renders
+ * NOWHERE, silently — which is exactly how `note` / `decision` shipped
+ * invisible the first time (BUG-2301). `ALL_TIMELINE_KINDS` plus the
+ * exhaustiveness check below turn that into a build error when a new kind is
+ * added to `TimelineEntry`, and a unit test asserts the union covers it.
+ */
+export const COMMENT_KINDS = ['comment'] as const;
+export const CHANGE_KINDS = ['activity', 'note', 'decision'] as const;
+export const VERSION_KINDS = ['version'] as const;
+
+/**
+ * Every kind `TimelineEntry` admits. Adding a kind to the type without adding
+ * it here is a COMPILE error (the assignment below is checked both ways), and
+ * adding it here without routing it to a view fails the coverage test.
+ */
+export const ALL_TIMELINE_KINDS = [
+	'comment',
+	'activity',
+	'version',
+	'note',
+	'decision'
+] as const;
+
+// Both directions: a missing kind fails the first, an invented one the second.
+const _kindsAreComplete: TimelineEntry['kind'] = null as unknown as (typeof ALL_TIMELINE_KINDS)[number];
+const _kindsAreValid: (typeof ALL_TIMELINE_KINDS)[number] = null as unknown as TimelineEntry['kind'];
+void _kindsAreComplete;
+void _kindsAreValid;

--- a/web/src/lib/components/timeline/feed.ts
+++ b/web/src/lib/components/timeline/feed.ts
@@ -16,9 +16,23 @@ import type { TimelineEntry } from '$lib/types';
 export interface TimelineFeed {
 	entries: TimelineEntry[];
 	loading: boolean;
+	/**
+	 * The owner's load error. Mirrored because a second view that renders only
+	 * entries shows a FAILED load as "No timeline entries yet." — an empty
+	 * timeline and an unreachable server look identical, and the second is the
+	 * one the reader needs to know about (codex round 1).
+	 */
+	error: string;
 	hasMore: boolean;
 	loadingMore: boolean;
-	loadMore: () => void;
+	/**
+	 * Fetch the next page. Returns a promise so a FILTERED view can page until
+	 * its own list grows: the owner's hop loop stops as soon as a page adds any
+	 * entry, of any kind, so a page of pure comments ends the loop having added
+	 * nothing to the changes view (codex round 1). Pre-existing on Versions;
+	 * widened to Activity when comments moved off it.
+	 */
+	loadMore: () => Promise<void>;
 }
 
 /**

--- a/web/src/lib/components/timeline/feed.ts
+++ b/web/src/lib/components/timeline/feed.ts
@@ -26,13 +26,13 @@ export interface TimelineFeed {
 	hasMore: boolean;
 	loadingMore: boolean;
 	/**
-	 * Fetch the next page. Returns a promise so a FILTERED view can page until
-	 * its own list grows: the owner's hop loop stops as soon as a page adds any
-	 * entry, of any kind, so a page of pure comments ends the loop having added
-	 * nothing to the changes view (codex round 1). Pre-existing on Versions;
-	 * widened to Activity when comments moved off it.
+	 * Fetch the next page, telling the owner which kinds count as progress for
+	 * THIS view. Without that the owner's hop loop stops on any new entry of
+	 * any kind, so a page of pure comments ends it having added nothing to a
+	 * changes view — a button that visibly does nothing (codex rounds 1-4).
+	 * Pass the view's kinds; omit them to use the owner's own filter.
 	 */
-	loadMore: () => Promise<void>;
+	loadMore: (forKinds?: readonly string[]) => Promise<void>;
 }
 
 /**

--- a/web/src/lib/components/timeline/timelineSecondView.svelte.test.ts
+++ b/web/src/lib/components/timeline/timelineSecondView.svelte.test.ts
@@ -46,8 +46,17 @@ vi.mock('$lib/api/client', () => ({
 const ItemTimeline = (await import('./ItemTimeline.svelte')).default;
 const TimelineEntryList = (await import('./TimelineEntryList.svelte')).default;
 
+let clock = 0;
+/**
+ * `created_at` descends per entry. The pagination test needs the DERIVED
+ * cursor to move between pages — identical timestamps trip the owner's
+ * "cursor did not move" guard, which ends the hop loop for a reason that has
+ * nothing to do with what the test is about.
+ */
 function entry(kind: TimelineEntry['kind'], id: string): TimelineEntry {
-	const base = { id, kind, created_at: '2026-09-02T10:00:00Z', actor: 'alice' };
+	clock += 1;
+	const ts = new Date(Date.UTC(2026, 8, 2, 10, 0, 0) - clock * 60_000).toISOString();
+	const base = { id, kind, created_at: ts, actor: 'alice' };
 	if (kind === 'comment') {
 		return {
 			...base,
@@ -190,6 +199,53 @@ describe('timeline second view — the mirrored error', () => {
 
 		expect(host.textContent).toContain('network is down');
 		expect(host.textContent).not.toContain('No timeline entries yet');
+	});
+});
+
+describe('timeline second view — filtered pagination', () => {
+	it('keeps paging until a page adds an entry THIS view renders', async () => {
+		// The hop loop used to stop on any new entry of any kind. With one feed
+		// serving views that render different kinds, a page of pure comments
+		// ended it having added nothing to a changes view — a button that
+		// visibly does nothing. Found twice by codex (rounds 1 and 4): the
+		// first fix covered the tabs and left the same class in the owner's own
+		// button, which is why the filter now travels with the request.
+		timelineListMock.mockReset();
+		timelineListMock
+			.mockResolvedValueOnce({ entries: [entry('comment', 'c1')], has_more: true } as unknown as TimelineResponse)
+			.mockResolvedValueOnce({ entries: [entry('comment', 'c2')], has_more: true } as unknown as TimelineResponse)
+			.mockResolvedValueOnce({ entries: [entry('activity', 'a9')], has_more: true } as unknown as TimelineResponse);
+
+		const state = $state<{ feed: TimelineFeed | undefined }>({ feed: undefined });
+		app = mount(ItemTimeline, {
+			target: host,
+			props: {
+				wsSlug: 'ws',
+				itemSlug: 'TASK-1',
+				itemId: 'item-a',
+				collectionId: 'coll-1',
+				currentContent: '',
+				visibleKinds: [...COMMENT_KINDS],
+				get feed() {
+					return state.feed;
+				},
+				set feed(v: TimelineFeed | undefined) {
+					state.feed = v;
+				}
+			}
+		}) as Record<string, unknown>;
+		await settle();
+
+		// A changes view asks for more. Page 2 is comments only — invisible
+		// here — so it must not end the walk.
+		await state.feed!.loadMore(CHANGE_KINDS);
+		await settle();
+
+		const kinds = state.feed!.entries.map((e) => e.kind);
+		expect(kinds).toContain('activity');
+		// Three requests: the initial load, the page that added nothing for
+		// this caller, and the one that did.
+		expect(timelineListMock).toHaveBeenCalledTimes(3);
 	});
 });
 

--- a/web/src/lib/components/timeline/timelineSecondView.svelte.test.ts
+++ b/web/src/lib/components/timeline/timelineSecondView.svelte.test.ts
@@ -161,6 +161,36 @@ describe('timeline second view — the mirrored error', () => {
 		expect(state.feed?.error).toBeTruthy();
 		expect(state.feed?.entries).toEqual([]);
 	});
+
+	it('does not claim the item has no history while reporting an error', async () => {
+		// The two states contradict each other: "No timeline entries yet" is a
+		// statement about the ITEM, and a failed load knows nothing about the
+		// item. Rendering both at once — an unguarded `showEmpty` — puts
+		// something false next to something true (codex round 2).
+		//
+		// Asserted against the MOUNTED owner's DOM rather than by re-evaluating
+		// the condition: a test that recomputes `entries.length === 0 &&
+		// !loading && !error` passes whatever the component actually renders.
+		// The second view's copy of this condition is identical, and this is
+		// the one a unit test can reach.
+		timelineListMock.mockReset();
+		timelineListMock.mockRejectedValue(new Error('network is down'));
+
+		app = mount(ItemTimeline, {
+			target: host,
+			props: {
+				wsSlug: 'ws',
+				itemSlug: 'TASK-1',
+				itemId: 'item-a',
+				collectionId: 'coll-1',
+				currentContent: ''
+			}
+		}) as Record<string, unknown>;
+		await settle();
+
+		expect(host.textContent).toContain('network is down');
+		expect(host.textContent).not.toContain('No timeline entries yet');
+	});
 });
 
 describe('timeline second view — kind routing', () => {

--- a/web/src/lib/components/timeline/timelineSecondView.svelte.test.ts
+++ b/web/src/lib/components/timeline/timelineSecondView.svelte.test.ts
@@ -202,6 +202,28 @@ describe('timeline second view — the mirrored error', () => {
 	});
 });
 
+describe('timeline second view — the composer identity gate', () => {
+	it('hides the composer when the loaded item does not match the requested one', () => {
+		// The host passes itemId/collectionId only while `itemMatchesRef`; during
+		// an A→B navigation it passes neither, and ItemTimeline must treat that
+		// as "cannot edit" rather than as a permissive default. An attachment
+		// dropped in the composer during that window would otherwise be
+		// associated with the PREVIOUS item (codex round 6).
+		app = mount(ItemTimeline, {
+			target: host,
+			props: {
+				wsSlug: 'ws',
+				itemSlug: 'TASK-2',
+				currentContent: ''
+				// itemId / collectionId deliberately absent — the A→B window.
+			}
+		}) as Record<string, unknown>;
+		flushSync();
+
+		expect(host.querySelector('.compose')).toBeNull();
+	});
+});
+
 describe('timeline second view — filtered pagination', () => {
 	it('keeps paging until a page adds an entry THIS view renders', async () => {
 		// The hop loop used to stop on any new entry of any kind. With one feed

--- a/web/src/lib/components/timeline/timelineSecondView.svelte.test.ts
+++ b/web/src/lib/components/timeline/timelineSecondView.svelte.test.ts
@@ -130,6 +130,39 @@ describe('timeline second view — the mirrored feed', () => {
 	});
 });
 
+describe('timeline second view — the mirrored error', () => {
+	it('mirrors a load FAILURE, so the second view can tell empty from broken', async () => {
+		timelineListMock.mockReset();
+		timelineListMock.mockRejectedValue(new Error('network is down'));
+
+		const state = $state<{ feed: TimelineFeed | undefined }>({ feed: undefined });
+		app = mount(ItemTimeline, {
+			target: host,
+			props: {
+				wsSlug: 'ws',
+				itemSlug: 'TASK-1',
+				itemId: 'item-a',
+				collectionId: 'coll-1',
+				currentContent: '',
+				visibleKinds: [...COMMENT_KINDS],
+				get feed() {
+					return state.feed;
+				},
+				set feed(v: TimelineFeed | undefined) {
+					state.feed = v;
+				}
+			}
+		}) as Record<string, unknown>;
+		await settle();
+
+		// Without this, a failed load reaches the Activity tab as zero entries
+		// and renders as "No timeline entries yet." — an unreachable server
+		// wearing an empty timeline's clothes (codex round 1).
+		expect(state.feed?.error).toBeTruthy();
+		expect(state.feed?.entries).toEqual([]);
+	});
+});
+
 describe('timeline second view — kind routing', () => {
 	it('renders only the kinds it is handed', () => {
 		app = mount(TimelineEntryList, {

--- a/web/src/lib/components/timeline/timelineSecondView.svelte.test.ts
+++ b/web/src/lib/components/timeline/timelineSecondView.svelte.test.ts
@@ -1,0 +1,161 @@
+// The two-view split of the item timeline (IDEA-2843, GitHub #1228).
+//
+// Comments render under the item content on Details; changes and versions
+// render in the pane's tabs. One component cannot be in two DOM locations, so
+// `ItemTimeline` stays the single owner — one fetch, one SSE subscription, one
+// composer — and MIRRORS its feed out for a second `TimelineEntryList`.
+//
+// Two properties hold the split up, and both fail SILENTLY if broken:
+//
+//  1. The mirror carries the WHOLE feed, not the owner's rendered slice. The
+//     owner renders comments only, so publishing `visibleEntries` instead of
+//     `entries` is a one-word edit that leaves Activity and Versions
+//     permanently empty with nothing to report.
+//  2. Every entry kind is routed to some view. A kind in none of the three
+//     filters renders NOWHERE — which is how `note` / `decision` shipped
+//     invisible the first time (BUG-2301).
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { flushSync, mount, unmount } from 'svelte';
+import type { TimelineEntry, TimelineResponse } from '$lib/types';
+import {
+	ALL_TIMELINE_KINDS,
+	CHANGE_KINDS,
+	COMMENT_KINDS,
+	VERSION_KINDS,
+	type TimelineFeed
+} from './feed';
+
+const timelineListMock = vi.fn<() => Promise<TimelineResponse>>();
+
+vi.mock('$lib/api/client', () => ({
+	api: {
+		timeline: { list: () => timelineListMock() },
+		comments: {
+			create: vi.fn(),
+			update: vi.fn(),
+			delete: vi.fn(),
+			addReaction: vi.fn(),
+			removeReaction: vi.fn()
+		},
+		attachments: {
+			downloadUrl: (ws: string, id: string) => `/api/v1/workspaces/${ws}/attachments/${id}`
+		}
+	}
+}));
+
+const ItemTimeline = (await import('./ItemTimeline.svelte')).default;
+const TimelineEntryList = (await import('./TimelineEntryList.svelte')).default;
+
+function entry(kind: TimelineEntry['kind'], id: string): TimelineEntry {
+	const base = { id, kind, created_at: '2026-09-02T10:00:00Z', actor: 'alice' };
+	if (kind === 'comment') {
+		return {
+			...base,
+			comment: { id, body: `comment ${id}`, created_at: base.created_at, user_id: 'u1' }
+		} as unknown as TimelineEntry;
+	}
+	if (kind === 'activity') {
+		return { ...base, activity: { id, action: 'updated', created_at: base.created_at } } as unknown as TimelineEntry;
+	}
+	if (kind === 'version') {
+		return { ...base, version: { id, version: 2, created_at: base.created_at } } as unknown as TimelineEntry;
+	}
+	return { ...base, [kind]: { body: `${kind} body` } } as unknown as TimelineEntry;
+}
+
+const FEED: TimelineEntry[] = [
+	entry('comment', 'c1'),
+	entry('activity', 'a1'),
+	entry('version', 'v1'),
+	entry('note', 'n1'),
+	entry('decision', 'd1')
+];
+
+let host: HTMLDivElement;
+let app: Record<string, unknown> | null = null;
+
+beforeEach(() => {
+	document.body.innerHTML = '';
+	host = document.body.appendChild(document.createElement('div'));
+	timelineListMock.mockReset();
+	timelineListMock.mockResolvedValue({ entries: FEED, has_more: false } as unknown as TimelineResponse);
+});
+
+afterEach(() => {
+	if (app) unmount(app as never);
+	app = null;
+	vi.restoreAllMocks();
+});
+
+async function settle() {
+	for (let i = 0; i < 8; i++) {
+		await Promise.resolve();
+		flushSync();
+	}
+}
+
+describe('timeline second view — the mirrored feed', () => {
+	it('mirrors the WHOLE feed, not the kinds the owner renders', async () => {
+		const state = $state<{ feed: TimelineFeed | undefined }>({ feed: undefined });
+		app = mount(ItemTimeline, {
+			target: host,
+			props: {
+				wsSlug: 'ws',
+				itemSlug: 'TASK-1',
+				itemId: 'item-a',
+				collectionId: 'coll-1',
+				currentContent: '',
+				// The owner renders comments only — exactly as ItemDetail mounts it.
+				visibleKinds: [...COMMENT_KINDS],
+				get feed() {
+					return state.feed;
+				},
+				set feed(v: TimelineFeed | undefined) {
+					state.feed = v;
+				}
+			}
+		}) as Record<string, unknown>;
+		await settle();
+
+		expect(state.feed).toBeDefined();
+		const kinds = state.feed!.entries.map((e) => e.kind).sort();
+
+		// The assertion that matters: kinds the OWNER does not render are still
+		// in the mirror. Publishing `visibleEntries` would leave this ['comment'].
+		expect(kinds).toEqual(['activity', 'comment', 'decision', 'note', 'version']);
+
+		// And pagination rides along, so a tab that shows older entries can ask
+		// for them instead of being a dead end.
+		expect(typeof state.feed!.loadMore).toBe('function');
+	});
+});
+
+describe('timeline second view — kind routing', () => {
+	it('renders only the kinds it is handed', () => {
+		app = mount(TimelineEntryList, {
+			target: host,
+			props: { entries: FEED.filter((e) => (CHANGE_KINDS as readonly string[]).includes(e.kind)), wsSlug: 'ws' }
+		}) as Record<string, unknown>;
+		flushSync();
+
+		// Three change entries, and no comment card — the composer and the
+		// comment thread belong to the Details view now.
+		expect(host.querySelectorAll('.entry').length).toBe(3);
+		expect(host.querySelector('.comment-card')).toBeNull();
+		expect(host.textContent).not.toContain('comment c1');
+	});
+
+	it('routes every kind to some view — none renders nowhere', () => {
+		const routed = new Set<string>([...COMMENT_KINDS, ...CHANGE_KINDS, ...VERSION_KINDS]);
+		const orphaned = ALL_TIMELINE_KINDS.filter((k) => !routed.has(k));
+
+		// BUG-2301's class, as a test rather than a comment: a kind in none of
+		// the three filters is invisible everywhere and nothing reports it.
+		expect(orphaned).toEqual([]);
+	});
+
+	it('keeps the three views disjoint, so nothing renders twice', () => {
+		const all = [...COMMENT_KINDS, ...CHANGE_KINDS, ...VERSION_KINDS];
+		expect(new Set(all).size).toBe(all.length);
+	});
+});

--- a/web/src/lib/utils/markdown.ts
+++ b/web/src/lib/utils/markdown.ts
@@ -572,6 +572,28 @@ export function relativeTime(dateStr: string): string {
  * Fix markdown output from tiptap-markdown which escapes [[ ]] as \[\[ \]\].
  * Must be called on getMarkdown() output before saving.
  */
+/**
+ * Wrap text as a markdown blockquote — the same thing a person typing `> `
+ * in front of each line would produce, and deliberately nothing more
+ * (IDEA-2843 / GitHub #1228).
+ *
+ * Every line is prefixed, blank lines included: an unprefixed blank line ENDS
+ * a blockquote in markdown, so quoting a two-paragraph selection without it
+ * would silently drop the second paragraph out of the quote and leave it
+ * looking like the commenter's own words. That is the whole reason this is a
+ * function rather than a template literal at the call site.
+ *
+ * Trailing whitespace on the prefix of an empty line is trimmed, so the
+ * result is what a linter-clean hand-typed quote looks like.
+ */
+export function toBlockquote(text: string): string {
+	return text
+		.replace(/\r\n?/g, '\n')
+		.split('\n')
+		.map((line) => (line.length > 0 ? `> ${line}` : '>'))
+		.join('\n');
+}
+
 export function unescapeDocLinks(markdown: string): string {
 	return markdown.replace(/\\\[\\\[([^\]]+)\\\]\\\]/g, '[[$1]]');
 }

--- a/web/src/lib/utils/toBlockquote.test.ts
+++ b/web/src/lib/utils/toBlockquote.test.ts
@@ -1,0 +1,34 @@
+// The quote grammar for the selection toolbar's Comment action (IDEA-2843).
+//
+// The triage pinned it: "the same markdown blockquote a manual quote would
+// produce, nothing new". The cases below are the ones where "prefix each line"
+// and "produce a valid blockquote" come apart.
+import { describe, it, expect } from 'vitest';
+import { toBlockquote } from './markdown';
+
+describe('toBlockquote', () => {
+	it('prefixes a single line', () => {
+		expect(toBlockquote('the passage')).toBe('> the passage');
+	});
+
+	it('prefixes BLANK lines too, or the quote ends early', () => {
+		// An unprefixed blank line terminates a blockquote in markdown, so the
+		// second paragraph would render as the commenter's own words — the
+		// quote silently losing half its content while looking fine.
+		expect(toBlockquote('para one\n\npara two')).toBe('> para one\n>\n> para two');
+	});
+
+	it('emits a bare > for a blank line rather than trailing whitespace', () => {
+		expect(toBlockquote('a\n\nb')).not.toContain('> \n');
+	});
+
+	it('normalizes CRLF, so a Windows selection quotes the same', () => {
+		expect(toBlockquote('one\r\ntwo')).toBe('> one\n> two');
+	});
+
+	it('leaves markdown inside the selection alone', () => {
+		// The selection is quoted, not re-rendered: a list stays a list inside
+		// the quote rather than being escaped or flattened.
+		expect(toBlockquote('- a\n- b')).toBe('> - a\n> - b');
+	});
+});


### PR DESCRIPTION
Selecting a passage in an item's content now offers **Comment** beside Extract; it quotes the selection into the comment composer, which has moved from behind the Activity tab to under the content itself.

Both halves come from [#1228](https://github.com/PerpetualSoftware/pad/issues/1228): reviewing an agent-written doc means many small comments, and every one cost a trip away from the passage being commented on. Dave ruled the full move — comments on Details, Activity keeps changes, Versions keeps versions.

Closes #1228

## The structural problem, and what it forced

One feed now has to render in two DOM locations, and one component cannot be in two places. The constraint was one subscription and one composer, so `ItemTimeline` stays the **single owner** — fetch, SSE, pagination, the attachment probe, the paint fence, every mutation — mounted under the content rendering comments, and mirrors its feed out through a bindable `feed` prop. Activity and Versions render that same feed through a second `TimelineEntryList`.

The alternatives are recorded because they look reasonable from the outside: portalling the comment section (the repo's portal helper is body-only, and re-parenting a live Tiptap composer risks selection and draft for no structural gain), and a second `ItemTimeline` (two subscriptions, two composers, two paint fences). An earlier plan to extract the whole ~900-line data layer into a store was cut after reading the render block — the thing that needs two homes is the LIST, not the data.

## Things that would have failed silently

- **The mirror carries the whole feed, not the owner's rendered slice.** The owner renders comments only, so publishing `visibleEntries` is a one-word edit that leaves both tabs permanently empty with nothing to report. Tested; the mutation fails it.
- **Kind routing is three shared constants with a compile-time exhaustiveness check.** A kind in none of the views renders NOWHERE — which is how `note`/`decision` shipped invisible the first time (BUG-2301). Adding a kind to `TimelineEntry` without routing it is now a build error or a red test.
- **`CommentEditor.appendMarkdown` is an imperative handle, not the `content` prop.** `content` is read once inside `new Editor({…})` and the component has no `$effect` syncing it, so writing it on a mounted composer is a silent no-op. A `{#key}` remount would work and would destroy an in-progress draft, which is what `doSubmit`'s identity capture (PLAN-2105 / TASK-2112) exists to protect.
- **`toBlockquote` prefixes blank lines too.** An unprefixed blank line ends a blockquote, so a two-paragraph quote would drop its second half out of the quote and leave it looking like the commenter's own words.

## Two findings that were mine, named rather than folded in

**A P1 this change WIDENED rather than wrote.** `ItemTimeline` already received the previous item's `itemId`/`collectionId` during an A→B load window — identical wiring on `main` — so an attachment dropped in the composer inside that window associates with the wrong item. It stayed latent because the composer sat behind the Activity tab and tabs reset to Details on an item switch; moving comments to Details puts it on the tab you land on. Widening a latent hole is opening one, so it is fixed here (identity props gated on `itemMatchesRef`) rather than filed for later.

**A gate that was argued for, built, measured, and dissolved.** Comment was briefly gated peek-independently, reasoning that a peeking master keeps a live composer (BUG-2263) but could not act on a selection. Measured in a browser: a drag-selection in a peeking master **re-activates it** (focus-follows-editing, PLAN-2179 DR-2), so a selection and a frozen master never coexist. The gate is back on `mutationsEnabled`, and the negative result is kept as an e2e assertion so a future change that makes selections survive the freeze turns red there instead of quietly reopening the question.

## Review and gates

Eight codex rounds, CLEAN on the eighth. 15 findings: 13 fixed, 2 declined with the reasoning written into the code (`Comments 1+` is a lower bound and knowing better means fetching the rest of the feed; the Load more button stays during an error because that is the retry affordance). Every fix carries a negative control that fails without it.

Rounds 2, 4 and 6 were each follow-through on the previous round's fix — instance fixed, class left — on defects introduced in this branch. The sweeps that closed them are in the commit messages.

- `vitest`: **119 files / 2005 tests passed**
- `svelte-check --threshold error`: **0 errors** (6 warnings, pre-existing, untouched files)
- **e2e desktop-chromium: 37 passed** across the five affected specs, against a binary built from this tree. Five specs asserted comments behind the Activity tab and are updated; `attachment-lifecycle`'s tab round-trip is preserved deliberately — its claim is that the panel is CSS-hidden rather than unmounted, so it now goes out to Activity and back.

### CI was red once, and the cause is not this branch

The first CI run failed `pane-controller.spec.ts:160` (the `j`/`k` re-target test) twice. Diagnosed from that run's trace artifacts and filed as **BUG-2848**:

At failure the pane was open on `DOC-164` while the list's first row was `DOC-168` — *"Ctrl detach alpha … just now"*, seeded by a **sibling test in the same file** (`pane-controller.spec.ts:299`). The suite runs `fullyParallel: true` against one shared workspace and the list is SSE-live, so the sibling's insert landed above the clicked row mid-test; `j` then moved the cursor onto `DOC-164`, the item already open, and `?item=` correctly did not change. The pane-follow logic is fine — the test asserts a property of a list it does not control.

The failing DOM snapshot **contains this PR's UI** (the relocated composer is in it) and the failure is explained without reference to any of it. Two other hypotheses were tested and refuted rather than left open: the composer stealing focus (`document.activeElement` is `BODY` before and after the keypress, never in the composer) and a same-second ordering tie-break (60 seeded docs / 180 rendered rows, 3/3 pass). Isolation is 10/10.

A re-run on the same SHA went green and the tip is now **7/7**, but the trace is the diagnosis; the green re-run is only consistent with it.

Separately, **BUG-2849**: capstone's `stale back-settle` test fails ~1 in 4 on **unmodified `origin/main`** under the same parallel load (vs 1 in 3 here), so it is pre-existing and environmental. Filed with the runs as evidence and explicitly NOT diagnosed — I did not open its trace.

https://claude.ai/code/session_011Q4b1iHtJtSyMs7BA2ySxo
