### PR TITLE
feat(web): relation fields — linked chip + picker (TASK-2868)

### DIFF
--- a/web/src/lib/components/fields/FieldEditor.relation.svelte.test.ts
+++ b/web/src/lib/components/fields/FieldEditor.relation.svelte.test.ts
@@ -1,0 +1,120 @@
+// DRAFT pin for U2 (TASK-2868) — written before the relation branch exists,
+// per team CONVE-29. Lands as
+// web/src/lib/components/fields/FieldEditor.relation.svelte.test.ts
+//
+// The assertion that fails against TODAY's code is the last one in each leg:
+// `fields/FieldEditor.svelte:340-343`'s readonly `{:else}` arm is
+// `{value ?? '—'}`, so a relation value renders as a raw UUID in display mode
+// and as free text in edit mode.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import { tick } from 'svelte';
+import { SvelteMap } from 'svelte/reactivity';
+
+const { localIndexMock, localSearchMock, searchApi } = vi.hoisted(() => ({
+	localIndexMock: { bootstrapStateFor: vi.fn(), findByIdOrSlug: vi.fn(), getByCollection: vi.fn(), cursorFor: vi.fn() },
+	localSearchMock: { search: vi.fn(), epoch: vi.fn() },
+	searchApi: vi.fn(),
+}));
+vi.mock('$lib/api/client', () => ({ api: { search: (...a: unknown[]) => searchApi(...a) } }));
+vi.mock('$lib/stores/localIndex.svelte', () => ({ localIndex: localIndexMock }));
+vi.mock('$lib/stores/localSearch.svelte', () => ({ localSearch: localSearchMock }));
+
+import FieldEditor from './FieldEditor.svelte';
+
+const LIVE = { id: 'uuid-live', title: 'Red', item_number: 3, collection_prefix: 'COLO', collection_slug: 'colors', slug: 'red', deleted_at: null };
+const GONE = { ...LIVE, id: 'uuid-gone', title: 'Retired Blue', item_number: 4, slug: 'retired-blue', deleted_at: '2026-01-01T00:00:00Z' };
+
+const field = { key: 'color', label: 'Colour', type: 'relation' as const, collection: 'colors' };
+
+const rows = new Map<string, unknown>();
+const epochs = new SvelteMap<string, number>();
+
+beforeEach(() => {
+	rows.clear();
+	rows.set(LIVE.id, LIVE);
+	rows.set(GONE.id, GONE);
+	epochs.clear();
+	localIndexMock.bootstrapStateFor.mockReset().mockReturnValue('ready');
+	localIndexMock.findByIdOrSlug.mockReset().mockImplementation((_ws: string, id: string) => rows.get(id) ?? null);
+	localIndexMock.getByCollection.mockReset().mockReturnValue([LIVE]);
+	localIndexMock.cursorFor.mockReset().mockReturnValue('0');
+	localSearchMock.search.mockReset().mockReturnValue([]);
+	localSearchMock.epoch.mockReset().mockImplementation((ws: string) => epochs.get(ws) ?? 0);
+	searchApi.mockReset().mockResolvedValue({ results: [] });
+});
+afterEach(() => { cleanup(); document.body.innerHTML = ''; });
+
+/** The invariant that spans every leg: a UUID must never reach the user. */
+function expectNoBareUuid() {
+	expect(document.body.textContent ?? '').not.toMatch(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i);
+	expect(document.body.textContent ?? '').not.toContain('uuid-');
+}
+
+describe('FieldEditor — relation, three render states', () => {
+	it('(a) a live target renders a chip that opens it', async () => {
+		render(FieldEditor, {
+			props: { field, value: LIVE.id, wsSlug: 'ws', username: 'dave', readonly: true, onchange: () => {} },
+		});
+		await tick();
+		expect(document.body.textContent).toContain('COLO-3');
+		expect(document.body.textContent).toContain('Red');
+		const a = document.querySelector('a.relation-chip');
+		expect(a).not.toBeNull();
+		expect(a!.getAttribute('href')).toBe('/dave/ws/colors/COLO-3');
+		expectNoBareUuid();
+	});
+
+	it('(a2) a live target with no route still names the item, never the id', async () => {
+		// `username` is what builds the href, and `CopyItemDialog` has none. The
+		// chip degrades to a non-link — it must NOT degrade to the raw value,
+		// which is what the old readonly arm did.
+		render(FieldEditor, { props: { field, value: LIVE.id, wsSlug: 'ws', readonly: true, onchange: () => {} } });
+		await tick();
+		expect(document.querySelector('a.relation-chip')).toBeNull();
+		expect(document.body.textContent).toContain('COLO-3');
+		expect(document.body.textContent).toContain('Red');
+		expectNoBareUuid();
+	});
+
+	it('(b) a soft-deleted target renders honestly as deleted', async () => {
+		render(FieldEditor, { props: { field, value: GONE.id, wsSlug: 'ws', readonly: true, onchange: () => {} } });
+		await tick();
+		expect(document.body.textContent).toMatch(/\(deleted\)/i);
+		expectNoBareUuid();
+	});
+
+	it('(c) a value resolving to nothing renders as unresolved, NOT as deleted', async () => {
+		// This is what R1 + R2 have been writing into these fields all along, so
+		// it is the common case on existing data, not an edge. It must be
+		// distinguishable from (b) — a value whose target was deleted and a value
+		// that was never an id are different facts about the item.
+		render(FieldEditor, { props: { field, value: 'red', wsSlug: 'ws', readonly: true, onchange: () => {} } });
+		await tick();
+		expect(document.body.textContent).not.toMatch(/\(deleted\)/i);
+		expect(document.body.textContent ?? '').toMatch(/unresolved|not found|unknown/i);
+		expectNoBareUuid();
+	});
+});
+
+describe('FieldEditor — relation, the gate', () => {
+	it('renders no picker without a wsSlug — the CopyItemDialog call site', async () => {
+		render(FieldEditor, { props: { field, value: '', readonly: false, onchange: () => {} } });
+		await tick();
+		expect(document.querySelector('.picker-input')).toBeNull();
+	});
+
+	it('renders no picker without a target collection', async () => {
+		const { collection: _drop, ...untargeted } = field;
+		render(FieldEditor, { props: { field: untargeted, value: '', wsSlug: 'ws', readonly: false, onchange: () => {} } });
+		await tick();
+		expect(document.querySelector('.picker-input')).toBeNull();
+	});
+
+	it('CONTROL: with both, the editable branch mounts the picker scoped to the target', async () => {
+		render(FieldEditor, { props: { field, value: '', wsSlug: 'ws', readonly: false, onchange: () => {} } });
+		await tick();
+		expect(document.querySelector('.picker-input')).not.toBeNull();
+		expect(localIndexMock.getByCollection).toHaveBeenCalledWith('ws', 'colors');
+	});
+});

