### PR TITLE
fix(web): capture the pane-follow target at keypress, not when the timer fires (BUG-2848)

### DIFF
--- a/web/e2e/pane-follow-live-list.spec.ts
+++ b/web/e2e/pane-follow-live-list.spec.ts
@@ -1,0 +1,142 @@
+import { test, expect } from './fixtures';
+import { browserLogin, seedDoc } from './lib/collab-helpers';
+import type { Page } from '@playwright/test';
+import type { SuiteFixture } from './fixtures';
+
+/**
+ * BUG-2848 — j/k must survive items arriving in a live list.
+ *
+ * The pane-follow is debounced by `PANE_FOLLOW_DEBOUNCE_MS` (140). It used to
+ * re-read `filteredItems[focusedIndex]` when the timer fired, which made a
+ * keypress depend on the list holding still for those 140 ms. This list is
+ * SSE-live and does not: an item arriving during the debounce shifts every
+ * index below it, the paned item slides down onto the advanced index, and the
+ * callback then finds "the focused row is already the paned item" and returns.
+ * The keystroke is discarded silently — no cursor move, no re-target, nothing
+ * to see.
+ *
+ * WHY THIS SPEC EXISTS SEPARATELY from pane-controller.spec.ts: that file's
+ * regression test asserts the same behaviour but cannot cause the race, so it
+ * only catches this when a SIBLING test's seed happens to land in the window —
+ * which is how it was found (an intermittent failure blamed on shared-workspace
+ * pollution, BUG-2848 as originally filed). This one CAUSES the insert, so the
+ * property is tested rather than waited for.
+ *
+ * THE THREE ASSERTIONS ARE NOT REDUNDANT, and the third is the reason the
+ * original diagnosis was wrong:
+ *
+ *   retargeted   the pane moved off the row that was open
+ *   cursorMoved  the list cursor actually moved across the keypress
+ *   intended     the pane landed on the row that was BELOW the cursor at
+ *                keypress time, identified by ref rather than by position
+ *
+ * `retargeted` alone passes if the pane wanders anywhere. `cursorMoved` alone
+ * passes if the cursor moves and the pane ignores it. A tempting fourth —
+ * "the pane agrees with the focused row" — passes VACUOUSLY on the bug, because
+ * cursor and pane are then both stuck on the opened row; it was measured doing
+ * exactly that and is deliberately not used.
+ */
+
+const DESKTOP = { width: 1200, height: 900 };
+
+// Three rounds. One round caught the unfixed build 11 times in 12; three make a
+// false green (~1 in 1700) not worth reasoning about, and the test still runs
+// in a couple of seconds.
+const ROUNDS = 3;
+
+function docsUrl(fixture: SuiteFixture, query = ''): string {
+	return `/${fixture.adminUsername}/${fixture.workspaceSlug}/docs${query}`;
+}
+
+function openItemParam(page: Page): string | null {
+	return new URL(page.url()).searchParams.get('item');
+}
+
+/** Refs of the rendered rows, in order. */
+async function rowRefs(page: Page): Promise<string[]> {
+	return page.evaluate(() =>
+		[...document.querySelectorAll('.item-card')].map(
+			(a) => ((a as HTMLAnchorElement).getAttribute('href') ?? '').split('/').pop() ?? '',
+		),
+	);
+}
+
+/** Ref of the row carrying the list cursor. `.focused` is a documented hook. */
+async function focusedRef(page: Page): Promise<string | null> {
+	return page.evaluate(() => {
+		const el = document.querySelector('.item-card.focused') as HTMLAnchorElement | null;
+		if (!el) return null;
+		return (el.getAttribute('href') ?? '').split('/').pop() ?? null;
+	});
+}
+
+test.describe('pane-follow over a live list (BUG-2848)', () => {
+	test.beforeEach(({}, testInfo) => {
+		test.skip(
+			testInfo.project.name !== 'desktop-chromium',
+			'pane-follow is viewport-agnostic; the desktop split project is enough',
+		);
+	});
+
+	test('j re-targets the pane even when rows arrive during the follow debounce', async ({
+		page,
+		fixture,
+		request,
+	}) => {
+		await page.setViewportSize(DESKTOP);
+		await browserLogin(page);
+		await seedDoc(fixture, request, 'Follow race base one');
+		await seedDoc(fixture, request, 'Follow race base two');
+		await page.goto(docsUrl(fixture, '?view=list'));
+
+		const firstRow = page.locator('.item-card').first();
+		await expect(firstRow).toBeVisible();
+		await firstRow.click();
+		await expect(page.locator('.item-pane')).toBeVisible();
+
+		for (let round = 1; round <= ROUNDS; round++) {
+			const openedBefore = openItemParam(page);
+			expect(openedBefore, `round ${round}: pane should be open`).not.toBeNull();
+
+			const rowCount = (await rowRefs(page)).length;
+
+			// Put a row above the cursor and wait for it to actually render, so
+			// the keypress starts from the shifted list rather than racing the
+			// first insert.
+			await seedDoc(fixture, request, `Follow race intruder ${round}`);
+			await expect
+				.poll(async () => (await rowRefs(page)).length, { timeout: 15000 })
+				.toBeGreaterThan(rowCount);
+
+			// The intended target, captured BY REF at keypress time — the row
+			// below wherever the cursor is now.
+			const rowsAtKey = await rowRefs(page);
+			const cursorBefore = await focusedRef(page);
+			expect(cursorBefore, `round ${round}: the cursor should be on a row`).not.toBeNull();
+			const cursorIdx = rowsAtKey.indexOf(cursorBefore as string);
+			const intended = rowsAtKey[cursorIdx + 1] ?? null;
+			expect(intended, `round ${round}: need a row below the cursor to move onto`).not.toBeNull();
+
+			// THE RACE: a second insert lands across the keypress, inside the
+			// 140 ms debounce. Not awaited before the key — that is the point.
+			const churn = seedDoc(fixture, request, `Follow race churn ${round}`);
+			await page.keyboard.press('j');
+			await churn;
+
+			await expect
+				.poll(() => openItemParam(page), { timeout: 5000 })
+				.toBe(intended as string);
+
+			const cursorAfter = await focusedRef(page);
+			expect(cursorAfter, `round ${round}: the cursor moved across the keypress`).not.toBe(
+				cursorBefore,
+			);
+			expect(openItemParam(page), `round ${round}: the pane left the opened row`).not.toBe(
+				openedBefore,
+			);
+		}
+
+		// The pane is still a pane: the race must not have detached or closed it.
+		await expect(page.locator('.item-pane')).toBeVisible();
+	});
+});

