### PR TITLE
fix(store): migrate relation fields when their target collection is renamed (BUG-2873)

### DIFF
--- a/internal/store/collections.go
+++ b/internal/store/collections.go
@@ -411,7 +411,7 @@ func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*mod
 	// target's SLUG and is the only pointer a relation has — there is no id
 	// beside it — so a rename leaves every field aimed here pointing at a name
 	// that no longer resolves.
-	var renamedFrom, renamedTo string
+	var renamedTo string
 
 	if input.Name != nil {
 		sets = append(sets, "name = ?")
@@ -430,9 +430,7 @@ func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*mod
 		}
 		sets = append(sets, "slug = ?")
 		args = append(args, newSlug)
-		if newSlug != existing.Slug {
-			renamedFrom, renamedTo = existing.Slug, newSlug
-		}
+		renamedTo = newSlug
 	}
 	if input.Prefix != nil {
 		sets = append(sets, "prefix = ?")
@@ -541,12 +539,23 @@ func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*mod
 		}
 	}
 
-	reread := "SELECT updated_at FROM collections WHERE id = ? AND deleted_at IS NULL"
+	// `slug` is re-read alongside the token, not taken from the pre-tx
+	// `existing` snapshot (codex round 1 P1). Two tokenless concurrent renames
+	// both read the ORIGINAL slug outside the lock; the second would then
+	// retarget relations from a slug the first already migrated away from,
+	// missing them entirely and stranding them at an intermediate name. The
+	// value under the lock is the only one that describes what the relations
+	// currently point at.
+	//
+	// This is the READ of the old slug. ALLOCATION of the new one is still
+	// outside the transaction and deliberately left alone here — IDEA-2874.
+	reread := "SELECT updated_at, slug FROM collections WHERE id = ? AND deleted_at IS NULL"
 	if s.dialect.Driver() == DriverPostgres {
 		reread += " FOR UPDATE"
 	}
 	var currentUpdatedAt string
