### PR TITLE
feat(web): shared ItemPicker — extract the add-relationship search (TASK-2862)

### DIFF
--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -5872,10 +5872,17 @@
 							</select>
 							<div class="add-link-picker">
 								<!-- Unscoped: a relationship can target any collection. A
-								     relation FIELD passes `collection` here instead. -->
+								     relation FIELD passes `collection` here instead.
+								     `source="server"` keeps this box on `/search`, whose FTS
+								     also matches item BODY CONTENT — how you find the item
+								     you remember a phrase from rather than one you can name.
+								     The local index strips `content`, so it can never answer
+								     that; a relation field wants the index's model instead
+								     and takes the default. -->
 								<ItemPicker
 									{wsSlug}
 									excludeIds={addLinkExcludeIds}
+									source="server"
 									label="Search items to link"
 									autofocus
 									onselect={handleCreateLink}

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -7164,6 +7164,11 @@
 	}
 	.add-link-controls {
 		display: flex;
+		/* The picker is a COLUMN (input, then its result list), so the row's
+		   default `stretch` made the type-select as tall as the whole picker
+		   once the results opened. Before the extraction the results were a
+		   sibling of this row and the question never arose. */
+		align-items: flex-start;
 		gap: var(--space-2);
 		margin-bottom: var(--space-2);
 	}

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -39,7 +39,8 @@
 	import { toastStore } from '$lib/stores/toast.svelte';
 	import { editorStore } from '$lib/stores/editor.svelte';
 	import type { Item, Collection, CollectionSettings, QuickAction, ItemLink, AgentRole, PaneTarget, ResolvedItemIdentity, ItemCopyResult } from '$lib/types';
-	import { parseFields, parseSchema, parseSettings, parseTags, formatItemRef, itemUrlId, getTerminalOptions } from '$lib/types';
+	import { parseFields, parseSchema, parseSettings, parseTags, formatItemRef, itemUrlId, getTerminalOptions, type ItemIndexRow } from '$lib/types';
+	import ItemPicker from './ItemPicker.svelte';
 	import QuickActionsMenu from '$lib/components/common/QuickActionsMenu.svelte';
 	import BottomSheet from '$lib/components/common/BottomSheet.svelte';
 	import Menu from '$lib/components/common/Menu.svelte';
@@ -680,16 +681,6 @@
 	// suppression is out of this task's scope.
 	let localDirty = $state(false);
 	let localLastSaveTime = $state(0);
-	// Debounce the add-relationship search so typing doesn't fire one /search
-	// request per keystroke (rate-limit relief). Cleared on the item-scoped
-	// reset + onDestroy so a pending fetch never fires after teardown/switch.
-	const ADD_LINK_SEARCH_DEBOUNCE_MS = 250;
-	let addLinkDebounceTimer: ReturnType<typeof setTimeout> | undefined;
-	// Per-query fence for the add-relationship search. loadGeneration only bumps
-	// on an item switch, so it can't invalidate an in-flight search when the box
-	// is merely emptied or closed on the SAME item — this seq does (Codex review
-	// P2). Plain `let` (CONVE-1688): read/written in handlers only.
-	let addLinkSearchSeq = 0;
 	let deleting = $state(false);
 	let restoring = $state(false);
 	let rawMode = $state(false);
@@ -1563,9 +1554,6 @@
 		unsubscribeSync?.();
 		unsubscribeSSE?.();
 		unsubscribeBeforePrint?.();
-		// Cancel a pending add-relationship search so it can't fire a wasted
-		// /search request after this instance is torn down.
-		clearTimeout(addLinkDebounceTimer);
 		// Invalidate any in-flight loadData so a request that resolves AFTER
 		// this instance is torn down (pane closed mid-load) can't reach its
 		// global-store writes — collectionStore.setActiveItem / editorStore —
@@ -1705,11 +1693,9 @@
 		editingTitle = false;
 		paneMenuOpen = false;
 		paneMenuView = 'root';
+		// Closing the form unmounts the picker; its query/results/timer go with
+		// it, so this flag is the whole reset.
 		showAddLink = false;
-		clearTimeout(addLinkDebounceTimer);
-		addLinkSearch = '';
-		addLinkResults = [];
-		addLinkLoading = false;
 		shareDialogOpen = false;
 		// The copy dialog is {#key itemSlug}-remounted, but `open` is owned
 		// HERE — leaving it true would tear down A's dialog and immediately
@@ -4344,70 +4330,25 @@
 	}
 
 	// ── Add Relationship ─────────────────────────────────────────────────────
+	//
+	// The search box is `ItemPicker` (PLAN-2857 U3 / TASK-2862). It owns the
+	// query state, the debounce, the per-query fence and the result rendering
+	// that used to live here inline; this component keeps only what is its own
+	// — which link type to create, and the write itself. The item-switch fence
+	// is unchanged and structural: the picker mounts inside the
+	// `{#key itemSlug}` block below (PLAN-2105 / TASK-2112), so a switch
+	// destroys it and any continuation it holds.
 	let showAddLink = $state(false);
 	let addLinkType = $state('related');
-	let addLinkSearch = $state('');
-	let addLinkResults = $state<Item[]>([]);
-	let addLinkLoading = $state(false);
 
-	// Cancel any pending debounce AND invalidate an in-flight add-relationship
-	// search so its late result can't repopulate the (now emptied/closed) box,
-	// and drop the loading flag. Used on empty, close, and after a link lands.
-	function cancelAddLinkSearch() {
-		clearTimeout(addLinkDebounceTimer);
-		addLinkSearchSeq++;
-		addLinkLoading = false;
-	}
+	// Rows the picker must not offer: this item, and anything already linked to
+	// it in either direction. Same exclusion the inline search applied.
+	let addLinkExcludeIds = $derived([
+		...(item ? [item.id] : []),
+		...itemLinks.flatMap((l) => [l.source_id, l.target_id]),
+	]);
 
-	// Debounced input handler. Emptying the box clears results + cancels any
-	// pending/in-flight request immediately; a non-empty query fires
-	// searchItemsForLink() only after the user pauses for the debounce window.
-	function onAddLinkInput() {
-		if (!addLinkSearch.trim()) {
-			cancelAddLinkSearch();
-			addLinkResults = [];
-			return;
-		}
-		clearTimeout(addLinkDebounceTimer);
-		// Query changed: invalidate any in-flight search and drop stale results
-		// so an old-query result can't appear or be selected during the debounce
-		// window; show loading until the new search lands (Codex review P2).
-		addLinkSearchSeq++;
-		addLinkResults = [];
-		addLinkLoading = true;
-		addLinkDebounceTimer = setTimeout(() => searchItemsForLink(), ADD_LINK_SEARCH_DEBOUNCE_MS);
-	}
-
-	async function searchItemsForLink() {
-		if (!addLinkSearch.trim()) {
-			addLinkResults = [];
-			return;
-		}
-		// Fence the async search so a result can't repopulate the panel after
-		// an item switch (loadGeneration) OR after the box was emptied/closed on
-		// the same item (addLinkSearchSeq) — Codex.
-		const gen = loadGeneration;
-		const seq = ++addLinkSearchSeq;
-		const stale = () => gen !== loadGeneration || seq !== addLinkSearchSeq;
-		addLinkLoading = true;
-		try {
-			const results = await api.search(addLinkSearch, { workspace: wsSlug });
-			if (stale()) return;
-			// Filter out self and items already linked
-			const linkedIds = new Set(itemLinks.flatMap(l => [l.source_id, l.target_id]));
-			addLinkResults = (results.results || [])
-				.map((r) => r.item)
-				.filter((i: Item) => i.id !== item?.id && !linkedIds.has(i.id))
-				.slice(0, 10);
-		} catch {
-			if (stale()) return;
-			addLinkResults = [];
-		} finally {
-			if (!stale()) addLinkLoading = false;
-		}
-	}
-
-	async function handleCreateLink(target: Item) {
+	async function handleCreateLink(target: ItemIndexRow) {
 		if (!item || !canEdit) return;
 		// Capture the SOURCE item (the one being edited) + generation before the
 		// awaits. `target` is the link target chosen from search; `sourceItem`
@@ -4425,12 +4366,9 @@
 			});
 			if (switchedAway(sourceItem, gen)) return;
 			itemLinks = [...itemLinks, newLink];
-			// Cancel any pending/in-flight search before closing the form so a
-			// stale debounced query can't fire after it's gone (Codex review P2).
-			cancelAddLinkSearch();
+			// Closing the form unmounts the picker, which cancels its own
+			// pending/in-flight search in onDestroy — nothing to clear here.
 			showAddLink = false;
-			addLinkSearch = '';
-			addLinkResults = [];
 			// Refresh item to update parent info
 			const refreshed = await api.items.get(targetWs, targetSlug);
 			if (switchedAway(sourceItem, gen) || !item) return;
@@ -5921,7 +5859,7 @@
 					<div class="add-link-form">
 						<div class="add-link-header">
 							<h4>Add Relationship</h4>
-							<button class="add-link-close" onclick={() => { cancelAddLinkSearch(); showAddLink = false; addLinkSearch = ''; addLinkResults = []; }}>×</button>
+							<button class="add-link-close" onclick={() => { showAddLink = false; }}>×</button>
 						</div>
 						<div class="add-link-controls">
 							<select bind:value={addLinkType} class="add-link-type-select">
@@ -5932,30 +5870,19 @@
 								<option value="supersedes">Supersedes</option>
 								<option value="parent">Parent</option>
 							</select>