--- a/web/e2e/pane-follow-live-list.spec.ts
+++ b/web/e2e/pane-follow-live-list.spec.ts
@@ -42,6 +42,15 @@ const DESKTOP = { width: 1200, height: 900 };
 // Three rounds. One round caught the unfixed build 11 times in 12; three make a
 // false green (~1 in 1700) not worth reasoning about, and the test still runs
 // in a couple of seconds.
+//
+// THE RACE IS PROBABILISTIC AND THE ASYMMETRY IS WHY THAT IS FINE. Nothing here
+// can guarantee the churn row's SSE update lands inside the 140 ms window —
+// there is no seam to hold it at, and adding one would put test machinery in
+// the page. But a round that MISSES the window still passes on a correct build:
+// the cursor moves, the pane follows, and the intended row is where it should
+// be. Missing the window costs POWER, not correctness, so the failure mode is a
+// false green and never a false red. Measured on the fixed build: 0 failures in
+// 12 pin runs and 6 in 6 of this spec.
 const ROUNDS = 3;
 
 function docsUrl(fixture: SuiteFixture, query = ''): string {

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -2225,11 +2225,11 @@
 		// snap-back $effect during the debounce was tried first and fixed
 		// NOTHING (12 of 12) — the stale index lands on the paned item on its
 		// own, so there is nothing for the snap-back to be blamed for.
-		const target =
+		const targetId =
 			focusedIndex >= 0 && focusedIndex < filteredItems.length
-				? filteredItems[focusedIndex]
+				? filteredItems[focusedIndex].id
 				: null;
-		if (!target) return;
+		if (!targetId) return;
 
 		cancelPaneFollow();
 		paneFollowTimer = setTimeout(() => {
@@ -2238,15 +2238,21 @@
 			// window (R14 fence-on-continuation).
 			if (!openItemRef) return;
 			if (currentPaneState().paneDepth > 0) return;
-			// The captured row must still EXIST. Identity, not index: it may
-			// have moved (an insert above), which is fine and is the point; if
-			// it was deleted during the debounce there is nothing to follow to.
-			if (!filteredItems.some((i) => i.id === target.id)) return;
+			// RE-RESOLVE BY ID, do not reuse the snapshot. What is captured is
+			// the identity; the OBJECT may be stale by the time this fires,
+			// because a rename during the debounce changes the slug and
+			// `openItemPane` builds the URL from it — an id-only existence check
+			// would pass and then navigate to a dead slug (codex round 1).
+			// Re-resolving also covers the row having MOVED, which is the whole
+			// point, while a row DELETED during the debounce has nothing to
+			// follow to and is skipped.
+			const current = filteredItems.find((i) => i.id === targetId);
+			if (!current) return;
 			// Skip if the captured row is already the paned item — avoids a
 			// redundant replaceState navigation on a same-item settle.
-			if (itemUrlId(target) === openItemRef || target.slug === openItemRef) return;
+			if (itemUrlId(current) === openItemRef || current.slug === openItemRef) return;
 			// Pane is open → openItemPane re-targets via replaceState (no push).
-			openItemPane(target);
+			openItemPane(current);
 		}, PANE_FOLLOW_DEBOUNCE_MS);
 	}
 

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -2206,6 +2206,31 @@
 		// below, since a timer armed at depth 0 can otherwise fire AFTER a drill
 		// (the R14 late-async-continuation clobber).
 		if (currentPaneState().paneDepth > 0) return;
