### PR TITLE
chore(deps): bump golang.org/x/crypto to v0.56.0 to unblock CI (BUG-2851)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/trustelem/zxcvbn v1.0.1
 	go.yaml.in/yaml/v4 v4.0.0-rc.6
-	golang.org/x/crypto v0.55.0
+	golang.org/x/crypto v0.56.0
 	golang.org/x/image v0.45.0
 	golang.org/x/term v0.45.0
 	golang.org/x/text v0.41.0

--- a/go.sum
+++ b/go.sum
@@ -586,8 +586,8 @@ golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.19.0/go.mod h1:Iy9bg/ha4yyC70EfRS8jz+B6ybOBKMaSxLj6P6oBDfU=
-golang.org/x/crypto v0.55.0 h1:+KWHjbgOaAQ66dh/YlkZKHlz9ZUlq61AFirAR9ntP8M=
-golang.org/x/crypto v0.55.0/go.mod h1:uq0V9dE/fzQuJtbnL+2EhWOE63vo164FY8xqEnV9xis=
+golang.org/x/crypto v0.56.0 h1:GUh5Ii4J5jtcseSMiRqr1jXCNHoxjeV9Fmekc2oLy6Y=
+golang.org/x/crypto v0.56.0/go.mod h1:OMW5y6CY9l38uPLmxU6l6pwcXp1obtLo3e6gT7gQR2I=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -61,13 +61,7 @@ buildGoModule {
 
   # Update alongside go.sum. Regenerate via:
   #   nix build .#default 2>&1 | grep -A2 'got:'
-  #
-  # PLACEHOLDER — this build is EXPECTED TO FAIL, and the failure is how the
-  # real hash is obtained. There is no nix on the box this was bumped from, so
-  # the value below comes from CI's own mismatch message on the first push of
-  # this branch. Replaced in the following commit; if you are reading this on
-  # main, something went wrong.
-  vendorHash = lib.fakeHash;
+  vendorHash = "sha256-8L7gH7Yy5+Fig3wK2SPLYSJjcY9nF/jumQ7PATJ3RIE=";
 
   subPackages = [ "cmd/pad" ];
 

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -61,7 +61,13 @@ buildGoModule {
 
   # Update alongside go.sum. Regenerate via:
   #   nix build .#default 2>&1 | grep -A2 'got:'
-  vendorHash = "sha256-vvIPEwTl0uU7y/L45GQuAeueUGj8kxUYh78NIMeT8po=";
+  #
+  # PLACEHOLDER — this build is EXPECTED TO FAIL, and the failure is how the
+  # real hash is obtained. There is no nix on the box this was bumped from, so
+  # the value below comes from CI's own mismatch message on the first push of
+  # this branch. Replaced in the following commit; if you are reading this on
+  # main, something went wrong.
+  vendorHash = lib.fakeHash;
 
   subPackages = [ "cmd/pad" ];
 


### PR DESCRIPTION
Closes BUG-2851, and unblocks the merge queue.

Two advisories published today at **19:12:04Z**:

- **GO-2026-6354** (CVE-2026-78662) — DoS on a deadlocked *undecided* channel in `golang.org/x/crypto/ssh`
- **GO-2026-6355** (CVE-2026-56855) — DoS on a deadlocked *established* channel in the same package

Both fixed in `golang.org/x/crypto` **v0.56.0**; we pinned **v0.55.0**.

Per the lead's ruling: **the bump, not an entry in `nix/accepted-advisories.txt`.**

## The failure is intermittent, which is the interesting part

No diff is responsible — `main` passed the same check on an identical dependency tree. But it is not a clean threshold either. Three Nix runs, all on the same Go dependencies:

| commit | Nix started | result |
|---|---|---|
| `704ba874` (main) | 19:29:16 | success |
| `7a7e9d66` (a branch based on it) | 19:45:45 | **success** |
| `9aa93f4f` | 19:49:37 | **failure** |

The middle two **overlapped**. `govulncheck` is installed per job and queries `vuln.go.dev` at scan time, near the end of the run, so those two scans were about four minutes apart — either side of whatever database or CDN refresh made the advisories visible to a given runner.

So a re-run can go green without anything being fixed. That is harder to reason about than a consistent failure, and it is why an exception entry would have been the worse answer: it would have left a check that disagrees with itself.

## Neither advisory is reachable in the artifact

Why this is a CI unblock and not a security incident:

```
$ go list -deps ./cmd/pad | grep -c golang.org/x/crypto/ssh
0
$ go mod why -m golang.org/x/crypto
github.com/PerpetualSoftware/pad/internal/server
golang.org/x/crypto/bcrypt
```

pad links `bcrypt`. Nothing reaches the `ssh` package. `nix/vulnscan.sh` runs `govulncheck -mode binary`, which is call-graph-precise only when the artifact carries symbol information and otherwise falls back to **module-level** reporting — the same shape as the nine advisories already on the accepted list.

The fix is worth taking on its merits — a real upstream fix, minimal diff — not because we were exposed.

## The diff

One line in `go.mod`, two in `go.sum`, no transitive drag, plus `nix/package.nix`'s `vendorHash`, which any `go.mod` change invalidates.

## About the two commits

There is no nix on the machine this was bumped from — no `/nix`, nothing on `PATH` — so `package.nix`'s own documented regeneration command (`nix build .#default 2>&1 | grep -A2 'got:'`) is unavailable locally and **CI's mismatch message is the only source for the hash**.

The first commit therefore carries `lib.fakeHash` and its Nix run **is expected to fail**; the second carries the real hash taken from that run. Split rather than amended so the provenance is legible: the hash came from a build, not a guess.

## Gates

Go suite on **both dialects**, `make lint`, `go build`, `go vet` — plus `Nix build & check` green on the final tip, which is the one that matters here and is the whole point of the unit.

## For whoever rebases

`#1234` and `#1235` both rebase onto this once it lands. Separately, `main`'s E2E is red at `704ba874` for an unrelated pre-existing reason — `pane-content-link-anchors.spec.ts`, the cross-spec SSE toast flake (BUG-2334), 193 passed / 1 failed. Do not bundle the two.

https://claude.ai/code/session_01B8Zo3gigqCJnDodciPd9kr