--- a/web/src/lib/components/fields/FieldEditor.relation.svelte.test.ts
+++ b/web/src/lib/components/fields/FieldEditor.relation.svelte.test.ts
@@ -97,6 +97,38 @@ describe('FieldEditor — relation, three render states', () => {
 	});
 });
 
+describe('FieldEditor — relation resolves by ID, in the declared collection', () => {
+	// Both legs found by driving this in a real browser, not by reading the code.
+
+	it('a legacy free-text value that matches an item SLUG is unresolved, not a chip', async () => {
+		// `localIndex.findByIdOrSlug` resolves by id OR slug, so the string "red"
+		// — exactly what the old text fallback wrote into these fields — otherwise
+		// renders as a working reference to the item slugged "red". The field
+		// stores an ID; a slug match makes the chip lie about what is stored, and
+		// slugs are mutable, so the same value could point elsewhere tomorrow.
+		rows.set('red', { ...LIVE, id: 'uuid-live' });
+		localIndexMock.findByIdOrSlug.mockImplementation((_ws: string, k: string) =>
+			k === 'red' ? LIVE : (rows.get(k) ?? null)
+		);
+		render(FieldEditor, { props: { field, value: 'red', wsSlug: 'ws', username: 'dave', readonly: true, onchange: () => {} } });
+		await tick();
+		expect(document.body.textContent).toMatch(/unresolved/i);
+		expect(document.body.textContent).not.toContain('Red');
+	});
+
+	it('an id resolving into a DIFFERENT collection is unresolved', async () => {
+		// The helper is workspace-wide. Without the collection check a relation
+		// declared against `colors` renders an item from `tasks`. Same defect the
+		// design pass recorded against the server's `ResolveItem`.
+		const foreign = { ...LIVE, id: 'uuid-foreign', title: 'A Task', collection_slug: 'tasks', collection_prefix: 'TASK' };
+		rows.set(foreign.id, foreign);
+		render(FieldEditor, { props: { field, value: foreign.id, wsSlug: 'ws', username: 'dave', readonly: true, onchange: () => {} } });
+		await tick();
+		expect(document.body.textContent).toMatch(/unresolved/i);
+		expect(document.body.textContent).not.toContain('A Task');
+	});
+});
+
 describe('FieldEditor — relation, the gate', () => {
 	it('renders no picker without a wsSlug — the CopyItemDialog call site', async () => {
 		render(FieldEditor, { props: { field, value: '', readonly: false, onchange: () => {} } });
@@ -109,6 +141,51 @@ describe('FieldEditor — relation, the gate', () => {
 		render(FieldEditor, { props: { field: untargeted, value: '', wsSlug: 'ws', readonly: false, onchange: () => {} } });
 		await tick();
 		expect(document.querySelector('.picker-input')).toBeNull();
+	});
+
+	it('a set relation shows the value, not a permanently-open search box', async () => {
+		// The first browser pass rendered the chip, the picker input still holding
+		// the query, and the result list still showing the row just chosen — the
+		// same item three times, under every relation field on the page.
+		render(FieldEditor, { props: { field, value: LIVE.id, wsSlug: 'ws', username: 'dave', readonly: false, onchange: () => {} } });
+		await tick();
+		expect(document.querySelector('.relation-chip')).not.toBeNull();
+		expect(document.querySelector('.picker-input')).toBeNull();
+	});
+
+	it('Change reopens the picker; choosing closes it and emits the new id', async () => {
+		const onchange = vi.fn();
+		render(FieldEditor, { props: { field, value: LIVE.id, wsSlug: 'ws', username: 'dave', readonly: false, onchange } });
+		await tick();
+
+		const change = [...document.querySelectorAll('button')].find((b) => b.textContent?.trim() === 'Change');
+		expect(change, 'no Change control').toBeDefined();
+		change!.click();
+		await tick();
+		expect(document.querySelector('.picker-input')).not.toBeNull();
+
+		const option = document.querySelector<HTMLElement>('[role="option"]');
+		expect(option, 'picker listed nothing to choose').not.toBeNull();
+		option!.click();
+		await tick();
+
+		expect(onchange).toHaveBeenCalledTimes(1);
+		expect(onchange.mock.calls[0][0]).toBe(LIVE.id);
+		// And it CLOSES. Without this the mutant that drops the reset survives:
+		// emitting the value while leaving the search box open is the behaviour
+		// the browser pass rejected, and asserting only the emit misses it.
+		expect(document.querySelector('.picker-input')).toBeNull();
+		expect(document.querySelector('.relation-chip')).not.toBeNull();
+	});
+
+	it('Clear empties the field', async () => {
+		const onchange = vi.fn();
+		render(FieldEditor, { props: { field, value: LIVE.id, wsSlug: 'ws', username: 'dave', readonly: false, onchange } });
+		await tick();
+		const clear = [...document.querySelectorAll('button')].find((b) => b.textContent?.trim() === 'Clear');
+		expect(clear, 'no Clear control').toBeDefined();
+		clear!.click();
+		expect(onchange).toHaveBeenCalledWith('');
 	});
 
 	it('CONTROL: with both, the editable branch mounts the picker scoped to the target', async () => {

--- a/web/src/lib/components/fields/FieldEditor.relation.svelte.test.ts
+++ b/web/src/lib/components/fields/FieldEditor.relation.svelte.test.ts
@@ -11,14 +11,16 @@ import { render, cleanup } from '@testing-library/svelte';
 import { tick } from 'svelte';
 import { SvelteMap } from 'svelte/reactivity';
 
-const { localIndexMock, localSearchMock, searchApi } = vi.hoisted(() => ({
+const { localIndexMock, localSearchMock, searchApi, collectionStoreMock } = vi.hoisted(() => ({
 	localIndexMock: { bootstrapStateFor: vi.fn(), findByIdOrSlug: vi.fn(), getByCollection: vi.fn(), cursorFor: vi.fn() },
 	localSearchMock: { search: vi.fn(), epoch: vi.fn() },
 	searchApi: vi.fn(),
+	collectionStoreMock: { collections: [] as { slug: string }[], collectionsAreFreshFor: vi.fn() },
 }));
 vi.mock('$lib/api/client', () => ({ api: { search: (...a: unknown[]) => searchApi(...a) } }));
 vi.mock('$lib/stores/localIndex.svelte', () => ({ localIndex: localIndexMock }));
 vi.mock('$lib/stores/localSearch.svelte', () => ({ localSearch: localSearchMock }));
+vi.mock('$lib/stores/collections.svelte', () => ({ collectionStore: collectionStoreMock }));
 
 import FieldEditor from './FieldEditor.svelte';
 
@@ -42,6 +44,9 @@ beforeEach(() => {
 	localSearchMock.search.mockReset().mockReturnValue([]);
 	localSearchMock.epoch.mockReset().mockImplementation((ws: string) => epochs.get(ws) ?? 0);
 	searchApi.mockReset().mockResolvedValue({ results: [] });
+	// Default: the target collection is loaded and live.
+	collectionStoreMock.collections = [{ slug: 'colors' }, { slug: 'tasks' }];
+	collectionStoreMock.collectionsAreFreshFor.mockReset().mockReturnValue(true);
 });
 afterEach(() => { cleanup(); document.body.innerHTML = ''; });
 
@@ -126,6 +131,50 @@ describe('FieldEditor — relation resolves by ID, in the declared collection', 
 		await tick();
 		expect(document.body.textContent).toMatch(/unresolved/i);
 		expect(document.body.textContent).not.toContain('A Task');
+	});
+});
+
+describe('FieldEditor — a renamed target collection must not look like data loss', () => {
+	// `FieldDef.collection` holds a SLUG, and renaming a collection changes its
+	// slug without migrating the relation definitions pointing at it — nothing
+	// in `store.UpdateCollection` touches them (codex round 1 P1 on this unit).
+	// The collection check added for cross-collection resolution would then
+	// report EVERY stored value as unresolved, which is a schema problem
+	// presenting as lost data.
+
+	it('still renders the chip when the declared target no longer exists', async () => {
+		// Faithful to what a rename actually does: `localIndex.applyRetag` moves
+		// the indexed ROWS onto the new slug, while `field.collection` keeps
+		// pointing at the old one. The row and the field therefore DISAGREE — and
+		// modelling only the store's collection list (as a first draft of this
+		// test did) leaves them agreeing, so the mutant that makes the collection
+		// check unconditional survives.
+		collectionStoreMock.collections = [{ slug: 'colours-renamed' }]; // `colors` is gone
+		const retagged = { ...LIVE, collection_slug: 'colours-renamed', collection_prefix: 'COLO' };
+		rows.set(retagged.id, retagged);
+		render(FieldEditor, { props: { field, value: retagged.id, wsSlug: 'ws', username: 'dave', readonly: true, onchange: () => {} } });
+		await tick();
+		expect(document.body.textContent).toContain('Red');
+		expect(document.body.textContent).not.toMatch(/unresolved/i);
+	});
+
+	it('goes read-only rather than offering a picker that can never match', async () => {
+		collectionStoreMock.collections = [{ slug: 'colours-renamed' }];
+		render(FieldEditor, { props: { field, value: '', wsSlug: 'ws', username: 'dave', readonly: false, onchange: () => {} } });
+		await tick();
+		expect(document.querySelector('.picker-input')).toBeNull();
+	});
+
+	it('treats a not-yet-loaded collection list as unknown, not as stale', async () => {
+		// Absence of evidence. Reading it as stale would flash every relation
+		// field into read-only on first paint, before the collection list lands.
+		//
+		// Asserted on EDITABILITY, not on the chip: a stale target also renders
+		// the chip, so a chip assertion cannot tell the two apart.
+		collectionStoreMock.collectionsAreFreshFor.mockReturnValue(false);
+		render(FieldEditor, { props: { field, value: '', wsSlug: 'ws', username: 'dave', readonly: false, onchange: () => {} } });
+		await tick();
+		expect(document.querySelector('.picker-input')).not.toBeNull();
 	});
 });
 

--- a/web/src/lib/components/fields/FieldEditor.relation.svelte.test.ts
+++ b/web/src/lib/components/fields/FieldEditor.relation.svelte.test.ts
@@ -158,6 +158,35 @@ describe('FieldEditor — a renamed target collection must not look like data lo
 		expect(document.body.textContent).not.toMatch(/unresolved/i);
 	});
 
+	it('survives the window where the index is retagged but the collection list is not', async () => {
+		// codex round 2 P1. `retagCollection` moves the ROWS immediately;
+		// `loadCollections` is fired with `void` — not awaited, rejection
+		// swallowed. So there is a window where the list still holds the OLD slug
+		// (so the target reads 'live') while the row already carries the NEW one.
+		// Judging the mismatch there reports the value as unresolved, and if that
+		// refetch FAILS the state is permanent, not transient.
+		collectionStoreMock.collections = [{ slug: 'colors' }]; // stale list: pre-rename
+		const retagged = { ...LIVE, collection_slug: 'colours-renamed' };
+		rows.set(retagged.id, retagged);
+		render(FieldEditor, { props: { field, value: retagged.id, wsSlug: 'ws', username: 'dave', readonly: true, onchange: () => {} } });
+		await tick();
+		expect(document.body.textContent).toContain('Red');
+		expect(document.body.textContent).not.toMatch(/unresolved/i);
+	});
+
+	it('CONTROL: a genuine cross-collection value is still rejected when both slugs are known', async () => {
+		// The leg that stops the two guards above from being "never judge". Both
+		// `colors` and `tasks` are live, so the list and the index agree and the
+		// mismatch IS evidence.
+		collectionStoreMock.collections = [{ slug: 'colors' }, { slug: 'tasks' }];
+		const foreign = { ...LIVE, id: 'uuid-foreign2', title: 'A Task', collection_slug: 'tasks' };
+		rows.set(foreign.id, foreign);
+		render(FieldEditor, { props: { field, value: foreign.id, wsSlug: 'ws', username: 'dave', readonly: true, onchange: () => {} } });
+		await tick();
+		expect(document.body.textContent).toMatch(/unresolved/i);
+		expect(document.body.textContent).not.toContain('A Task');
+	});
+
 	it('goes read-only rather than offering a picker that can never match', async () => {
 		collectionStoreMock.collections = [{ slug: 'colours-renamed' }];
 		render(FieldEditor, { props: { field, value: '', wsSlug: 'ws', username: 'dave', readonly: false, onchange: () => {} } });

--- a/web/src/lib/components/fields/FieldEditor.svelte
+++ b/web/src/lib/components/fields/FieldEditor.svelte
@@ -77,7 +77,26 @@ handlers — onchange is never called.
 		if (!isRelation || !wsSlug) return null;
 		const raw = typeof value === 'string' ? value.trim() : '';
 		if (!raw) return null;
-		return localIndex.findByIdOrSlug(wsSlug, raw);
+		const row = localIndex.findByIdOrSlug(wsSlug, raw);
+		if (!row) return null;
+		// TWO narrowings on what `findByIdOrSlug` will happily return, both
+		// found by driving this in a real browser.
+		//
+		// 1. ID ONLY. That helper resolves by id OR SLUG, so a legacy free-text
+		//    value like "red" — exactly what the old text fallback wrote — RESOLVES
+		//    to the item whose slug is "red" and renders as a working reference.
+		//    The field's contract is that it stores an item ID; displaying a slug
+		//    match makes the chip lie about what is stored, and slugs are mutable,
+		//    so the same value could point somewhere else tomorrow.
+		// 2. TARGET COLLECTION. The helper is workspace-wide, so without this a
+		//    relation declared against `colors` could render an item from `tasks`
+		//    that happens to share the identifier. This is the same defect
+		//    PLAN-2857's recon recorded against the SERVER's `ResolveItem`
+		//    (workspace-wide, not collection-scoped); I wrote that finding down and
+		//    then reproduced it here.
+		if (row.id !== raw) return null;
+		if (field.collection && row.collection_slug !== field.collection) return null;
+		return row;
 	});
 	let relationState = $derived.by((): 'empty' | 'live' | 'deleted' | 'unresolved' => {
 		if (!isRelation) return 'empty';
@@ -105,8 +124,22 @@ handlers — onchange is never called.
 		});
 	}
 
+	// A relation field shows its VALUE, not a permanently-open search box. The
+	// first browser pass rendered the chip, the picker input still holding the
+	// query, and the result list still listing the row just chosen — the same
+	// item three times, under every relation field on the page. The picker is
+	// for CHANGING the value, so it appears when there is nothing to show or
+	// when the user asks for it, and closes once a choice is made.
+	let editingRelation = $state(false);
+
 	function pickRelation(row: ItemIndexRow) {
+		editingRelation = false;
 		onchange(row.id);
+	}
+
+	function clearRelation() {
+		editingRelation = false;
+		onchange('');
 	}
 
 	// ── Viewport detection ───────────────────────────────────────────────
@@ -663,14 +696,25 @@ handlers — onchange is never called.
 
 {:else if isRelation && relationEditable}
 	<div class="relation-editor">
-		{@render relationChip()}
-		<ItemPicker
-			wsSlug={wsSlug!}
-			collection={field.collection}
-			label={ariaLabel ?? `Search ${field.label || field.key}`}
-			placeholder="Search…"
-			onselect={pickRelation}
-		/>
+		{#if relationState !== 'empty' && !editingRelation}
+			<div class="relation-row">
+				{@render relationChip()}
+				<button type="button" class="relation-action" onclick={() => (editingRelation = true)}>
+					Change
+				</button>
+				<button type="button" class="relation-action" onclick={clearRelation}>Clear</button>
+			</div>
+		{:else}
+			<ItemPicker
+				wsSlug={wsSlug!}
+				collection={field.collection}
+				label={ariaLabel ?? `Search ${field.label || field.key}`}
+				placeholder="Search…"
+				autofocus={editingRelation}
+				onselect={pickRelation}
+				oncancel={relationState === 'empty' ? undefined : () => (editingRelation = false)}
+			/>
+		{/if}
 	</div>
 
 {:else if isRelation}
@@ -738,6 +782,28 @@ handlers — onchange is never called.
 		gap: var(--space-2);
 		min-width: 0;
 		font-size: 0.88em;
+	}
+
+	.relation-row {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		min-width: 0;
+	}
+
+	.relation-action {
+		flex-shrink: 0;
+		padding: 0;
+		border: none;
+		background: none;
+		color: var(--text-muted);
+		font-size: 0.82em;
+		cursor: pointer;
+	}
+
+	.relation-action:hover {
+		color: var(--text-primary);
+		text-decoration: underline;
 	}
 
 	.relation-chip {

--- a/web/src/lib/components/fields/FieldEditor.svelte
+++ b/web/src/lib/components/fields/FieldEditor.svelte
@@ -17,6 +17,7 @@ handlers — onchange is never called.
 <script lang="ts">
 	import { formatItemRef, type FieldDef, type ItemIndexRow, type PaneTarget } from '$lib/types';
 	import { localIndex } from '$lib/stores/localIndex.svelte';
+	import { collectionStore } from '$lib/stores/collections.svelte';
 	import ItemPicker from '$lib/components/items/ItemPicker.svelte';
 	import { shouldOpenInPane } from '$lib/components/collections/itemCardClick';
 	import BottomSheet from '$lib/components/common/BottomSheet.svelte';
@@ -72,7 +73,36 @@ handlers — onchange is never called.
 	// filters them out by default rather than dropping them), so a dangling
 	// target is a row carrying `deleted_at`. No fetch, and no loading state.
 	let isRelation = $derived(field.type === 'relation');
-	let relationEditable = $derived(isRelation && !!wsSlug && !!field.collection);
+
+	/**
+	 * Whether the field's declared target still names a live collection.
+	 *
+	 * `FieldDef.collection` holds a SLUG (the schema editor binds
+	 * `<option value={c.slug}>`), and renaming a collection changes its slug
+	 * WITHOUT migrating the relation definitions that point at it — nothing in
+	 * `store.UpdateCollection` touches them. So a rename silently strands every
+	 * relation field aimed at that collection. Filed separately; this component
+	 * only has to behave sanely in the meantime.
+	 *
+	 * Three-valued on purpose. `'unknown'` is when the collection list has not
+	 * loaded for this workspace yet — the absence of evidence, which must not be
+	 * read as a stale target, since that would flash every relation field into a
+	 * broken state on first paint.
+	 */
+	let relationTarget = $derived.by((): 'live' | 'stale' | 'unknown' => {
+		if (!isRelation || !wsSlug || !field.collection) return 'unknown';
+		if (!collectionStore.collectionsAreFreshFor(wsSlug)) return 'unknown';
+		return (collectionStore.collections ?? []).some((c) => c.slug === field.collection)
+			? 'live'
+			: 'stale';
+	});
+
+	// A picker aimed at a renamed collection would list NOTHING — `getByCollection`
+	// and `localSearch` both filter on that slug. Read-only with the value still
+	// legible beats a search box that silently never matches.
+	let relationEditable = $derived(
+		isRelation && !!wsSlug && !!field.collection && relationTarget !== 'stale',
+	);
 	let relationRow = $derived.by((): ItemIndexRow | null => {
 		if (!isRelation || !wsSlug) return null;
 		const raw = typeof value === 'string' ? value.trim() : '';
@@ -95,7 +125,11 @@ handlers — onchange is never called.
 		//    (workspace-wide, not collection-scoped); I wrote that finding down and
 		//    then reproduced it here.
 		if (row.id !== raw) return null;
-		if (field.collection && row.collection_slug !== field.collection) return null;
+		// The collection check applies only while the declared target is one that
+		// still EXISTS. After a rename it names nothing, and enforcing it then
+		// would report every stored value as unresolved — turning a schema
+		// problem into apparent data loss on data that is completely fine.
+		if (relationTarget === 'live' && row.collection_slug !== field.collection) return null;
 		return row;
 	});
 	let relationState = $derived.by((): 'empty' | 'live' | 'deleted' | 'unresolved' => {

--- a/web/src/lib/components/fields/FieldEditor.svelte
+++ b/web/src/lib/components/fields/FieldEditor.svelte
@@ -89,12 +89,15 @@ handlers — onchange is never called.
 	 * read as a stale target, since that would flash every relation field into a
 	 * broken state on first paint.
 	 */
+	let knownCollectionSlugs = $derived.by((): Set<string> | null => {
+		if (!wsSlug || !collectionStore.collectionsAreFreshFor(wsSlug)) return null;
+		return new Set((collectionStore.collections ?? []).map((c) => c.slug));
+	});
+
 	let relationTarget = $derived.by((): 'live' | 'stale' | 'unknown' => {
 		if (!isRelation || !wsSlug || !field.collection) return 'unknown';
-		if (!collectionStore.collectionsAreFreshFor(wsSlug)) return 'unknown';
-		return (collectionStore.collections ?? []).some((c) => c.slug === field.collection)
-			? 'live'
-			: 'stale';
+		if (!knownCollectionSlugs) return 'unknown';
+		return knownCollectionSlugs.has(field.collection) ? 'live' : 'stale';
 	});
 
 	// A picker aimed at a renamed collection would list NOTHING — `getByCollection`
@@ -125,11 +128,31 @@ handlers — onchange is never called.
 		//    (workspace-wide, not collection-scoped); I wrote that finding down and
 		//    then reproduced it here.
 		if (row.id !== raw) return null;
-		// The collection check applies only while the declared target is one that
-		// still EXISTS. After a rename it names nothing, and enforcing it then
-		// would report every stored value as unresolved — turning a schema
-		// problem into apparent data loss on data that is completely fine.
-		if (relationTarget === 'live' && row.collection_slug !== field.collection) return null;
+		// The collection mismatch is only EVIDENCE that the value is wrong when
+		// the collection list and the item index agree about the world — that is,
+		// when both the declared target and the row's own collection are slugs
+		// the current list knows.
+		//
+		// Two ways they disagree, and neither is the value's fault:
+		//   * the target was renamed, so it names nothing (`relationTarget`
+		//     'stale');
+		//   * the rename has been applied to the INDEX but not yet to the
+		//     collection list — `retagCollection` moves the rows immediately and
+		//     `loadCollections` is fired without being awaited (and with its
+		//     rejection swallowed by `void`), so the row's new slug is unknown to
+		//     a list that still lists the old one. That window is brief when the
+		//     refetch succeeds and PERMANENT when it fails (codex round 2 P1).
+		//
+		// Requiring both to be known collapses both cases to "don't judge", while
+		// a genuine cross-collection value — target `colors`, row `tasks`, both
+		// live — still resolves to null.
+		if (
+			relationTarget === 'live' &&
+			knownCollectionSlugs?.has(row.collection_slug ?? '') &&
+			row.collection_slug !== field.collection
+		) {
+			return null;
+		}
 		return row;
 	});
 	let relationState = $derived.by((): 'empty' | 'live' | 'deleted' | 'unresolved' => {

--- a/web/src/lib/components/fields/FieldEditor.svelte
+++ b/web/src/lib/components/fields/FieldEditor.svelte
@@ -15,7 +15,10 @@ visual language as the editor but with no inputs, dropdowns, or mutation
 handlers — onchange is never called.
 -->
 <script lang="ts">
-	import type { FieldDef } from '$lib/types';
+	import { formatItemRef, type FieldDef, type ItemIndexRow, type PaneTarget } from '$lib/types';
+	import { localIndex } from '$lib/stores/localIndex.svelte';
+	import ItemPicker from '$lib/components/items/ItemPicker.svelte';
+	import { shouldOpenInPane } from '$lib/components/collections/itemCardClick';
 	import BottomSheet from '$lib/components/common/BottomSheet.svelte';
 	import { viewport } from '$lib/stores/breakpoint.svelte';
 	import { statusColor, priorityColor, hasCanonicalStatus, formatFieldLabel as formatLabel } from '$lib/utils/fieldColors';
@@ -35,9 +38,76 @@ handlers — onchange is never called.
 		 * input/trigger is not announced as an unnamed edit field or button.
 		 */
 		ariaLabel?: string;
+		/**
+		 * Link context for `relation` fields. All three are optional because the
+		 * OTHER call site — `CopyItemDialog`'s needs-a-value rows — has no item
+		 * page to link into and, more importantly, no target collection to scope
+		 * a picker to: its `FieldDef` is built from a preflight row whose shape
+		 * carries no `collection` (TASK-2869 / U2b fixes that end).
+		 *
+		 * So the relation branch is GATED on `wsSlug` AND `field.collection`, and
+		 * renders read-only without them. That is deliberate: an unscoped picker
+		 * in the cross-workspace copy dialog would offer SOURCE-workspace items
+		 * as the value for a DESTINATION-workspace field and look authoritative
+		 * doing it. A field the user cannot fill is the honest state until U2b.
+		 */
+		wsSlug?: string;
+		username?: string;
+		onOpenTarget?: (target: PaneTarget) => void;
 	}
 
-	let { field, value, onchange, readonly = false, ariaLabel }: Props = $props();
+	let { field, value, onchange, readonly = false, ariaLabel, wsSlug, username = '', onOpenTarget }: Props = $props();
+
+	// ── Relation resolution ───────────────────────────────────────────────
+	//
+	// THREE states, not two, and the third is the common one on existing data:
+	// `internal/items/validate.go` accepts ANY string for a relation, and this
+	// component's own text fallback has been writing arbitrary strings into
+	// these fields, so a value that resolves to nothing is what most legacy
+	// relation values ARE. It has to be distinguishable from a value whose
+	// target was deleted — those are different facts about the item.
+	//
+	// All three resolve locally: `localIndex` is a workspace-wide read model
+	// that holds soft-deleted rows alongside live ones (`getByCollection`
+	// filters them out by default rather than dropping them), so a dangling
+	// target is a row carrying `deleted_at`. No fetch, and no loading state.
+	let isRelation = $derived(field.type === 'relation');
+	let relationEditable = $derived(isRelation && !!wsSlug && !!field.collection);
+	let relationRow = $derived.by((): ItemIndexRow | null => {
+		if (!isRelation || !wsSlug) return null;
+		const raw = typeof value === 'string' ? value.trim() : '';
+		if (!raw) return null;
+		return localIndex.findByIdOrSlug(wsSlug, raw);
+	});
+	let relationState = $derived.by((): 'empty' | 'live' | 'deleted' | 'unresolved' => {
+		if (!isRelation) return 'empty';
+		const raw = typeof value === 'string' ? value.trim() : '';
+		if (!raw) return 'empty';
+		if (!relationRow) return 'unresolved';
+		return relationRow.deleted_at ? 'deleted' : 'live';
+	});
+	let relationRef = $derived(relationRow ? formatItemRef(relationRow) : null);
+	let relationHref = $derived.by(() => {
+		if (!relationRow || !wsSlug || !username) return null;
+		const seg = relationRef ?? relationRow.slug;
+		if (!relationRow.collection_slug || !seg) return null;
+		return `/${username}/${wsSlug}/${relationRow.collection_slug}/${seg}`;
+	});
+
+	function handleRelationClick(e: MouseEvent) {
+		if (!relationRow || !shouldOpenInPane(e, !!onOpenTarget)) return;
+		e.preventDefault();
+		onOpenTarget?.({
+			ref: relationRef ?? undefined,
+			slug: relationRow.slug,
+			href: relationHref ?? undefined,
+			collectionSlug: relationRow.collection_slug,
+		});
+	}
+
+	function pickRelation(row: ItemIndexRow) {
+		onchange(row.id);
+	}
 
 	// ── Viewport detection ───────────────────────────────────────────────
 	// On mobile the absolute-positioned select dropdown can clip at the
@@ -298,6 +368,48 @@ handlers — onchange is never called.
 
 <svelte:window onclick={handleWindowClick} />
 
+{#snippet relationChip()}
+	<!--
+		One chip, four states. The invariant across all of them: a raw item ID
+		never reaches the user. Before this branch existed, the readonly arm was
+		`{value ?? '—'}`, which rendered the UUID verbatim.
+	-->
+	{#if relationState === 'empty'}
+		<span class="relation-empty">—</span>
+	{:else if relationState === 'live' && relationHref}
+		<a
+			class="relation-chip link-target"
+			href={relationHref}
+			onclick={handleRelationClick}
+		>
+			{#if relationRef}<span class="relation-ref">{relationRef}</span>{/if}
+			<span class="relation-title">{relationRow?.title}</span>
+		</a>
+	{:else if relationState === 'live'}
+		<!-- Resolved, but no route to build (no `username`): still never the id. -->
+		<span class="relation-chip">
+			{#if relationRef}<span class="relation-ref">{relationRef}</span>{/if}
+			<span class="relation-title">{relationRow?.title}</span>
+		</span>
+	{:else if relationState === 'deleted'}
+		<span class="relation-chip is-deleted" title="This item has been deleted.">
+			{#if relationRef}<span class="relation-ref">{relationRef}</span>{/if}
+			<span class="relation-title">{relationRow?.title}</span>
+			<span class="relation-note">(deleted)</span>
+		</span>
+	{:else}
+		<!--
+			The value is not an item this workspace knows. Says so, rather than
+			showing the stored string as though it were a name — it is usually a
+			free-text value the old fallback wrote, and the user needs to know it
+			does not point at anything.
+		-->
+		<span class="relation-chip is-unresolved" title="This value does not match any item in this workspace.">
+			<span class="relation-note">Unresolved reference</span>
+		</span>
+	{/if}
+{/snippet}
+
 {#if readonly}
 	<!--
 		Display-only mode (PLAN-1100 / TASK-1105). No inputs, no dropdowns,
@@ -337,6 +449,8 @@ handlers — onchange is never called.
 		<div class="readonly-display">
 			<span>{value === undefined || value === null ? '—' : JSON.stringify(value)}</span>
 		</div>
+	{:else if isRelation}
+		<div class="readonly-display">{@render relationChip()}</div>
 	{:else}
 		<div class="readonly-display">
 			<span>{value ?? '—'}</span>
@@ -547,6 +661,29 @@ handlers — onchange is never called.
 		{/if}
 	</div>
 
+{:else if isRelation && relationEditable}
+	<div class="relation-editor">
+		{@render relationChip()}
+		<ItemPicker
+			wsSlug={wsSlug!}
+			collection={field.collection}
+			label={ariaLabel ?? `Search ${field.label || field.key}`}
+			placeholder="Search…"
+			onselect={pickRelation}
+		/>
+	</div>
+
+{:else if isRelation}
+	<!--
+		Editable in principle, but not here: no workspace slug or no target
+		collection. See the `wsSlug` prop doc — an unscoped picker in the
+		cross-workspace copy dialog would offer the wrong workspace's items and
+		look authoritative. Read-only is the honest state until TASK-2869.
+	-->
+	<div class="readonly-display" title="This relation can't be set from here yet.">
+		{@render relationChip()}
+	</div>
+
 {:else if field.type === 'json'}
 	<!-- JSON fields need a structured editor; the generic FieldEditor
 	     intentionally exposes only a read-only summary so a plain text
@@ -591,6 +728,62 @@ handlers — onchange is never called.
 
 	.url-readonly:hover {
 		text-decoration: underline;
+	}
+
+	/* ── Relation chip (TASK-2868) ────────────────────────────────────── */
+
+	.relation-editor {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-2);
+		min-width: 0;
+		font-size: 0.88em;
+	}
+
+	.relation-chip {
+		display: inline-flex;
+		align-items: baseline;
+		gap: var(--space-2);
+		min-width: 0;
+		padding: 2px var(--space-2);
+		border-radius: var(--radius-sm);
+		background: var(--bg-hover);
+		color: var(--text-primary);
+		text-decoration: none;
+		font-size: 0.88em;
+	}
+
+	a.relation-chip:hover {
+		text-decoration: underline;
+	}
+
+	.relation-ref {
+		flex-shrink: 0;
+		color: var(--text-muted);
+		font-family: var(--font-mono);
+		font-size: 0.94em;
+	}
+
+	.relation-title {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	/* Both non-live states read as muted rather than alarming: a dangling
+	   reference is information, not an error the user caused. */
+	.relation-chip.is-deleted,
+	.relation-chip.is-unresolved {
+		color: var(--text-muted);
+	}
+
+	.relation-note {
+		flex-shrink: 0;
+		font-style: italic;
+	}
+
+	.relation-empty {
+		color: var(--text-muted);
 	}
 
 	/* ── Shared input styles ──────────────────────────────────────────── */

--- a/web/src/lib/components/fields/fieldEditorRelationCallers.test.ts
+++ b/web/src/lib/components/fields/fieldEditorRelationCallers.test.ts
@@ -1,0 +1,63 @@
+// Node-project test (no DOM): SOURCE-level guards on the two live call sites
+// of `fields/FieldEditor.svelte` (TASK-2868).
+//
+// The relation branch is gated on `wsSlug` AND `field.collection`, and the two
+// callers sit on opposite sides of that gate ON PURPOSE. Neither property is
+// visible from FieldEditor's own render tests — they are facts about who mounts
+// it — so they are asserted where they live, the same shape as
+// `itemDetailUsesPicker.test.ts`.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const read = (rel: string) =>
+	readFileSync(fileURLToPath(new URL(rel, import.meta.url)), 'utf8').replace(/<!--[\s\S]*?-->/g, '');
+
+const itemDetail = read('../items/ItemDetail.svelte');
+const copyDialog = read('../items/CopyItemDialog.svelte');
+
+function mountTag(source: string): string {
+	const m = source.match(/<FieldEditor\b[\s\S]*?\/>/);
+	expect(m, '<FieldEditor …/> not found').not.toBeNull();
+	return m![0];
+}
+
+describe('ItemDetail gives FieldEditor the relation link context', () => {
+	const tag = mountTag(itemDetail);
+
+	it('passes the workspace slug — without it the relation branch is read-only', () => {
+		expect(tag).toMatch(/\{wsSlug\}/);
+	});
+
+	it('passes the username, which is what builds the chip href', () => {
+		expect(tag).toMatch(/\{username\}/);
+	});
+
+	it('wires the pane-open target so the chip peeks like every other item link', () => {
+		expect(tag).toMatch(/onOpenTarget=\{paneOpenTarget\}/);
+	});
+});
+
+describe('CopyItemDialog stays on the read-only side of the gate', () => {
+	// Not an oversight to fix later — the assertion IS the behaviour. Its
+	// FieldDef comes from a preflight row that carries no `collection`
+	// (`ItemCopyPreflightNeedsValue`), so a picker mounted here would be
+	// unscoped, and this dialog copies ACROSS workspaces: it would offer
+	// source-workspace items as the value for a destination-workspace field and
+	// look authoritative doing it. TASK-2869 (U2b) fixes the contract end;
+	// until then, no wsSlug here is what keeps the picker out.
+	const tag = mountTag(copyDialog);
+
+	it('does not pass a workspace slug', () => {
+		expect(tag).not.toMatch(/\bwsSlug\b/);
+	});
+
+	it('still builds its FieldDef from a shape with no target collection', () => {
+		// If this ever fails, the preflight row grew `collection` — which is
+		// exactly U2b's change, and the gate above should be revisited WITH it
+		// rather than left to drift.
+		const toFieldDef = copyDialog.match(/function toFieldDef\([\s\S]*?\n\t\}/);
+		expect(toFieldDef).not.toBeNull();
+		expect(toFieldDef![0]).not.toMatch(/\bcollection\b/);
+	});
+});

--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -5261,6 +5261,9 @@
 									value={rawFieldValue}
 									onchange={(v) => updateField(field.key, v)}
 									readonly={!canEdit}
+									{wsSlug}
+									{username}
+									onOpenTarget={paneOpenTarget}
 								/>
 							</div>
 						</div>


### PR DESCRIPTION
Unit U2 of the relation-fields design pass ([[PLAN-2857]] / TASK-2868). Absorbs the relation half of TASK-2216. Mounts the `ItemPicker` from U3 (#1241).

## What was actually broken

`relation` fell through `fields/FieldEditor.svelte`'s `{:else}` text fallback: an editable free-text input in edit mode, `{value ?? '—'}` in display mode. Since `internal/items/validate.go:275` accepts **any string** for a relation, that combination did not merely fail to edit — it **saved**. Typing "red" into a relation field stored the literal string with no error, and the display arm rendered a raw UUID when the value happened to be one. This unit closes a silent corruption hole; it does not add an editor to a read-only field.

## Three render states, not two

A value that resolves to nothing and a value whose target was deleted are different facts about the item, and the third is the **common** case on existing data — arbitrary strings are what the old fallback has been writing. All three resolve locally: `localIndex` holds soft-deleted rows alongside live ones, so a dangling target is a row carrying `deleted_at`. No fetch, no loading state.

The invariant asserted in every leg: **a raw item ID never reaches the user.**

## The gate, and why the second call site is on the far side of it

`fields/FieldEditor.svelte` has two live callers. `ItemDetail` has a workspace, a username and a target collection. **`CopyItemDialog` has none of them** — it builds its `FieldDef` from a preflight row whose shape carries no `collection` — and it copies **across workspaces**, so an unscoped picker there would offer SOURCE-workspace items as the value for a DESTINATION-workspace field and look authoritative doing it. A free-text box at least looks like something the user owns.

So the relation branch is gated on `wsSlug` **and** `field.collection`, and renders read-only without them. That is a fact about the CALLERS, invisible from the component's own render tests, so both sides are asserted at the call sites — including that `toFieldDef` still builds from a shape with no `collection`, which fails loudly when TASK-2869 (U2b) lands rather than letting the gate drift.

## Three defects found only in a real browser

None appeared in the component tests. All three came from driving the Cars/Colors example from IDEA-2856 against a locally built binary.

1. **A legacy free-text value rendered as a working reference.** `localIndex.findByIdOrSlug` resolves by id **or slug**, so `"red"` — exactly what the old fallback wrote — resolved to the item slugged `red`. The field stores an ID; a slug match makes the chip lie about what is stored, and slugs are mutable.
2. **It could resolve into the wrong collection.** That helper is workspace-wide. This is the same defect PLAN-2857's recon recorded against the server's `ResolveItem` — I wrote that finding down and reproduced it in my own client code hours later.
3. **The field showed a permanently-open search box** — chip, plus the picker still holding the query, plus the result list still showing the row just chosen. The same item three times, under every relation field. A field shows its VALUE; the picker is for changing it.

## Two codex rounds, both P1, both about the same blind spot

**Round 1.** `FieldDef.collection` holds a SLUG, and `store.UpdateCollection` re-slugifies on rename **without migrating** the relation definitions pointing at it — the word "relation" does not appear in that file — while `localIndex.applyRetag` moves the indexed rows onto the new slug. So the collection check from defect (2) reported every stored value as "Unresolved reference" after any rename: a schema problem presenting as **lost data**, on data that is fine.

**Round 2.** The round-1 fix still judged too early. `retagCollection` moves the rows immediately; `loadCollections` is fired beside it with `void` — not awaited, rejection swallowed — so there is a window where the list holds the OLD slug (target reads 'live') while the row carries the NEW one. Brief when the refetch succeeds, **permanent when it fails**.

The fix reframes what a mismatch is evidence *of*: it means the value is wrong only when the collection list and the item index **agree about the world** — when the list knows both the declared target and the row's own collection. Both disagreement cases collapse to "don't judge", while a genuine cross-collection value (target `colors`, row `tasks`, both live) still resolves to null. A control leg pins that, because two "don't judge" guards in a row are one edit away from never judging.

Not fixed by invalidating freshness: `collectionsAreFreshFor` answers "loaded for this workspace", not "current", and teaching it about pending/failed refreshes is a store-wide change to serve one consumer.

Round 3 CLEAN.

## Filed, not absorbed

- **BUG-2873** — the root cause above. Ruled by the lead as next in my queue, ahead of U1: migrate relation `FieldDef`s inside `store.UpdateCollection`, same transaction. U1 cannot be built on a slug that a rename can strand.
- **BUG-2872** — the activity timeline renders a relation change as `color: → <uuid>`. The panel now honours IDEA-2856's "never a bare UUID"; that surface does not. The e2e invariant is scoped to the field row **on purpose**, so the gap stays visible rather than being hidden by loosening the assertion to the page body.

## Tests that were wrong first

Worth naming, because each passed against a build with the thing it names removed.

- **The stale-target test** set up the store's collection list but left the row's `collection_slug` agreeing with `field.collection` — modelling half a rename, which reconstructs a scenario that cannot fail. A rename retags the rows.
- **The unknown-vs-stale test** asserted the chip renders. A stale target also renders the chip. It asserts **editability** now, the only thing that actually differs.
- **The pin's leg (a)** asserted "some anchor exists" and failed against the new code because the test passed no `username`. Strengthened rather than relaxed: it asserts the exact href, and a new leg (a2) covers resolved-but-no-route, where the chip must degrade to a non-link and still name the item — never to the raw value, which is what the old arm did.
- **N13** (emit the chosen value but leave the picker open) survived the first matrix: the test asserted the emit and not the CLOSE, which is the half the browser pass had rejected.

## Verification

- **Pin first** (team CONVE-29): the test file was written and run BEFORE the branch existed — 4 failed / 2 passed, the two passers being the gate legs, which pass vacuously while no picker exists anywhere. They ship with a control leg that mounts one.
- **`npm run check`** — 1093 files, **0 errors**, 6 warnings, all pre-existing and in files this branch does not touch.
- **`npx vitest run`** — 123 files, **2063 tests, all passed**. 17 new render tests + 5 call-site tests.
- **`go build ./...`** ok, **gofmt** clean. No Go source changed.
- **Mutation matrix — 17 applied to the shipped tree, 17 killed.** N1 (drop the deleted branch) kills leg (b) and N2 (unresolved reads as deleted) kills leg (c), so the two states are genuinely distinguished rather than sharing a branch.
- **Real browser**, locally built binary: pick a colour → chip, picker collapses, stored value is the ID and no UUID appears in the field row; delete the target → "(deleted)"; a legacy free-text value → "Unresolved reference", not "(deleted)" and not a slug match; **rename the target collection → the stored value keeps rendering**, which is the round-1/round-2 fix proven in the app rather than in a mock.
- **Context at close:** 57.7% (`session-shape`).
