### PR TITLE
fix(web): the sidebar footer's Settings label wrapped once the GitHub link joined the row (BUG-2844)

### DIFF
--- a/web/e2e/sidebar-footer-row.spec.ts
+++ b/web/e2e/sidebar-footer-row.spec.ts
@@ -1,0 +1,115 @@
+import { test, expect } from './fixtures';
+import type { Page } from '@playwright/test';
+
+/**
+ * BUG-2844 — the sidebar footer's Settings entry must not wrap.
+ *
+ * WHY THIS IS AN E2E TEST AND NOT A COMPONENT TEST. The defect is a layout
+ * outcome: five controls in 235px of usable row, and the Settings label
+ * breaking onto a second line when it no longer fits. jsdom performs no
+ * layout, so a vitest render of Sidebar.svelte reports the same geometry
+ * whether the bug is present or not. Only a real engine can answer it.
+ *
+ * WHAT IT ASSERTS, and why not the row's height. Height would grow for other
+ * reasons — a taller control, a changed line-height — so a height assertion
+ * would fail for changes that are not this bug and pass for a wrap that
+ * happened to keep the height. The discriminating observable is how many LINE
+ * BOXES the label occupies: Range.getClientRects() returns one rect per line,
+ * so the count IS the question, and a wrap is the only thing that makes it two.
+ *
+ * BOTH SUPPORTED WIDTHS, because the arithmetic differs and only one was ever
+ * broken. Desktop is 260px of sidebar and carries five controls; below the
+ * 768px breakpoint it is 280px AND drops the collapse button, so the same row
+ * has four controls and 60px more for the label. Measured before the fix: two
+ * line boxes on desktop, one on mobile. A desktop-only test would pass on a
+ * change that broke the mobile arm, and vice versa.
+ */
+
+const DESKTOP = { width: 1280, height: 900 };
+// Below the --sidebar-width breakpoint (max-width: 768px).
+const MOBILE = { width: 700, height: 900 };
+
+/**
+ * Counts the line boxes the Settings label occupies.
+ *
+ * Distinct `top` values rather than rect count: a single line can yield
+ * several rects when the content has multiple text nodes or inline children,
+ * and counting those would report a wrap that is not there.
+ */
+async function settingsLineBoxes(page: Page): Promise<number> {
+	return page.evaluate(() => {
+		const settings = document.querySelector('.sidebar-footer .footer-row .settings-btn');
+		if (!settings) return -1;
+		const range = document.createRange();
+		range.selectNodeContents(settings);
+		const tops = [...range.getClientRects()]
+			.filter((r) => r.width > 0 && r.height > 0)
+			.map((r) => Math.round(r.top));
+		return new Set(tops).size;
+	});
+}
+
+async function openSidebarIfDrawer(page: Page, width: number) {
+	if (width > 768) return;
+	// On mobile the sidebar is a drawer and starts closed; its footer is
+	// off-screen until opened, and measuring it closed reports a geometry no
+	// user ever sees.
+	const toggle = page.locator('button[aria-label*="idebar" i]').first();
+	if (await toggle.count()) {
+		await toggle.click().catch(() => {});
+	}
+}
+
+for (const [name, viewport] of [
+	['desktop', DESKTOP],
+	['mobile', MOBILE]
+] as const) {
+	test(`sidebar footer: the Settings label stays on one line (${name})`, async ({
+		page,
+		fixture
+	}) => {
+		await page.setViewportSize(viewport);
+		await page.goto(`/${fixture.adminUsername}/${fixture.workspaceSlug}`);
+		await openSidebarIfDrawer(page, viewport.width);
+
+		const row = page.locator('.sidebar-footer .footer-row');
+		await expect(row).toBeVisible();
+
+		// PREMISE FIRST: the row must actually hold the control this bug is
+		// about. Without this the test passes trivially on a build where the
+		// GitHub link — the control whose 32px pushed the label over the edge
+		// (IDEA-2711) — was removed or never rendered.
+		await expect(row.locator('.settings-btn')).toBeVisible();
+		await expect(row.locator('.github-btn')).toBeVisible();
+
+		expect(await settingsLineBoxes(page)).toBe(1);
+	});
+}
+
+/**
+ * The row's own layout, pinned because the fix depends on it.
+ *
+ * `.settings-btn` is the only shrinkable item, which is what makes every pixel
+ * recovered from the gaps land in the label. If another control loses its
+ * `flex-shrink: 0` the row starts distributing shrink elsewhere and the
+ * headroom this fix bought silently drains — a change that would not fail the
+ * line-box assertions until it had gone far enough to wrap again.
+ */
+test('sidebar footer: Settings is the only shrinkable control in the row', async ({
+	page,
+	fixture
+}) => {
+	await page.setViewportSize(DESKTOP);
+	await page.goto(`/${fixture.adminUsername}/${fixture.workspaceSlug}`);
+	await expect(page.locator('.sidebar-footer .footer-row')).toBeVisible();
+
+	const shrinkable = await page.evaluate(() => {
+		const row = document.querySelector('.sidebar-footer .footer-row');
+		if (!row) return null;
+		return [...row.children]
+			.filter((c) => getComputedStyle(c).flexShrink !== '0')
+			.map((c) => c.className.split(' ')[0]);
+	});
+
+	expect(shrinkable).toEqual(['settings-btn']);
+});