-	rerr := tx.QueryRow(s.q(reread), id).Scan(&currentUpdatedAt)
+	var lockedSlug string
+	rerr := tx.QueryRow(s.q(reread), id).Scan(&currentUpdatedAt, &lockedSlug)
 	if rerr == sql.ErrNoRows {
 		// Deleted between the pre-tx GetCollection and here — treat as not-found.
 		return nil, nil
@@ -600,8 +609,8 @@ func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*mod
 	// the same reason the field migrations are: a failure must roll the rename
 	// back rather than leave committed collections pointing at a slug that no
 	// longer exists.
-	if renamedTo != "" {
-		if err := s.retargetRelationFieldsTx(tx, existing.WorkspaceID, renamedFrom, renamedTo); err != nil {
+	if renamedTo != "" && lockedSlug != renamedTo {
+		if err := s.retargetRelationFieldsTx(tx, existing.WorkspaceID, lockedSlug, renamedTo, args[0]); err != nil {
 			return nil, fmt.Errorf("retarget relation fields: %w", err)
 		}
 	}
@@ -1108,33 +1117,56 @@ func isReservedCollectionSlug(slug string) bool {
 }
 
 // retargetRelationFieldsTx re-points every `relation` field in the workspace
-// from `oldSlug` to `newSlug` after a collection rename (BUG-2873).
+// from `oldSlug` to `newSlug` after a collection rename (BUG-2873), stamping
+// each rewritten row's `updated_at` with the same token as the rename itself.
 //
-// WHY THIS EXISTS. `models.FieldDef.Collection` stores the target's SLUG, and
-// it is the only pointer a relation field carries — there is no id beside it to
+// WHY THIS EXISTS. `models.FieldDef.Collection` stores the target's SLUG, and it
+// is the only pointer a relation field carries — there is no id beside it to
 // fall back on. `UpdateCollection` re-slugifies on rename, so without this every
 // relation field aimed at the renamed collection is stranded: the picker filters
 // on a slug that resolves to nothing, and the field silently stops being
 // fillable. See IDEA-2874 for the related, deliberately SEPARATE question of the
-// slug being allocated outside this transaction.
+// new slug being ALLOCATED outside this transaction.
 //
-// WHY IT PARSES INSTEAD OF STRING-REPLACING. A collection's schema JSON contains
-// the old slug in places that must NOT move: a text field's `default`, a
-// select's `options`, a label. Only `FieldDef.Collection` on a `relation` field
-// is a reference to the collection. Export's `remapFieldIDs` gets away with a
-// blind replace because it substitutes UUIDs, which cannot collide with prose;
-// a slug is a word.
+// THREE THINGS IT DOES THAT AN OBVIOUS VERSION DOES NOT, each from codex review:
 //
-// The renamed collection is included deliberately — a collection whose relation
-// field targets ITSELF needs the same rewrite, and it is reached through the same
-// UPDATE as any sibling. That write lands AFTER the caller's own `schema` write
-// in this transaction, so it composes with a simultaneous schema edit rather than
-// reverting it.
-func (s *Store) retargetRelationFieldsTx(tx *sql.Tx, workspaceID, oldSlug, newSlug string) error {
-	rows, err := tx.Query(
-		s.q("SELECT id, schema FROM collections WHERE workspace_id = ? AND deleted_at IS NULL ORDER BY id"),
-		workspaceID,
-	)
+//  1. It LOCKS the rows it will rewrite (`FOR UPDATE`, ordered by id, on
+//     Postgres). Without that a concurrent schema update to a sibling can commit
+//     between the scan and the rewrite, and this transaction then overwrites the
+//     newer schema with its own stale copy. Ordering by id keeps the multi-row
+//     acquisition deterministic; renames additionally serialize on the workspace
+//     lock taken before the row lock in the caller.
+//
+//  2. It ADVANCES `updated_at` on every row it rewrites. `collections.updated_at`
+//     doubles as the optimistic-concurrency token (BUG-2265), so leaving it
+//     unchanged would let a client still holding the pre-rename schema — and a
+//     token that still matches — write it straight back and undo the migration.
+//     The rename's own token is reused so the whole rename shares one instant.
+//
+//  3. It mutates the RAW JSON rather than round-tripping through
+//     `models.CollectionSchema`. That struct has fixed fields, so unmarshal +
+//     marshal silently drops any property it does not know about — a rename
+//     would quietly erase forward-compatible metadata from every
+//     relation-containing schema in the workspace. Editing the decoded map
+//     touches `fields[i].collection` and leaves everything else byte-intact
+//     (key ORDER is not preserved, which JSON does not make meaningful).
+//
+// WHY IT PARSES AT ALL, rather than string-replacing: a schema's JSON contains
+// the old slug in places that must NOT move — a text field's `default`, a
+// select's `options`, a label. Only `collection` on a `relation` field is a
+// reference to the collection. Export's `remapFieldIDs` gets away with a blind
+// replace because it substitutes UUIDs, which cannot collide with prose; a slug
+// is a word.
+//
+// The renamed collection is included deliberately — a relation targeting ITSELF
+// needs the same rewrite — and this runs AFTER the caller's own `schema` write in
+// the transaction, so a simultaneous schema edit composes rather than reverting.
+func (s *Store) retargetRelationFieldsTx(tx *sql.Tx, workspaceID, oldSlug, newSlug string, updatedAt interface{}) error {
+	listQ := "SELECT id, schema FROM collections WHERE workspace_id = ? AND deleted_at IS NULL ORDER BY id"
+	if s.dialect.Driver() == DriverPostgres {
+		listQ += " FOR UPDATE"
+	}
+	rows, err := tx.Query(s.q(listQ), workspaceID)
 	if err != nil {
 		return fmt.Errorf("list collections: %w", err)
 	}
@@ -1151,32 +1183,17 @@ func (s *Store) retargetRelationFieldsTx(tx *sql.Tx, workspaceID, oldSlug, newSl
 			rows.Close()
 			return fmt.Errorf("scan collection: %w", err)
 		}
-		if raw == "" {
-			continue
-		}
-		var sch models.CollectionSchema
-		if err := json.Unmarshal([]byte(raw), &sch); err != nil {
+		rewritten, changed, err := retargetRelationsInSchemaJSON(raw, oldSlug, newSlug)
+		if err != nil {
 			// A schema this store cannot parse is not one this migration can
 			// safely rewrite. Skipping leaves it exactly as it was — stranded,
 			// but not corrupted by a guess.
 			continue
 		}
-		changed := false
-		for i := range sch.Fields {
-			if sch.Fields[i].Type == "relation" && sch.Fields[i].Collection == oldSlug {
-				sch.Fields[i].Collection = newSlug
-				changed = true
-			}
-		}
 		if !changed {
 			continue
 		}
-		encoded, err := json.Marshal(sch)
-		if err != nil {
-			rows.Close()
-			return fmt.Errorf("encode schema for %s: %w", id, err)
-		}
-		updates = append(updates, pending{id: id, schema: string(encoded)})
+		updates = append(updates, pending{id: id, schema: rewritten})
 	}
 	if err := rows.Err(); err != nil {
 		rows.Close()
@@ -1189,11 +1206,51 @@ func (s *Store) retargetRelationFieldsTx(tx *sql.Tx, workspaceID, oldSlug, newSl
 	// BackfillWikiLinks documents.
 	for _, u := range updates {
 		if _, err := tx.Exec(
-			s.q("UPDATE collections SET schema = ? WHERE id = ?"),
-			u.schema, u.id,
+			s.q("UPDATE collections SET schema = ?, updated_at = ? WHERE id = ?"),
+			u.schema, updatedAt, u.id,
 		); err != nil {
 			return fmt.Errorf("rewrite schema for %s: %w", u.id, err)
 		}
 	}
 	return nil
+}
+
+// retargetRelationsInSchemaJSON rewrites `collection` on every `relation` field
+// in a raw schema document, preserving every other property including ones this
+// binary does not know about. Returns the new JSON and whether anything changed.
+func retargetRelationsInSchemaJSON(raw, oldSlug, newSlug string) (string, bool, error) {
+	if strings.TrimSpace(raw) == "" {
+		return raw, false, nil
+	}
+	var doc map[string]interface{}
+	if err := json.Unmarshal([]byte(raw), &doc); err != nil {
+		return raw, false, err
+	}
+	fields, ok := doc["fields"].([]interface{})
+	if !ok {
+		return raw, false, nil
+	}
+	changed := false
+	for _, entry := range fields {
+		f, ok := entry.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if t, _ := f["type"].(string); t != "relation" {
+			continue
+		}
+		if c, _ := f["collection"].(string); c != oldSlug {
+			continue
+		}
+		f["collection"] = newSlug
+		changed = true
+	}
+	if !changed {
+		return raw, false, nil
+	}
+	encoded, err := json.Marshal(doc)
+	if err != nil {
+		return raw, false, err
+	}
+	return string(encoded), true, nil
 }

--- a/internal/store/collections.go
+++ b/internal/store/collections.go
@@ -1162,7 +1162,7 @@ func isReservedCollectionSlug(slug string) bool {
 // needs the same rewrite — and this runs AFTER the caller's own `schema` write in
 // the transaction, so a simultaneous schema edit composes rather than reverting.
 func (s *Store) retargetRelationFieldsTx(tx *sql.Tx, workspaceID, oldSlug, newSlug string, updatedAt interface{}) error {
-	listQ := "SELECT id, schema FROM collections WHERE workspace_id = ? AND deleted_at IS NULL ORDER BY id"
+	listQ := "SELECT id, schema, updated_at FROM collections WHERE workspace_id = ? AND deleted_at IS NULL ORDER BY id"
 	if s.dialect.Driver() == DriverPostgres {
 		listQ += " FOR UPDATE"
 	}
@@ -1172,14 +1172,17 @@ func (s *Store) retargetRelationFieldsTx(tx *sql.Tx, workspaceID, oldSlug, newSl
 	}
 
 	type pending struct {
-		id     string
-		schema string
+		id      string
+		schema  string
+		stampAt string
 	}
 	var updates []pending
 
+	renameToken := parseTime(fmt.Sprint(updatedAt))
+
 	for rows.Next() {
-		var id, raw string
-		if err := rows.Scan(&id, &raw); err != nil {
+		var id, raw, rowUpdatedAt string
+		if err := rows.Scan(&id, &raw, &rowUpdatedAt); err != nil {
 			rows.Close()
 			return fmt.Errorf("scan collection: %w", err)
 		}
@@ -1193,7 +1196,17 @@ func (s *Store) retargetRelationFieldsTx(tx *sql.Tx, workspaceID, oldSlug, newSl
 		if !changed {
 			continue
 		}
-		updates = append(updates, pending{id: id, schema: rewritten})
+		// Never REGRESS a token. A sibling updated between this rename's
+		// timestamp and the scan already holds a NEWER one, and stamping the
+		// rename's value on it would move the optimistic-concurrency token
+		// backwards — breaking the strictly-increasing invariant the guard above
+		// this transaction exists to maintain, and re-validating a token a
+		// client should have lost (codex round 2 P1).
+		stamp := fmt.Sprint(updatedAt)
+		if cur := parseTime(rowUpdatedAt); !renameToken.After(cur) {
+			stamp = cur.Add(time.Nanosecond).UTC().Format(time.RFC3339Nano)
+		}
+		updates = append(updates, pending{id: id, schema: rewritten, stampAt: stamp})
 	}
 	if err := rows.Err(); err != nil {
 		rows.Close()
@@ -1207,7 +1220,7 @@ func (s *Store) retargetRelationFieldsTx(tx *sql.Tx, workspaceID, oldSlug, newSl
 	for _, u := range updates {
 		if _, err := tx.Exec(
 			s.q("UPDATE collections SET schema = ?, updated_at = ? WHERE id = ?"),
-			u.schema, updatedAt, u.id,
+			u.schema, u.stampAt, u.id,
 		); err != nil {
 			return fmt.Errorf("rewrite schema for %s: %w", u.id, err)
 		}
@@ -1222,8 +1235,15 @@ func retargetRelationsInSchemaJSON(raw, oldSlug, newSlug string) (string, bool, 
 	if strings.TrimSpace(raw) == "" {
 		return raw, false, nil
 	}
+	// `UseNumber` keeps integers as their literal text. A plain unmarshal into
+	// `interface{}` decodes every number as float64, so a large integer in a
+	// property this binary does not know about would come back CHANGED —
+	// 9007199254740993 is not representable — and a rename would silently
+	// corrupt it (codex round 2 P2).
+	dec := json.NewDecoder(strings.NewReader(raw))
+	dec.UseNumber()
 	var doc map[string]interface{}
-	if err := json.Unmarshal([]byte(raw), &doc); err != nil {
+	if err := dec.Decode(&doc); err != nil {
 		return raw, false, err
 	}
 	fields, ok := doc["fields"].([]interface{})

--- a/internal/store/collections.go
+++ b/internal/store/collections.go
@@ -406,6 +406,13 @@ func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*mod
 	sets := []string{"updated_at = ?"}
 	args := []interface{}{ts}
 
+	// Set when this update actually changes the slug, which is what strands
+	// relation fields (BUG-2873): `models.FieldDef.Collection` holds the
+	// target's SLUG and is the only pointer a relation has — there is no id
+	// beside it — so a rename leaves every field aimed here pointing at a name
+	// that no longer resolves.
+	var renamedFrom, renamedTo string
+
 	if input.Name != nil {
 		sets = append(sets, "name = ?")
 		args = append(args, *input.Name)
@@ -423,6 +430,9 @@ func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*mod
 		}
 		sets = append(sets, "slug = ?")
 		args = append(args, newSlug)
+		if newSlug != existing.Slug {
+			renamedFrom, renamedTo = existing.Slug, newSlug
+		}
 	}
 	if input.Prefix != nil {
 		sets = append(sets, "prefix = ?")
@@ -516,7 +526,16 @@ func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*mod
 	// migration path (the only path that touches the workspace seq lock); a
 	// plain update just takes the row lock and can't deadlock. On SQLite both
 	// are no-ops under the single BEGIN IMMEDIATE write lock.
-	if len(input.Migrations) > 0 {
+	// The comment above orders the workspace lock against ONE collection row
+	// lock, because until BUG-2873 nothing took more than one. Migrating relation
+	// targets writes SIBLING collection rows, so two concurrent renames of
+	// mutually-referencing collections would take those row locks in opposite
+	// orders and ABBA-deadlock — a hazard the existing comment reads as though it
+	// had already settled. Serializing renames under the workspace lock closes it
+	// without inventing a second ordering rule to keep in sync with the first,
+	// and it is taken BEFORE the row lock, preserving the order this comment
+	// exists to protect.
+	if len(input.Migrations) > 0 || renamedTo != "" {
 		if err := s.acquireWorkspaceSeqLock(tx, existing.WorkspaceID); err != nil {
 			return nil, err
 		}
@@ -574,6 +593,16 @@ func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*mod
 	if len(input.Migrations) > 0 {
 		if _, err := s.applyFieldMigrationsTx(tx, id, existing.WorkspaceID, input.Migrations); err != nil {
 			return nil, fmt.Errorf("apply field migrations: %w", err)
+		}
+	}
+
+	// Re-point relation fields at the new slug, in the SAME tx as the rename for
+	// the same reason the field migrations are: a failure must roll the rename
+	// back rather than leave committed collections pointing at a slug that no
+	// longer exists.
+	if renamedTo != "" {
+		if err := s.retargetRelationFieldsTx(tx, existing.WorkspaceID, renamedFrom, renamedTo); err != nil {
+			return nil, fmt.Errorf("retarget relation fields: %w", err)
 		}
 	}
 
@@ -1076,4 +1105,95 @@ var reservedCollectionSlugs = map[string]bool{
 // workspace-level UI route.
 func isReservedCollectionSlug(slug string) bool {
 	return reservedCollectionSlugs[strings.ToLower(slug)]
+}
+
+// retargetRelationFieldsTx re-points every `relation` field in the workspace
+// from `oldSlug` to `newSlug` after a collection rename (BUG-2873).
+//
+// WHY THIS EXISTS. `models.FieldDef.Collection` stores the target's SLUG, and
+// it is the only pointer a relation field carries — there is no id beside it to
+// fall back on. `UpdateCollection` re-slugifies on rename, so without this every
+// relation field aimed at the renamed collection is stranded: the picker filters
+// on a slug that resolves to nothing, and the field silently stops being
+// fillable. See IDEA-2874 for the related, deliberately SEPARATE question of the
+// slug being allocated outside this transaction.
+//
+// WHY IT PARSES INSTEAD OF STRING-REPLACING. A collection's schema JSON contains
+// the old slug in places that must NOT move: a text field's `default`, a
+// select's `options`, a label. Only `FieldDef.Collection` on a `relation` field
+// is a reference to the collection. Export's `remapFieldIDs` gets away with a
+// blind replace because it substitutes UUIDs, which cannot collide with prose;
+// a slug is a word.
+//
+// The renamed collection is included deliberately — a collection whose relation
+// field targets ITSELF needs the same rewrite, and it is reached through the same
+// UPDATE as any sibling. That write lands AFTER the caller's own `schema` write
+// in this transaction, so it composes with a simultaneous schema edit rather than
+// reverting it.
+func (s *Store) retargetRelationFieldsTx(tx *sql.Tx, workspaceID, oldSlug, newSlug string) error {
+	rows, err := tx.Query(
+		s.q("SELECT id, schema FROM collections WHERE workspace_id = ? AND deleted_at IS NULL ORDER BY id"),
+		workspaceID,
+	)
+	if err != nil {
+		return fmt.Errorf("list collections: %w", err)
+	}
+
+	type pending struct {
+		id     string
+		schema string
+	}
+	var updates []pending
+
+	for rows.Next() {
+		var id, raw string
+		if err := rows.Scan(&id, &raw); err != nil {
+			rows.Close()
+			return fmt.Errorf("scan collection: %w", err)
+		}
+		if raw == "" {
+			continue
+		}
+		var sch models.CollectionSchema
+		if err := json.Unmarshal([]byte(raw), &sch); err != nil {
+			// A schema this store cannot parse is not one this migration can
+			// safely rewrite. Skipping leaves it exactly as it was — stranded,
+			// but not corrupted by a guess.
+			continue
+		}
+		changed := false
+		for i := range sch.Fields {
+			if sch.Fields[i].Type == "relation" && sch.Fields[i].Collection == oldSlug {
+				sch.Fields[i].Collection = newSlug
+				changed = true
+			}
+		}
+		if !changed {
+			continue
+		}
+		encoded, err := json.Marshal(sch)
+		if err != nil {
+			rows.Close()
+			return fmt.Errorf("encode schema for %s: %w", id, err)
+		}
+		updates = append(updates, pending{id: id, schema: string(encoded)})
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return fmt.Errorf("iterate collections: %w", err)
+	}
+	rows.Close()
+
+	// Writes happen after the cursor is closed: SQLite will not accept an UPDATE
+	// on a table with an open SELECT cursor over it, the same caution
+	// BackfillWikiLinks documents.
+	for _, u := range updates {
+		if _, err := tx.Exec(
+			s.q("UPDATE collections SET schema = ? WHERE id = ?"),
+			u.schema, u.id,
+		); err != nil {
+			return fmt.Errorf("rewrite schema for %s: %w", u.id, err)
+		}
+	}
+	return nil
 }

--- a/internal/store/collections.go
+++ b/internal/store/collections.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
@@ -1245,6 +1246,14 @@ func retargetRelationsInSchemaJSON(raw, oldSlug, newSlug string) (string, bool, 
 	var doc map[string]interface{}
 	if err := dec.Decode(&doc); err != nil {
 		return raw, false, err
+	}
+	// `Decode` stops at the end of the FIRST value and ignores whatever follows,
+	// where `json.Unmarshal` would have refused it. Re-marshaling such a document
+	// would silently drop the trailing bytes, so treat it as unparseable and
+	// leave the row alone — the same posture as any other schema this migration
+	// cannot faithfully rewrite (codex round 3 P2).
+	if _, err := dec.Token(); err != io.EOF {
+		return raw, false, fmt.Errorf("trailing content after schema object")
 	}
 	fields, ok := doc["fields"].([]interface{})
 	if !ok {

--- a/internal/store/collections_relation_rename_test.go
+++ b/internal/store/collections_relation_rename_test.go
@@ -1,0 +1,275 @@
+package store
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// BUG-2873. `models.FieldDef.Collection` holds the target's SLUG — it is the
+// only pointer a relation field has, with no id alongside it — and renaming a
+// collection re-slugifies it. Nothing migrated the relation definitions aimed
+// at it, so every relation field pointing at a renamed collection was stranded:
+// its picker filters on a slug that names nothing.
+//
+// These are written BEFORE the fix (team CONVE-29). Against the unfixed tree
+// the propagation tests fail and the "leaves other fields alone" control
+// passes — a pin that passes on both sides would not be measuring anything.
+
+// relationSchema builds a one-relation-field schema aimed at `target`.
+func relationSchema(t *testing.T, key, target string) string {
+	t.Helper()
+	b, err := json.Marshal(models.CollectionSchema{
+		Fields: []models.FieldDef{
+			{Key: "note", Label: "Note", Type: "text"},
+			{Key: key, Label: "Rel", Type: "relation", Collection: target},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal schema: %v", err)
+	}
+	return string(b)
+}
+
+// relationTargetOf reads back the stored target slug for a relation field.
+func relationTargetOf(t *testing.T, s *Store, collID, key string) string {
+	t.Helper()
+	c, err := s.GetCollection(collID)
+	if err != nil {
+		t.Fatalf("GetCollection: %v", err)
+	}
+	if c == nil {
+		t.Fatalf("collection %s missing", collID)
+	}
+	var sch models.CollectionSchema
+	if err := json.Unmarshal([]byte(c.Schema), &sch); err != nil {
+		t.Fatalf("unmarshal schema %q: %v", c.Schema, err)
+	}
+	for _, f := range sch.Fields {
+		if f.Key == key {
+			return f.Collection
+		}
+	}
+	t.Fatalf("field %q not found in %s", key, c.Slug)
+	return ""
+}
+
+func TestRenameMigratesRelationTargetsInSiblingCollections(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "RelRenameSibling")
+
+	target, err := s.CreateCollection(ws.ID, models.CollectionCreate{Name: "Colors", Slug: "colors"})
+	if err != nil {
+		t.Fatalf("create target: %v", err)
+	}
+	cars, err := s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Cars", Slug: "cars", Schema: relationSchema(t, "color", "colors"),
+	})
+	if err != nil {
+		t.Fatalf("create sibling: %v", err)
+	}
+
+	name := "Palette"
+	renamed, err := s.UpdateCollection(target.ID, models.CollectionUpdate{Name: &name})
+	if err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+	if renamed.Slug == "colors" {
+		t.Fatalf("precondition: rename did not change the slug (got %q)", renamed.Slug)
+	}
+
+	if got := relationTargetOf(t, s, cars.ID, "color"); got != renamed.Slug {
+		t.Errorf("sibling relation target = %q, want the new slug %q", got, renamed.Slug)
+	}
+}
+
+func TestRenameMigratesASelfReferencingRelation(t *testing.T) {
+	// The renamed collection is also the row being UPDATEd, so its own schema
+	// rewrite has to compose with the update rather than be clobbered by it.
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "RelRenameSelf")
+
+	coll, err := s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Nodes", Slug: "nodes", Schema: relationSchema(t, "parent_node", "nodes"),
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	name := "Graph Nodes"
+	renamed, err := s.UpdateCollection(coll.ID, models.CollectionUpdate{Name: &name})
+	if err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+	if renamed.Slug == "nodes" {
+		t.Fatalf("precondition: rename did not change the slug")
+	}
+
+	if got := relationTargetOf(t, s, coll.ID, "parent_node"); got != renamed.Slug {
+		t.Errorf("self-referencing target = %q, want %q", got, renamed.Slug)
+	}
+}
+
+func TestRenameWithASimultaneousSchemaWriteMigratesTheSuppliedSchema(t *testing.T) {
+	// A caller that renames AND supplies a new schema in one call: the
+	// migration must apply to what the caller sent, not to what was stored,
+	// or the rewrite silently reverts their edit.
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "RelRenameWithSchema")
+
+	target, err := s.CreateCollection(ws.ID, models.CollectionCreate{Name: "Colors", Slug: "colors"})
+	if err != nil {
+		t.Fatalf("create target: %v", err)
+	}
+	_ = target
+
+	self, err := s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Cars", Slug: "cars", Schema: relationSchema(t, "color", "colors"),
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// Rename `cars` while ALSO adding a field. Its own relation points at
+	// `colors`, which is untouched — so the caller's schema must survive whole.
+	newSchema := `{"fields":[{"key":"note","label":"Note","type":"text"},{"key":"color","label":"Rel","type":"relation","collection":"colors"},{"key":"vin","label":"VIN","type":"text"}]}`
+	name := "Vehicles"
+	if _, err := s.UpdateCollection(self.ID, models.CollectionUpdate{Name: &name, Schema: &newSchema}); err != nil {
+		t.Fatalf("rename+schema: %v", err)
+	}
+
+	c, err := s.GetCollection(self.ID)
+	if err != nil {
+		t.Fatalf("GetCollection: %v", err)
+	}
+	var sch models.CollectionSchema
+	if err := json.Unmarshal([]byte(c.Schema), &sch); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(sch.Fields) != 3 {
+		t.Fatalf("caller's schema was not preserved: got %d fields, want 3 (%s)", len(sch.Fields), c.Schema)
+	}
+	if got := relationTargetOf(t, s, self.ID, "color"); got != "colors" {
+		t.Errorf("untouched target rewritten to %q, want %q", got, "colors")
+	}
+}
+
+func TestRenameLeavesUnrelatedFieldsAndCollectionsAlone(t *testing.T) {
+	// CONTROL. Without this the propagation tests are satisfied by a change
+	// that rewrites the string everywhere it appears.
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "RelRenameControl")
+
+	if _, err := s.CreateCollection(ws.ID, models.CollectionCreate{Name: "Colors", Slug: "colors"}); err != nil {
+		t.Fatalf("create target: %v", err)
+	}
+	// A relation aimed somewhere ELSE, plus a non-relation field whose VALUE
+	// happens to be the renamed slug.
+	other, err := s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Other", Slug: "other",
+		Schema: `{"fields":[{"key":"rel","label":"Rel","type":"relation","collection":"other"},{"key":"label","label":"Label","type":"text","default":"colors"},{"key":"pick","label":"Pick","type":"select","options":["colors","x"]}]}`,
+	})
+	if err != nil {
+		t.Fatalf("create other: %v", err)
+	}
+
+	name := "Palette"
+	// Rename `colors`, which `other` does NOT point at.
+	colors, err := s.GetCollectionBySlug(ws.ID, "colors")
+	if err != nil || colors == nil {
+		t.Fatalf("lookup colors: %v", err)
+	}
+	if _, err := s.UpdateCollection(colors.ID, models.CollectionUpdate{Name: &name}); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+
+	c, err := s.GetCollection(other.ID)
+	if err != nil {
+		t.Fatalf("GetCollection: %v", err)
+	}
+	var sch models.CollectionSchema
+	if err := json.Unmarshal([]byte(c.Schema), &sch); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, f := range sch.Fields {
+		switch f.Key {
+		case "rel":
+			if f.Collection != "other" {
+				t.Errorf("unrelated relation target rewritten to %q, want %q", f.Collection, "other")
+			}
+		case "label":
+			if fmt.Sprint(f.Default) != "colors" {
+				t.Errorf("text default rewritten to %v, want %q", f.Default, "colors")
+			}
+		case "pick":
+			if len(f.Options) == 0 || f.Options[0] != "colors" {
+				t.Errorf("select option rewritten to %v, want first option %q", f.Options, "colors")
+			}
+		}
+	}
+}
+
+func TestConcurrentRenamesOfMutuallyReferencingCollectionsDoNotDeadlock(t *testing.T) {
+	// The hazard the existing lock-order comment does NOT cover: it orders the
+	// workspace lock against ONE collection row lock, because nothing took two.
+	// A sibling-schema rewrite takes many, so two renames of mutually
+	// referencing collections can take them in opposite orders.
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "RelRenameDeadlock")
+
+	a, err := s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Alpha", Slug: "alpha", Schema: relationSchema(t, "beta_ref", "beta"),
+	})
+	if err != nil {
+		t.Fatalf("create alpha: %v", err)
+	}
+	b, err := s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Beta", Slug: "beta", Schema: relationSchema(t, "alpha_ref", "alpha"),
+	})
+	if err != nil {
+		t.Fatalf("create beta: %v", err)
+	}
+
+	// REPEATED, and released together. A single unsynchronised pair almost never
+	// interleaves at the point that matters — measured: the first version of
+	// this test passed with the serialization REMOVED, in 0.44s, because the two
+	// goroutines simply never collided. A start barrier plus repetition is what
+	// turns it into an instrument. Each round renames back and forth so the pair
+	// keeps referencing each other.
+	const rounds = 40
+	ids := [2]string{a.ID, b.ID}
+	for round := 0; round < rounds; round++ {
+		start := make(chan struct{})
+		done := make(chan error, 2)
+		var wg sync.WaitGroup
+		for i := 0; i < 2; i++ {
+			wg.Add(1)
+			go func(id string, n int) {
+				defer wg.Done()
+				name := fmt.Sprintf("Coll%d R%d", n, round)
+				<-start
+				_, err := s.UpdateCollection(id, models.CollectionUpdate{Name: &name})
+				done <- err
+			}(ids[i], i)
+		}
+		close(start)
+
+		finished := make(chan struct{})
+		go func() { wg.Wait(); close(finished) }()
+		select {
+		case <-finished:
+		case <-time.After(20 * time.Second):
+			t.Fatalf("round %d: concurrent renames did not complete within 20s: deadlock", round)
+		}
+		close(done)
+		for err := range done {
+			if err != nil {
+				t.Fatalf("round %d: concurrent rename failed: %v", round, err)
+			}
+		}
+	}
+}

--- a/internal/store/collections_relation_rename_test.go
+++ b/internal/store/collections_relation_rename_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -420,5 +421,87 @@ func TestConcurrentRenamesOfTheSameCollectionLeaveRelationsPointingAtIt(t *testi
 		if got := relationTargetOf(t, s, cars.ID, "color"); got != final.Slug {
 			t.Fatalf("round %d: relation points at %q but the collection is %q", round, got, final.Slug)
 		}
+	}
+}
+
+func TestRenameNeverRegressesAMigratedSiblingsToken(t *testing.T) {
+	// codex round 2 P1. A sibling updated between the rename's timestamp and
+	// the scan already holds a NEWER token; stamping the rename's value on it
+	// moves the OCC token BACKWARDS, breaking the strictly-increasing invariant
+	// and re-validating a token the client should have lost.
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "RelRenameNoRegress")
+
+	target, err := s.CreateCollection(ws.ID, models.CollectionCreate{Name: "Colors", Slug: "colors"})
+	if err != nil {
+		t.Fatalf("create target: %v", err)
+	}
+	cars, err := s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Cars", Slug: "cars", Schema: relationSchema(t, "color", "colors"),
+	})
+	if err != nil {
+		t.Fatalf("create sibling: %v", err)
+	}
+
+	// Push the sibling's token well past anything this rename will compute.
+	future := time.Now().UTC().Add(2 * time.Hour).Format(time.RFC3339Nano)
+	if _, err := s.db.Exec(s.q("UPDATE collections SET updated_at = ? WHERE id = ?"), future, cars.ID); err != nil {
+		t.Fatalf("seed future token: %v", err)
+	}
+	before, err := s.GetCollection(cars.ID)
+	if err != nil {
+		t.Fatalf("GetCollection: %v", err)
+	}
+
+	name := "Palette"
+	renamed, err := s.UpdateCollection(target.ID, models.CollectionUpdate{Name: &name})
+	if err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+
+	after, err := s.GetCollection(cars.ID)
+	if err != nil {
+		t.Fatalf("GetCollection: %v", err)
+	}
+	if !after.UpdatedAt.After(before.UpdatedAt) {
+		t.Errorf("token regressed or stalled: before=%v after=%v", before.UpdatedAt, after.UpdatedAt)
+	}
+	// The migration itself still has to have happened.
+	if got := relationTargetOf(t, s, cars.ID, "color"); got != renamed.Slug {
+		t.Errorf("target = %q, want %q", got, renamed.Slug)
+	}
+}
+
+func TestRenamePreservesLargeIntegersInUnknownSchemaProperties(t *testing.T) {
+	// codex round 2 P2. Decoding into `interface{}` turns every JSON number
+	// into float64, so an integer past 2^53 comes back CHANGED and the rename
+	// silently corrupts a property it was only meant to carry through.
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "RelRenameBigInt")
+
+	target, err := s.CreateCollection(ws.ID, models.CollectionCreate{Name: "Colors", Slug: "colors"})
+	if err != nil {
+		t.Fatalf("create target: %v", err)
+	}
+	const big = "9007199254740993" // 2^53 + 1: not representable as float64
+	cars, err := s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Cars", Slug: "cars",
+		Schema: `{"fields":[{"key":"color","label":"Rel","type":"relation","collection":"colors","future_id":` + big + `}]}`,
+	})
+	if err != nil {
+		t.Fatalf("create sibling: %v", err)
+	}
+
+	name := "Palette"
+	if _, err := s.UpdateCollection(target.ID, models.CollectionUpdate{Name: &name}); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+
+	after, err := s.GetCollection(cars.ID)
+	if err != nil {
+		t.Fatalf("GetCollection: %v", err)
+	}
+	if !strings.Contains(after.Schema, big) {
+		t.Errorf("large integer corrupted by the rewrite: %s", after.Schema)
 	}
 }

--- a/internal/store/collections_relation_rename_test.go
+++ b/internal/store/collections_relation_rename_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -270,6 +271,154 @@ func TestConcurrentRenamesOfMutuallyReferencingCollectionsDoNotDeadlock(t *testi
 			if err != nil {
 				t.Fatalf("round %d: concurrent rename failed: %v", round, err)
 			}
+		}
+	}
+}
+
+func TestRenameAdvancesTheMigratedSiblingsConcurrencyToken(t *testing.T) {
+	// codex round 1 P1. `collections.updated_at` doubles as the OCC token
+	// (BUG-2265). Rewriting a sibling's schema without advancing it lets a
+	// client still holding the PRE-rename schema — and a token that still
+	// matches — write it straight back and undo the migration.
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "RelRenameToken")
+
+	target, err := s.CreateCollection(ws.ID, models.CollectionCreate{Name: "Colors", Slug: "colors"})
+	if err != nil {
+		t.Fatalf("create target: %v", err)
+	}
+	cars, err := s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Cars", Slug: "cars", Schema: relationSchema(t, "color", "colors"),
+	})
+	if err != nil {
+		t.Fatalf("create sibling: %v", err)
+	}
+	before, err := s.GetCollection(cars.ID)
+	if err != nil {
+		t.Fatalf("GetCollection: %v", err)
+	}
+
+	name := "Palette"
+	if _, err := s.UpdateCollection(target.ID, models.CollectionUpdate{Name: &name}); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+
+	after, err := s.GetCollection(cars.ID)
+	if err != nil {
+		t.Fatalf("GetCollection: %v", err)
+	}
+	if !after.UpdatedAt.After(before.UpdatedAt) {
+		t.Fatalf("migrated sibling token did not advance: before=%v after=%v", before.UpdatedAt, after.UpdatedAt)
+	}
+
+	// And the stale token is now refused, which is the property the advance buys.
+	stale := before.UpdatedAt.Format(time.RFC3339)
+	revert := relationSchema(t, "color", "colors")
+	_, err = s.UpdateCollection(cars.ID, models.CollectionUpdate{
+		Schema: &revert, ExpectedUpdatedAt: stale,
+	})
+	var conflict *CollectionUpdateConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("a write with the pre-rename token should 409, got err=%v", err)
+	}
+}
+
+func TestRenamePreservesSchemaPropertiesItDoesNotUnderstand(t *testing.T) {
+	// codex round 1 P2. Round-tripping through `models.CollectionSchema` drops
+	// every property that struct does not declare, so a rename would silently
+	// erase forward-compatible metadata from any relation-bearing schema.
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "RelRenameUnknownKeys")
+
+	target, err := s.CreateCollection(ws.ID, models.CollectionCreate{Name: "Colors", Slug: "colors"})
+	if err != nil {
+		t.Fatalf("create target: %v", err)
+	}
+	exotic := `{"fields":[{"key":"color","label":"Rel","type":"relation","collection":"colors","future_prop":{"nested":[1,2]}}],"schema_level_extra":"keep me"}`
+	cars, err := s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Cars", Slug: "cars", Schema: exotic,
+	})
+	if err != nil {
+		t.Fatalf("create sibling: %v", err)
+	}
+
+	name := "Palette"
+	renamed, err := s.UpdateCollection(target.ID, models.CollectionUpdate{Name: &name})
+	if err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+
+	after, err := s.GetCollection(cars.ID)
+	if err != nil {
+		t.Fatalf("GetCollection: %v", err)
+	}
+	var doc map[string]interface{}
+	if err := json.Unmarshal([]byte(after.Schema), &doc); err != nil {
+		t.Fatalf("unmarshal rewritten schema: %v", err)
+	}
+	if doc["schema_level_extra"] != "keep me" {
+		t.Errorf("schema-level unknown property lost: %s", after.Schema)
+	}
+	fields, _ := doc["fields"].([]interface{})
+	if len(fields) != 1 {
+		t.Fatalf("expected 1 field, got %s", after.Schema)
+	}
+	f, _ := fields[0].(map[string]interface{})
+	if f["future_prop"] == nil {
+		t.Errorf("field-level unknown property lost: %s", after.Schema)
+	}
+	if f["collection"] != renamed.Slug {
+		t.Errorf("target not migrated: got %v want %q", f["collection"], renamed.Slug)
+	}
+}
+
+func TestConcurrentRenamesOfTheSameCollectionLeaveRelationsPointingAtIt(t *testing.T) {
+	// codex round 1 P1 (the third one). Both racers read the collection's slug
+	// via the pre-transaction GetCollection. If the retarget uses THAT value
+	// rather than the one re-read under the row lock, the loser migrates
+	// `original -> its own new slug` while the relations already say the
+	// WINNER's slug — so it matches nothing, and the relation is stranded at a
+	// name no collection holds.
+	//
+	// The invariant is end-state and therefore honest under any interleaving:
+	// whatever slug the collection ends up with, every relation aimed at it
+	// points there.
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "RelRenameSameColl")
+
+	target, err := s.CreateCollection(ws.ID, models.CollectionCreate{Name: "Colors", Slug: "colors"})
+	if err != nil {
+		t.Fatalf("create target: %v", err)
+	}
+	cars, err := s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Cars", Slug: "cars", Schema: relationSchema(t, "color", "colors"),
+	})
+	if err != nil {
+		t.Fatalf("create sibling: %v", err)
+	}
+
+	const rounds = 40
+	for round := 0; round < rounds; round++ {
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		for i := 0; i < 2; i++ {
+			wg.Add(1)
+			go func(n int) {
+				defer wg.Done()
+				name := fmt.Sprintf("Palette %d-%d", round, n)
+				<-start
+				_, _ = s.UpdateCollection(target.ID, models.CollectionUpdate{Name: &name})
+			}(i)
+		}
+		close(start)
+		wg.Wait()
+
+		final, err := s.GetCollection(target.ID)
+		if err != nil {
+			t.Fatalf("round %d: GetCollection: %v", round, err)
+		}
+		if got := relationTargetOf(t, s, cars.ID, "color"); got != final.Slug {
+			t.Fatalf("round %d: relation points at %q but the collection is %q", round, got, final.Slug)
 		}
 	}
 }