+
+		// THE TARGET IS CAPTURED HERE, BY IDENTITY, NOT READ BACK LATER
+		// (BUG-2848). The callback used to re-read `filteredItems[focusedIndex]`
+		// when the timer fired, which made the keypress depend on the list
+		// holding still for 140 ms. It does not: this list is SSE-live, and an
+		// item arriving during the debounce shifts every index below it.
+		//
+		// The failure that produced was silent. `focusedIndex` had been advanced
+		// by the keypress; an insert above then shifted the paned item DOWN onto
+		// that very index; the callback read it back, found the focused row was
+		// already the paned item, and returned through the guard below. The
+		// cursor did not move and the pane did not re-target — a discarded
+		// keystroke with nothing to show for it.
+		//
+		// Measured on this branch with e2e/zz-pin2848.spec.ts: 11 of 12 runs lost
+		// the keypress before this change, 0 of 12 after. Suppressing the
+		// snap-back $effect during the debounce was tried first and fixed
+		// NOTHING (12 of 12) — the stale index lands on the paned item on its
+		// own, so there is nothing for the snap-back to be blamed for.
+		const target =
+			focusedIndex >= 0 && focusedIndex < filteredItems.length
+				? filteredItems[focusedIndex]
+				: null;
+		if (!target) return;
+
 		cancelPaneFollow();
 		paneFollowTimer = setTimeout(() => {
 			paneFollowTimer = null;
@@ -2213,13 +2238,15 @@
 			// window (R14 fence-on-continuation).
 			if (!openItemRef) return;
 			if (currentPaneState().paneDepth > 0) return;
-			if (focusedIndex < 0 || focusedIndex >= filteredItems.length) return;
-			const item = filteredItems[focusedIndex];
-			// Skip if the focused row is already the paned item — avoids a
+			// The captured row must still EXIST. Identity, not index: it may
+			// have moved (an insert above), which is fine and is the point; if
+			// it was deleted during the debounce there is nothing to follow to.
+			if (!filteredItems.some((i) => i.id === target.id)) return;
+			// Skip if the captured row is already the paned item — avoids a
 			// redundant replaceState navigation on a same-item settle.
-			if (itemUrlId(item) === openItemRef || item.slug === openItemRef) return;
+			if (itemUrlId(target) === openItemRef || target.slug === openItemRef) return;
 			// Pane is open → openItemPane re-targets via replaceState (no push).
-			openItemPane(item);
+			openItemPane(target);
 		}, PANE_FOLLOW_DEBOUNCE_MS);
 	}
 