--- a/web/src/lib/components/layout/Sidebar.svelte
+++ b/web/src/lib/components/layout/Sidebar.svelte
@@ -1203,10 +1203,36 @@
 		font-size: 0.85em;
 	}
 	.search-btn:hover { background: var(--bg-hover); color: var(--text-secondary); }
+	/*
+		BUG-2844. The gap and the Settings padding are both one step tighter
+		than the rest of this file's spacing, and that is deliberate rather
+		than taste: this row holds five controls in 235px of usable width, and
+		it did not fit.
+
+		MEASURED, on the desktop sidebar (--sidebar-width: 260px, less the
+		24px of .sidebar-inner padding):
+
+		  before  .settings-btn box 75px, content 51px after its 12px padding;
+		          the label "⚙ Settings" needs 56.3px (measured on the mobile
+		          arm, where it fits on one line). 5.3px short, so the gear and
+		          the word landed on separate lines and the row grew from
+		          33.9px to 51.7px.
+
+		Four 32px controls and four gaps are fixed cost; .settings-btn is the
+		only flex:1 item, so every pixel recovered from the gaps lands in it.
+		space-2 -> space-1 returns 16px and the padding another 8px, giving a
+		75px content box against 56.3px of text — a 33% margin rather than the
+		5% a single change would have left.
+
+		Only the DESKTOP arm was ever broken. Below 768px the sidebar is 280px
+		AND the collapse button is gone, so the row carries four controls in
+		255px and the label had 135px to itself; it measured one line box
+		before this change and still does.
+	*/
 	.footer-row {
 		display: flex;
 		align-items: center;
-		gap: var(--space-2);
+		gap: var(--space-1);
 		margin-top: var(--space-2);
 	}
 	.settings-btn {
@@ -1214,7 +1240,9 @@
 		display: flex;
 		align-items: center;
 		gap: var(--space-2);
-		padding: var(--space-2) var(--space-3);
+		/* Horizontal padding matches the icon controls beside it — see the
+		   measurement on .footer-row for why it is not var(--space-3). */
+		padding: var(--space-2);
 		border-radius: var(--radius);
 		color: var(--text-muted);
 		font-size: 0.85em;
@@ -1227,6 +1255,11 @@
 		display: inline-flex;
 		align-items: center;
 		justify-content: center;
+		/* flex-shrink: 0 like every other control in this row. It was the only
+		   one without it; harmless today because its automatic minimum size
+		   equals its 32px content box, but it made the row's one shrinkable
+		   item ambiguous, and .settings-btn is meant to be that item. */
+		flex-shrink: 0;
 		padding: var(--space-2);
 		border-radius: var(--radius);
 		color: var(--text-muted);


### PR DESCRIPTION
Closes BUG-2844. The regression Dave spotted right after PR #1229 shipped the footer GitHub link (IDEA-2711).

## The five pixels

The desktop sidebar is 260px, less 24px of `.sidebar-inner` padding — so the footer row has **235px**. Four 32px controls and four 8px gaps are fixed cost; `.settings-btn` is the only `flex: 1` item and gets what is left.

| | before | after |
|---|---|---|
| `.settings-btn` box | 75px | 91px |
| its content box | 51px | 75px |
| `"⚙ Settings"` needs | 56.3px | 56.3px |
| line boxes | **2 — wrapped** | 1 |
| row height | 51.72px | 33.86px |

Five pixels short. They arrived with the GitHub link: a 32px control plus a fifth gap took 40px out of a box that had about 22px of slack.

`space-2` → `space-1` on the row returns 16px and the Settings padding another 8px, all of which lands in the one shrinkable item — a 33% margin rather than the 5% either change alone would have left.

`.github-btn` also gains `flex-shrink: 0`, which every other control in the row already had. Harmless today, since its automatic minimum equals its 32px content box, but it made the row's one shrinkable item ambiguous and `.settings-btn` is meant to be that item.

## Only the desktop arm was ever broken

Below 768px the sidebar is 280px **and** the collapse button is gone, so the row carries four controls in 255px and the label had 135px to itself. One line box before this change, one after.

That is worth more than a footnote: **both mobile legs of the new spec pass against the unfixed CSS.** A test that failed everywhere would not be telling us it found this bug.

## Why an e2e spec

jsdom performs no layout, so a vitest render of `Sidebar.svelte` reports identical geometry with and without the defect. Only a real engine can answer it.

It asserts **line boxes**, not row height. Height grows for unrelated reasons and could stay put through a wrap; `Range.getClientRects()` returns one rect per line, so the count *is* the question. Distinct `top` values rather than rect count, since one line can yield several rects.

Counterfactual, run against the three declarations reverted:

```
✘ the Settings label stays on one line (desktop)   Expected: 1  Received: 2
✘ Settings is the only shrinkable control          Expected -0  Received +1
✓ the Settings label stays on one line (mobile)
```

The spec also pins its own premise — it fails if `.github-btn` is absent — so it cannot pass trivially on a build where the control that caused the bug was removed.

## How it was measured

The `:7777` dev server binds the LAN IP, so vite's hardcoded loopback proxy cannot reach it, and reading the developer's credentials was denied. Rather than route around either, the measurement ran against a self-contained instance on its own port with its own database and its own bootstrapped admin.

One thing that nearly produced a wrong result: after rebuilding, the numbers were unchanged. The old rig had survived a `pkill -f "pad server start"` — its argv is `pad-2844 server start`, so the pattern never matched — and the new process failed to bind and exited. Comparing the **served** asset hash against the one on disk is what caught it; the exit codes were all clean.

## Gates

web unit tests 115 files / 1978 tests green · `svelte-check` 0 errors (6 warnings pre-existing, in files this does not touch) · `go build ./...` · `go vet ./...` · new e2e spec 6/6 across both projects. The full Go suite was **not** re-run locally — no Go file changed — and CI covers it; naming the narrowing rather than reporting a leg I did not run.

## One thing for the reviewer to rule on, not a blocker

The row now has about 19px of headroom. A sixth control in it would spend that again, and the next person would be back here. If that comes up, the question is whether Settings keeps its label — which is a design change, not a spacing fix.

https://claude.ai/code/session_01B8Zo3gigqCJnDodciPd9kr