--- a/internal/store/collections_relation_rename_test.go
+++ b/internal/store/collections_relation_rename_test.go
@@ -505,3 +505,50 @@ func TestRenamePreservesLargeIntegersInUnknownSchemaProperties(t *testing.T) {
 		t.Errorf("large integer corrupted by the rewrite: %s", after.Schema)
 	}
 }
+
+func TestRenameLeavesASchemaWithTrailingJunkUntouched(t *testing.T) {
+	// codex round 3 P2. `json.Decoder.Decode` stops at the end of the first
+	// value and ignores the rest, where `json.Unmarshal` refuses it — so
+	// re-marshaling such a document would silently discard the trailing bytes.
+	// Better to leave the row exactly as it is: stranded, but not quietly
+	// truncated by a migration that was only meant to rename a target.
+	s := testStore(t)
+	// SQLite only, and that is the finding rather than a limitation of the test:
+	// `collections.schema` is TEXT on SQLite (`005_collections.sql:10`) and JSONB
+	// on Postgres (`pgmigrations/001_initial.sql:114`), so a value with trailing
+	// content after the object cannot be STORED on Postgres at all — seeding it
+	// fails at the driver with `invalid input syntax for type json (22P02)`.
+	// The guard this pins is therefore defensive on one dialect and unreachable
+	// on the other. Skipping is honest; asserting would be asserting about a
+	// state that cannot exist.
+	if s.dialect.Driver() == DriverPostgres {
+		t.Skip("collections.schema is JSONB on Postgres: trailing content cannot be stored")
+	}
+	ws := createTestWorkspace(t, s, "RelRenameTrailing")
+
+	target, err := s.CreateCollection(ws.ID, models.CollectionCreate{Name: "Colors", Slug: "colors"})
+	if err != nil {
+		t.Fatalf("create target: %v", err)
+	}
+	cars, err := s.CreateCollection(ws.ID, models.CollectionCreate{Name: "Cars", Slug: "cars"})
+	if err != nil {
+		t.Fatalf("create sibling: %v", err)
+	}
+	junk := `{"fields":[{"key":"color","label":"Rel","type":"relation","collection":"colors"}]} trailing-junk`
+	if _, err := s.db.Exec(s.q("UPDATE collections SET schema = ? WHERE id = ?"), junk, cars.ID); err != nil {
+		t.Fatalf("seed trailing junk: %v", err)
+	}
+
+	name := "Palette"
+	if _, err := s.UpdateCollection(target.ID, models.CollectionUpdate{Name: &name}); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+
+	after, err := s.GetCollection(cars.ID)
+	if err != nil {
+		t.Fatalf("GetCollection: %v", err)
+	}
+	if after.Schema != junk {
+		t.Errorf("schema with trailing content was rewritten:\n got %q\nwant %q", after.Schema, junk)
+	}
+}