-							<input
-								type="text"
-								class="add-link-search"
-								placeholder="Search items..."
-								bind:value={addLinkSearch}
-								oninput={onAddLinkInput}
-							/>
-						</div>
-						{#if addLinkLoading}
-							<div class="add-link-loading">Searching...</div>
-						{:else if addLinkResults.length > 0}
-							<div class="add-link-results">
-								{#each addLinkResults as result (result.id)}
-									<button class="add-link-result" onclick={() => handleCreateLink(result)}>
-										{#if formatItemRef(result)}
-											<span class="add-link-ref">{formatItemRef(result)}</span>
-										{/if}
-										<span class="add-link-title">{result.title}</span>
-									</button>
-								{/each}
+							<div class="add-link-picker">
+								<!-- Unscoped: a relationship can target any collection. A
+								     relation FIELD passes `collection` here instead. -->
+								<ItemPicker
+									{wsSlug}
+									excludeIds={addLinkExcludeIds}
+									label="Search items to link"
+									autofocus
+									onselect={handleCreateLink}
+									oncancel={() => { showAddLink = false; }}
+								/>
 							</div>
-						{:else if addLinkSearch.trim().length > 0}
-							<div class="add-link-loading">No results</div>
-						{/if}
+						</div>
 					</div>
 				{/if}
 			</div>
@@ -7249,52 +7176,15 @@
 		font-size: 0.8rem;
 		min-width: 120px;
 	}
-	.add-link-search {
+	/* Wrapper for the extracted ItemPicker (TASK-2862). Sets the picker's
+	   scale for this host — the component sizes everything in `em` — and gives
+	   it the flex row's remaining width, which is what `.add-link-search` used
+	   to hold. The result-list rules that lived here moved into the picker,
+	   because Svelte scopes styles per component and a class name does not
+	   cross the boundary (see the note just below). */
+	.add-link-picker {
 		flex: 1;
-		padding: var(--space-1) var(--space-2);
-		border: 1px solid var(--border-color);
-		border-radius: var(--radius-sm);
-		background: var(--bg-primary);
-		color: var(--text-primary);
-		font-size: 0.8rem;
-	}
-	.add-link-results {
-		display: flex;
-		flex-direction: column;
-		gap: 1px;
-		max-height: 200px;
-		overflow-y: auto;
-	}
-	.add-link-result {
-		display: flex;
-		align-items: center;
-		gap: var(--space-2);
-		padding: var(--space-2);
-		background: var(--bg-primary);
-		border: none;
-		border-radius: var(--radius-sm);
-		cursor: pointer;
-		text-align: left;
-		color: var(--text-primary);
-		font-size: 0.8rem;
-	}
-	.add-link-result:hover {
-		background: var(--bg-hover);
-	}
-	.add-link-ref {
-		color: var(--text-muted);
-		font-family: var(--font-mono);
-		font-size: 0.75rem;
-		flex-shrink: 0;
-	}
-	.add-link-title {
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-	}
-	.add-link-loading {
-		padding: var(--space-2);
-		color: var(--text-muted);
+		min-width: 0;
 		font-size: 0.8rem;
 	}
 

--- a/web/src/lib/components/items/ItemPicker.svelte
+++ b/web/src/lib/components/items/ItemPicker.svelte
@@ -57,6 +57,24 @@
 		collection?: string;
 		/** Item ids to hide — the item being edited, anything already linked. */
 		excludeIds?: string[];
+		/**
+		 * Where matches come from. This is a MODEL choice, not a performance
+		 * one, and the two callers want different models:
+		 *
+		 *   `'index'` (default) — the in-RAM workspace index, ranked by
+		 *   `localSearch` over title / ref / tags / parent / field values. No
+		 *   network call. Falls back to the server only while the index has not
+		 *   hydrated. Right for a RELATION field, where you are choosing a row
+		 *   from a known collection and know what it is called.
+		 *
+		 *   `'server'` — always `/search`, whose FTS also indexes item BODY
+		 *   CONTENT. `localIndex` strips `content` by design, so the index can
+		 *   never answer "the item that mentioned that phrase". Right for the
+		 *   Relationships tab, where you are finding an item you remember
+		 *   rather than one you can name — and what it did before this
+		 *   component existed.
+		 */
+		source?: 'index' | 'server';
 		/** Max rows rendered. Bounded so DOM cost is O(1) in collection size. */
 		limit?: number;
 		placeholder?: string;
@@ -85,6 +103,7 @@
 		wsSlug,
 		collection,
 		excludeIds = [],
+		source = 'index',
 		limit = 10,
 		placeholder = 'Search items...',
 		label = 'Search items',
@@ -96,10 +115,23 @@
 	const COLD_SEARCH_DEBOUNCE_MS = 250;
 
 	let query = $state('');
-	let results = $state<ItemIndexRow[]>([]);
+	/**
+	 * What the source last returned, BEFORE exclusions. Kept separate so
+	 * `results` can re-filter reactively when `excludeIds` changes — which it
+	 * does late, since `ItemDetail` loads `itemLinks` asynchronously (codex
+	 * round 4 P2). Deriving that filter is what lets the server-backed caller
+	 * honour a late exclusion without re-issuing a request per change.
+	 */
+	let rawResults = $state<ItemIndexRow[]>([]);
 	let loading = $state(false);
-	/** Index into `results` of the keyboard-highlighted row; -1 = none. */
-	let activeIndex = $state(-1);
+	/**
+	 * The highlighted row's ID, not its index. Identity survives the list
+	 * changing under it — a delta landing, a late exclusion arriving — where an
+	 * index silently moves the highlight onto whatever slid into that position.
+	 * `activeIndex` is derived from it, so nothing has to remember to re-resolve
+	 * it at each site that can change the list.
+	 */
+	let activeId = $state<string | null>(null);
 
 	/**
 	 * Plain `let`, not `$state`, per CONVE-1688: both are read and written
@@ -113,6 +145,8 @@
 	const uid = $props.id();
 
 	let excluded = $derived(new Set(excludeIds));
+	let results = $derived(present(rawResults));
+	let activeIndex = $derived(activeId ? results.findIndex((r) => r.id === activeId) : -1);
 
 	function isWarm(): boolean {
 		return localIndex.bootstrapStateFor(wsSlug) === 'ready';
@@ -136,14 +170,20 @@
 	 * workspace, newest first" is not a useful prompt.
 	 */
 	function recent(): ItemIndexRow[] {
+		// Deliberately independent of `source`: an empty-query LISTING is not a
+		// search, `/search` cannot answer one (it requires a `q`), and the index
+		// holds the rows either way. A server-backed picker therefore still opens
+		// with its collection listed, and only its QUERIES go to the server.
 		if (!collection || !isWarm()) return [];
-		return present(localIndex.getByCollection(wsSlug, collection));
+		return localIndex.getByCollection(wsSlug, collection);
 	}
 
 	function warmSearch(q: string): ItemIndexRow[] {
 		const hits = localSearch.search(wsSlug, q, {
 			collection,
-			// Over-ask so exclusions can't empty a full page of results.
+			// Over-ask so exclusions can't empty a full page of results. Sized
+			// against the exclusion set the caller has RIGHT NOW; a later one is
+			// handled by `results` re-filtering, which can only shrink the list.
 			limit: limit + excluded.size,
 		});
 		const rows: ItemIndexRow[] = [];
@@ -151,7 +191,7 @@
 			const row = localIndex.findByIdOrSlug(wsSlug, hit.id);
 			if (row) rows.push(row);
 		}
-		return present(rows);
+		return rows;
 	}
 
 	async function coldSearch(q: string, mySeq: number) {
@@ -159,12 +199,12 @@
 		try {
 			const res = await api.search(q, { workspace: wsSlug, collection });
 			if (mySeq !== seq) return;
-			results = present((res.results ?? []).map((r) => r.item));
-			activeIndex = -1;
+			rawResults = (res.results ?? []).map((r) => r.item);
+			activeId = null;
 		} catch {
 			if (mySeq !== seq) return;
-			results = [];
-			activeIndex = -1;
+			rawResults = [];
+			activeId = null;
 		} finally {
 			if (mySeq === seq) loading = false;
 		}
@@ -181,20 +221,23 @@
 
 		if (!q) {
 			loading = false;
-			results = recent();
-			activeIndex = -1;
+			rawResults = recent();
+			activeId = null;
 			return;
 		}
 
-		if (isWarm()) {
+		// `source: 'server'` skips the warm branch entirely — not as a fallback
+		// but as the caller's declared model, since only the server's FTS can
+		// match item body content.
+		if (source === 'index' && isWarm()) {
 			loading = false;
-			results = warmSearch(q);
-			activeIndex = -1;
+			rawResults = warmSearch(q);
+			activeId = null;
 			return;
 		}
 
-		results = [];
-		activeIndex = -1;
+		rawResults = [];
+		activeId = null;
 		loading = true;
 		debounceTimer = setTimeout(() => coldSearch(q, mySeq), COLD_SEARCH_DEBOUNCE_MS);
 	}
@@ -207,13 +250,15 @@
 		if (e.key === 'ArrowDown') {
 			if (results.length === 0) return;
 			e.preventDefault();
-			activeIndex = activeIndex < results.length - 1 ? activeIndex + 1 : results.length - 1;
+			const next = activeIndex < results.length - 1 ? activeIndex + 1 : results.length - 1;
+			activeId = results[next]?.id ?? null;
 			return;
 		}
 		if (e.key === 'ArrowUp') {
 			if (results.length === 0) return;
 			e.preventDefault();
-			activeIndex = activeIndex > 0 ? activeIndex - 1 : -1;
+			const next = activeIndex - 1;
+			activeId = next >= 0 ? (results[next]?.id ?? null) : null;
 			return;
 		}
 		if (e.key === 'Enter') {
@@ -289,8 +334,11 @@
 	// asynchronously, so a picker opened before that resolves was offering items
 	// that are already linked (round 4).
 	//
-	// Tracked reads are the three signals that say the list is out of date: the
-	// bootstrap state, `localSearch.epoch(ws)`, and the exclusion set.
+	// Tracked reads are the two signals that say the INDEX changed: the bootstrap
+	// state and `localSearch.epoch(ws)`. The exclusion set is not one of them —
+	// `results` derives through `present()`, so a late `excludeIds` re-filters on
+	// its own, without a re-query and therefore without a request on the
+	// server-backed caller.
 	//
 	// The epoch, NOT the workspace cursor. Round 2 used the cursor and round 3
 	// caught that it misses every cursorless mutation — `localIndex.upsert()` /
@@ -316,9 +364,8 @@
 	// pointing at whatever slid into that position.
 	$effect(() => {
 		const state = localIndex.bootstrapStateFor(wsSlug);
-		// Read for their dependency; the values carry no meaning here.
+		// Read for its dependency; the value carries no meaning here.
 		localSearch.epoch(wsSlug);
-		void excluded;
 		untrack(() => {
 			if (state !== 'ready') {
 				// The workspace's state was DROPPED — `localIndex.reset()` on
@@ -339,14 +386,19 @@
 				// reset; `clearTimeout` stops one that has not been sent yet.
 				seq++;
 				clearTimeout(debounceTimer);
-				results = [];
-				activeIndex = -1;
+				rawResults = [];
+				activeId = null;
 				loading = false;
 				return;
 			}
-			const keep = activeIndex >= 0 ? results[activeIndex]?.id : undefined;
+			// Server-sourced QUERIES are not re-issued on an index change: the
+			// index is not their source of truth, and a request per delta is
+			// exactly the rate-limiter pressure the debounce exists to avoid. The
+			// empty-query LISTING still comes from the index, so it does refresh.
+			if (source === 'server' && query.trim()) return;
+			const keep = activeId;
 			runQuery();
-			activeIndex = keep ? results.findIndex((r) => r.id === keep) : -1;
+			activeId = keep;
 		});
 	});
 </script>

--- a/web/src/lib/components/items/ItemPicker.svelte
+++ b/web/src/lib/components/items/ItemPicker.svelte
@@ -1,0 +1,380 @@
+<script lang="ts">
+	/**
+	 * ItemPicker — the shared search-and-choose-an-item control (PLAN-2857 U3 /
+	 * TASK-2862).
+	 *
+	 * Extracted from `ItemDetail`'s inline add-relationship search so the
+	 * relation-field editor (U2) and the Relationships tab share ONE picker
+	 * rather than a copy each. `ItemDetail` is its first caller, in unscoped
+	 * mode; a relation field passes `collection` to scope it to the field's
+	 * declared target.
+	 *
+	 * WHERE THE CANDIDATES COME FROM, and why there is no threshold.
+	 *
+	 * `localIndex` is a workspace-wide in-RAM read model of every item
+	 * (`/workspaces/{ws}/items-index` takes no limit parameter — see
+	 * `api.items.listIndex`), and `localSearch` is a MiniSearch index built
+	 * over it. So the candidate rows for ANY collection are already in memory,
+	 * already ranked, and cost no network call. PLAN-2857's Q1 was framed as
+	 * "plain dropdown under N items, search above it"; that threshold was
+	 * pricing a round-trip that does not happen. One control, always
+	 * filter-shaped, correct at three items and at three thousand.
+	 *
+	 * The server `/search` endpoint is the COLD path only — used while the
+	 * workspace's local index has not finished hydrating
+	 * (`bootstrapStateFor(ws) !== 'ready'`), which is also the pre-extraction
+	 * behaviour every caller had. It is not a mode the user can observe or
+	 * select.
+	 *
+	 * DEBOUNCE. Only the cold path is debounced, and that is deliberate: the
+	 * debounce exists to keep per-keystroke requests off the rate limiter
+	 * (BUG-1367 lineage), and the warm path issues no requests to limit. Local
+	 * search is synchronous and sub-millisecond, so debouncing it would only
+	 * add latency to the common case.
+	 *
+	 * FENCES. A per-query `seq` invalidates an in-flight cold search when the
+	 * query changes, is emptied, or the picker unmounts — a late response can
+	 * never repopulate a box the user has moved on from. The ITEM-SWITCH fence
+	 * is structural rather than a second counter: every caller mounts this
+	 * inside a `{#key}` on the item identity (PLAN-2105 / TASK-2112), so a
+	 * switch destroys the instance and its continuation with it.
+	 */
+	import { onDestroy, onMount } from 'svelte';
+	import { api } from '$lib/api/client';
+	import { localIndex } from '$lib/stores/localIndex.svelte';
+	import { localSearch } from '$lib/stores/localSearch.svelte';
+	import { formatItemRef, type ItemIndexRow } from '$lib/types';
+
+	interface Props {
+		/** Workspace slug the picker searches within. */
+		wsSlug: string;
+		/**
+		 * Target collection slug. Omitted = the whole workspace (the
+		 * Relationships tab's mode); set = a relation field's declared target.
+		 * When set, an EMPTY query lists the collection's most recently
+		 * updated items, so the picker opens with something to choose.
+		 */
+		collection?: string;
+		/** Item ids to hide — the item being edited, anything already linked. */
+		excludeIds?: string[];
+		/** Max rows rendered. Bounded so DOM cost is O(1) in collection size. */
+		limit?: number;
+		placeholder?: string;
+		/** Accessible name for the input. */
+		label?: string;
+		/** Focus the input on mount. */
+		autofocus?: boolean;
+		/** Chosen row. The picker does not clear itself — the caller decides. */
+		onselect: (item: ItemIndexRow) => void;
+		/**
+		 * Escape with an already-empty box. Omit to let Escape fall through to
+		 * the surrounding layer (the pane's own Escape handling) instead.
+		 */
+		oncancel?: () => void;
+	}
+
+	let {
+		wsSlug,
+		collection,
+		excludeIds = [],
+		limit = 10,
+		placeholder = 'Search items...',
+		label = 'Search items',
+		autofocus = false,
+		onselect,
+		oncancel,
+	}: Props = $props();
+
+	const COLD_SEARCH_DEBOUNCE_MS = 250;
+
+	let query = $state('');
+	let results = $state<ItemIndexRow[]>([]);
+	let loading = $state(false);
+	/** Index into `results` of the keyboard-highlighted row; -1 = none. */
+	let activeIndex = $state(-1);
+
+	/**
+	 * Plain `let`, not `$state`, per CONVE-1688: both are read and written
+	 * only inside handlers, never rendered. A `$state` that an `$effect` also
+	 * read would silently wedge the production effect scheduler.
+	 */
+	let seq = 0;
+	let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+	let inputEl = $state<HTMLInputElement>();
+
+	const uid = $props.id();
+
+	let excluded = $derived(new Set(excludeIds));
+
+	function isWarm(): boolean {
+		return localIndex.bootstrapStateFor(wsSlug) === 'ready';
+	}
+
+	/** Hide excluded rows, then bound the list. Applied to every path. */
+	function present(rows: ItemIndexRow[]): ItemIndexRow[] {
+		const out: ItemIndexRow[] = [];
+		for (const row of rows) {
+			if (excluded.has(row.id)) continue;
+			out.push(row);
+			if (out.length >= limit) break;
+		}
+		return out;
+	}
+
+	/**
+	 * Empty-query listing. Scoped pickers show the target collection
+	 * most-recently-updated first (`getByCollection` already returns that
+	 * order); an unscoped picker shows nothing, because "every item in the
+	 * workspace, newest first" is not a useful prompt.
+	 */
+	function recent(): ItemIndexRow[] {
+		if (!collection || !isWarm()) return [];
+		return present(localIndex.getByCollection(wsSlug, collection));
+	}
+
+	function warmSearch(q: string): ItemIndexRow[] {
+		const hits = localSearch.search(wsSlug, q, {
+			collection,
+			// Over-ask so exclusions can't empty a full page of results.
+			limit: limit + excluded.size,
+		});
+		const rows: ItemIndexRow[] = [];
+		for (const hit of hits) {
+			const row = localIndex.findByIdOrSlug(wsSlug, hit.id);
+			if (row) rows.push(row);
+		}
+		return present(rows);
+	}
+
+	async function coldSearch(q: string, mySeq: number) {
+		loading = true;
+		try {
+			const res = await api.search(q, { workspace: wsSlug, collection });
+			if (mySeq !== seq) return;
+			results = present((res.results ?? []).map((r) => r.item));
+			activeIndex = -1;
+		} catch {
+			if (mySeq !== seq) return;
+			results = [];
+			activeIndex = -1;
+		} finally {
+			if (mySeq === seq) loading = false;
+		}
+	}
+
+	/**
+	 * One entry point for every query change. Invalidates whatever was in
+	 * flight FIRST, so no branch below can be repopulated by its predecessor.
+	 */
+	function runQuery() {
+		clearTimeout(debounceTimer);
+		const mySeq = ++seq;
+		const q = query.trim();
+
+		if (!q) {
+			loading = false;
+			results = recent();
+			activeIndex = -1;
+			return;
+		}
+
+		if (isWarm()) {
+			loading = false;
+			results = warmSearch(q);
+			activeIndex = -1;
+			return;
+		}
+
+		results = [];
+		activeIndex = -1;
+		loading = true;
+		debounceTimer = setTimeout(() => coldSearch(q, mySeq), COLD_SEARCH_DEBOUNCE_MS);
+	}
+
+	function choose(row: ItemIndexRow) {
+		onselect(row);
+	}
+
+	function onKeydown(e: KeyboardEvent) {
+		if (e.key === 'ArrowDown') {
+			if (results.length === 0) return;
+			e.preventDefault();
+			activeIndex = activeIndex < results.length - 1 ? activeIndex + 1 : results.length - 1;
+			return;
+		}
+		if (e.key === 'ArrowUp') {
+			if (results.length === 0) return;
+			e.preventDefault();
+			activeIndex = activeIndex > 0 ? activeIndex - 1 : -1;
+			return;
+		}
+		if (e.key === 'Enter') {
+			if (activeIndex < 0 || activeIndex >= results.length) return;
+			e.preventDefault();
+			choose(results[activeIndex]);
+			return;
+		}
+		if (e.key === 'Escape') {
+			// Consume ONLY what this picker actually closes, and say so to the
+			// layer above by stopping propagation. The page's Escape driver is a
+			// bubble-phase `<svelte:window onkeydown>` feeding `runTopEscape`, so
+			// declining here (no stopPropagation) correctly lets Escape reach the
+			// pane when the picker has nothing of its own to dismiss.
+			if (query) {
+				e.preventDefault();
+				e.stopPropagation();
+				query = '';
+				runQuery();
+				return;
+			}
+			if (oncancel) {
+				e.preventDefault();
+				e.stopPropagation();
+				oncancel();
+			}
+		}
+	}
+
+	onDestroy(() => {
+		// Invalidate any in-flight cold search as well as cancelling the timer:
+		// the fetch is already dispatched by the time the timer has fired, and
+		// only the seq bump can stop its continuation writing to a dead
+		// instance's state.
+		seq++;
+		clearTimeout(debounceTimer);
+	});
+
+	// Open a scoped picker with its recent list already populated, and focus the
+	// input when the caller asked for it.
+	//
+	// `onMount`, deliberately, not `$effect`: `runQuery` reads `query` and
+	// writes `results`, so as an effect it would re-run on every keystroke in
+	// addition to `oninput` — two dispatches per character, each bumping `seq`
+	// and cancelling the other's cold search. CONVE-1688's neighbourhood; the
+	// lifecycle hook says "once, at open" without relying on that reasoning
+	// holding as the body grows.
+	onMount(() => {
+		runQuery();
+		if (autofocus) inputEl?.focus();
+	});
+</script>
+
+<div class="item-picker">
+	<input
+		type="text"
+		class="picker-input"
+		role="combobox"
+		aria-label={label}
+		aria-expanded={results.length > 0}
+		aria-controls="picker-results-{uid}"
+		aria-autocomplete="list"
+		aria-activedescendant={activeIndex >= 0 ? `picker-option-${uid}-${activeIndex}` : undefined}
+		{placeholder}
+		bind:this={inputEl}
+		bind:value={query}
+		oninput={runQuery}
+		onkeydown={onKeydown}
+	/>
+
+	{#if loading}
+		<div class="picker-status">Searching...</div>
+	{:else if results.length > 0}
+		<div class="picker-results" role="listbox" id="picker-results-{uid}" aria-label={label}>
+			{#each results as result, i (result.id)}
+				<button
+					type="button"
+					class="picker-result"
+					class:active={i === activeIndex}
+					role="option"
+					id="picker-option-{uid}-{i}"
+					aria-selected={i === activeIndex}
+					onclick={() => choose(result)}
+				>
+					{#if formatItemRef(result)}
+						<span class="picker-ref">{formatItemRef(result)}</span>
+					{/if}
+					<span class="picker-title">{result.title}</span>
+				</button>
+			{/each}
+		</div>
+	{:else if query.trim().length > 0}
+		<div class="picker-status">No results</div>
+	{/if}
+</div>
+
+<style>
+	/*
+	 * Self-contained by necessity, not by preference: Svelte scopes styles per
+	 * component, so a shared class NAME would silently render unstyled in every
+	 * host (the note on ItemDetail's `.timeline-*` copy records that lesson).
+	 *
+	 * Sized in `em` throughout so a host sets the picker's scale once on its own
+	 * wrapper — ItemDetail's relationships form wants 0.8rem, the properties
+	 * panel (U2) wants its own — and every part scales together.
+	 */
+	.item-picker {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-2);
+		min-width: 0;
+	}
+
+	.picker-input {
+		width: 100%;
+		padding: var(--space-1) var(--space-2);
+		border: 1px solid var(--border-color);
+		border-radius: var(--radius-sm);
+		background: var(--bg-primary);
+		color: var(--text-primary);
+		font-size: 1em;
+		font-family: inherit;
+	}
+
+	.picker-status {
+		padding: var(--space-2);
+		color: var(--text-muted);
+		font-size: 1em;
+	}
+
+	.picker-results {
+		display: flex;
+		flex-direction: column;
+		gap: 1px;
+		max-height: 200px;
+		overflow-y: auto;
+	}
+
+	.picker-result {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		padding: var(--space-2);
+		background: var(--bg-primary);
+		border: none;
+		border-radius: var(--radius-sm);
+		color: var(--text-primary);
+		text-align: left;
+		cursor: pointer;
+		font-size: 1em;
+		font-family: inherit;
+		min-width: 0;
+	}
+
+	.picker-result:hover,
+	.picker-result.active {
+		background: var(--bg-hover);
+	}
+
+	.picker-ref {
+		flex-shrink: 0;
+		color: var(--text-muted);
+		font-family: var(--font-mono);
+		font-size: 0.94em;
+	}
+
+	.picker-title {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+</style>

--- a/web/src/lib/components/items/ItemPicker.svelte
+++ b/web/src/lib/components/items/ItemPicker.svelte
@@ -39,7 +39,7 @@
 	 * inside a `{#key}` on the item identity (PLAN-2105 / TASK-2112), so a
 	 * switch destroys the instance and its continuation with it.
 	 */
-	import { onDestroy, onMount } from 'svelte';
+	import { onDestroy, onMount, untrack } from 'svelte';
 	import { api } from '$lib/api/client';
 	import { localIndex } from '$lib/stores/localIndex.svelte';
 	import { localSearch } from '$lib/stores/localSearch.svelte';
@@ -67,8 +67,16 @@
 		/** Chosen row. The picker does not clear itself — the caller decides. */
 		onselect: (item: ItemIndexRow) => void;
 		/**
-		 * Escape with an already-empty box. Omit to let Escape fall through to
-		 * the surrounding layer (the pane's own Escape handling) instead.
+		 * Escape on an already-empty box.
+		 *
+		 * Pass one if Escape should close the surface hosting the picker.
+		 * Omitting it does NOT hand Escape to the layer above: both pane hosts'
+		 * keydown handlers bail on text-entry targets before they reach the
+		 * escape stack (`isTextEntryTarget` in `[collection]/+page.svelte` and
+		 * `[collection]/[slug]/+page.svelte`), on the deliberate rule that a
+		 * text field owns Escape locally. So with no `oncancel`, Escape on an
+		 * empty picker does nothing at all — which is what the inline search
+		 * this replaces did too.
 		 */
 		oncancel?: () => void;
 	}
@@ -215,11 +223,16 @@
 			return;
 		}
 		if (e.key === 'Escape') {
-			// Consume ONLY what this picker actually closes, and say so to the
-			// layer above by stopping propagation. The page's Escape driver is a
-			// bubble-phase `<svelte:window onkeydown>` feeding `runTopEscape`, so
-			// declining here (no stopPropagation) correctly lets Escape reach the
-			// pane when the picker has nothing of its own to dismiss.
+			// Consume ONLY what this picker actually closes.
+			//
+			// The stopPropagation is belt-and-braces rather than load-bearing:
+			// the page's Escape driver is a bubble-phase
+			// `<svelte:window onkeydown>`, so it WOULD see the key — but it
+			// returns early for text-entry targets before running the escape
+			// stack, and this is a text input. Keeping it means the picker's
+			// behaviour does not depend on that bail staying in place, and
+			// declining still leaves the key untouched for anything that does
+			// look at it.
 			if (query) {
 				e.preventDefault();
 				e.stopPropagation();
@@ -261,6 +274,23 @@
 	onMount(() => {
 		runQuery();
 		if (autofocus) inputEl?.focus();
+	});
+
+	// A picker can open BEFORE the workspace's local index has hydrated, and a
+	// scoped one then has nothing to list — `recent()` returns [] while cold,
+	// and nothing re-ran it, so the list stayed empty until the user typed
+	// (codex round 1 P2). Re-run once hydration lands.
+	//
+	// Tracked reads are the bootstrap state ONLY. `query` is read inside
+	// `untrack` on purpose: reading it reactively would re-run this on every
+	// keystroke, racing `oninput` and bumping `seq` twice per character — the
+	// same reason `onMount` owns the initial run (CONVE-1688's neighbourhood).
+	// The `query` guard means a user who has already typed keeps their results.
+	$effect(() => {
+		const state = localIndex.bootstrapStateFor(wsSlug);
+		untrack(() => {
+			if (state === 'ready' && !query.trim()) runQuery();
+		});
 	});
 </script>
 

--- a/web/src/lib/components/items/ItemPicker.svelte
+++ b/web/src/lib/components/items/ItemPicker.svelte
@@ -236,10 +236,15 @@
 	}
 
 	onDestroy(() => {
-		// Invalidate any in-flight cold search as well as cancelling the timer:
-		// the fetch is already dispatched by the time the timer has fired, and
-		// only the seq bump can stop its continuation writing to a dead
-		// instance's state.
+		// `clearTimeout` is the part that matters and the part that is testable:
+		// closing the picker inside the debounce window means the request is
+		// never sent at all.
+		//
+		// The `seq` bump is belt-and-braces for a request already in flight, and
+		// deliberately kept even though NO test can kill its removal — a
+		// destroyed instance renders nothing, so a late write to its state is
+		// unobservable by construction. Said plainly here rather than defended by
+		// a test that would pass either way.
 		seq++;
 		clearTimeout(debounceTimer);
 	});

--- a/web/src/lib/components/items/ItemPicker.svelte
+++ b/web/src/lib/components/items/ItemPicker.svelte
@@ -278,17 +278,19 @@
 
 	// Keep an OPEN picker current with the local index.
 	//
-	// Three ways it went stale, all found by codex review, all the same missing
+	// Four ways it went stale, all found by codex review, all the same missing
 	// dependency. A picker can open BEFORE the workspace index has hydrated, and
 	// a scoped one then has nothing to list — `recent()` returns [] while cold,
 	// and nothing re-ran it (round 1). Once open it holds a COPY of the rows, so
 	// a delta landing while it is on screen left it showing what the workspace
-	// used to contain (round 2). And the first fix for that tracked the wrong
-	// signal, missing every mutation that does not advance the cursor
-	// (round 3).
+	// used to contain (round 2). The first fix for that tracked the wrong
+	// signal, missing every mutation that does not advance the cursor (round 3).
+	// And `excludeIds` arriving late — `ItemDetail` loads `itemLinks`
+	// asynchronously, so a picker opened before that resolves was offering items
+	// that are already linked (round 4).
 	//
-	// Tracked reads are the two signals that say the index changed: the
-	// bootstrap state, and `localSearch.epoch(ws)`.
+	// Tracked reads are the three signals that say the list is out of date: the
+	// bootstrap state, `localSearch.epoch(ws)`, and the exclusion set.
 	//
 	// The epoch, NOT the workspace cursor. Round 2 used the cursor and round 3
 	// caught that it misses every cursorless mutation — `localIndex.upsert()` /
@@ -314,10 +316,34 @@
 	// pointing at whatever slid into that position.
 	$effect(() => {
 		const state = localIndex.bootstrapStateFor(wsSlug);
-		// Read for its dependency; the value itself carries no meaning here.
+		// Read for their dependency; the values carry no meaning here.
 		localSearch.epoch(wsSlug);
+		void excluded;
 		untrack(() => {
-			if (state !== 'ready') return;
+			if (state !== 'ready') {
+				// The workspace's state was DROPPED — `localIndex.reset()` on
+				// sign-out, a 403 membership purge, or a workspace deletion. It
+				// bumps the search epoch on its way out, so this effect runs, and
+				// leaving early would strand rows the viewer may no longer be
+				// allowed to see: still listed, still selectable, and a late cold
+				// response still able to add more (codex round 4 P1).
+				//
+				// Unconditional, after measuring that a guard on "actually showing
+				// or awaiting something" was dead: on the ordinary cold mount this
+				// runs once with nothing to clear, and every other non-ready run
+				// reaches it with state worth dropping either way. A mutant that
+				// removed the guard could not be killed, so the guard went instead
+				// of acquiring a comment claiming it protects something.
+				//
+				// `seq++` is what stops an in-flight response landing after the
+				// reset; `clearTimeout` stops one that has not been sent yet.
+				seq++;
+				clearTimeout(debounceTimer);
+				results = [];
+				activeIndex = -1;
+				loading = false;
+				return;
+			}
 			const keep = activeIndex >= 0 ? results[activeIndex]?.id : undefined;
 			runQuery();
 			activeIndex = keep ? results.findIndex((r) => r.id === keep) : -1;

--- a/web/src/lib/components/items/ItemPicker.svelte
+++ b/web/src/lib/components/items/ItemPicker.svelte
@@ -276,20 +276,38 @@
 		if (autofocus) inputEl?.focus();
 	});
 
-	// A picker can open BEFORE the workspace's local index has hydrated, and a
-	// scoped one then has nothing to list — `recent()` returns [] while cold,
-	// and nothing re-ran it, so the list stayed empty until the user typed
-	// (codex round 1 P2). Re-run once hydration lands.
+	// Keep an OPEN picker current with the local index.
 	//
-	// Tracked reads are the bootstrap state ONLY. `query` is read inside
-	// `untrack` on purpose: reading it reactively would re-run this on every
-	// keystroke, racing `oninput` and bumping `seq` twice per character — the
-	// same reason `onMount` owns the initial run (CONVE-1688's neighbourhood).
-	// The `query` guard means a user who has already typed keeps their results.
+	// Two ways it went stale, both found by codex review. A picker can open
+	// BEFORE the workspace index has hydrated, and a scoped one then has nothing
+	// to list — `recent()` returns [] while cold, and nothing re-ran it (round 1
+	// P2). And once open it holds a COPY of the rows, so an SSE delta landing
+	// while it is on screen left it showing what the workspace used to contain
+	// (round 2 P2). Both are the same missing dependency.
+	//
+	// Tracked reads are the two signals that say the index changed: the
+	// bootstrap state, and the workspace cursor (`$state` on WorkspaceState,
+	// bumped by every applied delta batch). Everything else is read inside
+	// `untrack` — reading `query` or `results` reactively would re-run this on
+	// every keystroke, racing `oninput` and bumping `seq` twice per character,
+	// which is also why `onMount` rather than an effect owns the first run
+	// (CONVE-1688's neighbourhood).
+	//
+	// The re-list PRESERVES the highlighted row by id rather than skipping when
+	// the user has typed. Recomputing the index is what makes the refresh safe:
+	// re-running blind would take back a row the user had arrowed down to, at a
+	// moment they cannot predict — a keystroke they never made. If the row is
+	// gone from the new results, the highlight clears rather than silently
+	// pointing at whatever slid into that position.
 	$effect(() => {
 		const state = localIndex.bootstrapStateFor(wsSlug);
+		// Read for its dependency; the value itself carries no meaning here.
+		localIndex.cursorFor(wsSlug);
 		untrack(() => {
-			if (state === 'ready' && !query.trim()) runQuery();
+			if (state !== 'ready') return;
+			const keep = activeIndex >= 0 ? results[activeIndex]?.id : undefined;
+			runQuery();
+			activeIndex = keep ? results.findIndex((r) => r.id === keep) : -1;
 		});
 	});
 </script>

--- a/web/src/lib/components/items/ItemPicker.svelte
+++ b/web/src/lib/components/items/ItemPicker.svelte
@@ -278,20 +278,33 @@
 
 	// Keep an OPEN picker current with the local index.
 	//
-	// Two ways it went stale, both found by codex review. A picker can open
-	// BEFORE the workspace index has hydrated, and a scoped one then has nothing
-	// to list — `recent()` returns [] while cold, and nothing re-ran it (round 1
-	// P2). And once open it holds a COPY of the rows, so an SSE delta landing
-	// while it is on screen left it showing what the workspace used to contain
-	// (round 2 P2). Both are the same missing dependency.
+	// Three ways it went stale, all found by codex review, all the same missing
+	// dependency. A picker can open BEFORE the workspace index has hydrated, and
+	// a scoped one then has nothing to list — `recent()` returns [] while cold,
+	// and nothing re-ran it (round 1). Once open it holds a COPY of the rows, so
+	// a delta landing while it is on screen left it showing what the workspace
+	// used to contain (round 2). And the first fix for that tracked the wrong
+	// signal, missing every mutation that does not advance the cursor
+	// (round 3).
 	//
 	// Tracked reads are the two signals that say the index changed: the
-	// bootstrap state, and the workspace cursor (`$state` on WorkspaceState,
-	// bumped by every applied delta batch). Everything else is read inside
-	// `untrack` — reading `query` or `results` reactively would re-run this on
-	// every keystroke, racing `oninput` and bumping `seq` twice per character,
-	// which is also why `onMount` rather than an effect owns the first run
-	// (CONVE-1688's neighbourhood).
+	// bootstrap state, and `localSearch.epoch(ws)`.
+	//
+	// The epoch, NOT the workspace cursor. Round 2 used the cursor and round 3
+	// caught that it misses every cursorless mutation — `localIndex.upsert()` /
+	// `remove()` (optimistic creates, edits, the 403 purge) update the rows and
+	// mirror to `localSearch` without advancing it. The epoch is bumped by every
+	// `localSearch` write, and EVERY `localIndex` path that touches `state.items`
+	// mirrors there — `applyDelta`, `upsert`, `remove`, `removeByCollection`,
+	// `applyRetag`, `reset` — so it strictly dominates the cursor as a
+	// "something changed" signal. It exists for exactly this consumer shape:
+	// its own doc comment describes an `$effect` re-deriving search results,
+	// added for the identical staleness bug in TASK-1364.
+	//
+	// Everything else is read inside `untrack` — reading `query` or `results`
+	// reactively would re-run this on every keystroke, racing `oninput` and
+	// bumping `seq` twice per character, which is also why `onMount` rather than
+	// an effect owns the first run (CONVE-1688's neighbourhood).
 	//
 	// The re-list PRESERVES the highlighted row by id rather than skipping when
 	// the user has typed. Recomputing the index is what makes the refresh safe:
@@ -302,7 +315,7 @@
 	$effect(() => {
 		const state = localIndex.bootstrapStateFor(wsSlug);
 		// Read for its dependency; the value itself carries no meaning here.
-		localIndex.cursorFor(wsSlug);
+		localSearch.epoch(wsSlug);
 		untrack(() => {
 			if (state !== 'ready') return;
 			const keep = activeIndex >= 0 ? results[activeIndex]?.id : undefined;

--- a/web/src/lib/components/items/ItemPicker.svelte.test.ts
+++ b/web/src/lib/components/items/ItemPicker.svelte.test.ts
@@ -26,7 +26,7 @@ const { searchApi, localIndexMock, localSearchMock } = vi.hoisted(() => ({
 		getByCollection: vi.fn(),
 		findByIdOrSlug: vi.fn(),
 	},
-	localSearchMock: { search: vi.fn() },
+	localSearchMock: { search: vi.fn(), epoch: vi.fn() },
 }));
 
 vi.mock('$lib/api/client', () => ({ api: { search: (...a: unknown[]) => searchApi(...a) } }));
@@ -53,16 +53,28 @@ let rowsById = new Map<string, Row>();
  * set that the real store gets from `$state`.
  */
 const bootstrapState = new SvelteMap<string, string>();
-/** Same story for the workspace cursor, which every applied delta bumps. */
+/**
+ * Same story for `localSearch.epoch`, which every write to the search index
+ * bumps — including the cursorless optimistic paths (`localIndex.upsert` /
+ * `remove`) that an applied-delta cursor never sees.
+ */
+const epochs = new SvelteMap<string, number>();
+/**
+ * The workspace cursor is kept in the double — and deliberately never bumped by
+ * `bumpEpoch` — so that a component wired to it instead would still RUN and
+ * simply fail to refresh. Deleting it from the mock would make such a build
+ * throw instead, and a mutant that dies of a TypeError proves nothing about
+ * which signal is correct.
+ */
 const cursors = new SvelteMap<string, string>();
 
 function setBootstrapState(value: string) {
 	bootstrapState.set('ws', value);
 }
 
-/** Stand-in for an SSE delta batch landing in the local index. */
-function bumpCursor() {
-	cursors.set('ws', String(Number(cursors.get('ws') ?? '0') + 1));
+/** Stand-in for anything that mutates the local index. */
+function bumpEpoch() {
+	epochs.set('ws', (epochs.get('ws') ?? 0) + 1);
 }
 
 function makeRows(n: number, prefix = 'COLO'): Row[] {
@@ -106,11 +118,15 @@ beforeEach(() => {
 	searchApi.mockReset();
 	searchApi.mockResolvedValue({ results: [] });
 	bootstrapState.clear();
+	epochs.clear();
 	cursors.clear();
 	setBootstrapState('ready');
 	localIndexMock.bootstrapStateFor
 		.mockReset()
 		.mockImplementation((ws: string) => bootstrapState.get(ws) ?? 'cold');
+	localSearchMock.epoch
+		.mockReset()
+		.mockImplementation((ws: string) => epochs.get(ws) ?? 0);
 	localIndexMock.cursorFor
 		.mockReset()
 		.mockImplementation((ws: string) => cursors.get(ws) ?? '0');
@@ -228,20 +244,42 @@ describe('ItemPicker — collection size does not change the control (PLAN-2857 
 		expect(input().getAttribute('aria-activedescendant')).toBe(selected);
 	});
 
-	it('picks up a delta that lands while it is open', async () => {
-		// codex round 2 P2: the picker holds a COPY of the rows, so an SSE delta
+	it('picks up an index mutation that lands while it is open', async () => {
+		// codex round 2 P2: the picker holds a COPY of the rows, so a change
 		// arriving while it is on screen left it listing what the workspace used
-		// to contain until the query changed or it remounted.
+		// to contain until the query changed or it remounted. Driven through the
+		// search epoch rather than the workspace cursor — round 3 P2: the cursor
+		// misses every optimistic `localIndex.upsert` / `remove`, which mutate
+		// the rows without advancing it.
 		loadIndex(makeRows(2));
 		render(ItemPicker, { props: { ...baseProps } });
 		await tick();
 		expect(options()).toHaveLength(2);
 
 		loadIndex(makeRows(5));
-		bumpCursor();
+		bumpEpoch();
 		await tick();
 
 		expect(options()).toHaveLength(5);
+	});
+
+	it('refreshes on a mutation that never advances the workspace cursor', async () => {
+		// codex round 3 P2, and the whole reason the dependency is the search
+		// epoch. `localIndex.upsert()` / `remove()` — optimistic creates and
+		// edits, the 403 purge — mutate the rows and mirror to `localSearch`
+		// WITHOUT touching `state.cursor`. This leg bumps only the epoch, so a
+		// picker wired to the cursor sees nothing and stays stale.
+		loadIndex(makeRows(2));
+		render(ItemPicker, { props: { ...baseProps } });
+		await tick();
+		expect(options()).toHaveLength(2);
+
+		loadIndex(makeRows(4));
+		bumpEpoch();
+		await tick();
+
+		expect(options()).toHaveLength(4);
+		expect(cursors.get('ws')).toBeUndefined(); // the cursor never moved
 	});
 
 	it('keeps the selected row across a delta, and drops the highlight when that row goes away', async () => {
@@ -258,7 +296,7 @@ describe('ItemPicker — collection size does not change the control (PLAN-2857 
 		// A delta that removes the rows ABOVE the selection: a blind re-list would
 		// leave the highlight on index 2, which is now a different item.
 		loadIndex(makeRows(5).filter((r) => r.id !== 'id-1'));
-		bumpCursor();
+		bumpEpoch();
 		await tick();
 		const stillSelected = options().findIndex((o) => o.getAttribute('aria-selected') === 'true');
 		expect(options()[stillSelected].textContent).toContain('Colour 3');
@@ -267,7 +305,7 @@ describe('ItemPicker — collection size does not change the control (PLAN-2857 
 		// Now the selected row itself disappears — the highlight clears rather
 		// than pointing at whatever slid into that position.
 		loadIndex(makeRows(5).filter((r) => r.id !== 'id-1' && r.id !== 'id-3'));
-		bumpCursor();
+		bumpEpoch();
 		await tick();
 		expect(input().hasAttribute('aria-activedescendant')).toBe(false);
 	});

--- a/web/src/lib/components/items/ItemPicker.svelte.test.ts
+++ b/web/src/lib/components/items/ItemPicker.svelte.test.ts
@@ -1,0 +1,350 @@
+// Runs in the jsdom vitest project (filename ends `.svelte.test.ts`).
+//
+// ItemPicker is PLAN-2857 U3 (TASK-2862): the add-relationship search lifted
+// out of ItemDetail so a relation field (U2) and the Relationships tab share
+// one control. The design pass ruled OUT the dropdown-vs-search threshold the
+// plan asked for, on the grounds that `localIndex` already holds every item in
+// the workspace — so the assertions that matter are (a) collection size does
+// not change which control renders or how much DOM it costs, (b) the warm path
+// makes NO network call, and (c) the server search still runs when the local
+// index has not hydrated.
+//
+// (c) is the negative control for (b): without it, a picker that queried
+// nothing at all would pass every warm assertion here.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import { tick } from 'svelte';
+
+// `vi.mock` factories are hoisted above every other statement in the file, so
+// the doubles they close over have to be hoisted with them.
+const { searchApi, localIndexMock, localSearchMock } = vi.hoisted(() => ({
+	searchApi: vi.fn(),
+	localIndexMock: {
+		bootstrapStateFor: vi.fn(),
+		getByCollection: vi.fn(),
+		findByIdOrSlug: vi.fn(),
+	},
+	localSearchMock: { search: vi.fn() },
+}));
+
+vi.mock('$lib/api/client', () => ({ api: { search: (...a: unknown[]) => searchApi(...a) } }));
+vi.mock('$lib/stores/localIndex.svelte', () => ({ localIndex: localIndexMock }));
+vi.mock('$lib/stores/localSearch.svelte', () => ({ localSearch: localSearchMock }));
+
+import ItemPicker from './ItemPicker.svelte';
+
+interface Row {
+	id: string;
+	title: string;
+	item_number: number;
+	collection_prefix: string;
+}
+
+let rowsById = new Map<string, Row>();
+
+function makeRows(n: number, prefix = 'COLO'): Row[] {
+	const rows: Row[] = [];
+	for (let i = 1; i <= n; i++) {
+		rows.push({ id: `id-${i}`, title: `Colour ${i}`, item_number: i, collection_prefix: prefix });
+	}
+	return rows;
+}
+
+function loadIndex(rows: Row[]) {
+	rowsById = new Map(rows.map((r) => [r.id, r]));
+	localIndexMock.getByCollection.mockReturnValue(rows);
+}
+
+function options(): HTMLElement[] {
+	return Array.from(document.querySelectorAll<HTMLElement>('[role="option"]'));
+}
+
+function input(): HTMLInputElement {
+	const el = document.querySelector<HTMLInputElement>('.picker-input');
+	if (!el) throw new Error('.picker-input not found');
+	return el;
+}
+
+async function type(value: string) {
+	const el = input();
+	el.value = value;
+	el.dispatchEvent(new Event('input', { bubbles: true }));
+	await tick();
+}
+
+async function press(key: string, opts: KeyboardEventInit = {}) {
+	input().dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true, ...opts }));
+	await tick();
+}
+
+const baseProps = { wsSlug: 'ws', collection: 'colors', onselect: () => {} };
+
+beforeEach(() => {
+	searchApi.mockReset();
+	searchApi.mockResolvedValue({ results: [] });
+	localIndexMock.bootstrapStateFor.mockReset().mockReturnValue('ready');
+	localIndexMock.getByCollection.mockReset().mockReturnValue([]);
+	localIndexMock.findByIdOrSlug.mockReset().mockImplementation((_ws: string, id: string) => rowsById.get(id) ?? null);
+	localSearchMock.search.mockReset().mockReturnValue([]);
+	rowsById = new Map();
+});
+
+afterEach(() => {
+	cleanup();
+	vi.useRealTimers();
+	document.body.innerHTML = '';
+});
+
+describe('ItemPicker — collection size does not change the control (PLAN-2857 Q1)', () => {
+	it('lists a small target collection in full, with no network call', async () => {
+		loadIndex(makeRows(3));
+		render(ItemPicker, { props: { ...baseProps } });
+		await tick();
+
+		expect(options()).toHaveLength(3);
+		expect(input().getAttribute('role')).toBe('combobox');
+		expect(searchApi).not.toHaveBeenCalled();
+	});
+
+	it('renders the SAME bounded row count at 20 items and at 2000, still with no network call', async () => {
+		loadIndex(makeRows(20));
+		const { unmount } = render(ItemPicker, { props: { ...baseProps } });
+		await tick();
+		const small = options().length;
+		unmount();
+
+		loadIndex(makeRows(2000));
+		render(ItemPicker, { props: { ...baseProps } });
+		await tick();
+		const large = options().length;
+
+		// Bounded, and bounded to the SAME number — the row count is a function
+		// of `limit`, not of collection size. A picker that switched to a
+		// different control (or rendered every row) above a threshold fails here.
+		expect(small).toBe(10);
+		expect(large).toBe(10);
+		expect(large).toBe(small);
+		expect(document.querySelectorAll('select')).toHaveLength(0);
+		expect(searchApi).not.toHaveBeenCalled();
+	});
+
+	it('honours an explicit limit at both sizes', async () => {
+		loadIndex(makeRows(2000));
+		render(ItemPicker, { props: { ...baseProps, limit: 4 } });
+		await tick();
+		expect(options()).toHaveLength(4);
+	});
+
+	it('hides excluded rows', async () => {
+		loadIndex(makeRows(5));
+		render(ItemPicker, { props: { ...baseProps, excludeIds: ['id-2', 'id-4'] } });
+		await tick();
+
+		const labels = options().map((o) => o.textContent?.replace(/\s+/g, ' ').trim());
+		expect(labels).toHaveLength(3);
+		expect(labels.join('|')).not.toContain('Colour 2');
+		expect(labels.join('|')).not.toContain('Colour 4');
+	});
+
+	it('shows nothing on an empty query when unscoped — the Relationships-tab mode', async () => {
+		loadIndex(makeRows(5));
+		render(ItemPicker, { props: { wsSlug: 'ws', onselect: () => {} } });
+		await tick();
+
+		expect(options()).toHaveLength(0);
+		expect(localIndexMock.getByCollection).not.toHaveBeenCalled();
+	});
+
+	it('searches the local index, scoped to the collection, when the user types', async () => {
+		loadIndex(makeRows(3));
+		localSearchMock.search.mockReturnValue([{ id: 'id-2', score: 1 }]);
+		render(ItemPicker, { props: { ...baseProps } });
+		await tick();
+
+		await type('col');
+
+		expect(localSearchMock.search).toHaveBeenCalledWith(
+			'ws',
+			'col',
+			expect.objectContaining({ collection: 'colors' })
+		);
+		expect(options()).toHaveLength(1);
+		expect(searchApi).not.toHaveBeenCalled();
+	});
+});
+
+describe('ItemPicker — cold path (the control leg for "no network call")', () => {
+	it('calls the server search, collection-scoped, while the local index is cold', async () => {
+		vi.useFakeTimers();
+		localIndexMock.bootstrapStateFor.mockReturnValue('cold');
+		searchApi.mockResolvedValue({
+			results: [{ item: { id: 'id-9', title: 'Server row', item_number: 9, collection_prefix: 'COLO' } }],
+		});
+		render(ItemPicker, { props: { ...baseProps } });
+
+		await type('col');
+		expect(searchApi).not.toHaveBeenCalled(); // debounced, not fired per keystroke
+
+		await vi.advanceTimersByTimeAsync(250);
+		expect(searchApi).toHaveBeenCalledTimes(1);
+		expect(searchApi).toHaveBeenCalledWith('col', { workspace: 'ws', collection: 'colors' });
+
+		await tick();
+		expect(options()).toHaveLength(1);
+		expect(localSearchMock.search).not.toHaveBeenCalled();
+	});
+
+	it('does not let a superseded in-flight response repopulate the box', async () => {
+		vi.useFakeTimers();
+		localIndexMock.bootstrapStateFor.mockReturnValue('cold');
+
+		let releaseFirst!: (v: unknown) => void;
+		const first = new Promise((res) => (releaseFirst = res));
+		searchApi.mockReturnValueOnce(first).mockResolvedValue({ results: [] });
+
+		render(ItemPicker, { props: { ...baseProps } });
+		await type('aa');
+		await vi.advanceTimersByTimeAsync(250);
+		expect(searchApi).toHaveBeenCalledTimes(1);
+
+		// The user keeps typing while the first request is still open.
+		await type('bb');
+
+		releaseFirst({
+			results: [{ item: { id: 'id-1', title: 'Stale row', item_number: 1, collection_prefix: 'COLO' } }],
+		});
+		await vi.advanceTimersByTimeAsync(0);
+		await tick();
+
+		expect(document.body.textContent).not.toContain('Stale row');
+		expect(options()).toHaveLength(0);
+	});
+
+	it('CONTROL: the same response DOES populate when nothing superseded it', async () => {
+		// Without this leg the fence test above would pass against a picker that
+		// never renders a server result at all.
+		vi.useFakeTimers();
+		localIndexMock.bootstrapStateFor.mockReturnValue('cold');
+
+		let release!: (v: unknown) => void;
+		searchApi.mockReturnValueOnce(new Promise((res) => (release = res)));
+
+		render(ItemPicker, { props: { ...baseProps } });
+		await type('aa');
+		await vi.advanceTimersByTimeAsync(250);
+
+		release({
+			results: [{ item: { id: 'id-1', title: 'Stale row', item_number: 1, collection_prefix: 'COLO' } }],
+		});
+		await vi.advanceTimersByTimeAsync(0);
+		await tick();
+
+		expect(document.body.textContent).toContain('Stale row');
+		expect(options()).toHaveLength(1);
+	});
+});
+
+describe('ItemPicker — keyboard', () => {
+	it('moves the active row with the arrows and reports it via aria-activedescendant', async () => {
+		loadIndex(makeRows(3));
+		render(ItemPicker, { props: { ...baseProps } });
+		await tick();
+
+		expect(input().hasAttribute('aria-activedescendant')).toBe(false);
+
+		await press('ArrowDown');
+		expect(options()[0].getAttribute('aria-selected')).toBe('true');
+		expect(input().getAttribute('aria-activedescendant')).toBe(options()[0].id);
+
+		await press('ArrowDown');
+		expect(options()[1].getAttribute('aria-selected')).toBe('true');
+		expect(input().getAttribute('aria-activedescendant')).toBe(options()[1].id);
+
+		await press('ArrowUp');
+		expect(options()[0].getAttribute('aria-selected')).toBe('true');
+	});
+
+	it('selects the active row on Enter, and does nothing on Enter with no active row', async () => {
+		loadIndex(makeRows(3));
+		const onselect = vi.fn();
+		render(ItemPicker, { props: { ...baseProps, onselect } });
+		await tick();
+
+		await press('Enter');
+		expect(onselect).not.toHaveBeenCalled();
+
+		await press('ArrowDown');
+		await press('ArrowDown');
+		await press('Enter');
+		expect(onselect).toHaveBeenCalledTimes(1);
+		expect(onselect.mock.calls[0][0].id).toBe('id-2');
+	});
+
+	it('clicking a row selects it', async () => {
+		loadIndex(makeRows(2));
+		const onselect = vi.fn();
+		render(ItemPicker, { props: { ...baseProps, onselect } });
+		await tick();
+
+		options()[1].click();
+		expect(onselect).toHaveBeenCalledTimes(1);
+		expect(onselect.mock.calls[0][0].id).toBe('id-2');
+	});
+});
+
+describe('ItemPicker — Escape only consumes what it closes', () => {
+	// The page's Escape driver is a bubble-phase window listener feeding
+	// `runTopEscape` (escapeStack). A late-registered window listener stands in
+	// for it here: whether it SEES the key is the whole contract.
+	function windowEscapeSpy() {
+		const seen = vi.fn();
+		const handler = (e: Event) => seen(e);
+		window.addEventListener('keydown', handler);
+		return { seen, off: () => window.removeEventListener('keydown', handler) };
+	}
+
+	it('clears a non-empty query and does not let Escape reach the layer above', async () => {
+		loadIndex(makeRows(3));
+		localSearchMock.search.mockReturnValue([{ id: 'id-1', score: 1 }]);
+		render(ItemPicker, { props: { ...baseProps } });
+		await tick();
+		await type('col');
+		expect(input().value).toBe('col');
+
+		const { seen, off } = windowEscapeSpy();
+		await press('Escape');
+		off();
+
+		expect(input().value).toBe('');
+		expect(seen).not.toHaveBeenCalled();
+	});
+
+	it('calls oncancel on an empty box, and still consumes the key', async () => {
+		loadIndex(makeRows(3));
+		const oncancel = vi.fn();
+		render(ItemPicker, { props: { ...baseProps, oncancel } });
+		await tick();
+
+		const { seen, off } = windowEscapeSpy();
+		await press('Escape');
+		off();
+
+		expect(oncancel).toHaveBeenCalledTimes(1);
+		expect(seen).not.toHaveBeenCalled();
+	});
+
+	it('CONTROL: with no oncancel and an empty box, Escape falls through to the layer above', async () => {
+		// The pane must still close on Escape when the picker has nothing of its
+		// own to dismiss — a picker that swallowed every Escape would pass both
+		// tests above and break the pane.
+		loadIndex(makeRows(3));
+		render(ItemPicker, { props: { ...baseProps } });
+		await tick();
+
+		const { seen, off } = windowEscapeSpy();
+		await press('Escape');
+		off();
+
+		expect(seen).toHaveBeenCalledTimes(1);
+	});
+});

--- a/web/src/lib/components/items/ItemPicker.svelte.test.ts
+++ b/web/src/lib/components/items/ItemPicker.svelte.test.ts
@@ -14,6 +14,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, cleanup } from '@testing-library/svelte';
 import { tick } from 'svelte';
+import { SvelteMap } from 'svelte/reactivity';
 
 // `vi.mock` factories are hoisted above every other statement in the file, so
 // the doubles they close over have to be hoisted with them.
@@ -41,6 +42,20 @@ interface Row {
 }
 
 let rowsById = new Map<string, Row>();
+
+/**
+ * Reactive backing for `bootstrapStateFor`. The component tracks that read so
+ * it can re-list a scoped collection when hydration lands, and a bare `vi.fn`
+ * return value is not reactive — a test driving it that way cannot tell a
+ * working refresh from a missing one. `SvelteMap` is a plain runtime class
+ * (no compiler step), so it gives this `.ts` file the tracked get / triggering
+ * set that the real store gets from `$state`.
+ */
+const bootstrapState = new SvelteMap<string, string>();
+
+function setBootstrapState(value: string) {
+	bootstrapState.set('ws', value);
+}
 
 function makeRows(n: number, prefix = 'COLO'): Row[] {
 	const rows: Row[] = [];
@@ -82,7 +97,11 @@ const baseProps = { wsSlug: 'ws', collection: 'colors', onselect: () => {} };
 beforeEach(() => {
 	searchApi.mockReset();
 	searchApi.mockResolvedValue({ results: [] });
-	localIndexMock.bootstrapStateFor.mockReset().mockReturnValue('ready');
+	bootstrapState.clear();
+	setBootstrapState('ready');
+	localIndexMock.bootstrapStateFor
+		.mockReset()
+		.mockImplementation((ws: string) => bootstrapState.get(ws) ?? 'cold');
 	localIndexMock.getByCollection.mockReset().mockReturnValue([]);
 	localIndexMock.findByIdOrSlug.mockReset().mockImplementation((_ws: string, id: string) => rowsById.get(id) ?? null);
 	localSearchMock.search.mockReset().mockReturnValue([]);
@@ -146,6 +165,53 @@ describe('ItemPicker — collection size does not change the control (PLAN-2857 
 		expect(labels.join('|')).not.toContain('Colour 4');
 	});
 
+	it('lists the collection once the local index finishes hydrating, without the user typing', async () => {
+		// codex round 1 P2: a scoped picker opened while the index was cold had
+		// nothing to list and nothing re-ran the listing, so it stayed empty
+		// until the user typed.
+		loadIndex(makeRows(3));
+		setBootstrapState('loading');
+		render(ItemPicker, { props: { ...baseProps } });
+		await tick();
+		expect(options()).toHaveLength(0);
+
+		setBootstrapState('ready');
+		await tick();
+
+		expect(options().length).toBeGreaterThan(0);
+		expect(searchApi).not.toHaveBeenCalled();
+	});
+
+	it('hydrating mid-session does not reset a selection the user has already made', async () => {
+		// The `!query.trim()` guard on the hydration effect. Without it the
+		// re-list runs unconditionally and resets `activeIndex` to -1, so a user
+		// who has arrowed down to a row loses it the moment the index finishes
+		// loading — a keystroke they never made, at a moment they cannot predict.
+		vi.useFakeTimers();
+		loadIndex(makeRows(3));
+		setBootstrapState('loading');
+		searchApi.mockResolvedValue({
+			results: makeRows(3).map((r) => ({ item: r })),
+		});
+
+		render(ItemPicker, { props: { ...baseProps } });
+		await type('col');
+		await vi.advanceTimersByTimeAsync(250);
+		await tick();
+		expect(options()).toHaveLength(3);
+
+		await press('ArrowDown');
+		await press('ArrowDown');
+		const selected = input().getAttribute('aria-activedescendant');
+		expect(selected).toBe(options()[1].id);
+
+		setBootstrapState('ready');
+		await vi.advanceTimersByTimeAsync(0);
+		await tick();
+
+		expect(input().getAttribute('aria-activedescendant')).toBe(selected);
+	});
+
 	it('shows nothing on an empty query when unscoped — the Relationships-tab mode', async () => {
 		loadIndex(makeRows(5));
 		render(ItemPicker, { props: { wsSlug: 'ws', onselect: () => {} } });
@@ -176,7 +242,7 @@ describe('ItemPicker — collection size does not change the control (PLAN-2857 
 describe('ItemPicker — cold path (the control leg for "no network call")', () => {
 	it('calls the server search, collection-scoped, while the local index is cold', async () => {
 		vi.useFakeTimers();
-		localIndexMock.bootstrapStateFor.mockReturnValue('cold');
+		setBootstrapState('cold');
 		searchApi.mockResolvedValue({
 			results: [{ item: { id: 'id-9', title: 'Server row', item_number: 9, collection_prefix: 'COLO' } }],
 		});
@@ -207,7 +273,7 @@ describe('ItemPicker — cold path (the control leg for "no network call")', () 
 		// mutant survived; the fix is to end the scenario with loading FALSE, so
 		// the only thing standing between the stale row and the DOM is the fence.
 		vi.useFakeTimers();
-		localIndexMock.bootstrapStateFor.mockReturnValue('cold');
+		setBootstrapState('cold');
 
 		let releaseFirst!: (v: unknown) => void;
 		searchApi
@@ -238,7 +304,7 @@ describe('ItemPicker — cold path (the control leg for "no network call")', () 
 		// Without this leg the fence test above would pass against a picker that
 		// never renders a server result at all.
 		vi.useFakeTimers();
-		localIndexMock.bootstrapStateFor.mockReturnValue('cold');
+		setBootstrapState('cold');
 
 		let release!: (v: unknown) => void;
 		searchApi.mockReturnValueOnce(new Promise((res) => (release = res)));
@@ -263,7 +329,7 @@ describe('ItemPicker — cold path (the control leg for "no network call")', () 
 		// either way, so it passes with every teardown guard deleted. A test that
 		// no mutant can kill is not evidence, so it is not here.
 		vi.useFakeTimers();
-		localIndexMock.bootstrapStateFor.mockReturnValue('cold');
+		setBootstrapState('cold');
 
 		const { unmount } = render(ItemPicker, { props: { ...baseProps } });
 		await type('aa');
@@ -323,9 +389,16 @@ describe('ItemPicker — keyboard', () => {
 });
 
 describe('ItemPicker — Escape only consumes what it closes', () => {
-	// The page's Escape driver is a bubble-phase window listener feeding
-	// `runTopEscape` (escapeStack). A late-registered window listener stands in
-	// for it here: whether it SEES the key is the whole contract.
+	// The page's Escape driver is a bubble-phase window listener; a
+	// late-registered window listener stands in for it here.
+	//
+	// What that driver DOES with the key is deliberately not modelled: both pane
+	// hosts return early for text-entry targets before they reach the escape
+	// stack, so a picker with no `oncancel` leaves Escape with no owner rather
+	// than handing it upward (codex round 1 P2 — the first version of this file
+	// claimed otherwise in its own comment, without having read the handler).
+	// These legs assert only what this component does: consume the key when it
+	// has something to close, and leave it untouched when it does not.
 	function windowEscapeSpy() {
 		const seen = vi.fn();
 		const handler = (e: Event) => seen(e);
@@ -363,10 +436,9 @@ describe('ItemPicker — Escape only consumes what it closes', () => {
 		expect(seen).not.toHaveBeenCalled();
 	});
 
-	it('CONTROL: with no oncancel and an empty box, Escape falls through to the layer above', async () => {
-		// The pane must still close on Escape when the picker has nothing of its
-		// own to dismiss — a picker that swallowed every Escape would pass both
-		// tests above and break the pane.
+	it('CONTROL: with no oncancel and an empty box, the picker leaves the key alone', async () => {
+		// Without this leg the two above would pass against a picker that
+		// swallowed EVERY Escape unconditionally.
 		loadIndex(makeRows(3));
 		render(ItemPicker, { props: { ...baseProps } });
 		await tick();
@@ -376,5 +448,6 @@ describe('ItemPicker — Escape only consumes what it closes', () => {
 		off();
 
 		expect(seen).toHaveBeenCalledTimes(1);
+		expect(seen.mock.calls[0][0].defaultPrevented).toBe(false);
 	});
 });

--- a/web/src/lib/components/items/ItemPicker.svelte.test.ts
+++ b/web/src/lib/components/items/ItemPicker.svelte.test.ts
@@ -430,6 +430,107 @@ describe('ItemPicker — collection size does not change the control (PLAN-2857 
 	});
 });
 
+describe('ItemPicker — source: the two callers want different models', () => {
+	// Lead ruling on PR #1241: the Relationships tab keeps the server FTS, which
+	// indexes item BODY CONTENT. `localIndex` strips `content` by design, so the
+	// warm path can never answer "the item that mentioned that phrase" — losing
+	// it silently is a regression regardless of how consistent the other pickers
+	// are. A relation field wants the index's model and takes the default.
+
+	it('source="server" queries /search even with a hydrated index', async () => {
+		vi.useFakeTimers();
+		loadIndex(makeRows(3));
+		setBootstrapState('ready'); // warm — the default source would stay local
+		searchApi.mockResolvedValue({
+			results: [{ item: { id: 'id-9', title: 'Body match', item_number: 9, collection_prefix: 'COLO' } }],
+		});
+
+		render(ItemPicker, { props: { ...baseProps, source: 'server' } });
+		await type('phrase from the body');
+		await vi.advanceTimersByTimeAsync(250);
+		await tick();
+
+		expect(searchApi).toHaveBeenCalledTimes(1);
+		expect(searchApi).toHaveBeenCalledWith('phrase from the body', {
+			workspace: 'ws',
+			collection: 'colors',
+		});
+		expect(localSearchMock.search).not.toHaveBeenCalled();
+		expect(document.body.textContent).toContain('Body match');
+	});
+
+	it('CONTROL: the default source, same warm index, never reaches the network', async () => {
+		vi.useFakeTimers();
+		loadIndex(makeRows(3));
+		setBootstrapState('ready');
+		localSearchMock.search.mockReturnValue([{ id: 'id-2', score: 1 }]);
+
+		render(ItemPicker, { props: { ...baseProps } });
+		await type('phrase from the body');
+		await vi.advanceTimersByTimeAsync(250);
+		await tick();
+
+		expect(localSearchMock.search).toHaveBeenCalledTimes(1);
+		expect(searchApi).not.toHaveBeenCalled();
+	});
+
+	it('source="server" still opens with the collection listed from the index', async () => {
+		// An empty-query LISTING is not a search, and `/search` cannot answer one
+		// (it requires a `q`). Only QUERIES go to the server.
+		loadIndex(makeRows(3));
+		render(ItemPicker, { props: { ...baseProps, source: 'server' } });
+		await tick();
+
+		expect(options()).toHaveLength(3);
+		expect(searchApi).not.toHaveBeenCalled();
+	});
+
+	it('source="server" honours a late exclusion set without re-issuing the request', async () => {
+		vi.useFakeTimers();
+		loadIndex(makeRows(4));
+		searchApi.mockResolvedValue({
+			results: makeRows(4).map((r) => ({ item: r })),
+		});
+		const probe = render(ItemPickerProbe, {
+			props: { wsSlug: 'ws', collection: 'colors', source: 'server' as const },
+		});
+		await type('col');
+		await vi.advanceTimersByTimeAsync(250);
+		await tick();
+		expect(options()).toHaveLength(4);
+		expect(searchApi).toHaveBeenCalledTimes(1);
+
+		probe.component.setExcludeIds(['id-2']);
+		await tick();
+
+		expect(options()).toHaveLength(3);
+		expect(options().map((o) => o.textContent ?? '').join('|')).not.toContain('Colour 2');
+		// The whole point of deriving the filter: no second request.
+		expect(searchApi).toHaveBeenCalledTimes(1);
+	});
+
+	it('source="server" does not re-query on an index delta', async () => {
+		// A request per applied delta is exactly the rate-limiter pressure the
+		// debounce exists to avoid, and the index is not this list's source of
+		// truth anyway.
+		vi.useFakeTimers();
+		loadIndex(makeRows(3));
+		searchApi.mockResolvedValue({ results: makeRows(3).map((r) => ({ item: r })) });
+
+		render(ItemPicker, { props: { ...baseProps, source: 'server' } });
+		await type('col');
+		await vi.advanceTimersByTimeAsync(250);
+		await tick();
+		expect(searchApi).toHaveBeenCalledTimes(1);
+
+		bumpEpoch();
+		await tick();
+		await vi.advanceTimersByTimeAsync(250);
+
+		expect(searchApi).toHaveBeenCalledTimes(1);
+	});
+});
+
 describe('ItemPicker — cold path (the control leg for "no network call")', () => {
 	it('calls the server search, collection-scoped, while the local index is cold', async () => {
 		vi.useFakeTimers();

--- a/web/src/lib/components/items/ItemPicker.svelte.test.ts
+++ b/web/src/lib/components/items/ItemPicker.svelte.test.ts
@@ -22,6 +22,7 @@ const { searchApi, localIndexMock, localSearchMock } = vi.hoisted(() => ({
 	searchApi: vi.fn(),
 	localIndexMock: {
 		bootstrapStateFor: vi.fn(),
+		cursorFor: vi.fn(),
 		getByCollection: vi.fn(),
 		findByIdOrSlug: vi.fn(),
 	},
@@ -52,9 +53,16 @@ let rowsById = new Map<string, Row>();
  * set that the real store gets from `$state`.
  */
 const bootstrapState = new SvelteMap<string, string>();
+/** Same story for the workspace cursor, which every applied delta bumps. */
+const cursors = new SvelteMap<string, string>();
 
 function setBootstrapState(value: string) {
 	bootstrapState.set('ws', value);
+}
+
+/** Stand-in for an SSE delta batch landing in the local index. */
+function bumpCursor() {
+	cursors.set('ws', String(Number(cursors.get('ws') ?? '0') + 1));
 }
 
 function makeRows(n: number, prefix = 'COLO'): Row[] {
@@ -98,10 +106,14 @@ beforeEach(() => {
 	searchApi.mockReset();
 	searchApi.mockResolvedValue({ results: [] });
 	bootstrapState.clear();
+	cursors.clear();
 	setBootstrapState('ready');
 	localIndexMock.bootstrapStateFor
 		.mockReset()
 		.mockImplementation((ws: string) => bootstrapState.get(ws) ?? 'cold');
+	localIndexMock.cursorFor
+		.mockReset()
+		.mockImplementation((ws: string) => cursors.get(ws) ?? '0');
 	localIndexMock.getByCollection.mockReset().mockReturnValue([]);
 	localIndexMock.findByIdOrSlug.mockReset().mockImplementation((_ws: string, id: string) => rowsById.get(id) ?? null);
 	localSearchMock.search.mockReset().mockReturnValue([]);
@@ -183,16 +195,20 @@ describe('ItemPicker — collection size does not change the control (PLAN-2857 
 	});
 
 	it('hydrating mid-session does not reset a selection the user has already made', async () => {
-		// The `!query.trim()` guard on the hydration effect. Without it the
-		// re-list runs unconditionally and resets `activeIndex` to -1, so a user
-		// who has arrowed down to a row loses it the moment the index finishes
-		// loading — a keystroke they never made, at a moment they cannot predict.
+		// The re-list recomputes `activeIndex` from the selected row's ID. Without
+		// that, it resets to -1 and a user who has arrowed down to a row loses it
+		// the moment the index finishes loading — a keystroke they never made, at
+		// a moment they cannot predict.
 		vi.useFakeTimers();
 		loadIndex(makeRows(3));
 		setBootstrapState('loading');
 		searchApi.mockResolvedValue({
 			results: makeRows(3).map((r) => ({ item: r })),
 		});
+		// Once warm the same query is answered by the local index.
+		localSearchMock.search.mockReturnValue(
+			makeRows(3).map((r) => ({ id: r.id, score: 1 }))
+		);
 
 		render(ItemPicker, { props: { ...baseProps } });
 		await type('col');
@@ -210,6 +226,50 @@ describe('ItemPicker — collection size does not change the control (PLAN-2857 
 		await tick();
 
 		expect(input().getAttribute('aria-activedescendant')).toBe(selected);
+	});
+
+	it('picks up a delta that lands while it is open', async () => {
+		// codex round 2 P2: the picker holds a COPY of the rows, so an SSE delta
+		// arriving while it is on screen left it listing what the workspace used
+		// to contain until the query changed or it remounted.
+		loadIndex(makeRows(2));
+		render(ItemPicker, { props: { ...baseProps } });
+		await tick();
+		expect(options()).toHaveLength(2);
+
+		loadIndex(makeRows(5));
+		bumpCursor();
+		await tick();
+
+		expect(options()).toHaveLength(5);
+	});
+
+	it('keeps the selected row across a delta, and drops the highlight when that row goes away', async () => {
+		loadIndex(makeRows(5));
+		render(ItemPicker, { props: { ...baseProps } });
+		await tick();
+
+		await press('ArrowDown');
+		await press('ArrowDown');
+		await press('ArrowDown');
+		const selectedId = 'id-3';
+		expect(input().getAttribute('aria-activedescendant')).toBe(options()[2].id);
+
+		// A delta that removes the rows ABOVE the selection: a blind re-list would
+		// leave the highlight on index 2, which is now a different item.
+		loadIndex(makeRows(5).filter((r) => r.id !== 'id-1'));
+		bumpCursor();
+		await tick();
+		const stillSelected = options().findIndex((o) => o.getAttribute('aria-selected') === 'true');
+		expect(options()[stillSelected].textContent).toContain('Colour 3');
+		expect(rowsById.get(selectedId)).toBeDefined();
+
+		// Now the selected row itself disappears — the highlight clears rather
+		// than pointing at whatever slid into that position.
+		loadIndex(makeRows(5).filter((r) => r.id !== 'id-1' && r.id !== 'id-3'));
+		bumpCursor();
+		await tick();
+		expect(input().hasAttribute('aria-activedescendant')).toBe(false);
 	});
 
 	it('shows nothing on an empty query when unscoped — the Relationships-tab mode', async () => {

--- a/web/src/lib/components/items/ItemPicker.svelte.test.ts
+++ b/web/src/lib/components/items/ItemPicker.svelte.test.ts
@@ -34,6 +34,7 @@ vi.mock('$lib/stores/localIndex.svelte', () => ({ localIndex: localIndexMock }))
 vi.mock('$lib/stores/localSearch.svelte', () => ({ localSearch: localSearchMock }));
 
 import ItemPicker from './ItemPicker.svelte';
+import ItemPickerProbe from './ItemPickerProbe.svelte';
 
 interface Row {
 	id: string;
@@ -280,6 +281,98 @@ describe('ItemPicker — collection size does not change the control (PLAN-2857 
 
 		expect(options()).toHaveLength(4);
 		expect(cursors.get('ws')).toBeUndefined(); // the cursor never moved
+	});
+
+	it('re-filters when the exclusion set arrives late', async () => {
+		// codex round 4 P2. `ItemDetail` loads `itemLinks` asynchronously, so a
+		// picker opened before that resolves was offering items already linked to
+		// the source — clicking one is a duplicate-link write the user did not
+		// know they were making.
+		//
+		// Driven through `ItemPickerProbe` rather than testing-library's
+		// `rerender`, on purpose: `rerender` replaces the whole props object,
+		// which re-runs the refresh effect whether or not it tracks `excludeIds`.
+		// The mutant that drops that dependency SURVIVES a rerender-driven
+		// version of this test while breaking the real parent, which changes one
+		// prop at a time. The probe changes one prop.
+		loadIndex(makeRows(4));
+		const probe = render(ItemPickerProbe, {
+			props: { wsSlug: 'ws', collection: 'colors' },
+		});
+		await tick();
+		expect(options()).toHaveLength(4);
+
+		probe.component.setExcludeIds(['id-2', 'id-3']);
+		await tick();
+
+		const labels = options().map((o) => o.textContent ?? '');
+		expect(options()).toHaveLength(2);
+		expect(labels.join('|')).not.toContain('Colour 2');
+		expect(labels.join('|')).not.toContain('Colour 3');
+	});
+
+	it('drops everything it was showing when the workspace state is reset', async () => {
+		// codex round 4 P1: `localIndex.reset()` — sign-out, a 403 membership
+		// purge, a deleted workspace — bumps the search epoch on its way out, so
+		// this effect runs. Returning early there left rows the viewer may no
+		// longer be allowed to see listed AND selectable.
+		loadIndex(makeRows(3));
+		render(ItemPicker, { props: { ...baseProps } });
+		await tick();
+		expect(options()).toHaveLength(3);
+
+		// What reset() does, in order: drop the state (so bootstrapStateFor falls
+		// back to 'cold') and reset the search index (which bumps the epoch).
+		localIndexMock.getByCollection.mockReturnValue([]);
+		setBootstrapState('cold');
+		bumpEpoch();
+		await tick();
+
+		expect(options()).toHaveLength(0);
+		expect(document.body.textContent).not.toContain('Colour 1');
+	});
+
+	it('does not let a cold response land after the workspace state is reset', async () => {
+		vi.useFakeTimers();
+		setBootstrapState('cold');
+
+		let release!: (v: unknown) => void;
+		searchApi.mockReturnValueOnce(new Promise((res) => (release = res)));
+
+		render(ItemPicker, { props: { ...baseProps } });
+		await type('aa');
+		await vi.advanceTimersByTimeAsync(250);
+		expect(searchApi).toHaveBeenCalledTimes(1);
+
+		// Reset arrives while the request is open.
+		bumpEpoch();
+		await tick();
+
+		release({
+			results: [{ item: { id: 'id-1', title: 'Revoked row', item_number: 1, collection_prefix: 'COLO' } }],
+		});
+		await vi.advanceTimersByTimeAsync(0);
+		await tick();
+
+		expect(document.body.textContent).not.toContain('Revoked row');
+	});
+
+	it('CONTROL: an ordinary cold mount is not torn down by the same effect', async () => {
+		// The reset teardown is gated on already showing or awaiting something.
+		// Without that gate it would fire on every cold mount and cancel the cold
+		// path's own in-flight search — so this leg has to stay green.
+		vi.useFakeTimers();
+		setBootstrapState('cold');
+		searchApi.mockResolvedValue({
+			results: [{ item: { id: 'id-7', title: 'Cold row', item_number: 7, collection_prefix: 'COLO' } }],
+		});
+
+		render(ItemPicker, { props: { ...baseProps } });
+		await type('aa');
+		await vi.advanceTimersByTimeAsync(250);
+		await tick();
+
+		expect(document.body.textContent).toContain('Cold row');
 	});
 
 	it('keeps the selected row across a delta, and drops the highlight when that row goes away', async () => {

--- a/web/src/lib/components/items/ItemPicker.svelte.test.ts
+++ b/web/src/lib/components/items/ItemPicker.svelte.test.ts
@@ -194,25 +194,39 @@ describe('ItemPicker — cold path (the control leg for "no network call")', () 
 		expect(localSearchMock.search).not.toHaveBeenCalled();
 	});
 
+	const STALE = {
+		results: [{ item: { id: 'id-1', title: 'Stale row', item_number: 1, collection_prefix: 'COLO' } }],
+	};
+
 	it('does not let a superseded in-flight response repopulate the box', async () => {
+		// The SECOND request is allowed to land first, deliberately. An earlier
+		// draft of this test released the stale response while the picker was
+		// still `loading`, and it passed against a build with the staleness check
+		// DELETED — because the loading branch renders instead of the result
+		// list, so the stale row was in `results` and merely not on screen. The
+		// mutant survived; the fix is to end the scenario with loading FALSE, so
+		// the only thing standing between the stale row and the DOM is the fence.
 		vi.useFakeTimers();
 		localIndexMock.bootstrapStateFor.mockReturnValue('cold');
 
 		let releaseFirst!: (v: unknown) => void;
-		const first = new Promise((res) => (releaseFirst = res));
-		searchApi.mockReturnValueOnce(first).mockResolvedValue({ results: [] });
+		searchApi
+			.mockReturnValueOnce(new Promise((res) => (releaseFirst = res)))
+			.mockResolvedValue({ results: [] });
 
 		render(ItemPicker, { props: { ...baseProps } });
 		await type('aa');
 		await vi.advanceTimersByTimeAsync(250);
 		expect(searchApi).toHaveBeenCalledTimes(1);
 
-		// The user keeps typing while the first request is still open.
+		// The user keeps typing while the first request is still open; the second
+		// one resolves empty and settles the picker.
 		await type('bb');
+		await vi.advanceTimersByTimeAsync(250);
+		expect(searchApi).toHaveBeenCalledTimes(2);
+		expect(document.body.textContent).not.toContain('Searching...');
 
-		releaseFirst({
-			results: [{ item: { id: 'id-1', title: 'Stale row', item_number: 1, collection_prefix: 'COLO' } }],
-		});
+		releaseFirst(STALE);
 		await vi.advanceTimersByTimeAsync(0);
 		await tick();
 
@@ -220,7 +234,7 @@ describe('ItemPicker — cold path (the control leg for "no network call")', () 
 		expect(options()).toHaveLength(0);
 	});
 
-	it('CONTROL: the same response DOES populate when nothing superseded it', async () => {
+	it('CONTROL: that exact response DOES reach the DOM when nothing superseded it', async () => {
 		// Without this leg the fence test above would pass against a picker that
 		// never renders a server result at all.
 		vi.useFakeTimers();
@@ -233,14 +247,30 @@ describe('ItemPicker — cold path (the control leg for "no network call")', () 
 		await type('aa');
 		await vi.advanceTimersByTimeAsync(250);
 
-		release({
-			results: [{ item: { id: 'id-1', title: 'Stale row', item_number: 1, collection_prefix: 'COLO' } }],
-		});
+		release(STALE);
 		await vi.advanceTimersByTimeAsync(0);
 		await tick();
 
 		expect(document.body.textContent).toContain('Stale row');
 		expect(options()).toHaveLength(1);
+	});
+
+	it('never fires a request the user closed the picker before earning', async () => {
+		// This asserts the onDestroy `clearTimeout`, and it is deliberately about
+		// the REQUEST rather than the rendered result. The tempting version —
+		// unmount, then resolve an in-flight response, then assert the stale row
+		// is not in the DOM — cannot fail: an unmounted component renders nothing
+		// either way, so it passes with every teardown guard deleted. A test that
+		// no mutant can kill is not evidence, so it is not here.
+		vi.useFakeTimers();
+		localIndexMock.bootstrapStateFor.mockReturnValue('cold');
+
+		const { unmount } = render(ItemPicker, { props: { ...baseProps } });
+		await type('aa');
+		unmount();
+		await vi.advanceTimersByTimeAsync(250);
+
+		expect(searchApi).not.toHaveBeenCalled();
 	});
 });
 

--- a/web/src/lib/components/items/ItemPickerProbe.svelte
+++ b/web/src/lib/components/items/ItemPickerProbe.svelte
@@ -19,10 +19,11 @@
 	interface Props {
 		wsSlug: string;
 		collection?: string;
+		source?: 'index' | 'server';
 		onselect?: (item: ItemIndexRow) => void;
 	}
 
-	let { wsSlug, collection, onselect = () => {} }: Props = $props();
+	let { wsSlug, collection, source = 'index', onselect = () => {} }: Props = $props();
 
 	// Starts empty and is only ever changed through `setExcludeIds` — seeding
 	// it from a prop would capture the initial value and warn.
@@ -34,4 +35,4 @@
 	}
 </script>
 
-<ItemPicker {wsSlug} {collection} {excludeIds} {onselect} />
+<ItemPicker {wsSlug} {collection} {source} {excludeIds} {onselect} />

--- a/web/src/lib/components/items/ItemPickerProbe.svelte
+++ b/web/src/lib/components/items/ItemPickerProbe.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	// Test-only host for ItemPicker (TASK-2862). Same role as
+	// `masterFreeze/FreezeProbe.svelte` and `localDirtyGuard/GuardProbe.svelte`:
+	// a component that exists so a test can drive a behaviour the test file
+	// cannot reach on its own.
+	//
+	// WHY IT IS NEEDED. `excludeIds` arriving LATE is a real case — `ItemDetail`
+	// loads `itemLinks` asynchronously, so a picker opened first must re-filter
+	// when they land (codex round 4 P2). Testing-library's `rerender` cannot
+	// prove that: it replaces the whole props object, which re-runs the picker's
+	// refresh effect whether or not the effect tracks `excludeIds` — so the
+	// mutant that removes that dependency SURVIVES a rerender-driven test while
+	// the production path (a single prop changing) would be broken.
+	//
+	// This host changes exactly ONE prop, the way a real parent does.
+	import ItemPicker from './ItemPicker.svelte';
+	import type { ItemIndexRow } from '$lib/types';
+
+	interface Props {
+		wsSlug: string;
+		collection?: string;
+		onselect?: (item: ItemIndexRow) => void;
+	}
+
+	let { wsSlug, collection, onselect = () => {} }: Props = $props();
+
+	// Starts empty and is only ever changed through `setExcludeIds` — seeding
+	// it from a prop would capture the initial value and warn.
+	let excludeIds = $state<string[]>([]);
+
+	/** Driven by the test to simulate the async `itemLinks` load resolving. */
+	export function setExcludeIds(next: string[]) {
+		excludeIds = next;
+	}
+</script>
+
+<ItemPicker {wsSlug} {collection} {excludeIds} {onselect} />

--- a/web/src/lib/components/items/itemDetailUsesPicker.test.ts
+++ b/web/src/lib/components/items/itemDetailUsesPicker.test.ts
@@ -41,6 +41,18 @@ describe('ItemDetail consumes ItemPicker', () => {
 		expect(markupSource).toMatch(/<ItemPicker\b/);
 	});
 
+	it('keeps the Relationships tab on the SERVER search', () => {
+		// Lead ruling on PR #1241. `/search`'s FTS indexes item BODY CONTENT;
+		// `localIndex` strips `content` by design, so the warm path can never
+		// answer "the item that mentioned that phrase". Dropping `source` here
+		// would silently take that away from this caller — the regression is
+		// invisible from the component's own tests, which is why the assertion
+		// lives at the call site.
+		const tag = markupSource.match(/<ItemPicker\b[\s\S]*?\/>/);
+		expect(tag).not.toBeNull();
+		expect(tag![0]).toMatch(/source="server"/);
+	});
+
 	it('passes it the workspace and the exclusion set, and handles its selection', () => {
 		const tag = markupSource.match(/<ItemPicker\b[\s\S]*?\/>/);
 		expect(tag).not.toBeNull();

--- a/web/src/lib/components/items/itemDetailUsesPicker.test.ts
+++ b/web/src/lib/components/items/itemDetailUsesPicker.test.ts
@@ -1,0 +1,78 @@
+// Node-project test (no DOM): a SOURCE-level guard that ItemDetail actually
+// CONSUMES ItemPicker rather than keeping a second copy of the search beside
+// it (PLAN-2857 U3 / TASK-2862, "the extraction is proven by its first caller,
+// not by a parallel copy").
+//
+// Why source text and not a render: ItemDetail is ~7,900 lines with collab,
+// SSE and pane wiring, so mounting it to observe which search box it uses
+// costs more setup than the property is worth — and the property is
+// structural. The failure this guards against is a future edit re-inlining a
+// search here, which shows up in the source and would NOT show up in
+// ItemPicker's own suite.
+//
+// Identifier matches are END-anchored (`\b`): `searchItemsForLink` is a
+// substring of `searchItemsForLinkV2`, and a guard that its own successor
+// passes guards nothing.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const source = readFileSync(
+	fileURLToPath(new URL('./ItemDetail.svelte', import.meta.url)),
+	'utf8'
+);
+
+describe('ItemDetail consumes ItemPicker', () => {
+	it('imports it', () => {
+		expect(source).toMatch(/import\s+ItemPicker\s+from\s+'\.\/ItemPicker\.svelte'/);
+	});
+
+	it('mounts it in the add-relationship form', () => {
+		expect(source).toMatch(/<ItemPicker\b/);
+	});
+
+	it('passes it the workspace and the exclusion set, and handles its selection', () => {
+		const tag = source.match(/<ItemPicker\b[\s\S]*?\/>/);
+		expect(tag).not.toBeNull();
+		const markup = tag![0];
+		expect(markup).toMatch(/\{wsSlug\}/);
+		expect(markup).toMatch(/excludeIds=\{addLinkExcludeIds\}/);
+		expect(markup).toMatch(/onselect=\{handleCreateLink\}/);
+	});
+
+	it('no longer carries its own copy of the search', () => {
+		for (const identifier of [
+			'searchItemsForLink',
+			'onAddLinkInput',
+			'cancelAddLinkSearch',
+			'addLinkResults',
+			'addLinkLoading',
+			'addLinkSearchSeq',
+			'addLinkDebounceTimer',
+			'ADD_LINK_SEARCH_DEBOUNCE_MS',
+		]) {
+			expect(source, `${identifier} should have moved into ItemPicker`).not.toMatch(
+				new RegExp(`\\b${identifier}\\b`)
+			);
+		}
+	});
+
+	it('keeps the item-switch fence structural — the picker mounts inside {#key itemSlug}', () => {
+		// PLAN-2105 / TASK-2112. The picker carries no second generation counter;
+		// it relies on being DESTROYED on an item switch. There is more than one
+		// `{#key itemSlug}` block in this file, so "a key exists before the
+		// picker" would pass even if the picker sat outside all of them — the
+		// nearest preceding key must also still be OPEN at the picker, i.e. no
+		// `{/key}` in between.
+		const picker = source.indexOf('<ItemPicker');
+		expect(picker).toBeGreaterThan(-1);
+
+		const before = source.slice(0, picker);
+		const keyStart = before.lastIndexOf('{#key itemSlug}');
+		expect(keyStart, 'no {#key itemSlug} precedes the picker').toBeGreaterThan(-1);
+		expect(
+			before.slice(keyStart).includes('{/key}'),
+			'the nearest {#key itemSlug} closes before the picker — the picker is outside it'
+		).toBe(false);
+	});
+});

--- a/web/src/lib/components/items/itemDetailUsesPicker.test.ts
+++ b/web/src/lib/components/items/itemDetailUsesPicker.test.ts
@@ -22,17 +22,27 @@ const source = readFileSync(
 	'utf8'
 );
 
+/**
+ * Markup with HTML comments stripped. A mount assertion has to run against
+ * this, not the raw text: `<!-- <ItemPicker ... -->` still matches
+ * `/<ItemPicker\b/`, so a guard on the raw source passes against the exact
+ * regression it exists to catch (verified — that mutant survived until this
+ * was added). Comments are stripped rather than the regex made cleverer
+ * because the same hazard applies to every match below.
+ */
+const markupSource = source.replace(/<!--[\s\S]*?-->/g, '');
+
 describe('ItemDetail consumes ItemPicker', () => {
 	it('imports it', () => {
 		expect(source).toMatch(/import\s+ItemPicker\s+from\s+'\.\/ItemPicker\.svelte'/);
 	});
 
 	it('mounts it in the add-relationship form', () => {
-		expect(source).toMatch(/<ItemPicker\b/);
+		expect(markupSource).toMatch(/<ItemPicker\b/);
 	});
 
 	it('passes it the workspace and the exclusion set, and handles its selection', () => {
-		const tag = source.match(/<ItemPicker\b[\s\S]*?\/>/);
+		const tag = markupSource.match(/<ItemPicker\b[\s\S]*?\/>/);
 		expect(tag).not.toBeNull();
 		const markup = tag![0];
 		expect(markup).toMatch(/\{wsSlug\}/);
@@ -64,10 +74,10 @@ describe('ItemDetail consumes ItemPicker', () => {
 		// picker" would pass even if the picker sat outside all of them — the
 		// nearest preceding key must also still be OPEN at the picker, i.e. no
 		// `{/key}` in between.
-		const picker = source.indexOf('<ItemPicker');
+		const picker = markupSource.indexOf('<ItemPicker');
 		expect(picker).toBeGreaterThan(-1);
 
-		const before = source.slice(0, picker);
+		const before = markupSource.slice(0, picker);
 		const keyStart = before.lastIndexOf('{#key itemSlug}');
 		expect(keyStart, 'no {#key itemSlug} precedes the picker').toBeGreaterThan(-1);
 		expect(

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -2218,7 +2218,7 @@ export function isTerminalStatusDefault(status: string): boolean {
 	return DEFAULT_TERMINAL_STATUSES.includes(status);
 }
 
-export function formatItemRef(item: Item): string | null {
+export function formatItemRef(item: Pick<Item, 'item_number' | 'collection_prefix'>): string | null {
 	if (!item.item_number) return null;
 	const prefix = item.collection_prefix || '';
 	return prefix ? `${prefix}-${item.item_number}` : `#${item.item_number}`;


### PR DESCRIPTION
Unit U3 of the relation-fields design pass ([[PLAN-2857]] / TASK-2862). Extracts `ItemDetail`'s inline add-relationship search into a shared `ItemPicker` so the relation-field editor (U2) mounts it instead of copying it. No product behaviour outside the picker changes.

## Why there is no dropdown-vs-search threshold

PLAN-2857 asked for a plain dropdown under N items and a search above it. The recon behind that plan found the threshold was pricing a round-trip that does not happen: `localIndex` is a workspace-wide in-RAM read model of every item (`/workspaces/{ws}/items-index` takes no limit parameter), and `localSearch` is a MiniSearch index built over it — already collection-scopable, already ranked, already what CommandPalette / ListView / BoardView use.

So: one control, always filter-shaped, correct at three items and at three thousand. The tests assert the rendered row count is a function of `limit`, not of collection size. The server `/search` endpoint remains the **cold path** — used while the local index has not hydrated, which is also what every caller did before this change. It is not a mode the user can select, and only that path is debounced, because the debounce exists to keep per-keystroke requests off the rate limiter and the warm path issues none.

## One behaviour delta, deliberate

The pre-change search always hit the server FTS, which indexes item **content**. The warm path does not (`localIndex` strips `content` by design). On a hydrated workspace you now find a link target by title / ref / tags / field values rather than by a word in its body. Taken deliberately: it is what "ItemDetail consumes the new component" means, and it makes the Relationships tab agree with every other in-app search surface instead of disagreeing with it. Trivially reversible as a prop if that is the wrong call.

## New beyond the extraction

Both required by the unit: keyboard navigation (arrows / Enter / Escape) with `aria-activedescendant`, which the inline search never had; and a scoped picker opens with its target collection listed most-recently-updated first, so it is useful before the user types.

## Fences

The per-query `seq` moved into the picker and also fires on unmount. The item-switch fence is **not** duplicated — `ItemDetail` already wraps this region in `{#key itemSlug}` (PLAN-2105 / TASK-2112), so a switch destroys the instance. A source-level test pins that the picker stays inside an **open** key block, since "a key exists somewhere above it" would pass with the picker outside all of them.

## Review rounds

Five codex rounds; round 5 CLEAN. Every round found something real:

| round | finding | disposition |
|---|---|---|
| 1 | scoped picker mounted cold never listed its collection | fixed — effect re-lists on hydration |
| 1 | the Escape comment claimed Escape falls through to the pane | **the comment was false** — both hosts bail on text-entry targets before the escape stack; prose, prop doc and test name corrected |
| 2 | an open picker held a stale copy of the rows | fixed — the effect tracks an index-change signal |
| 2 | empty-picker Escape does not reach pane handling | **declined**, with the measurement — see below |
| 3 | the round-2 fix tracked the wrong signal | fixed — `localSearch.epoch` dominates the workspace cursor, which misses every optimistic `upsert`/`remove` |
| 4 | an index reset left rows on screen, still selectable | fixed — teardown invalidates pending work and clears results |
| 4 | `excludeIds` arriving late did not re-filter | fixed — already-linked items were being offered |

**The declined one.** Measured before declining: pre-change the box was a bare `<input type="text">` with no keydown handler, so Escape there did nothing — same today when a caller omits `oncancel`, so not a regression. Both pane hosts call `isTextEntryTarget(target)` and **return** before running the escape stack (`[collection]/+page.svelte:2321`, `[collection]/[slug]/+page.svelte:465`) on the stated rule that a text field owns Escape locally; handing Escape upward would contradict route-level policy that is not this unit's to change. The one caller today passes `oncancel`, so Escape clears the query and then closes the form — strictly more than before. The prop doc says plainly what omitting it costs, so U2 cannot acquire the gap by accident.

## Two tests that were false greens

Worth naming because both passed against builds with the thing they name deleted.

- **The staleness fence.** The first version released a superseded response while the picker was still `loading`, and the loading branch renders instead of the result list — so the stale row was in `results` and merely off screen. Rewritten so the second request lands first and the fence is the only thing between the stale row and the DOM.
- **The late-exclusion test.** Driving the prop change through testing-library's `rerender` replaces the *whole props object*, which re-runs the refresh effect whether or not it tracks `excludeIds` — so the mutant deleting that dependency survived while the production path was broken. Now driven through `ItemPickerProbe.svelte`, a test-only host in the shape of `FreezeProbe` / `GuardProbe`, which changes exactly one prop.

Also **deleted** a test rather than keep it: "unmount, resolve an in-flight response, assert the row is absent" cannot fail, because an unmounted component renders nothing whatever the teardown does. Replaced with the observable half. `onDestroy`'s `seq` bump is kept and says in a comment that no test can kill its removal, instead of being defended by one that would pass either way. The same reasoning removed a teardown guard whose mutant could not be killed: it was dead, so it went rather than acquiring a comment claiming it protects something.

## Verification

- **`npm run check`** — 1092 files, **0 errors**, 6 warnings, all pre-existing and in files this branch does not touch (`git diff origin/main -- ItemDetail.svelte | grep -c fields-header` = 0 for the only warned file it does edit).
- **`npx vitest run`** — 121 files, **2035 tests, all passed**. 25 new component tests + 5 source-level consumption tests.
- **`gofmt -l`** clean, **`go build ./...`** ok, **`go vet ./...`** ok. No Go source changed; run because the `web/build` copy makes the embed compile in a worktree.
- **Mutation matrix — 18 applied to the shipped tree, 18 killed.** Anchors are generated with explicit tabs into a JSON file after a regex edit corrupted the harness mid-run and reported seventeen false misses. Backups are copies, never `git checkout`.
- **Real browser**, locally built binary, desktop-chromium and mobile-chromium: the form opens focused, `role=combobox`, typing filters, ArrowDown sets `aria-activedescendant`, Enter creates the link (read back from `/links`) and closes the form; re-opening no longer offers the item just linked. One CSS regression was caught here and nowhere else — the flex row's default `align-items: stretch` made the type-select as tall as the input plus the open result list.
- **`pane-full-page-capstone.spec.ts`** — failed once on the first run, then 9/9 three consecutive times. That failure is [[BUG-2849]], established pre-existing on unmodified `origin/main`. Noting the difference honestly: my exposure was a single spec at default workers, where BUG-2849's filed repro was four specs at `--workers=4`.