### PR DESCRIPTION
Closes BUG-2848 — as the **product defect** it turned out to be, not the test-pollution flake it was filed as.

## The defect

The collection list is SSE-live. The pane-follow is debounced by `PANE_FOLLOW_DEBOUNCE_MS` (140), and its callback re-read `filteredItems[focusedIndex]` when the timer fired — which made a keystroke depend on the list holding still for those 140 ms.

It does not. And the failure was silent, which is why it read as flakiness:

1. `j` advances `focusedIndex` and schedules the follow.
2. An item arrives inside the debounce and shifts every index below it — sliding the **paned** item down onto that very index.
3. The callback reads it back, finds *"the focused row is already the paned item"*, and returns through its own guard.

No cursor move, no re-target, no error. A discarded keystroke.

**A user pressing `j` in a live list loses the keypress if any item arrives within 140 ms.**

## The fix

Capture the target **by identity** at keypress time; re-resolve the current row by id when the timer fires. A row that MOVED is followed (the point); a row DELETED during the debounce is skipped; a row RENAMED is picked up fresh, rather than navigating to a stale slug.

## Two wrong explanations first, both measured

The trail's diagnosis was that an insert leaves `focusedIndex` behind so `j` lands on the already-open row. A snap-back `$effect` re-syncs the cursor on every `filteredItems` change and prevents exactly that — a pin that waited for the row to settle passed every candidate.

So the second hypothesis was that the snap-back undoes the cursor move, and the fix was to suppress it while a follow is in flight. Measured:

| | keypress lost |
|---|---|
| baseline (unfixed) | **11 / 12** |
| suppress the snap-back | **12 / 12** |
| capture target at keypress | **0 / 12** |

Suppressing the snap-back fixed *nothing* — the stale index lands on the paned item by itself. Three properties were measured each run: the pane re-targeted, the cursor moved, and the pane landed on the row actually below the cursor.

## The test

`pane-follow-live-list.spec.ts` **causes** the race rather than waiting for it: it seeds a row above the cursor, then lands a second insert across the keypress inside the debounce. Three rounds per run.

Counterfactual against the unfixed controller: **3 of 4** desktop runs fail with the bug's signature — `Expected: "DOC-16"` (intended) vs `Received: "DOC-15"` (the row already open).

Three assertions, none redundant: `retargeted` alone passes if the pane wanders anywhere; `cursorMoved` alone passes if the cursor moves and the pane ignores it; `intended` pins the contract. A tempting fourth — *"the pane agrees with the focused row"* — passes **vacuously** on the bug, since cursor and pane are both stuck on the opened row. It was measured doing that and is deliberately absent.

The race cannot be made deterministic without a seam in the page, and the asymmetry is why that is fine: a round that misses the window still passes on a correct build, so missing costs **power, not correctness** — false green, never false red.

## Scope

`pane-controller.spec.ts` is unchanged and green (21/21). Its intermittent failure was this defect; it simply could not cause the race, so it only caught it when a sibling test's seed happened to land in the window. Nothing touched in `fullyParallel` or the shared-workspace fixture.

**BUG-2849 is filed as the same shared-workspace family** — worth revisiting, since at least one member of that family turned out to be a product race rather than pollution.

## Gates

web unit 119 files / 2005 tests · `svelte-check` 0 errors (6 warnings pre-existing, untouched files) · `go build` · `go vet` · e2e 44/44 across both projects · codex round 2 CLEAN.

https://claude.ai/code/session_01B8Zo3gigqCJnDodciPd9kr