### PR DESCRIPTION
`models.FieldDef.Collection` holds the target's **slug**, and it is the only pointer a relation field carries — there is no id beside it. `UpdateCollection` re-slugifies on rename and nothing migrated the definitions aimed at it, so every relation field pointing at a renamed collection was stranded: the picker filters on a slug that resolves to nothing and the field silently stops being fillable.

`retargetRelationFieldsTx` re-points them in the **same transaction** as the rename, for the reason the field-value migrations already run there — a failure must roll the rename back rather than commit collections pointing at a name that no longer exists.

## Zero affected rows, deliberately

A census across every workspace on this instance found **no relation fields anywhere**, and no shipped template declares one. The feature has been unusable, which is what PLAN-2857 exists to change. So this repairs the rename path *before* the population exists, which is why there is no data migration — and the "zero live rows" property is what makes the change cheap to review. Three findings were split out rather than folded in to preserve it (below).

## What it does that an obvious version does not

- **Parses instead of string-replacing.** A schema's JSON contains the old slug in places that must not move — a text field's `default`, a select's `options`, a label. Only `collection` on a `relation` field is a reference. Export's `remapFieldIDs` gets away with a blind replace because it substitutes UUIDs, which cannot collide with prose; a slug is a word. Pinned by a control test.
- **Locks the rows it rewrites** (`FOR UPDATE`, ordered by id, on Postgres). Otherwise a concurrent sibling schema update commits between the scan and the rewrite and gets clobbered by a stale copy.
- **Advances each rewritten row's OCC token, without ever regressing it.** `collections.updated_at` doubles as the concurrency token (BUG-2265): leaving it unchanged lets a client holding the pre-rename schema write it straight back; stamping the rename's value on a sibling that was updated *later* moves the token backwards. Each row takes `max(current + 1ns, renameToken)`, computed in Go rather than by comparing timestamp text, which the surrounding comment warns is never safe.
- **Preserves properties it does not understand**, including large integers. Round-tripping through `models.CollectionSchema` drops unknown keys; decoding into `interface{}` turns numbers into float64, so `9007199254740993` came back changed. Raw decode with `UseNumber`.
- **Refuses a schema with trailing content** rather than truncating it — `Decode` ignores what follows the first value where `Unmarshal` refuses it.
- **Includes the renamed collection itself** (a relation may target itself) and runs **after** the caller's own `schema` write, so a simultaneous schema edit composes rather than being reverted.

## The deadlock hazard, and why the existing comment does not cover it

The lock-order comment above this transaction is a Codex P1 fix ordering the workspace lock against **one** collection row lock, because until now nothing took more than one. This change writes sibling rows, so two concurrent renames of mutually-referencing collections take them in opposite orders.

**Reproduced, not theorised:** with the serialization removed the test fails in 1.4s with `ERROR: deadlock detected (SQLSTATE 40P01)` on Postgres. Renames now take the workspace lock — previously acquired only when `len(input.Migrations) > 0` — **before** the row lock, closing it without inventing a second ordering rule to keep in sync with the first.

Raised in review by a teammate who read the function on being asked, and flagged that a reviewer would hit that comment and assume the question was settled. It was not.

## Split out rather than folded in

Each has dependents that are **not** the relation feature, so none belongs in a change whose reviewability rests on affecting zero live rows:

- **IDEA-2874** — the new slug is *allocated* outside the transaction (`uniqueSlugExcluding(s.db, …)` at :420, before `s.db.Begin()` at :503). Its dependents are every collection rename in every workspace. `UNIQUE(workspace_id, slug)` makes today's behaviour loud rather than lossy, so it can wait. (The *read* of the old slug **is** fixed here — see below.)
- **BUG-2875** — a collection **created** during a rename escapes the scan's `FOR UPDATE`. Closing it means `CreateCollection` takes the workspace lock, changing every collection creation on the instance.
- **IDEA-2876** — migrated siblings emit no `collection_updated` event, so an open page keeps the pre-rename schema until reload. Handler layer; the store publishes nothing.

The **read** of the old slug was in scope and is fixed: it came from the pre-transaction snapshot, so two tokenless concurrent renames both saw the original, and the loser migrated `original → its own new slug` while the relations already said the winner's — matching nothing. It is now re-read alongside the token under the row lock.

## Three instruments that were not instruments

Every one found by mutation rather than by reading, and each would have shipped a false green:

1. **The deadlock test passed against its own mutant in 0.44s.** Two unsynchronised goroutines never collided. A start barrier plus 40 rounds turned it into evidence.
2. **The pre-tx-slug mutant survived the first matrix**, because nothing forced the interleaving. Pinned instead by an end-state invariant that holds under *any* interleaving — whatever slug the collection ends up with, every relation aimed at it points there — over 40 concurrent rounds. It fails at round 1 under the mutant.
3. **The mutation harness itself reported two false survivors.** It counted `--- FAIL` lines, so a mutant that fails to COMPILE reads as one that survived. Deleting the token guard leaves `rowUpdatedAt`/`renameToken` unused; deleting the trailing-content guard leaves `io` unused. Both died immediately once made to compile. Twice in one unit is a harness defect, not bad luck.

## One dialect asymmetry the Postgres gate caught

`TestRenameLeavesASchemaWithTrailingJunkUntouched` failed on Postgres **at the seed, not the assertion**: `invalid input syntax for type json (22P02)`. `collections.schema` is TEXT on SQLite and JSONB on Postgres, so the state that guard defends against cannot be stored there at all. The test skips on Postgres with the reason recorded. Reading *which line* failed is what separated "my test is not portable" from "the product is broken on PG".

## Verification

- **Pin written and run BEFORE the fix** (team CONVE-29): 2 propagation tests failed, the control passed.
- **`gofmt`** clean, **`go vet ./...`** ok.
- **Full `go test ./...` green on SQLite.**
- **Full `internal/store` green on Postgres** — 502.2s, private container at `127.0.0.1:5473`, never the shared 5445 a sibling seat may tear down. Run detached with a sentinel after the first attempt was killed at a turn boundary.
- **Mutation matrix: 7 applied, 7 killed.**
