### PR TITLE
feat(web): inline create from the relation picker (TASK-2877)

### DIFF
--- a/web/src/lib/components/fields/FieldEditor.relation.svelte.test.ts
+++ b/web/src/lib/components/fields/FieldEditor.relation.svelte.test.ts
@@ -576,6 +576,74 @@ describe('FieldEditor — relation, inline create (PLAN-2857 U8)', () => {
 		expect(onchange).not.toHaveBeenCalled();
 	});
 
+	it('a create that lands after the user escaped out of the picker writes nothing', async () => {
+		// codex round 2 P1. Backing out is as explicit a choice as picking a
+		// different row, and it was not fenced: `oncancel` only closed the
+		// picker. The pending create then resolved and selected an item the user
+		// had just declined.
+		let release!: (v: unknown) => void;
+		createApi.mockReturnValue(new Promise((r) => { release = r; }));
+		localIndexMock.getByCollection.mockReturnValue([]);
+		localSearchMock.search.mockReturnValue([]);
+		const onchange = vi.fn();
+		// An EXISTING value, because that is when the picker is given an
+		// `oncancel` at all — with an empty relation there is nothing to cancel
+		// back to.
+		render(FieldEditor, { props: { ...editableProps, value: LIVE.id, onchange } });
+		await tick();
+		document.querySelector<HTMLButtonElement>('.relation-action')!.click(); // "Change"
+		await tick();
+
+		await typeQuery('Purple');
+		createRow()!.click();
+		await tick();
+
+		// Escape clears the query, then escapes the picker.
+		const el = document.querySelector<HTMLInputElement>('.picker-input')!;
+		el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }));
+		await tick();
+		el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }));
+		await tick();
+
+		release({ id: 'uuid-new', title: 'Purple', collection_slug: 'colors' });
+		await tick();
+		await tick();
+
+		expect(onchange).not.toHaveBeenCalled();
+	});
+
+	it('a create that lands after a workspace switch writes nothing', async () => {
+		// codex round 2 P1. `ItemDetail`'s fields subtree is keyed on `itemSlug`
+		// ALONE, so switching workspaces to an item carrying the SAME ref —
+		// every workspace has a TASK-5 — does not remount this component and
+		// leaves `destroyed` false. Without comparing the captured workspace to
+		// the current one, the completion writes an item ID from the previous
+		// workspace into the new workspace's item.
+		let release!: (v: unknown) => void;
+		createApi.mockReturnValue(new Promise((r) => { release = r; }));
+		localIndexMock.getByCollection.mockReturnValue([]);
+		localSearchMock.search.mockReturnValue([]);
+		const onchange = vi.fn();
+		const { rerender } = render(FieldEditor, { props: { ...editableProps, onchange } });
+		await tick();
+
+		await typeQuery('Purple');
+		createRow()!.click();
+		await tick();
+
+		await rerender({ ...editableProps, wsSlug: 'other-ws', onchange });
+		await tick();
+
+		release({ id: 'uuid-new', title: 'Purple', collection_slug: 'colors' });
+		await tick();
+		await tick();
+
+		expect(onchange).not.toHaveBeenCalled();
+		// The row still belongs in the workspace it was created in — the fence
+		// is about where the VALUE is written, not about hiding a real item.
+		expect(localIndexMock.upsert).toHaveBeenCalledWith('ws', expect.anything(), 7);
+	});
+
 	it('offers no create row while the collection list is not fresh for this workspace', async () => {
 		// codex round 1 P2. `collectionStore.collections` is a single global
 		// list, so during a workspace switch it still holds the PREVIOUS

--- a/web/src/lib/components/fields/FieldEditor.relation.svelte.test.ts
+++ b/web/src/lib/components/fields/FieldEditor.relation.svelte.test.ts
@@ -676,6 +676,33 @@ describe('FieldEditor — relation, inline create (PLAN-2857 U8)', () => {
 		expect(toastMock.show).not.toHaveBeenCalled();
 	});
 
+	it('a create that lands after the workspace index was reset writes nothing', async () => {
+		// codex round 5 P1. `localIndex.reset()` DELETES the workspace state and
+		// the next bootstrap starts a fresh one at `scopeEpoch` 0, so a captured
+		// epoch of 7 is NOT below the current 0 and sails through `upsert`'s
+		// one-sided guard — linking a row minted under an identity that no
+		// longer holds. Equality is what catches the downward jump.
+		let release!: (v: unknown) => void;
+		createApi.mockReturnValue(new Promise((r) => { release = r; }));
+		localIndexMock.getByCollection.mockReturnValue([]);
+		localSearchMock.search.mockReturnValue([]);
+		const onchange = vi.fn();
+		render(FieldEditor, { props: { ...editableProps, onchange } });
+		await tick();
+
+		await typeQuery('Purple');
+		createRow()!.click();
+		await tick();
+
+		// The purge: state deleted, re-bootstrapped, epoch back to 0.
+		localIndexMock.scopeEpochFor.mockReturnValue(0);
+		release({ id: 'uuid-new', title: 'Purple', collection_slug: 'colors' });
+		await tick();
+		await tick();
+
+		expect(onchange).not.toHaveBeenCalled();
+	});
+
 	it('offers no create row while the collection list is not fresh for this workspace', async () => {
 		// codex round 1 P2. `collectionStore.collections` is a single global
 		// list, so during a workspace switch it still holds the PREVIOUS

--- a/web/src/lib/components/fields/FieldEditor.relation.svelte.test.ts
+++ b/web/src/lib/components/fields/FieldEditor.relation.svelte.test.ts
@@ -508,16 +508,111 @@ describe('FieldEditor — relation, inline create (PLAN-2857 U8)', () => {
 		expect(document.querySelector<HTMLInputElement>('.picker-input')!.value).toBe('Purple');
 	});
 
-	it('offers no create row when the target collection is unknown to the store', async () => {
-		// A renamed target already renders read-only (`relationEditable`), but
-		// the permission question has no answer without a collection ID, and
-		// "no answer" must not read as "allowed".
+	it('a create that lands after the user picked another row does not overwrite it', async () => {
+		// codex round 1 P1. The create is a round trip and the picker stays open
+		// through it, so the user can settle on a different row before it
+		// resolves. Last write wins is the WRONG rule here: the later write is
+		// the user's explicit choice and the earlier one is a promise they have
+		// already moved past.
+		let release!: (v: unknown) => void;
+		createApi.mockReturnValue(new Promise((r) => { release = r; }));
+		const picked = {
+			id: 'uuid-picked', title: 'Teal', item_number: 5, collection_prefix: 'COLO',
+			collection_slug: 'colors', slug: 'teal', deleted_at: null,
+		};
+		rows.set(picked.id, picked);
+		localIndexMock.getByCollection.mockReturnValue([picked]);
+		localSearchMock.search.mockReturnValue([]);
+		const onchange = vi.fn();
+		render(FieldEditor, { props: { ...editableProps, onchange } });
+		await tick();
+
+		await typeQuery('Purple');
+		createRow()!.click();
+		await tick();
+
+		// The user settles on an existing row while the create is in flight.
+		localSearchMock.search.mockReturnValue([{ id: picked.id, score: 1 }]);
+		await typeQuery('Teal');
+		document.querySelector<HTMLElement>('.picker-result')!.click();
+		await tick();
+		expect(onchange).toHaveBeenCalledWith('uuid-picked');
+
+		release({ id: 'uuid-new', title: 'Purple', collection_slug: 'colors' });
+		await tick();
+		await tick();
+
+		// The created item is REAL and belongs in the index either way — it just
+		// must not become the field's value.
+		expect(localIndexMock.upsert).toHaveBeenCalled();
+		expect(onchange).toHaveBeenCalledTimes(1);
+		expect(onchange).not.toHaveBeenCalledWith('uuid-new');
+	});
+
+	it('a create that lands after this editor is destroyed writes nothing', async () => {
+		// codex round 1 P1, the other half. ItemDetail's fields section is
+		// `{#key itemSlug}`-remounted on an item switch, so a switch DESTROYS
+		// this component — but not the in-flight promise, and `onchange` calls
+		// into the persistent parent, whose `updateField` builds its PATCH
+		// against whatever item is current at CALL time. An unfenced completion
+		// therefore writes the new colour onto a DIFFERENT car.
+		let release!: (v: unknown) => void;
+		createApi.mockReturnValue(new Promise((r) => { release = r; }));
+		localIndexMock.getByCollection.mockReturnValue([]);
+		localSearchMock.search.mockReturnValue([]);
+		const onchange = vi.fn();
+		render(FieldEditor, { props: { ...editableProps, onchange } });
+		await tick();
+
+		await typeQuery('Purple');
+		createRow()!.click();
+		await tick();
+
+		cleanup(); // the {#key itemSlug} remount
+		release({ id: 'uuid-new', title: 'Purple', collection_slug: 'colors' });
+		await tick();
+		await tick();
+
+		expect(onchange).not.toHaveBeenCalled();
+	});
+
+	it('offers no create row while the collection list is not fresh for this workspace', async () => {
+		// codex round 1 P2. `collectionStore.collections` is a single global
+		// list, so during a workspace switch it still holds the PREVIOUS
+		// workspace's rows. A slug match against those yields another
+		// workspace's collection ID, and gating permission on it is asking the
+		// wrong question — the same freshness gate `relationTarget` already
+		// applies, which this derivation was missing.
+		collectionStoreMock.collectionsAreFreshFor.mockReturnValue(false);
+		localIndexMock.getByCollection.mockReturnValue([]);
+		localSearchMock.search.mockReturnValue([]);
+		render(FieldEditor, { props: editableProps });
+		await tick();
+		// A query is required or this asserts nothing: an EMPTY query never
+		// offers a create row, so the leg would pass against the ungated build.
+		await typeQuery('Purple');
+
+		expect(createRow()).toBeNull();
+	});
+
+	it('a target the collection list does not name renders read-only — there is no picker to create from', async () => {
+		// Worth stating rather than asserting a bare absence. When the declared
+		// target is absent from a FRESH list it is a renamed collection, and
+		// `relationEditable` already refuses to mount a picker at all (a picker
+		// scoped to a slug nothing matches would list nothing, forever). So the
+		// create row is unreachable one layer ABOVE the permission gate, and a
+		// test that typed a query here would fail on a missing input rather than
+		// on the behaviour it names.
+		//
+		// The permission gate's own "no collection ID" branch is exercised by
+		// the not-fresh leg above, where the picker DOES mount.
 		collectionStoreMock.collections = [{ id: 'coll-tasks', slug: 'tasks', name: 'Tasks' }];
 		localIndexMock.getByCollection.mockReturnValue([]);
 		localSearchMock.search.mockReturnValue([]);
 		render(FieldEditor, { props: editableProps });
 		await tick();
 
+		expect(document.querySelector('.picker-input')).toBeNull();
 		expect(createRow()).toBeNull();
 	});
 });

--- a/web/src/lib/components/fields/FieldEditor.relation.svelte.test.ts
+++ b/web/src/lib/components/fields/FieldEditor.relation.svelte.test.ts
@@ -28,6 +28,7 @@ const {
 		upsert: vi.fn(),
 		scopeEpochFor: vi.fn(),
 		pendingResyncFor: vi.fn(),
+		resetGenerationFor: vi.fn(),
 	},
 	localSearchMock: { search: vi.fn(), epoch: vi.fn() },
 	searchApi: vi.fn(),
@@ -87,6 +88,7 @@ beforeEach(() => {
 	toastMock.show.mockReset();
 	localIndexMock.upsert.mockReset();
 	localIndexMock.scopeEpochFor.mockReset().mockReturnValue(7);
+	localIndexMock.resetGenerationFor.mockReset().mockReturnValue(3);
 });
 afterEach(() => { cleanup(); document.body.innerHTML = ''; });
 
@@ -670,6 +672,64 @@ describe('FieldEditor — relation, inline create (PLAN-2857 U8)', () => {
 		await tick();
 
 		reject(new Error('field "shade" is required'));
+		await tick();
+		await tick();
+
+		expect(toastMock.show).not.toHaveBeenCalled();
+	});
+
+	it('a create that lands after the workspace was PURGED writes nothing and upserts nothing', async () => {
+		// codex round 6. The epoch check alone cannot see a drop: `reset()`
+		// deletes the state and the replacement starts at `scopeEpoch` 0 — which
+		// is also the value whenever no resync has ever happened, i.e. almost
+		// always. So equality passes across exactly the event it was meant to
+		// catch. `resetGenerationFor` is the identity signal, and it outlives
+		// the state it counts.
+		//
+		// The upsert matters as much as the link here: a brand-new id was never
+		// in `upsert`'s fenced set (nothing to fence — the row did not exist
+		// when the purge ran), so without this the purged workspace gets a row
+		// written back into it and persisted to IDB.
+		let release!: (v: unknown) => void;
+		createApi.mockReturnValue(new Promise((r) => { release = r; }));
+		localIndexMock.getByCollection.mockReturnValue([]);
+		localSearchMock.search.mockReturnValue([]);
+		const onchange = vi.fn();
+		render(FieldEditor, { props: { ...editableProps, onchange } });
+		await tick();
+
+		await typeQuery('Purple');
+		createRow()!.click();
+		await tick();
+
+		// The purge, with the epoch landing back where it started — the common
+		// case, not a coincidence.
+		localIndexMock.resetGenerationFor.mockReturnValue(4);
+		localIndexMock.scopeEpochFor.mockReturnValue(7);
+		release({ id: 'uuid-new', title: 'Purple', collection_slug: 'colors' });
+		await tick();
+		await tick();
+
+		expect(onchange).not.toHaveBeenCalled();
+		expect(localIndexMock.upsert).not.toHaveBeenCalled();
+	});
+
+	it('a failed create whose workspace was purged surfaces no toast', async () => {
+		// codex round 6 P2: the failure path carried a copy of SOME of the
+		// success path's conditions and had drifted. Both now ask one predicate.
+		let reject!: (e: unknown) => void;
+		createApi.mockReturnValue(new Promise((_r, rj) => { reject = rj; }));
+		localIndexMock.getByCollection.mockReturnValue([]);
+		localSearchMock.search.mockReturnValue([]);
+		render(FieldEditor, { props: editableProps });
+		await tick();
+
+		await typeQuery('Purple');
+		createRow()!.click();
+		await tick();
+
+		localIndexMock.resetGenerationFor.mockReturnValue(4);
+		reject(new Error('boom'));
 		await tick();
 		await tick();
 

--- a/web/src/lib/components/fields/FieldEditor.relation.svelte.test.ts
+++ b/web/src/lib/components/fields/FieldEditor.relation.svelte.test.ts
@@ -27,6 +27,7 @@ const {
 		cursorFor: vi.fn(),
 		upsert: vi.fn(),
 		scopeEpochFor: vi.fn(),
+		pendingResyncFor: vi.fn(),
 	},
 	localSearchMock: { search: vi.fn(), epoch: vi.fn() },
 	searchApi: vi.fn(),
@@ -69,6 +70,7 @@ beforeEach(() => {
 	localIndexMock.findByIdOrSlug.mockReset().mockImplementation((_ws: string, id: string) => rows.get(id) ?? null);
 	localIndexMock.getByCollection.mockReset().mockReturnValue([LIVE]);
 	localIndexMock.cursorFor.mockReset().mockReturnValue('0');
+	localIndexMock.pendingResyncFor.mockReset().mockReturnValue(false);
 	localSearchMock.search.mockReset().mockReturnValue([]);
 	localSearchMock.epoch.mockReset().mockImplementation((ws: string) => epochs.get(ws) ?? 0);
 	searchApi.mockReset().mockResolvedValue({ results: [] });
@@ -642,6 +644,36 @@ describe('FieldEditor — relation, inline create (PLAN-2857 U8)', () => {
 		// The row still belongs in the workspace it was created in — the fence
 		// is about where the VALUE is written, not about hiding a real item.
 		expect(localIndexMock.upsert).toHaveBeenCalledWith('ws', expect.anything(), 7);
+	});
+
+	it('a failed create the user already escaped out of surfaces no toast', async () => {
+		// codex round 4 P2. The success path was fenced and the failure path was
+		// not, so a create the user backed out of still threw an error over
+		// whatever they moved on to.
+		let reject!: (e: unknown) => void;
+		createApi.mockReturnValue(new Promise((_r, rj) => { reject = rj; }));
+		localIndexMock.getByCollection.mockReturnValue([]);
+		localSearchMock.search.mockReturnValue([]);
+		render(FieldEditor, { props: { ...editableProps, value: LIVE.id } });
+		await tick();
+		document.querySelector<HTMLButtonElement>('.relation-action')!.click();
+		await tick();
+
+		await typeQuery('Purple');
+		createRow()!.click();
+		await tick();
+
+		const el = document.querySelector<HTMLInputElement>('.picker-input')!;
+		el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }));
+		await tick();
+		el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true }));
+		await tick();
+
+		reject(new Error('field "shade" is required'));
+		await tick();
+		await tick();
+
+		expect(toastMock.show).not.toHaveBeenCalled();
 	});
 
 	it('offers no create row while the collection list is not fresh for this workspace', async () => {

--- a/web/src/lib/components/fields/FieldEditor.relation.svelte.test.ts
+++ b/web/src/lib/components/fields/FieldEditor.relation.svelte.test.ts
@@ -11,16 +11,44 @@ import { render, cleanup } from '@testing-library/svelte';
 import { tick } from 'svelte';
 import { SvelteMap } from 'svelte/reactivity';
 
-const { localIndexMock, localSearchMock, searchApi, collectionStoreMock } = vi.hoisted(() => ({
-	localIndexMock: { bootstrapStateFor: vi.fn(), findByIdOrSlug: vi.fn(), getByCollection: vi.fn(), cursorFor: vi.fn() },
+const {
+	localIndexMock,
+	localSearchMock,
+	searchApi,
+	createApi,
+	collectionStoreMock,
+	workspaceStoreMock,
+	toastMock,
+} = vi.hoisted(() => ({
+	localIndexMock: {
+		bootstrapStateFor: vi.fn(),
+		findByIdOrSlug: vi.fn(),
+		getByCollection: vi.fn(),
+		cursorFor: vi.fn(),
+		upsert: vi.fn(),
+		scopeEpochFor: vi.fn(),
+	},
 	localSearchMock: { search: vi.fn(), epoch: vi.fn() },
 	searchApi: vi.fn(),
-	collectionStoreMock: { collections: [] as { slug: string }[], collectionsAreFreshFor: vi.fn() },
+	createApi: vi.fn(),
+	collectionStoreMock: {
+		collections: [] as { id: string; slug: string; name?: string }[],
+		collectionsAreFreshFor: vi.fn(),
+	},
+	workspaceStoreMock: { canEditCollection: vi.fn() },
+	toastMock: { show: vi.fn() },
 }));
-vi.mock('$lib/api/client', () => ({ api: { search: (...a: unknown[]) => searchApi(...a) } }));
+vi.mock('$lib/api/client', () => ({
+	api: {
+		search: (...a: unknown[]) => searchApi(...a),
+		items: { create: (...a: unknown[]) => createApi(...a) },
+	},
+}));
 vi.mock('$lib/stores/localIndex.svelte', () => ({ localIndex: localIndexMock }));
 vi.mock('$lib/stores/localSearch.svelte', () => ({ localSearch: localSearchMock }));
 vi.mock('$lib/stores/collections.svelte', () => ({ collectionStore: collectionStoreMock }));
+vi.mock('$lib/stores/workspace.svelte', () => ({ workspaceStore: workspaceStoreMock }));
+vi.mock('$lib/stores/toast.svelte', () => ({ toastStore: toastMock }));
 
 import FieldEditor from './FieldEditor.svelte';
 
@@ -44,9 +72,19 @@ beforeEach(() => {
 	localSearchMock.search.mockReset().mockReturnValue([]);
 	localSearchMock.epoch.mockReset().mockImplementation((ws: string) => epochs.get(ws) ?? 0);
 	searchApi.mockReset().mockResolvedValue({ results: [] });
-	// Default: the target collection is loaded and live.
-	collectionStoreMock.collections = [{ slug: 'colors' }, { slug: 'tasks' }];
+	// Default: the target collection is loaded and live. `tasks` is here so a
+	// build that reached for "some collection" rather than the DECLARED target
+	// has something wrong to reach for.
+	collectionStoreMock.collections = [
+		{ id: 'coll-colors', slug: 'colors', name: 'Colors' },
+		{ id: 'coll-tasks', slug: 'tasks', name: 'Tasks' },
+	];
 	collectionStoreMock.collectionsAreFreshFor.mockReset().mockReturnValue(true);
+	workspaceStoreMock.canEditCollection.mockReset().mockReturnValue(true);
+	createApi.mockReset();
+	toastMock.show.mockReset();
+	localIndexMock.upsert.mockReset();
+	localIndexMock.scopeEpochFor.mockReset().mockReturnValue(7);
 });
 afterEach(() => { cleanup(); document.body.innerHTML = ''; });
 
@@ -271,5 +309,215 @@ describe('FieldEditor — relation, the gate', () => {
 		await tick();
 		expect(document.querySelector('.picker-input')).not.toBeNull();
 		expect(localIndexMock.getByCollection).toHaveBeenCalledWith('ws', 'colors');
+	});
+});
+
+
+// ── U8: inline create from the relation picker (TASK-2877) ───────────────
+//
+// Pins written before the wiring exists, per team CONVE-29.
+//
+// `ItemPicker` owns the ROW (suite in ItemPicker.svelte.test.ts). What is
+// pinned here is everything the picker deliberately does not know: which
+// collection the item lands in, whether this user may put one there, and the
+// upsert that makes the no-duplicate suppression true on the next keystroke.
+describe('FieldEditor — relation, inline create (PLAN-2857 U8)', () => {
+	const editableProps = {
+		field,
+		value: '',
+		wsSlug: 'ws',
+		username: 'dave',
+		onchange: () => {},
+	};
+
+	function createRow(): HTMLElement | null {
+		return document.querySelector<HTMLElement>('.picker-create');
+	}
+
+	async function typeQuery(value: string) {
+		const el = document.querySelector<HTMLInputElement>('.picker-input');
+		if (!el) throw new Error('.picker-input not found');
+		el.value = value;
+		el.dispatchEvent(new Event('input', { bubbles: true }));
+		await tick();
+	}
+
+	it('offers no create row to a user who cannot create in the TARGET collection', async () => {
+		// The gate is collection-level `canEditCollection` — the "+ New"
+		// predicate — asked about the target, NOT about wherever the item being
+		// edited lives. A viewer with edit rights on this item and none on
+		// `colors` still gets no create row.
+		workspaceStoreMock.canEditCollection.mockReturnValue(false);
+		localIndexMock.getByCollection.mockReturnValue([]);
+		localSearchMock.search.mockReturnValue([]);
+		render(FieldEditor, { props: editableProps });
+		await tick();
+
+		await typeQuery('Purple');
+
+		expect(createRow()).toBeNull();
+		expect(workspaceStoreMock.canEditCollection).toHaveBeenCalledWith('coll-colors');
+	});
+
+	it('CONTROL: the same query offers the row when the user CAN create there', async () => {
+		localIndexMock.getByCollection.mockReturnValue([]);
+		localSearchMock.search.mockReturnValue([]);
+		render(FieldEditor, { props: editableProps });
+		await tick();
+
+		await typeQuery('Purple');
+
+		expect(createRow()).not.toBeNull();
+		// Named by its display name, not its slug.
+		expect(createRow()!.textContent).toContain('Colors');
+	});
+
+	it('creates in the TARGET collection and sets the field to the new id', async () => {
+		// The unit's proving test, first leg. The mutant it kills is creating in
+		// any collection other than the field's declared target — `tasks` is in
+		// the store precisely so that mutant has somewhere to land.
+		const created = {
+			id: 'uuid-new',
+			title: 'Purple',
+			item_number: 9,
+			collection_prefix: 'COLO',
+			collection_slug: 'colors',
+			slug: 'purple',
+			deleted_at: null,
+		};
+		createApi.mockResolvedValue(created);
+		localIndexMock.getByCollection.mockReturnValue([]);
+		localSearchMock.search.mockReturnValue([]);
+		const onchange = vi.fn();
+		render(FieldEditor, { props: { ...editableProps, onchange } });
+		await tick();
+
+		await typeQuery('Purple');
+		createRow()!.click();
+		await vi.waitFor(() => expect(onchange).toHaveBeenCalled());
+
+		expect(createApi).toHaveBeenCalledTimes(1);
+		const [ws, coll, body] = createApi.mock.calls[0] as [string, string, { title: string }];
+		expect(ws).toBe('ws');
+		expect(coll).toBe('colors');
+		expect(body.title).toBe('Purple');
+		expect(onchange).toHaveBeenCalledWith('uuid-new');
+	});
+
+	it('sends no field values, so the server applies the collection schema defaults', async () => {
+		// `items.ValidateFields` fills every missing key that declares a
+		// `Default` and the create handler marshals the DEFAULTED map back
+		// (internal/server/handlers_items.go, "Marshal validated/defaulted
+		// fields back"). Guessing a status here — e.g. the first `options`
+		// entry, as the collection page's "+ New" does — would override that
+		// answer with a worse one, and would be wrong for any schema whose
+		// default is not its first option.
+		createApi.mockResolvedValue({ id: 'uuid-new', title: 'Purple', collection_slug: 'colors' });
+		localIndexMock.getByCollection.mockReturnValue([]);
+		localSearchMock.search.mockReturnValue([]);
+		render(FieldEditor, { props: editableProps });
+		await tick();
+
+		await typeQuery('Purple');
+		createRow()!.click();
+		await vi.waitFor(() => expect(createApi).toHaveBeenCalled());
+
+		const body = (createApi.mock.calls[0] as [string, string, Record<string, unknown>])[2];
+		expect(body.fields).toBeUndefined();
+	});
+
+	it('upserts the new row into the local index, under the epoch captured before the call', async () => {
+		// This is what makes U8's second leg true: the picker suppresses its
+		// create row when an exact title is already in `rawResults`, and
+		// `rawResults` comes from the index. Without this upsert the row is
+		// invisible to the very next keystroke and the same text offers to
+		// create a SECOND item.
+		//
+		// The epoch is BUG-2098's guard, and it has to be read before the
+		// request, not after: a projection resync landing mid-flight means the
+		// response was authorized under a scope that no longer applies.
+		const created = { id: 'uuid-new', title: 'Purple', collection_slug: 'colors' };
+		createApi.mockImplementation(async () => {
+			localIndexMock.scopeEpochFor.mockReturnValue(99);
+			return created;
+		});
+		localIndexMock.getByCollection.mockReturnValue([]);
+		localSearchMock.search.mockReturnValue([]);
+		render(FieldEditor, { props: editableProps });
+		await tick();
+
+		await typeQuery('Purple');
+		createRow()!.click();
+		await vi.waitFor(() => expect(localIndexMock.upsert).toHaveBeenCalled());
+
+		expect(localIndexMock.upsert).toHaveBeenCalledWith('ws', created, 7);
+	});
+
+	it('a second pass at the same text offers the existing row and no create', async () => {
+		// The proving test's second leg, driven through the state the first one
+		// leaves behind: the created row is now in the index, so the picker
+		// answers with it and withholds the affordance entirely. There is no
+		// create-time uniqueness check to rely on, and this is why one is not
+		// needed.
+		const created = {
+			id: 'uuid-new',
+			title: 'Purple',
+			item_number: 9,
+			collection_prefix: 'COLO',
+			collection_slug: 'colors',
+			slug: 'purple',
+			deleted_at: null,
+		};
+		rows.set(created.id, created);
+		localIndexMock.getByCollection.mockReturnValue([created]);
+		localSearchMock.search.mockReturnValue([{ id: created.id, score: 1 }]);
+		const onchange = vi.fn();
+		render(FieldEditor, { props: { ...editableProps, onchange } });
+		await tick();
+
+		await typeQuery('Purple');
+
+		expect(createRow()).toBeNull();
+		const row = document.querySelector<HTMLElement>('.picker-result');
+		expect(row).not.toBeNull();
+		row!.click();
+		await tick();
+		expect(createApi).not.toHaveBeenCalled();
+		expect(onchange).toHaveBeenCalledWith('uuid-new');
+	});
+
+	it('a failed create surfaces the error and leaves the field alone', async () => {
+		// A required field with no schema default makes the server 400 here, so
+		// this is a reachable path and not a hypothetical. The value must not
+		// move, and the query must survive so the user can retry or pick
+		// something else.
+		createApi.mockRejectedValue(new Error('field "shade" is required'));
+		localIndexMock.getByCollection.mockReturnValue([]);
+		localSearchMock.search.mockReturnValue([]);
+		const onchange = vi.fn();
+		render(FieldEditor, { props: { ...editableProps, onchange } });
+		await tick();
+
+		await typeQuery('Purple');
+		createRow()!.click();
+		await vi.waitFor(() => expect(toastMock.show).toHaveBeenCalled());
+
+		expect(toastMock.show.mock.calls[0][0]).toContain('shade');
+		expect(onchange).not.toHaveBeenCalled();
+		expect(localIndexMock.upsert).not.toHaveBeenCalled();
+		expect(document.querySelector<HTMLInputElement>('.picker-input')!.value).toBe('Purple');
+	});
+
+	it('offers no create row when the target collection is unknown to the store', async () => {
+		// A renamed target already renders read-only (`relationEditable`), but
+		// the permission question has no answer without a collection ID, and
+		// "no answer" must not read as "allowed".
+		collectionStoreMock.collections = [{ id: 'coll-tasks', slug: 'tasks', name: 'Tasks' }];
+		localIndexMock.getByCollection.mockReturnValue([]);
+		localSearchMock.search.mockReturnValue([]);
+		render(FieldEditor, { props: editableProps });
+		await tick();
+
+		expect(createRow()).toBeNull();
 	});
 });

--- a/web/src/lib/components/fields/FieldEditor.svelte
+++ b/web/src/lib/components/fields/FieldEditor.svelte
@@ -308,8 +308,34 @@ handlers — onchange is never called.
 		// meant to catch (codex round 6, correcting the residual round 5
 		// dismissed as needing a coincidence; it needs none).
 		const indexStillOurs = () => localIndex.resetGenerationFor(ws) === resetGen;
-		// Typing a new query is deliberately NOT one of these, and it has been
-		// raised twice. The three that ARE fences each stand for an act meaning
+		// THREE things are deliberately NOT fenced here, each raised by review
+		// and each declined for a reason that belongs next to the code rather
+		// than in a commit message nobody downstream reads.
+		//
+		// 1. A CONCURRENT CHANGE TO THE FIELD (SSE, another tab) landing while
+		//    the POST is pending. Overwriting it is ordinary last-write-wins on
+		//    a field the user is actively editing, and it is what every other
+		//    type in this component already does — a text field blurred after a
+		//    remote change overwrites it too. The server, not this component, is
+		//    where that race is adjudicated: `ItemDetail.updateField` sends
+		//    `expected_updated_at` and refetch-retries a 409 (BUG-2273 /
+		//    IDEA-1480). Fencing it HERE would make relation fields alone behave
+		//    differently from every other field, on a rule the item's own
+		//    optimistic-concurrency check already enforces.
+		//
+		// 2. A LOST RESPONSE on a create that actually committed. Real, and not
+		//    fixable here: `item create` has no idempotency key, and titles are
+		//    not unique (colliding slugs just get `-2` suffixes,
+		//    `store.uniqueSlug`). Nothing auto-retries — the retry would be a
+		//    person clicking Create again, seeing the picker's current state —
+		//    and the repo's standing rule for the same shape is exactly that
+		//    (`item copy` "NEVER retry it automatically"). Filed as IDEA-2880
+		//    rather than papered over with a client-side guess — checking for a
+		//    same-title item before retrying would rest on the same ranked,
+		//    paged, possibly-stale evidence the create row itself rests on, and
+		//    would look like a guarantee the client cannot make.
+		//
+		// 3. Typing a new query, which has been raised twice. The three that ARE fences each stand for an act meaning
 		// "not this one": escaping out, choosing a different row, and landing on
 		// a different item or workspace. Typing is none of those — it is
 		// mid-thought, and the user did explicitly ask for the item now being

--- a/web/src/lib/components/fields/FieldEditor.svelte
+++ b/web/src/lib/components/fields/FieldEditor.svelte
@@ -18,6 +18,9 @@ handlers — onchange is never called.
 	import { formatItemRef, type FieldDef, type ItemIndexRow, type PaneTarget } from '$lib/types';
 	import { localIndex } from '$lib/stores/localIndex.svelte';
 	import { collectionStore } from '$lib/stores/collections.svelte';
+	import { workspaceStore } from '$lib/stores/workspace.svelte';
+	import { toastStore } from '$lib/stores/toast.svelte';
+	import { api } from '$lib/api/client';
 	import ItemPicker from '$lib/components/items/ItemPicker.svelte';
 	import { shouldOpenInPane } from '$lib/components/collections/itemCardClick';
 	import BottomSheet from '$lib/components/common/BottomSheet.svelte';
@@ -197,6 +200,62 @@ handlers — onchange is never called.
 	function clearRelation() {
 		editingRelation = false;
 		onchange('');
+	}
+
+	// ── Inline create from the picker (PLAN-2857 U8) ─────────────────────
+	//
+	// The picker offers a create row only when handed an `oncreate`, so this
+	// component decides BOTH of U8's gates by deciding whether to pass one.
+	//
+	// The permission gate is `canEditCollection` on the TARGET collection — the
+	// same predicate behind the collection page's "+ New", asked about where the
+	// item would LAND rather than about where the user is standing. It needs the
+	// collection's ID, which only the loaded collection list has; a target the
+	// list does not know yields `null` here and therefore no create row, because
+	// "no answer" must not read as "allowed".
+	let targetCollection = $derived.by(() => {
+		if (!isRelation || !field.collection) return null;
+		return (collectionStore.collections ?? []).find((c) => c.slug === field.collection) ?? null;
+	});
+	let canCreateInTarget = $derived(
+		!!targetCollection && workspaceStore.canEditCollection(targetCollection.id),
+	);
+
+	/**
+	 * Create the item the user just described, then select it.
+	 *
+	 * NO field values are sent. The server fills every missing key that declares
+	 * a `Default` and stores the defaulted map (`items.ValidateFields`, then
+	 * "Marshal validated/defaulted fields back" in `createItemChecked`), so the
+	 * schema's own answer is already the right one. Guessing here — the
+	 * collection page's "+ New" uses `status.options[0]` — would override it,
+	 * and would be wrong for any schema whose default is not its first option.
+	 * The cost is that a target with a REQUIRED field carrying no default
+	 * refuses the create; that surfaces as a toast naming the field, which is
+	 * the honest outcome for a row this picker cannot fill in.
+	 *
+	 * The epoch is read BEFORE the request (BUG-2098): a projection resync while
+	 * it is in flight means the response was authorized under a scope that no
+	 * longer applies, and `upsert` refuses it rather than resurrecting a row no
+	 * delta will evict. Upserting at all is what makes the picker's
+	 * exact-title suppression true on the NEXT keystroke — without it the same
+	 * text would offer to create a second item.
+	 */
+	async function createRelationTarget(title: string) {
+		const ws = wsSlug;
+		const collSlug = field.collection;
+		if (!ws || !collSlug) return;
+		const epoch = localIndex.scopeEpochFor(ws);
+		try {
+			const item = await api.items.create(ws, collSlug, { title, source: 'web' });
+			localIndex.upsert(ws, item, epoch);
+			editingRelation = false;
+			onchange(item.id);
+		} catch (e: any) {
+			// The picker keeps the query, so the user can retry or pick something
+			// else; nothing about the field's value has moved.
+			toastStore.show(e?.message || 'Failed to create item', 'error');
+		}
 	}
 
 	// ── Viewport detection ───────────────────────────────────────────────
@@ -769,6 +828,8 @@ handlers — onchange is never called.
 				placeholder="Search…"
 				autofocus={editingRelation}
 				onselect={pickRelation}
+				oncreate={canCreateInTarget ? createRelationTarget : undefined}
+				createLabel={targetCollection?.name}
 				oncancel={relationState === 'empty' ? undefined : () => (editingRelation = false)}
 			/>
 		{/if}

--- a/web/src/lib/components/fields/FieldEditor.svelte
+++ b/web/src/lib/components/fields/FieldEditor.svelte
@@ -303,6 +303,21 @@ handlers — onchange is never called.
 			localIndex.upsert(ws, item, epoch);
 			if (destroyed || mySeq !== relationWrite) return;
 			if (ws !== wsSlug || collSlug !== field.collection) return;
+			// The workspace's index must still be the one this create was
+			// authorized against (codex round 5). `upsert`'s own guard is
+			// ONE-SIDED — it refuses a captured epoch BELOW the current one, so
+			// it catches a resync — but `localIndex.reset()` on a sign-out or a
+			// 403 purge DELETES the state, and the next bootstrap starts a fresh
+			// one at epoch 0. A captured 7 is not below 0, so the write sails
+			// through and links a row minted under an identity that no longer
+			// holds. Equality catches both directions.
+			//
+			// Residual, stated rather than papered over: a reset followed by
+			// resyncs that land the epoch back on exactly the captured number
+			// would compare equal. An exposed reset generation would be exact;
+			// this needs no new store surface and the coincidence requires the
+			// purge and N resyncs to complete inside one create round trip.
+			if (localIndex.scopeEpochFor(ws) !== epoch) return;
 			editingRelation = false;
 			onchange(item.id);
 		} catch (e: any) {

--- a/web/src/lib/components/fields/FieldEditor.svelte
+++ b/web/src/lib/components/fields/FieldEditor.svelte
@@ -199,6 +199,13 @@ handlers — onchange is never called.
 		onchange(row.id);
 	}
 
+	// Backing out is a decision, so it supersedes an in-flight create exactly as
+	// picking another row does (codex round 2).
+	function cancelRelationEdit() {
+		relationWrite++;
+		editingRelation = false;
+	}
+
 	function clearRelation() {
 		relationWrite++;
 		editingRelation = false;
@@ -277,10 +284,15 @@ handlers — onchange is never called.
 		//     whose `updateField` builds its PATCH against whatever item is
 		//     current at CALL time. Unfenced, a create started on car A writes
 		//     its colour onto car B.
-		//   * SUPERSEDED. The user can settle on another row (or clear the
-		//     field) while this is in flight. Last-write-wins is the wrong rule:
-		//     the later write is an explicit choice and this one is a promise
-		//     they have moved past.
+		//   * SUPERSEDED. The user can settle on another row, clear the field, or
+		//     back out of the picker entirely while this is in flight.
+		//     Last-write-wins is the wrong rule: each of those is an explicit
+		//     choice and this one is a promise they have moved past.
+		//   * RETARGETED. The `{#key itemSlug}` above keys on the SLUG ONLY, so
+		//     switching workspaces to an item carrying the same ref — every
+		//     workspace has a TASK-5 — reuses this instance and never sets
+		//     `destroyed`. Comparing the captured workspace and target collection
+		//     to the current props is what catches that (codex round 2).
 		const mySeq = ++relationWrite;
 		const epoch = localIndex.scopeEpochFor(ws);
 		try {
@@ -290,6 +302,7 @@ handlers — onchange is never called.
 			// index would leave a picker offering to create it a second time.
 			localIndex.upsert(ws, item, epoch);
 			if (destroyed || mySeq !== relationWrite) return;
+			if (ws !== wsSlug || collSlug !== field.collection) return;
 			editingRelation = false;
 			onchange(item.id);
 		} catch (e: any) {
@@ -871,7 +884,7 @@ handlers — onchange is never called.
 				onselect={pickRelation}
 				oncreate={canCreateInTarget ? createRelationTarget : undefined}
 				createLabel={targetCollection?.name}
-				oncancel={relationState === 'empty' ? undefined : () => (editingRelation = false)}
+				oncancel={relationState === 'empty' ? undefined : cancelRelationEdit}
 			/>
 		{/if}
 	</div>

--- a/web/src/lib/components/fields/FieldEditor.svelte
+++ b/web/src/lib/components/fields/FieldEditor.svelte
@@ -306,8 +306,16 @@ handlers — onchange is never called.
 			editingRelation = false;
 			onchange(item.id);
 		} catch (e: any) {
-			// The picker keeps the query, so the user can retry or pick something
-			// else; nothing about the field's value has moved.
+			// Fenced exactly like the success path (codex round 4): a create the
+			// user escaped out of, or one belonging to a workspace they have
+			// left, must not surface its failure over whatever they are looking
+			// at now. Same three conditions, same reasoning — the difference
+			// between reporting and not is whether they are still waiting on it.
+			if (destroyed || mySeq !== relationWrite) return;
+			if (ws !== wsSlug || collSlug !== field.collection) return;
+			// Still here and still waiting: the picker keeps the query, so the
+			// user can retry or pick something else; the field's value has not
+			// moved.
 			toastStore.show(e?.message || 'Failed to create item', 'error');
 		}
 	}

--- a/web/src/lib/components/fields/FieldEditor.svelte
+++ b/web/src/lib/components/fields/FieldEditor.svelte
@@ -308,6 +308,15 @@ handlers — onchange is never called.
 		// meant to catch (codex round 6, correcting the residual round 5
 		// dismissed as needing a coincidence; it needs none).
 		const indexStillOurs = () => localIndex.resetGenerationFor(ws) === resetGen;
+		// Typing a new query is deliberately NOT one of these, and it has been
+		// raised twice. The three that ARE fences each stand for an act meaning
+		// "not this one": escaping out, choosing a different row, and landing on
+		// a different item or workspace. Typing is none of those — it is
+		// mid-thought, and the user did explicitly ask for the item now being
+		// created. Treating it as a cancel would leave that row orphaned in the
+		// target collection with the field still empty, which is worse than a
+		// field holding exactly what was asked for.
+		//
 		// Is the USER still waiting on this specific create?
 		const stillWaiting = () =>
 			!destroyed &&

--- a/web/src/lib/components/fields/FieldEditor.svelte
+++ b/web/src/lib/components/fields/FieldEditor.svelte
@@ -15,6 +15,7 @@ visual language as the editor but with no inputs, dropdowns, or mutation
 handlers — onchange is never called.
 -->
 <script lang="ts">
+	import { onDestroy } from 'svelte';
 	import { formatItemRef, type FieldDef, type ItemIndexRow, type PaneTarget } from '$lib/types';
 	import { localIndex } from '$lib/stores/localIndex.svelte';
 	import { collectionStore } from '$lib/stores/collections.svelte';
@@ -193,14 +194,27 @@ handlers — onchange is never called.
 	let editingRelation = $state(false);
 
 	function pickRelation(row: ItemIndexRow) {
+		relationWrite++;
 		editingRelation = false;
 		onchange(row.id);
 	}
 
 	function clearRelation() {
+		relationWrite++;
 		editingRelation = false;
 		onchange('');
 	}
+
+	/**
+	 * Fences for the in-flight create (see `createRelationTarget`). Plain `let`
+	 * per CONVE-1688 — written and read only in handlers and lifecycle, never
+	 * rendered, so neither belongs in the effect graph.
+	 */
+	let relationWrite = 0;
+	let destroyed = false;
+	onDestroy(() => {
+		destroyed = true;
+	});
 
 	// ── Inline create from the picker (PLAN-2857 U8) ─────────────────────
 	//
@@ -213,8 +227,16 @@ handlers — onchange is never called.
 	// collection's ID, which only the loaded collection list has; a target the
 	// list does not know yields `null` here and therefore no create row, because
 	// "no answer" must not read as "allowed".
+	// FRESHNESS, for the same reason `knownCollectionSlugs` has it (codex round
+	// 1 P2): `collectionStore.collections` is one global list, so during a
+	// workspace switch it still holds the PREVIOUS workspace's rows. A slug
+	// match against those yields another workspace's collection ID, and asking
+	// `canEditCollection` about that ID is asking the wrong question — it can
+	// answer yes and put a create row on a field whose target is not that
+	// collection at all.
 	let targetCollection = $derived.by(() => {
-		if (!isRelation || !field.collection) return null;
+		if (!isRelation || !field.collection || !wsSlug) return null;
+		if (!collectionStore.collectionsAreFreshFor(wsSlug)) return null;
 		return (collectionStore.collections ?? []).find((c) => c.slug === field.collection) ?? null;
 	});
 	let canCreateInTarget = $derived(
@@ -245,10 +267,29 @@ handlers — onchange is never called.
 		const ws = wsSlug;
 		const collSlug = field.collection;
 		if (!ws || !collSlug) return;
+		// Two fences on the completion, both found by codex round 1 P1, both
+		// about the same gap: the create is a round trip and the picker stays
+		// open across it, so the world can move before it lands.
+		//
+		//   * DESTROYED. `ItemDetail` wraps its fields section in
+		//     `{#key itemSlug}`, so an item switch destroys this component — but
+		//     not this promise, and `onchange` calls into the PERSISTENT parent,
+		//     whose `updateField` builds its PATCH against whatever item is
+		//     current at CALL time. Unfenced, a create started on car A writes
+		//     its colour onto car B.
+		//   * SUPERSEDED. The user can settle on another row (or clear the
+		//     field) while this is in flight. Last-write-wins is the wrong rule:
+		//     the later write is an explicit choice and this one is a promise
+		//     they have moved past.
+		const mySeq = ++relationWrite;
 		const epoch = localIndex.scopeEpochFor(ws);
 		try {
 			const item = await api.items.create(ws, collSlug, { title, source: 'web' });
+			// Upserted UNCONDITIONALLY, ahead of the fences: the row exists on
+			// the server whatever happened here, and withholding it from the
+			// index would leave a picker offering to create it a second time.
 			localIndex.upsert(ws, item, epoch);
+			if (destroyed || mySeq !== relationWrite) return;
 			editingRelation = false;
 			onchange(item.id);
 		} catch (e: any) {

--- a/web/src/lib/components/fields/FieldEditor.svelte
+++ b/web/src/lib/components/fields/FieldEditor.svelte
@@ -295,39 +295,49 @@ handlers — onchange is never called.
 		//     to the current props is what catches that (codex round 2).
 		const mySeq = ++relationWrite;
 		const epoch = localIndex.scopeEpochFor(ws);
+		const resetGen = localIndex.resetGenerationFor(ws);
+
+		// Is the index still the one this request was authorized against?
+		//
+		// Both halves are needed and neither substitutes for the other.
+		// `scopeEpoch` moves on a projection RESYNC; `resetGeneration` moves on
+		// a DROP. Epoch alone cannot see a drop, because `reset()` deletes the
+		// state and the replacement starts at 0 — and 0 is also the value in the
+		// overwhelmingly common case where no resync ever happened, so an
+		// equality check on it passes trivially across exactly the event it was
+		// meant to catch (codex round 6, correcting the residual round 5
+		// dismissed as needing a coincidence; it needs none).
+		const indexStillOurs = () => localIndex.resetGenerationFor(ws) === resetGen;
+		// Is the USER still waiting on this specific create?
+		const stillWaiting = () =>
+			!destroyed &&
+			mySeq === relationWrite &&
+			ws === wsSlug &&
+			collSlug === field.collection &&
+			indexStillOurs() &&
+			localIndex.scopeEpochFor(ws) === epoch;
 		try {
 			const item = await api.items.create(ws, collSlug, { title, source: 'web' });
-			// Upserted UNCONDITIONALLY, ahead of the fences: the row exists on
-			// the server whatever happened here, and withholding it from the
-			// index would leave a picker offering to create it a second time.
-			localIndex.upsert(ws, item, epoch);
-			if (destroyed || mySeq !== relationWrite) return;
-			if (ws !== wsSlug || collSlug !== field.collection) return;
-			// The workspace's index must still be the one this create was
-			// authorized against (codex round 5). `upsert`'s own guard is
-			// ONE-SIDED — it refuses a captured epoch BELOW the current one, so
-			// it catches a resync — but `localIndex.reset()` on a sign-out or a
-			// 403 purge DELETES the state, and the next bootstrap starts a fresh
-			// one at epoch 0. A captured 7 is not below 0, so the write sails
-			// through and links a row minted under an identity that no longer
-			// holds. Equality catches both directions.
-			//
-			// Residual, stated rather than papered over: a reset followed by
-			// resyncs that land the epoch back on exactly the captured number
-			// would compare equal. An exposed reset generation would be exact;
-			// this needs no new store surface and the coincidence requires the
-			// purge and N resyncs to complete inside one create round trip.
-			if (localIndex.scopeEpochFor(ws) !== epoch) return;
+			// The upsert is gated on INDEX IDENTITY only — not on whether the
+			// user is still waiting. Those are different questions: a create the
+			// user navigated away from still produced a real row that belongs in
+			// the index (it is what stops the picker offering to create it
+			// again), whereas a create whose workspace was PURGED must not write
+			// anything back. `upsert`'s own fenced-id guard cannot help there,
+			// because a brand-new id was never in the map to be fenced — the
+			// exact gap BUG-2098's comment describes.
+			if (indexStillOurs()) localIndex.upsert(ws, item, epoch);
+			if (!stillWaiting()) return;
 			editingRelation = false;
 			onchange(item.id);
 		} catch (e: any) {
-			// Fenced exactly like the success path (codex round 4): a create the
-			// user escaped out of, or one belonging to a workspace they have
-			// left, must not surface its failure over whatever they are looking
-			// at now. Same three conditions, same reasoning — the difference
-			// between reporting and not is whether they are still waiting on it.
-			if (destroyed || mySeq !== relationWrite) return;
-			if (ws !== wsSlug || collSlug !== field.collection) return;
+			// The SAME predicate as the success path, not a copy of some of it
+			// (codex rounds 4 and 6). A create the user escaped out of, or one
+			// belonging to a workspace they have since left or been purged from,
+			// must not throw its error over whatever they are looking at now —
+			// and the reset half was missing here while the success path had it.
+			// One predicate means the two paths cannot drift again.
+			if (!stillWaiting()) return;
 			// Still here and still waiting: the picker keeps the query, so the
 			// user can retry or pick something else; the field's value has not
 			// moved.

--- a/web/src/lib/components/items/ItemPicker.svelte
+++ b/web/src/lib/components/items/ItemPicker.svelte
@@ -236,10 +236,21 @@
 		if (coldFailed) return false;
 		const wanted = createTitle.toLowerCase();
 		if (rawResults.some((r) => titleIs(r, wanted))) return false;
-		// Cold: no authoritative set to consult, so the ranked answer above is
-		// all there is. Offering create is the right call — refusing it because
-		// the index has not hydrated would strand the user.
+		// Offer only where SOMETHING authoritative has answered "no such item",
+		// which is the same rule the permission gate and `coldFailed` follow: no
+		// evidence must not read as permission.
+		//
+		//   * COLD — `rawResults` came from `/search`, which is the server and
+		//     therefore authoritative. Its empty answer is real evidence, so
+		//     offer. (Refusing here would strand every user whose index has not
+		//     hydrated.)
+		//   * READY, settled — the in-RAM collection is authoritative; scan it.
+		//   * READY, resyncing — the rows are a cache snapshot that delta-sync
+		//     has not reconciled, and `rawResults` came from THAT, so nothing in
+		//     reach can support the inference. Withhold until it settles; the
+		//     window is seconds and a duplicate outlives it.
 		if (!isWarm()) return true;
+		if (!indexCanProveAbsence()) return false;
 		return !localIndex.getByCollection(wsSlug, collection).some((r) => titleIs(r, wanted));
 	});
 
@@ -257,6 +268,24 @@
 
 	function isWarm(): boolean {
 		return localIndex.bootstrapStateFor(wsSlug) === 'ready';
+	}
+
+	/**
+	 * Is the local index a source we may reason about ABSENCE from?
+	 *
+	 * `ready` is not enough (codex round 4). It coexists with `pendingResync`:
+	 * `localIndex` hydrates from the IDB cache and serves those rows while
+	 * delta-sync catches up, so during that window a row that EXISTS can be
+	 * missing from the snapshot. Presence in the index is still evidence — the
+	 * row was real when it was cached — but absence is not, and absence is
+	 * exactly what the create row is derived from.
+	 *
+	 * Only `showCreate` asks this. Search and listing deliberately keep using
+	 * `isWarm`: showing cached rows during a resync is right, and it is only
+	 * the inference "therefore no such item exists" that the cache cannot bear.
+	 */
+	function indexCanProveAbsence(): boolean {
+		return isWarm() && !localIndex.pendingResyncFor(wsSlug);
 	}
 
 	/** Hide excluded rows, then bound the list. Applied to every path. */

--- a/web/src/lib/components/items/ItemPicker.svelte
+++ b/web/src/lib/components/items/ItemPicker.svelte
@@ -85,6 +85,36 @@
 		/** Chosen row. The picker does not clear itself — the caller decides. */
 		onselect: (item: ItemIndexRow) => void;
 		/**
+		 * Inline create (PLAN-2857 U8). Passing this adds a trailing
+		 * "Create \"<query>\" in <collection>" row; omitting it is how a caller
+		 * declines the affordance, and the ONLY way to decline it.
+		 *
+		 * That opt-in shape is deliberate. Both rules in U8's scope are the
+		 * caller's to know and neither is this component's:
+		 *
+		 *   * *Relation fields only.* The Relationships tab links items that
+		 *     already exist, so it passes nothing and renders exactly as before.
+		 *   * *Permission.* "Can this user create in the TARGET collection" is
+		 *     the collection-level `canEditCollection` cascade — the same
+		 *     predicate behind "+ New" — which lives in the workspace store. A
+		 *     picker that consulted it here would be a second copy of an answer
+		 *     the server also enforces.
+		 *
+		 * Awaited, and re-entrant calls are dropped while one is in flight, so
+		 * two Enters inside one round trip cannot mint two items. Rejections are
+		 * swallowed HERE and belong to the caller: it owns the API call, so it
+		 * owns the error surface (a toast) and the decision to leave the query in
+		 * place for a retry.
+		 */
+		oncreate?: (title: string) => void | Promise<void>;
+		/**
+		 * Display name of the target collection for the create row. Falls back to
+		 * the slug, which is the wrong register ("in colors" vs "in Colors") but
+		 * never wrong about WHERE the item would land — the fact the row exists
+		 * to convey.
+		 */
+		createLabel?: string;
+		/**
 		 * Escape on an already-empty box.
 		 *
 		 * Pass one if Escape should close the surface hosting the picker.
@@ -109,6 +139,8 @@
 		label = 'Search items',
 		autofocus = false,
 		onselect,
+		oncreate,
+		createLabel,
 		oncancel,
 	}: Props = $props();
 
@@ -144,9 +176,56 @@
 
 	const uid = $props.id();
 
+	/**
+	 * Identifier for the create row in the same namespace as the result rows'
+	 * ids, so ONE `activeId` addresses either. A NUL-prefixed sentinel because
+	 * item ids are UUIDs and can never collide with it.
+	 */
+	const CREATE_OPTION_ID = '\u0000create';
+
+	type PickerOption =
+		| { kind: 'item'; id: string; row: ItemIndexRow }
+		| { kind: 'create'; id: string };
+
 	let excluded = $derived(new Set(excludeIds));
 	let results = $derived(present(rawResults));
-	let activeIndex = $derived(activeId ? results.findIndex((r) => r.id === activeId) : -1);
+
+	/**
+	 * Whether to offer the create row, for the query as it stands.
+	 *
+	 * "Matches nothing, or nothing EXACTLY" — the exact-title test is against
+	 * `rawResults`, the source's answer BEFORE exclusion and the row bound.
+	 * Presented rows would be the wrong population twice over: an exact match
+	 * pushed past `limit`, or one the caller excluded, would both read as "no
+	 * such item" and offer to mint a duplicate of a row that exists.
+	 *
+	 * This suppression IS the no-duplicate half of U8's proving test. There is
+	 * no create-time uniqueness check anywhere below, and deliberately so: the
+	 * second invocation with the same text never reaches a create, because by
+	 * then the row exists and this returns false. What makes that true on the
+	 * next keystroke is the caller upserting the new item into `localIndex`.
+	 *
+	 * Not offered while `loading`: mid-flight, "nothing matched" is not yet
+	 * known, and a create row there invites a duplicate of a row about to land.
+	 */
+	let createTitle = $derived(query.trim());
+	let showCreate = $derived.by((): boolean => {
+		if (!oncreate || !collection || !createTitle || loading) return false;
+		const wanted = createTitle.toLowerCase();
+		return !rawResults.some((r) => (r.title ?? '').trim().toLowerCase() === wanted);
+	});
+
+	/**
+	 * Result rows plus the create row, in render AND keyboard order — one list,
+	 * so arrowing onto the create row needs no special case and cannot fall out
+	 * of step with what is on screen.
+	 */
+	let options = $derived.by((): PickerOption[] => {
+		const out: PickerOption[] = results.map((row) => ({ kind: 'item', id: row.id, row }));
+		if (showCreate) out.push({ kind: 'create', id: CREATE_OPTION_ID });
+		return out;
+	});
+	let activeIndex = $derived(activeId ? options.findIndex((o) => o.id === activeId) : -1);
 
 	function isWarm(): boolean {
 		return localIndex.bootstrapStateFor(wsSlug) === 'ready';
@@ -246,25 +325,57 @@
 		onselect(row);
 	}
 
+	/**
+	 * Plain `let` for the same reason `seq` is (CONVE-1688): written in a
+	 * handler, read in a handler, never rendered. Making it `$state` would put a
+	 * write inside the effect graph for a value nothing displays.
+	 */
+	let creating = false;
+
+	async function invokeCreate() {
+		if (creating || !oncreate) return;
+		const title = createTitle;
+		if (!title) return;
+		creating = true;
+		try {
+			await oncreate(title);
+		} catch {
+			// The caller owns the error surface — see the `oncreate` prop doc.
+			// Swallowed rather than rethrown so an unhandled rejection cannot
+			// escape a keydown handler.
+		} finally {
+			// A write to a destroyed instance is a no-op, so this needs no fence.
+			creating = false;
+		}
+	}
+
+	function activate(option: PickerOption) {
+		if (option.kind === 'create') {
+			void invokeCreate();
+			return;
+		}
+		choose(option.row);
+	}
+
 	function onKeydown(e: KeyboardEvent) {
 		if (e.key === 'ArrowDown') {
-			if (results.length === 0) return;
+			if (options.length === 0) return;
 			e.preventDefault();
-			const next = activeIndex < results.length - 1 ? activeIndex + 1 : results.length - 1;
-			activeId = results[next]?.id ?? null;
+			const next = activeIndex < options.length - 1 ? activeIndex + 1 : options.length - 1;
+			activeId = options[next]?.id ?? null;
 			return;
 		}
 		if (e.key === 'ArrowUp') {
-			if (results.length === 0) return;
+			if (options.length === 0) return;
 			e.preventDefault();
 			const next = activeIndex - 1;
-			activeId = next >= 0 ? (results[next]?.id ?? null) : null;
+			activeId = next >= 0 ? (options[next]?.id ?? null) : null;
 			return;
 		}
 		if (e.key === 'Enter') {
-			if (activeIndex < 0 || activeIndex >= results.length) return;
+			if (activeIndex < 0 || activeIndex >= options.length) return;
 			e.preventDefault();
-			choose(results[activeIndex]);
+			activate(options[activeIndex]);
 			return;
 		}
 		if (e.key === 'Escape') {
@@ -409,7 +520,7 @@
 		class="picker-input"
 		role="combobox"
 		aria-label={label}
-		aria-expanded={results.length > 0}
+		aria-expanded={options.length > 0}
 		aria-controls="picker-results-{uid}"
 		aria-autocomplete="list"
 		aria-activedescendant={activeIndex >= 0 ? `picker-option-${uid}-${activeIndex}` : undefined}
@@ -422,23 +533,40 @@
 
 	{#if loading}
 		<div class="picker-status">Searching...</div>
-	{:else if results.length > 0}
+	{:else if options.length > 0}
 		<div class="picker-results" role="listbox" id="picker-results-{uid}" aria-label={label}>
-			{#each results as result, i (result.id)}
-				<button
-					type="button"
-					class="picker-result"
-					class:active={i === activeIndex}
-					role="option"
-					id="picker-option-{uid}-{i}"
-					aria-selected={i === activeIndex}
-					onclick={() => choose(result)}
-				>
-					{#if formatItemRef(result)}
-						<span class="picker-ref">{formatItemRef(result)}</span>
-					{/if}
-					<span class="picker-title">{result.title}</span>
-				</button>
+			{#each options as option, i (option.id)}
+				{#if option.kind === 'create'}
+					<button
+						type="button"
+						class="picker-result picker-create"
+						class:active={i === activeIndex}
+						role="option"
+						id="picker-option-{uid}-{i}"
+						aria-selected={i === activeIndex}
+						onclick={() => void invokeCreate()}
+					>
+						<span class="picker-create-mark" aria-hidden="true">+</span>
+						<span class="picker-title">
+							Create "{createTitle}" in {createLabel ?? collection}
+						</span>
+					</button>
+				{:else}
+					<button
+						type="button"
+						class="picker-result"
+						class:active={i === activeIndex}
+						role="option"
+						id="picker-option-{uid}-{i}"
+						aria-selected={i === activeIndex}
+						onclick={() => choose(option.row)}
+					>
+						{#if formatItemRef(option.row)}
+							<span class="picker-ref">{formatItemRef(option.row)}</span>
+						{/if}
+						<span class="picker-title">{option.row.title}</span>
+					</button>
+				{/if}
 			{/each}
 		</div>
 	{:else if query.trim().length > 0}
@@ -520,5 +648,21 @@
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
+	}
+
+	/*
+	 * The create row reads as an action, not as another item — it is the one
+	 * row that mints something. Muted until it is the active/hovered row, which
+	 * `.picker-result`'s own rule already handles.
+	 */
+	.picker-create {
+		color: var(--text-secondary, var(--text-muted));
+	}
+
+	.picker-create-mark {
+		flex-shrink: 0;
+		color: var(--text-muted);
+		font-family: var(--font-mono);
+		font-size: 0.94em;
 	}
 </style>

--- a/web/src/lib/components/items/ItemPicker.svelte
+++ b/web/src/lib/components/items/ItemPicker.svelte
@@ -572,6 +572,17 @@
 		const state = localIndex.bootstrapStateFor(wsSlug);
 		// Read for its dependency; the value carries no meaning here.
 		localSearch.epoch(wsSlug);
+		// TRACKED (codex round 10): the scope itself. Every other read below is
+		// untracked to keep this off the keystroke path, and `collection` was
+		// swept up in that — but it is not a per-keystroke value, it is the
+		// question the results answer. `ItemDetail` can change a relation
+		// field's declared target (a schema edit, or an SSE-driven refresh)
+		// without remounting this picker, and the rows then on screen belong to
+		// the collection it USED to point at while remaining selectable under
+		// the new one. Predates U8 (it arrived with the extraction in
+		// TASK-2862); fixed here because U8 makes `collection` load-bearing —
+		// it is now the destination an inline create writes to.
+		void collection;
 		untrack(() => {
 			if (state !== 'ready') {
 				// The workspace's state was DROPPED — `localIndex.reset()` on

--- a/web/src/lib/components/items/ItemPicker.svelte
+++ b/web/src/lib/components/items/ItemPicker.svelte
@@ -608,7 +608,6 @@
 		// a non-empty query) is unreachable then. Measured, not assumed — a line
 		// that cannot change an outcome does not get to look like a guard.
 		const scopeChanged = scope !== lastScope;
-		lastScope = scope;
 		untrack(() => {
 			if (state !== 'ready') {
 				// The workspace's state was DROPPED — `localIndex.reset()` on
@@ -636,6 +635,15 @@
 				coldAnswered = false;
 				activeId = null;
 				loading = false;
+				// `lastScope` is deliberately NOT committed here (codex round
+				// 12). This branch clears and gives up without serving the
+				// scope, so recording it as served would consume a pending
+				// refresh: a scope change arriving while the index is cold would
+				// be forgotten, and at hydration `scopeChanged` would read false
+				// and a server-sourced picker would take the early return below
+				// and sit empty until the user retyped or the picker remounted.
+				// Leaving it stale keeps the refresh owed until a run performs
+				// it.
 				return;
 			}
 			// Server-sourced QUERIES are not re-issued on an index change: the
@@ -651,6 +659,9 @@
 			// happens when a schema is edited or a pane is retargeted, not per
 			// delta, so the rate-limiter argument does not reach it.
 			if (source === 'server' && query.trim() && !scopeChanged) return;
+			// Committed only now, by a run that is actually going to serve this
+			// scope — see the note in the non-ready branch above.
+			lastScope = scope;
 			const keep = activeId;
 			runQuery();
 			activeId = keep;

--- a/web/src/lib/components/items/ItemPicker.svelte
+++ b/web/src/lib/components/items/ItemPicker.svelte
@@ -193,11 +193,19 @@
 	/**
 	 * Whether to offer the create row, for the query as it stands.
 	 *
-	 * "Matches nothing, or nothing EXACTLY" — the exact-title test is against
-	 * `rawResults`, the source's answer BEFORE exclusion and the row bound.
-	 * Presented rows would be the wrong population twice over: an exact match
-	 * pushed past `limit`, or one the caller excluded, would both read as "no
-	 * such item" and offer to mint a duplicate of a row that exists.
+	 * "Matches nothing, or nothing EXACTLY" — and the exact-title question is
+	 * asked of the INDEX, not of the ranking.
+	 *
+	 * `rawResults` is checked first because it is free and is the only answer
+	 * available while the index is cold. But it is a RANKED, WINDOWED answer:
+	 * `warmSearch` asks for `limit + excluded.size` hits, so an exact row that
+	 * the ranker placed outside that window is simply absent, and resting the
+	 * no-duplicate guarantee on a relevance score rests it on the wrong thing
+	 * (codex round 1 P2). "Does an item with this exact title exist in this
+	 * collection" has an authoritative answer in `localIndex`, already in RAM,
+	 * so the warm path asks it directly. `getByCollection` excludes
+	 * soft-deleted rows, which is right: a deleted "Purple" should not stop the
+	 * user minting a live one.
 	 *
 	 * This suppression IS the no-duplicate half of U8's proving test. There is
 	 * no create-time uniqueness check anywhere below, and deliberately so: the
@@ -209,10 +217,18 @@
 	 * known, and a create row there invites a duplicate of a row about to land.
 	 */
 	let createTitle = $derived(query.trim());
+	function titleIs(row: ItemIndexRow, wanted: string): boolean {
+		return (row.title ?? '').trim().toLowerCase() === wanted;
+	}
 	let showCreate = $derived.by((): boolean => {
 		if (!oncreate || !collection || !createTitle || loading) return false;
 		const wanted = createTitle.toLowerCase();
-		return !rawResults.some((r) => (r.title ?? '').trim().toLowerCase() === wanted);
+		if (rawResults.some((r) => titleIs(r, wanted))) return false;
+		// Cold: no authoritative set to consult, so the ranked answer above is
+		// all there is. Offering create is the right call — refusing it because
+		// the index has not hydrated would strand the user.
+		if (!isWarm()) return true;
+		return !localIndex.getByCollection(wsSlug, collection).some((r) => titleIs(r, wanted));
 	});
 
 	/**

--- a/web/src/lib/components/items/ItemPicker.svelte
+++ b/web/src/lib/components/items/ItemPicker.svelte
@@ -354,8 +354,19 @@
 			// A TRUNCATED page is not an answer to "does this exact title
 			// exist" — the row could be on a page we never fetched (codex round
 			// 7). Same defect as trusting the local ranker's window, arriving
-			// from the server side; `total` is what distinguishes them.
-			coldAnswered = (res.total ?? rows.length) <= rows.length;
+			// from the server side.
+			//
+			// Completeness is read from the PAGE LENGTH, not from `total`
+			// (codex round 8). `total` cannot answer it: when the count query
+			// fails, `store.search` sets total = -1, floors it to 0, and then
+			// floors it again to `len(results)` — "Ensure total is never less
+			// than actual results", search.go:604-608 — so a failed count is
+			// indistinguishable on the wire from an exact-fit page. A page
+			// SHORTER than the limit the server echoes back is proof there is no
+			// next page, and it holds whatever the count did. A full page is not
+			// proof either way, so it does not count as an answer.
+			const pageLimit = res.limit ?? 0;
+			coldAnswered = pageLimit > 0 && rows.length < pageLimit;
 			activeId = null;
 		} catch {
 			if (mySeq !== seq) return;

--- a/web/src/lib/components/items/ItemPicker.svelte
+++ b/web/src/lib/components/items/ItemPicker.svelte
@@ -187,6 +187,18 @@
 	 * read would silently wedge the production effect scheduler.
 	 */
 	let seq = 0;
+	/**
+	 * The (workspace, collection) pair the rows on screen answer for.
+	 *
+	 * Plain `let` per CONVE-1688 — written and read only inside the refresh
+	 * effect, never rendered. Starts NULL rather than seeded from the props:
+	 * seeding it would capture their mount-time values outside any reactive
+	 * scope (svelte warns `state_referenced_locally`, correctly). The null makes
+	 * the effect's first run compare unequal and so report "changed", which is
+	 * inert: the query box is empty at mount, and the only reader of that flag
+	 * needs a non-empty query.
+	 */
+	let lastScope: string | null = null;
 	let debounceTimer: ReturnType<typeof setTimeout> | undefined;
 	let inputEl = $state<HTMLInputElement>();
 
@@ -572,17 +584,31 @@
 		const state = localIndex.bootstrapStateFor(wsSlug);
 		// Read for its dependency; the value carries no meaning here.
 		localSearch.epoch(wsSlug);
-		// TRACKED (codex round 10): the scope itself. Every other read below is
-		// untracked to keep this off the keystroke path, and `collection` was
-		// swept up in that — but it is not a per-keystroke value, it is the
-		// question the results answer. `ItemDetail` can change a relation
-		// field's declared target (a schema edit, or an SSE-driven refresh)
-		// without remounting this picker, and the rows then on screen belong to
-		// the collection it USED to point at while remaining selectable under
-		// the new one. Predates U8 (it arrived with the extraction in
-		// TASK-2862); fixed here because U8 makes `collection` load-bearing —
-		// it is now the destination an inline create writes to.
-		void collection;
+		// TRACKED (codex round 10), by being read right here: the scope itself.
+		// Every other read below is untracked to keep this effect off the
+		// keystroke path, and `collection` was swept up in that — but it is not
+		// a per-keystroke value, it is the question the results answer.
+		// `ItemDetail` can change a relation field's declared target (a schema
+		// edit, or an SSE-driven refresh) without remounting this picker, and
+		// the rows then on screen belong to the collection it USED to point at
+		// while remaining selectable under the new one. Predates U8 (it arrived
+		// with the extraction in TASK-2862); fixed here because U8 makes
+		// `collection` load-bearing in a new way — it is now the destination an
+		// inline create writes to.
+		//
+		// A SCOPE CHANGE is also not an index delta, and the two need opposite
+		// handling below, so decide which this run is while the reads are still
+		// tracked (codex round 11). Computing the pair is what SUBSCRIBES to it;
+		// a separate `void collection` alongside was redundant and went, since
+		// its mutant could not be killed.
+		const scope = `${wsSlug}\u0000${collection ?? ''}`;
+		// No `lastScope !== null` guard on the first run: its mutant could not be
+		// killed, because at mount the query box is empty, so the only branch
+		// that reads `scopeChanged` (the server-source early return, which needs
+		// a non-empty query) is unreachable then. Measured, not assumed — a line
+		// that cannot change an outcome does not get to look like a guard.
+		const scopeChanged = scope !== lastScope;
+		lastScope = scope;
 		untrack(() => {
 			if (state !== 'ready') {
 				// The workspace's state was DROPPED — `localIndex.reset()` on
@@ -616,7 +642,15 @@
 			// index is not their source of truth, and a request per delta is
 			// exactly the rate-limiter pressure the debounce exists to avoid. The
 			// empty-query LISTING still comes from the index, so it does refresh.
-			if (source === 'server' && query.trim()) return;
+			//
+			// A SCOPE change is the exception, and it is the reason this early
+			// return is conditional (codex round 11). Rows fetched for the old
+			// workspace or collection are not merely stale, they are answers to a
+			// different question — and left in place they stay selectable under
+			// the new scope. Re-querying costs one request at an event that
+			// happens when a schema is edited or a pane is retargeted, not per
+			// delta, so the rate-limiter argument does not reach it.
+			if (source === 'server' && query.trim() && !scopeChanged) return;
 			const keep = activeId;
 			runQuery();
 			activeId = keep;

--- a/web/src/lib/components/items/ItemPicker.svelte
+++ b/web/src/lib/components/items/ItemPicker.svelte
@@ -157,16 +157,21 @@
 	let rawResults = $state<ItemIndexRow[]>([]);
 	let loading = $state(false);
 	/**
-	 * The last cold search FAILED, as opposed to returning nothing.
+	 * A cold search ANSWERED, and `rawResults` is that answer.
 	 *
-	 * Both leave `rawResults` empty and `loading` false, and for the result
-	 * list that is the same picture — "No results" either way. It is not the
-	 * same picture for the create row: an empty answer is evidence that no such
-	 * item exists, and a failed one is no evidence at all (codex round 3).
-	 * Offering to create on no evidence is how a duplicate gets minted while
-	 * the index is cold and the network is unhappy.
+	 * Stated positively on purpose (codex rounds 3 and 5). The negative form
+	 * — "the last search failed" — was false in three different states that
+	 * are not answers at all: before the first request, after a failure, and
+	 * after `localIndex.reset()` drops everything on a sign-out or 403 purge.
+	 * Each left the flag reading "fine" and put a create row on screen backed
+	 * by no evidence. A flag that must be cleared everywhere is a flag that
+	 * will be missed somewhere; this one is set in exactly one place, by the
+	 * event that earns it.
+	 *
+	 * Only the COLD path needs it. A settled warm index is authoritative by
+	 * itself, and `indexCanProveAbsence` is what asks that question.
 	 */
-	let coldFailed = $state(false);
+	let coldAnswered = $state(false);
 	/**
 	 * The highlighted row's ID, not its index. Identity survives the list
 	 * changing under it — a delta landing, a late exclusion arriving — where an
@@ -232,24 +237,33 @@
 		return (row.title ?? '').trim().toLowerCase() === wanted;
 	}
 	let showCreate = $derived.by((): boolean => {
-		if (!oncreate || !collection || !createTitle || loading) return false;
-		if (coldFailed) return false;
+		// No `loading` term. It and the per-query `coldAnswered` reset below are
+		// a redundant PAIR — either alone suppresses the row for the whole
+		// in-flight window, and a mutant removing either one survived while the
+		// other stood. That is not defence in depth, it is one guard and one
+		// line that looks like a guard. `coldAnswered` is the one kept, because
+		// it states the actual rule (something authoritative has answered FOR
+		// THIS QUERY) where `loading` is a UI state that merely correlates with
+		// it, and only the warm path can be settled while nothing is loading.
+		if (!oncreate || !collection || !createTitle) return false;
 		const wanted = createTitle.toLowerCase();
 		if (rawResults.some((r) => titleIs(r, wanted))) return false;
 		// Offer only where SOMETHING authoritative has answered "no such item",
 		// which is the same rule the permission gate and `coldFailed` follow: no
 		// evidence must not read as permission.
 		//
-		//   * COLD — `rawResults` came from `/search`, which is the server and
-		//     therefore authoritative. Its empty answer is real evidence, so
-		//     offer. (Refusing here would strand every user whose index has not
-		//     hydrated.)
+		//   * COLD — offer only once `/search` has actually ANSWERED. The server
+		//     is authoritative and its empty answer is real evidence; not having
+		//     asked yet, a failed request, and a workspace whose state was just
+		//     dropped are all silence, and silence is not evidence. (Refusing
+		//     outright would strand every user whose index has not hydrated,
+		//     which is why this waits for the answer rather than the index.)
 		//   * READY, settled — the in-RAM collection is authoritative; scan it.
 		//   * READY, resyncing — the rows are a cache snapshot that delta-sync
 		//     has not reconciled, and `rawResults` came from THAT, so nothing in
 		//     reach can support the inference. Withhold until it settles; the
 		//     window is seconds and a duplicate outlives it.
-		if (!isWarm()) return true;
+		if (!isWarm()) return coldAnswered;
 		if (!indexCanProveAbsence()) return false;
 		return !localIndex.getByCollection(wsSlug, collection).some((r) => titleIs(r, wanted));
 	});
@@ -336,12 +350,12 @@
 			const res = await api.search(q, { workspace: wsSlug, collection });
 			if (mySeq !== seq) return;
 			rawResults = (res.results ?? []).map((r) => r.item);
-			coldFailed = false;
+			coldAnswered = true;
 			activeId = null;
 		} catch {
 			if (mySeq !== seq) return;
 			rawResults = [];
-			coldFailed = true;
+			coldAnswered = false;
 			activeId = null;
 		} finally {
 			if (mySeq === seq) loading = false;
@@ -370,22 +384,17 @@
 		if (source === 'index' && isWarm()) {
 			loading = false;
 			rawResults = warmSearch(q);
-			coldFailed = false;
 			activeId = null;
 			return;
 		}
 
 		rawResults = [];
-		// NO `coldFailed` reset here, measured rather than assumed: mutants
-		// removing one here, on the empty-query branch, and in the
-		// workspace-reset effect all SURVIVED, so all three went. `loading` is
-		// true for the whole window this would cover and already suppresses the
-		// create row; when the request settles, both `coldSearch` branches
-		// assign `coldFailed` outright. The empty-query branch is covered
-		// twice over, since an empty query offers no create row at all. The
-		// ONE reachable reset is the warm branch above — the only path that
-		// produces a fresh verdict without going through `coldSearch`, so
-		// without it a single blip suppresses the affordance past hydration.
+		// The previous answer described the PREVIOUS query. This is the line
+		// that makes `coldAnswered` mean "answered for what is in the box now",
+		// and with the `loading` term gone it is load-bearing on its own: drop
+		// it and query B offers a create row on the strength of query A's
+		// answer, while B is still in flight.
+		coldAnswered = false;
 		activeId = null;
 		loading = true;
 		debounceTimer = setTimeout(() => coldSearch(q, mySeq), COLD_SEARCH_DEBOUNCE_MS);
@@ -568,6 +577,10 @@
 				seq++;
 				clearTimeout(debounceTimer);
 				rawResults = [];
+				// The rows this answer described were just dropped, so it
+				// describes nothing (codex round 5). Without this the picker
+				// offers to create over a purged workspace.
+				coldAnswered = false;
 				activeId = null;
 				loading = false;
 				return;

--- a/web/src/lib/components/items/ItemPicker.svelte
+++ b/web/src/lib/components/items/ItemPicker.svelte
@@ -349,8 +349,13 @@
 		try {
 			const res = await api.search(q, { workspace: wsSlug, collection });
 			if (mySeq !== seq) return;
-			rawResults = (res.results ?? []).map((r) => r.item);
-			coldAnswered = true;
+			const rows = (res.results ?? []).map((r) => r.item);
+			rawResults = rows;
+			// A TRUNCATED page is not an answer to "does this exact title
+			// exist" — the row could be on a page we never fetched (codex round
+			// 7). Same defect as trusting the local ranker's window, arriving
+			// from the server side; `total` is what distinguishes them.
+			coldAnswered = (res.total ?? rows.length) <= rows.length;
 			activeId = null;
 		} catch {
 			if (mySeq !== seq) return;

--- a/web/src/lib/components/items/ItemPicker.svelte
+++ b/web/src/lib/components/items/ItemPicker.svelte
@@ -157,6 +157,17 @@
 	let rawResults = $state<ItemIndexRow[]>([]);
 	let loading = $state(false);
 	/**
+	 * The last cold search FAILED, as opposed to returning nothing.
+	 *
+	 * Both leave `rawResults` empty and `loading` false, and for the result
+	 * list that is the same picture — "No results" either way. It is not the
+	 * same picture for the create row: an empty answer is evidence that no such
+	 * item exists, and a failed one is no evidence at all (codex round 3).
+	 * Offering to create on no evidence is how a duplicate gets minted while
+	 * the index is cold and the network is unhappy.
+	 */
+	let coldFailed = $state(false);
+	/**
 	 * The highlighted row's ID, not its index. Identity survives the list
 	 * changing under it — a delta landing, a late exclusion arriving — where an
 	 * index silently moves the highlight onto whatever slid into that position.
@@ -222,6 +233,7 @@
 	}
 	let showCreate = $derived.by((): boolean => {
 		if (!oncreate || !collection || !createTitle || loading) return false;
+		if (coldFailed) return false;
 		const wanted = createTitle.toLowerCase();
 		if (rawResults.some((r) => titleIs(r, wanted))) return false;
 		// Cold: no authoritative set to consult, so the ranked answer above is
@@ -295,10 +307,12 @@
 			const res = await api.search(q, { workspace: wsSlug, collection });
 			if (mySeq !== seq) return;
 			rawResults = (res.results ?? []).map((r) => r.item);
+			coldFailed = false;
 			activeId = null;
 		} catch {
 			if (mySeq !== seq) return;
 			rawResults = [];
+			coldFailed = true;
 			activeId = null;
 		} finally {
 			if (mySeq === seq) loading = false;
@@ -327,11 +341,22 @@
 		if (source === 'index' && isWarm()) {
 			loading = false;
 			rawResults = warmSearch(q);
+			coldFailed = false;
 			activeId = null;
 			return;
 		}
 
 		rawResults = [];
+		// NO `coldFailed` reset here, measured rather than assumed: mutants
+		// removing one here, on the empty-query branch, and in the
+		// workspace-reset effect all SURVIVED, so all three went. `loading` is
+		// true for the whole window this would cover and already suppresses the
+		// create row; when the request settles, both `coldSearch` branches
+		// assign `coldFailed` outright. The empty-query branch is covered
+		// twice over, since an empty query offers no create row at all. The
+		// ONE reachable reset is the warm branch above — the only path that
+		// produces a fresh verdict without going through `coldSearch`, so
+		// without it a single blip suppresses the affordance past hydration.
 		activeId = null;
 		loading = true;
 		debounceTimer = setTimeout(() => coldSearch(q, mySeq), COLD_SEARCH_DEBOUNCE_MS);

--- a/web/src/lib/components/items/ItemPicker.svelte
+++ b/web/src/lib/components/items/ItemPicker.svelte
@@ -193,10 +193,11 @@
 	 * Plain `let` per CONVE-1688 — written and read only inside the refresh
 	 * effect, never rendered. Starts NULL rather than seeded from the props:
 	 * seeding it would capture their mount-time values outside any reactive
-	 * scope (svelte warns `state_referenced_locally`, correctly). The null makes
-	 * the effect's first run compare unequal and so report "changed", which is
-	 * inert: the query box is empty at mount, and the only reader of that flag
-	 * needs a non-empty query.
+	 * scope (svelte warns `state_referenced_locally`, correctly). Null is also
+	 * the value the not-ready branch restores, and it reads the same way in both
+	 * places: the rows on screen answer for NO scope, so the next run owes a
+	 * refresh. At mount that is inert — the query box is empty, and the only
+	 * reader of `scopeChanged` needs a non-empty query.
 	 */
 	let lastScope: string | null = null;
 	let debounceTimer: ReturnType<typeof setTimeout> | undefined;
@@ -608,6 +609,7 @@
 		// a non-empty query) is unreachable then. Measured, not assumed — a line
 		// that cannot change an outcome does not get to look like a guard.
 		const scopeChanged = scope !== lastScope;
+		lastScope = scope;
 		untrack(() => {
 			if (state !== 'ready') {
 				// The workspace's state was DROPPED — `localIndex.reset()` on
@@ -635,15 +637,24 @@
 				coldAnswered = false;
 				activeId = null;
 				loading = false;
-				// `lastScope` is deliberately NOT committed here (codex round
-				// 12). This branch clears and gives up without serving the
-				// scope, so recording it as served would consume a pending
-				// refresh: a scope change arriving while the index is cold would
-				// be forgotten, and at hydration `scopeChanged` would read false
-				// and a server-sourced picker would take the early return below
-				// and sit empty until the user retyped or the picker remounted.
-				// Leaving it stale keeps the refresh owed until a run performs
-				// it.
+				// INVALIDATED, not committed and not left alone (codex rounds 12
+				// and 13). `lastScope` means "the scope the rows on screen
+				// answer for", and this branch just removed the rows — so after
+				// it they answer for nothing, which is what null says.
+				//
+				// Both neighbouring mistakes fall out of that one reading. A
+				// scope change arriving while the state is dropped must not be
+				// forgotten at hydration; and rehydrating on the SAME scope must
+				// not compare equal, or a server-sourced picker takes the early
+				// return below and sits empty forever, its rows cleared and
+				// nothing left to re-query it.
+				//
+				// This also settles WHERE the commit above belongs: deferring it
+				// past the early return was a second mechanism aimed at the
+				// first of those two, and with this invalidation in place it
+				// changed no outcome — its mutant could not be killed, so it
+				// went. One rule, stated once.
+				lastScope = null;
 				return;
 			}
 			// Server-sourced QUERIES are not re-issued on an index change: the
@@ -659,9 +670,6 @@
 			// happens when a schema is edited or a pane is retargeted, not per
 			// delta, so the rate-limiter argument does not reach it.
 			if (source === 'server' && query.trim() && !scopeChanged) return;
-			// Committed only now, by a run that is actually going to serve this
-			// scope — see the note in the non-ready branch above.
-			lastScope = scope;
 			const keep = activeId;
 			runQuery();
 			activeId = keep;

--- a/web/src/lib/components/items/ItemPicker.svelte.test.ts
+++ b/web/src/lib/components/items/ItemPicker.svelte.test.ts
@@ -1061,6 +1061,66 @@ describe('ItemPicker — inline create (PLAN-2857 U8)', () => {
 		expect(createRow()).not.toBeNull();
 	});
 
+	it('does not carry one query\u2019s answer onto the next', async () => {
+		// `coldAnswered` has to mean "answered for what is in the box NOW".
+		// Without the per-query reset, typing a second query offers a create row
+		// immediately, on the strength of the first query's answer and against
+		// an empty result list that describes nothing.
+		vi.useFakeTimers();
+		setBootstrapState('cold');
+		loadIndex([]);
+		searchApi.mockResolvedValue({ results: [] });
+		render(ItemPicker, { props: { ...createProps, oncreate: vi.fn() } });
+		await tick();
+
+		await type('Purple');
+		await vi.advanceTimersByTimeAsync(300);
+		await vi.waitFor(() => expect(createRow()).not.toBeNull());
+
+		// Second query, still in flight — nothing has answered for it yet.
+		let release!: (v: unknown) => void;
+		searchApi.mockReturnValue(new Promise((r) => { release = r; }));
+		await type('Teal');
+		await vi.advanceTimersByTimeAsync(300);
+		// `aria-expanded`, not the row's absence — the markup renders the
+		// loading branch INSTEAD of the listbox, so `.picker-create` is missing
+		// either way and asserting on it measures the branch rather than the
+		// rule. Same trap this suite hit on the `loading` guard; it is the
+		// options list, and therefore the combobox's expanded state, that
+		// carries the stale answer.
+		expect(input().getAttribute('aria-expanded')).toBe('false');
+		expect(createRow()).toBeNull();
+
+		release({ results: [] });
+		await vi.waitFor(() => expect(createRow()).not.toBeNull());
+		vi.useRealTimers();
+	});
+
+	it('offers nothing to create after the workspace state is dropped', async () => {
+		// codex round 5 P1. `localIndex.reset()` — sign-out, a 403 membership
+		// purge, a deleted workspace — drops every row, and the picker's own
+		// effect clears what it was showing. The query is still in the box, so
+		// with a negative "did it fail" flag the picker read that silence as a
+		// clean empty answer and offered to create over a workspace it can no
+		// longer see anything in.
+		setBootstrapState('cold');
+		loadIndex([]);
+		searchApi.mockResolvedValue({ results: [] });
+		render(ItemPicker, { props: { ...createProps, oncreate: vi.fn() } });
+		await tick();
+
+		await type('Purple');
+		await vi.waitFor(() => expect(createRow()).not.toBeNull());
+
+		// The drop.
+		setBootstrapState('reset');
+		bumpEpoch();
+		await tick();
+		await tick();
+
+		expect(createRow()).toBeNull();
+	});
+
 	it('CONTROL: a cold index falls back to the returned rows and still offers create', async () => {
 		// The collection scan needs a hydrated index. While cold there is no
 		// authoritative answer to fall back ON, so the behaviour is the

--- a/web/src/lib/components/items/ItemPicker.svelte.test.ts
+++ b/web/src/lib/components/items/ItemPicker.svelte.test.ts
@@ -120,6 +120,17 @@ async function press(key: string, opts: KeyboardEventInit = {}) {
 	await tick();
 }
 
+/**
+ * A COMPLETE `/search` page, in the shape the server actually returns.
+ *
+ * `total`, `limit` and `offset` are non-optional on `SearchResponse` and the Go
+ * handler always sends them, so a fixture omitting them is not a smaller
+ * version of a real response — it is one that cannot occur, and it was quietly
+ * deciding the page-completeness question several of these tests are about.
+ */
+const page = (results: unknown[]) => ({ results, total: results.length, limit: 50, offset: 0 });
+const emptyPage = () => page([]);
+
 const baseProps = { wsSlug: 'ws', collection: 'colors', onselect: () => {} };
 
 beforeEach(() => {
@@ -472,6 +483,43 @@ describe('ItemPicker — the collection scope is a tracked input', () => {
 
 		expect(options().map((o) => o.textContent)).toEqual([expect.stringContaining('Large')]);
 	});
+
+	it('re-queries a SERVER-sourced picker when the scope changes mid-query', async () => {
+		// codex round 11, the tail of the fix above. The effect skips
+		// server-sourced queries on an index delta — right, since the index is
+		// not their source of truth — but a scope change is not a delta. Rows
+		// fetched for the old collection are answers to a different question,
+		// and left in place they stay selectable under the new scope.
+		searchApi.mockResolvedValue(
+			page([{ item: { id: 'c-1', title: 'Red', item_number: 1, collection_prefix: 'COLO' } }]),
+		);
+		// Index READY, which is the Relationships tab's ordinary state: that
+		// caller uses the server for QUERIES by choice, not because the index is
+		// cold. (With a cold index the non-ready branch of the effect clears the
+		// rows first and there is nothing stale left to be selectable, so this
+		// leg would not be measuring the early return.)
+		setBootstrapState('ready');
+		loadIndex([]);
+		const { component } = render(ItemPickerProbe, {
+			props: { wsSlug: 'ws', collection: 'colors', source: 'server', onselect: () => {} },
+		});
+		await tick();
+		await type('e');
+		await vi.waitFor(() => expect(options().length).toBe(1));
+		expect(searchApi).toHaveBeenCalledTimes(1);
+		expect(searchApi.mock.calls[0][1]).toMatchObject({ collection: 'colors' });
+
+		searchApi.mockResolvedValue(
+			page([{ item: { id: 's-1', title: 'Large', item_number: 1, collection_prefix: 'SIZE' } }]),
+		);
+		(component as unknown as { setCollection: (c: string) => void }).setCollection('sizes');
+
+		await vi.waitFor(() => expect(searchApi).toHaveBeenCalledTimes(2));
+		expect(searchApi.mock.calls[1][1]).toMatchObject({ collection: 'sizes' });
+		await vi.waitFor(() =>
+			expect(options().map((o) => o.textContent)).toEqual([expect.stringContaining('Large')]),
+		);
+	});
 });
 
 describe('ItemPicker — source: the two callers want different models', () => {
@@ -813,16 +861,6 @@ describe('ItemPicker — inline create (PLAN-2857 U8)', () => {
 
 	const createProps = { ...baseProps, createLabel: 'Colors' };
 
-	/**
-	 * A COMPLETE `/search` page, in the shape the server actually returns.
-	 *
-	 * `total`, `limit` and `offset` are non-optional on `SearchResponse` and the
-	 * Go handler always sends them, so a fixture omitting them is not a smaller
-	 * version of a real response — it is one that cannot occur, and it was
-	 * quietly deciding the completeness question these tests are about.
-	 */
-	const page = (results: unknown[]) => ({ results, total: results.length, limit: 50, offset: 0 });
-	const emptyPage = () => page([]);
 
 	it('offers no create row when the host passes no oncreate — the Relationships-tab caller', async () => {
 		loadIndex(makeRows(3));

--- a/web/src/lib/components/items/ItemPicker.svelte.test.ts
+++ b/web/src/lib/components/items/ItemPicker.svelte.test.ts
@@ -980,6 +980,53 @@ describe('ItemPicker — inline create (PLAN-2857 U8)', () => {
 		expect(createRow()).toBeNull();
 	});
 
+	it('offers nothing to create when the cold search FAILED', async () => {
+		// codex round 3 P2. A failed search and an empty one leave identical
+		// state — no rows, not loading — and the result list is right to render
+		// both as "No results". The create row is not: an empty answer says no
+		// such item exists, a failed one says nothing at all, and offering to
+		// create on no evidence is how the duplicate gets minted. Same rule the
+		// permission gate follows: no answer must not read as permission.
+		setBootstrapState('cold');
+		loadIndex([]);
+		searchApi.mockRejectedValue(new Error('network'));
+		render(ItemPicker, { props: { ...createProps, oncreate: vi.fn() } });
+		await tick();
+
+		await type('Purple');
+		await vi.waitFor(() => expect(document.body.textContent).toContain('No results'));
+		expect(createRow()).toBeNull();
+
+		// And it must not latch: the next query gets a fresh verdict.
+		searchApi.mockResolvedValue({ results: [] });
+		await type('Purple Haze');
+		await vi.waitFor(() => expect(createRow()).not.toBeNull());
+	});
+
+	it('a cold failure does not outlive hydration — the warm answer supersedes it', async () => {
+		// The reachable half of "must not latch". The failure flag is cleared by
+		// whatever produces the NEXT verdict, and the warm branch never reaches
+		// `coldSearch` to clear it on the way through — so without its own reset
+		// a single network blip suppresses the create row for the rest of the
+		// session, even once the authoritative in-RAM answer is available.
+		setBootstrapState('cold');
+		loadIndex([]);
+		searchApi.mockRejectedValue(new Error('network'));
+		render(ItemPicker, { props: { ...createProps, oncreate: vi.fn() } });
+		await tick();
+
+		await type('Purple');
+		await vi.waitFor(() => expect(document.body.textContent).toContain('No results'));
+		expect(createRow()).toBeNull();
+
+		setBootstrapState('ready');
+		bumpEpoch();
+		await tick();
+		await tick();
+
+		expect(createRow()).not.toBeNull();
+	});
+
 	it('CONTROL: a cold index falls back to the returned rows and still offers create', async () => {
 		// The collection scan needs a hydrated index. While cold there is no
 		// authoritative answer to fall back ON, so the behaviour is the

--- a/web/src/lib/components/items/ItemPicker.svelte.test.ts
+++ b/web/src/lib/components/items/ItemPicker.svelte.test.ts
@@ -936,6 +936,65 @@ describe('ItemPicker — inline create (PLAN-2857 U8)', () => {
 		expect(oncreate).toHaveBeenCalledWith('Purple');
 	});
 
+	it('withholds create for an exact title the SEARCH RANKING did not return', async () => {
+		// codex round 1 P2. `warmSearch` asks `localSearch` for `limit +
+		// excluded.size` hits, so the exact match is only in `rawResults` if the
+		// RANKER put it there. Resting the no-duplicate guarantee on a relevance
+		// score is resting it on the wrong thing: the question "does an item with
+		// this exact title exist in this collection" has an authoritative answer
+		// in the index itself, and the index is already in RAM.
+		//
+		// The scenario is the ranker returning a full page of near-misses with
+		// the exact row outside the window.
+		loadIndex([
+			{ id: 'id-1', title: 'Purple Rain', item_number: 1, collection_prefix: 'COLO' },
+			{ id: 'id-2', title: 'Purple', item_number: 2, collection_prefix: 'COLO' },
+		]);
+		// The ranker returns ONLY the near-miss; the exact row is off the window.
+		localSearchMock.search.mockReturnValue([{ id: 'id-1', score: 1 }]);
+		render(ItemPicker, { props: { ...createProps, oncreate: vi.fn(), limit: 1 } });
+		await tick();
+
+		await type('Purple');
+
+		expect(options().map((o) => o.textContent)).toHaveLength(1);
+		expect(createRow()).toBeNull();
+	});
+
+	it('withholds create when the COLD path returns an exact title', async () => {
+		// The `rawResults` check is not redundant with the collection scan, and
+		// this is the case that proves it: while the index is cold there is no
+		// collection to scan, and the server's answer is the only evidence that
+		// the row exists. A build relying on the scan alone offers to create a
+		// duplicate of a row `/search` just returned.
+		setBootstrapState('cold');
+		loadIndex([]);
+		searchApi.mockResolvedValue({
+			results: [{ item: { id: 'id-2', title: 'Purple', item_number: 2, collection_prefix: 'COLO' } }],
+		});
+		render(ItemPicker, { props: { ...createProps, oncreate: vi.fn() } });
+		await tick();
+
+		await type('Purple');
+		await vi.waitFor(() => expect(options()).toHaveLength(1));
+		expect(createRow()).toBeNull();
+	});
+
+	it('CONTROL: a cold index falls back to the returned rows and still offers create', async () => {
+		// The collection scan needs a hydrated index. While cold there is no
+		// authoritative answer to fall back ON, so the behaviour is the
+		// rawResults check alone — which is the pre-fix behaviour, and correct
+		// here because refusing to offer create while cold would strand the user.
+		setBootstrapState('cold');
+		loadIndex([{ id: 'id-2', title: 'Purple', item_number: 2, collection_prefix: 'COLO' }]);
+		searchApi.mockResolvedValue({ results: [] });
+		render(ItemPicker, { props: { ...createProps, oncreate: vi.fn() } });
+		await tick();
+
+		await type('Purple');
+		await vi.waitFor(() => expect(createRow()).not.toBeNull());
+	});
+
 	it('does not fire a second create while the first is still in flight', async () => {
 		// The duplicate this guards is not the same-text-twice case the exact
 		// match covers — it is one impatient user and two Enters inside a single

--- a/web/src/lib/components/items/ItemPicker.svelte.test.ts
+++ b/web/src/lib/components/items/ItemPicker.svelte.test.ts
@@ -484,6 +484,42 @@ describe('ItemPicker — the collection scope is a tracked input', () => {
 		expect(options().map((o) => o.textContent)).toEqual([expect.stringContaining('Large')]);
 	});
 
+	it('serves a scope change that arrived while the index was cold, once it hydrates', async () => {
+		// codex round 12. The not-ready branch clears and gives up WITHOUT
+		// serving the scope, so committing `lastScope` there consumes a refresh
+		// nobody performed: at hydration `scopeChanged` reads false, a
+		// server-sourced picker takes the early return, and it sits empty until
+		// the user retypes or the picker remounts.
+		searchApi.mockResolvedValue(
+			page([{ item: { id: 'c-1', title: 'Red', item_number: 1, collection_prefix: 'COLO' } }]),
+		);
+		setBootstrapState('ready');
+		loadIndex([]);
+		const { component } = render(ItemPickerProbe, {
+			props: { wsSlug: 'ws', collection: 'colors', source: 'server', onselect: () => {} },
+		});
+		await tick();
+		await type('e');
+		await vi.waitFor(() => expect(searchApi).toHaveBeenCalledTimes(1));
+
+		// The workspace's state is dropped, and the scope changes while it is
+		// gone — the refresh is owed but cannot be served yet.
+		setBootstrapState('reset');
+		bumpEpoch();
+		await tick();
+		searchApi.mockResolvedValue(
+			page([{ item: { id: 's-1', title: 'Large', item_number: 1, collection_prefix: 'SIZE' } }]),
+		);
+		(component as unknown as { setCollection: (c: string) => void }).setCollection('sizes');
+		await tick();
+
+		// Hydration lands. The owed refresh must be served now.
+		setBootstrapState('ready');
+		bumpEpoch();
+		await vi.waitFor(() => expect(searchApi).toHaveBeenCalledTimes(2));
+		expect(searchApi.mock.calls[1][1]).toMatchObject({ collection: 'sizes' });
+	});
+
 	it('re-queries a SERVER-sourced picker when the scope changes mid-query', async () => {
 		// codex round 11, the tail of the fix above. The effect skips
 		// server-sourced queries on an index delta — right, since the index is

--- a/web/src/lib/components/items/ItemPicker.svelte.test.ts
+++ b/web/src/lib/components/items/ItemPicker.svelte.test.ts
@@ -1096,6 +1096,38 @@ describe('ItemPicker — inline create (PLAN-2857 U8)', () => {
 		vi.useRealTimers();
 	});
 
+	it('offers nothing to create when the cold answer was TRUNCATED', async () => {
+		// codex round 7. `/search` pages, so a page that does not contain the
+		// exact title is not evidence the title is unused — the row may be on a
+		// page nobody fetched. Same defect as trusting the local ranker's
+		// window, arriving from the server side.
+		setBootstrapState('cold');
+		loadIndex([]);
+		searchApi.mockResolvedValue({
+			results: [{ item: { id: 'id-9', title: 'Purple Haze', item_number: 9, collection_prefix: 'COLO' } }],
+			total: 84,
+			limit: 50,
+			offset: 0,
+		});
+		render(ItemPicker, { props: { ...createProps, oncreate: vi.fn() } });
+		await tick();
+
+		await type('Purple');
+		await vi.waitFor(() => expect(options().length).toBeGreaterThan(0));
+		expect(createRow()).toBeNull();
+
+		// CONTROL: the identical shape with a COMPLETE page does offer it, so
+		// this leg is measuring truncation and not the query.
+		searchApi.mockResolvedValue({
+			results: [{ item: { id: 'id-9', title: 'Purple Haze', item_number: 9, collection_prefix: 'COLO' } }],
+			total: 1,
+			limit: 50,
+			offset: 0,
+		});
+		await type('Purpl');
+		await vi.waitFor(() => expect(createRow()).not.toBeNull());
+	});
+
 	it('offers nothing to create after the workspace state is dropped', async () => {
 		// codex round 5 P1. `localIndex.reset()` — sign-out, a 403 membership
 		// purge, a deleted workspace — drops every row, and the picker's own

--- a/web/src/lib/components/items/ItemPicker.svelte.test.ts
+++ b/web/src/lib/components/items/ItemPicker.svelte.test.ts
@@ -25,6 +25,7 @@ const { searchApi, localIndexMock, localSearchMock } = vi.hoisted(() => ({
 		cursorFor: vi.fn(),
 		getByCollection: vi.fn(),
 		findByIdOrSlug: vi.fn(),
+		pendingResyncFor: vi.fn(),
 	},
 	localSearchMock: { search: vi.fn(), epoch: vi.fn() },
 }));
@@ -68,6 +69,12 @@ const epochs = new SvelteMap<string, number>();
  * which signal is correct.
  */
 const cursors = new SvelteMap<string, string>();
+/**
+ * `pendingResync` — true while the index is serving IDB-cached rows that
+ * delta-sync has not reconciled. Reactive for the same reason
+ * `bootstrapState` is: the create row must reappear when it settles.
+ */
+const resyncing = new SvelteMap<string, boolean>();
 
 function setBootstrapState(value: string) {
 	bootstrapState.set('ws', value);
@@ -121,6 +128,7 @@ beforeEach(() => {
 	bootstrapState.clear();
 	epochs.clear();
 	cursors.clear();
+	resyncing.clear();
 	setBootstrapState('ready');
 	localIndexMock.bootstrapStateFor
 		.mockReset()
@@ -132,6 +140,9 @@ beforeEach(() => {
 		.mockReset()
 		.mockImplementation((ws: string) => cursors.get(ws) ?? '0');
 	localIndexMock.getByCollection.mockReset().mockReturnValue([]);
+	localIndexMock.pendingResyncFor
+		.mockReset()
+		.mockImplementation((ws: string) => resyncing.get(ws) ?? false);
 	localIndexMock.findByIdOrSlug.mockReset().mockImplementation((_ws: string, id: string) => rowsById.get(id) ?? null);
 	localSearchMock.search.mockReset().mockReturnValue([]);
 	rowsById = new Map();
@@ -1024,6 +1035,29 @@ describe('ItemPicker — inline create (PLAN-2857 U8)', () => {
 		await tick();
 		await tick();
 
+		expect(createRow()).not.toBeNull();
+	});
+
+	it('offers nothing to create while the index is ready but still resyncing', async () => {
+		// codex round 4 P1. `ready` coexists with `pendingResync`: the rows on
+		// screen came from the IDB cache and delta-sync has not reconciled them,
+		// so an item that EXISTS can be missing from the snapshot. Presence
+		// would still be evidence; absence is not, and absence is what the
+		// create row is derived from.
+		loadIndex([]);
+		localSearchMock.search.mockReturnValue([]);
+		resyncing.set('ws', true);
+		render(ItemPicker, { props: { ...createProps, oncreate: vi.fn() } });
+		await tick();
+
+		await type('Purple');
+		expect(createRow()).toBeNull();
+
+		// It must come back once the snapshot is reconciled, without retyping.
+		resyncing.set('ws', false);
+		bumpEpoch();
+		await tick();
+		await tick();
 		expect(createRow()).not.toBeNull();
 	});
 

--- a/web/src/lib/components/items/ItemPicker.svelte.test.ts
+++ b/web/src/lib/components/items/ItemPicker.svelte.test.ts
@@ -743,3 +743,217 @@ describe('ItemPicker — Escape only consumes what it closes', () => {
 		expect(seen.mock.calls[0][0].defaultPrevented).toBe(false);
 	});
 });
+
+// ── U8: inline create from the picker (TASK-2877) ────────────────────────
+//
+// Pins written BEFORE the affordance exists, per team CONVE-29.
+//
+// The whole affordance is OPT-IN at the call site: the picker offers a create
+// row only when the host passes `oncreate`. That is not decoration — it is
+// where the two rules in the unit's scope live. "Relation-field pickers only"
+// is the Relationships tab simply not passing it, and "no create row unless the
+// user can create in the target collection" is `FieldEditor` withholding it
+// (pinned separately in `FieldEditor.relation.svelte.test.ts`, since the
+// permission cascade is not this component's to know).
+//
+// The no-duplicate half of the proving test lives here rather than in the
+// caller: it is EXACT-TITLE SUPPRESSION, not a create-time check. Once the
+// item exists, a picker asked for the same text again offers the row and
+// withholds the create affordance, so a second invocation cannot be a create
+// at all. `FieldEditor` upserting the new row into `localIndex` is what makes
+// that true on the very next keystroke; the mechanism is pinned there.
+describe('ItemPicker — inline create (PLAN-2857 U8)', () => {
+	function createRow(): HTMLElement | null {
+		return document.querySelector<HTMLElement>('.picker-create');
+	}
+
+	const createProps = { ...baseProps, createLabel: 'Colors' };
+
+	it('offers no create row when the host passes no oncreate — the Relationships-tab caller', async () => {
+		loadIndex(makeRows(3));
+		localSearchMock.search.mockReturnValue([]);
+		render(ItemPicker, { props: { ...baseProps } });
+		await tick();
+
+		await type('Purple');
+
+		expect(createRow()).toBeNull();
+		// CONTROL: the same query DOES produce the row when a host opts in, so
+		// this leg is measuring the opt-in and not a query that never renders.
+		cleanup();
+		render(ItemPicker, { props: { ...createProps, oncreate: vi.fn() } });
+		await tick();
+		await type('Purple');
+		expect(createRow()).not.toBeNull();
+	});
+
+	it('offers the create row, naming the query and the TARGET collection, when nothing matches', async () => {
+		loadIndex(makeRows(3));
+		localSearchMock.search.mockReturnValue([]);
+		render(ItemPicker, { props: { ...createProps, oncreate: vi.fn() } });
+		await tick();
+
+		await type('Purple');
+
+		expect(createRow()).not.toBeNull();
+		expect(createRow()!.textContent).toContain('Purple');
+		// The collection is named so the row cannot be read as "create it here".
+		// U8 creates in the field's declared target, which is frequently NOT the
+		// collection the user is looking at.
+		expect(createRow()!.textContent).toContain('Colors');
+	});
+
+	it('still offers create when matches exist but none is EXACT — the "or nothing exactly" half', async () => {
+		loadIndex([
+			{ id: 'id-1', title: 'Purple Rain', item_number: 1, collection_prefix: 'COLO' },
+		]);
+		localSearchMock.search.mockReturnValue([{ id: 'id-1', score: 1 }]);
+		render(ItemPicker, { props: { ...createProps, oncreate: vi.fn() } });
+		await tick();
+
+		await type('Purple');
+
+		expect(options()).toHaveLength(2);
+		// Trailing, per the unit: the matches are what the user most likely wants.
+		expect(options()[1]).toBe(createRow());
+	});
+
+	it('withholds create when an exact title already exists — the no-duplicate mechanism', async () => {
+		loadIndex([
+			{ id: 'id-1', title: 'Purple', item_number: 1, collection_prefix: 'COLO' },
+		]);
+		localSearchMock.search.mockReturnValue([{ id: 'id-1', score: 1 }]);
+		render(ItemPicker, { props: { ...createProps, oncreate: vi.fn() } });
+		await tick();
+
+		await type('Purple');
+
+		expect(createRow()).toBeNull();
+		expect(options()).toHaveLength(1);
+	});
+
+	it('matches an existing title case- and whitespace-insensitively', async () => {
+		// A user who typed "purple " must not mint a second "Purple". Exactness
+		// here is about the user's INTENT to name an existing row, and neither
+		// case nor a trailing space changes that intent.
+		loadIndex([
+			{ id: 'id-1', title: 'Purple', item_number: 1, collection_prefix: 'COLO' },
+		]);
+		localSearchMock.search.mockReturnValue([{ id: 'id-1', score: 1 }]);
+		render(ItemPicker, { props: { ...createProps, oncreate: vi.fn() } });
+		await tick();
+
+		await type('  purple ');
+
+		expect(createRow()).toBeNull();
+	});
+
+	it('offers nothing to create on an empty query, or without a target collection', async () => {
+		loadIndex(makeRows(3));
+		render(ItemPicker, { props: { ...createProps, oncreate: vi.fn() } });
+		await tick();
+		// Empty query: the scoped picker is LISTING, and "Create ''" is not a
+		// thing the user asked for.
+		expect(createRow()).toBeNull();
+
+		cleanup();
+		// Unscoped: there is no target collection to create into, so the row
+		// would have to guess. A host that passes `oncreate` without a
+		// `collection` gets nothing rather than a wrong destination.
+		localSearchMock.search.mockReturnValue([]);
+		render(ItemPicker, {
+			props: { wsSlug: 'ws', onselect: () => {}, oncreate: vi.fn(), createLabel: 'Colors' },
+		});
+		await tick();
+		await type('Purple');
+		expect(createRow()).toBeNull();
+	});
+
+	it('offers nothing to create while a cold search is still in flight', async () => {
+		// "Nothing matched" is not yet known while the server is answering. A
+		// create row here would invite a duplicate of a row about to arrive.
+		//
+		// `aria-expanded` is the assertion that can actually FAIL, and the
+		// reason this leg is worth having. The markup renders the loading
+		// branch INSTEAD of the listbox, so a build that offered the create row
+		// mid-flight would still show no `.picker-create` — the row would exist
+		// in the options list and merely be off screen, which is trap #1 from
+		// this plan's false-green note. What leaks is the combobox announcing
+		// itself expanded while no listbox is rendered.
+		vi.useFakeTimers();
+		setBootstrapState('cold');
+		let release!: (v: unknown) => void;
+		searchApi.mockReturnValue(new Promise((r) => { release = r; }));
+		render(ItemPicker, { props: { ...createProps, oncreate: vi.fn() } });
+		await tick();
+
+		await type('Purple');
+		await vi.advanceTimersByTimeAsync(300);
+		expect(createRow()).toBeNull();
+		expect(input().getAttribute('aria-expanded')).toBe('false');
+
+		release({ results: [] });
+		await vi.waitFor(() => expect(createRow()).not.toBeNull());
+		expect(input().getAttribute('aria-expanded')).toBe('true');
+		vi.useRealTimers();
+	});
+
+	it('is keyboard-reachable as the last row, and Enter invokes it with the trimmed query', async () => {
+		loadIndex([
+			{ id: 'id-1', title: 'Purple Rain', item_number: 1, collection_prefix: 'COLO' },
+		]);
+		localSearchMock.search.mockReturnValue([{ id: 'id-1', score: 1 }]);
+		const oncreate = vi.fn();
+		const onselect = vi.fn();
+		render(ItemPicker, { props: { ...createProps, oncreate, onselect } });
+		await tick();
+
+		await type('  Purple  ');
+		await press('ArrowDown');
+		expect(options()[0].getAttribute('aria-selected')).toBe('true');
+		await press('ArrowDown');
+		expect(createRow()!.getAttribute('aria-selected')).toBe('true');
+		expect(input().getAttribute('aria-activedescendant')).toBe(createRow()!.id);
+
+		await press('Enter');
+		expect(oncreate).toHaveBeenCalledTimes(1);
+		expect(oncreate).toHaveBeenCalledWith('Purple');
+		// Enter on the create row must not ALSO select whatever row it replaced.
+		expect(onselect).not.toHaveBeenCalled();
+	});
+
+	it('clicking the create row invokes it', async () => {
+		loadIndex([]);
+		localSearchMock.search.mockReturnValue([]);
+		const oncreate = vi.fn();
+		render(ItemPicker, { props: { ...createProps, oncreate } });
+		await tick();
+
+		await type('Purple');
+		createRow()!.click();
+
+		expect(oncreate).toHaveBeenCalledTimes(1);
+		expect(oncreate).toHaveBeenCalledWith('Purple');
+	});
+
+	it('does not fire a second create while the first is still in flight', async () => {
+		// The duplicate this guards is not the same-text-twice case the exact
+		// match covers — it is one impatient user and two Enters inside a single
+		// round trip, when no row exists yet to suppress anything.
+		loadIndex([]);
+		localSearchMock.search.mockReturnValue([]);
+		let release!: () => void;
+		const oncreate = vi.fn(() => new Promise<void>((r) => { release = () => r(); }));
+		render(ItemPicker, { props: { ...createProps, oncreate } });
+		await tick();
+
+		await type('Purple');
+		await press('ArrowDown');
+		await press('Enter');
+		await press('Enter');
+		expect(oncreate).toHaveBeenCalledTimes(1);
+
+		release();
+		await tick();
+	});
+});

--- a/web/src/lib/components/items/ItemPicker.svelte.test.ts
+++ b/web/src/lib/components/items/ItemPicker.svelte.test.ts
@@ -484,6 +484,37 @@ describe('ItemPicker — the collection scope is a tracked input', () => {
 		expect(options().map((o) => o.textContent)).toEqual([expect.stringContaining('Large')]);
 	});
 
+	it('re-queries after a reset even when the scope never changed', async () => {
+		// codex round 13. The reset CLEARED the rows, so the picker has nothing
+		// for its scope — but the scope itself is unchanged, and a `lastScope`
+		// left in place compares equal at rehydration. A server-sourced picker
+		// then takes the early return and sits empty permanently, because
+		// nothing else will re-query it.
+		searchApi.mockResolvedValue(
+			page([{ item: { id: 'c-1', title: 'Red', item_number: 1, collection_prefix: 'COLO' } }]),
+		);
+		setBootstrapState('ready');
+		loadIndex([]);
+		render(ItemPickerProbe, {
+			props: { wsSlug: 'ws', collection: 'colors', source: 'server', onselect: () => {} },
+		});
+		await tick();
+		await type('e');
+		await vi.waitFor(() => expect(options().length).toBe(1));
+
+		setBootstrapState('reset');
+		bumpEpoch();
+		await tick();
+		await tick();
+		expect(options()).toHaveLength(0);
+
+		// Same workspace, same collection, back to ready.
+		setBootstrapState('ready');
+		bumpEpoch();
+		await vi.waitFor(() => expect(searchApi).toHaveBeenCalledTimes(2));
+		await vi.waitFor(() => expect(options().length).toBe(1));
+	});
+
 	it('serves a scope change that arrived while the index was cold, once it hydrates', async () => {
 		// codex round 12. The not-ready branch clears and gives up WITHOUT
 		// serving the scope, so committing `lastScope` there consumes a refresh

--- a/web/src/lib/components/items/ItemPicker.svelte.test.ts
+++ b/web/src/lib/components/items/ItemPicker.svelte.test.ts
@@ -780,6 +780,17 @@ describe('ItemPicker — inline create (PLAN-2857 U8)', () => {
 
 	const createProps = { ...baseProps, createLabel: 'Colors' };
 
+	/**
+	 * A COMPLETE `/search` page, in the shape the server actually returns.
+	 *
+	 * `total`, `limit` and `offset` are non-optional on `SearchResponse` and the
+	 * Go handler always sends them, so a fixture omitting them is not a smaller
+	 * version of a real response — it is one that cannot occur, and it was
+	 * quietly deciding the completeness question these tests are about.
+	 */
+	const page = (results: unknown[]) => ({ results, total: results.length, limit: 50, offset: 0 });
+	const emptyPage = () => page([]);
+
 	it('offers no create row when the host passes no oncreate — the Relationships-tab caller', async () => {
 		loadIndex(makeRows(3));
 		localSearchMock.search.mockReturnValue([]);
@@ -903,7 +914,7 @@ describe('ItemPicker — inline create (PLAN-2857 U8)', () => {
 		expect(createRow()).toBeNull();
 		expect(input().getAttribute('aria-expanded')).toBe('false');
 
-		release({ results: [] });
+		release(emptyPage());
 		await vi.waitFor(() => expect(createRow()).not.toBeNull());
 		expect(input().getAttribute('aria-expanded')).toBe('true');
 		vi.useRealTimers();
@@ -980,9 +991,9 @@ describe('ItemPicker — inline create (PLAN-2857 U8)', () => {
 		// duplicate of a row `/search` just returned.
 		setBootstrapState('cold');
 		loadIndex([]);
-		searchApi.mockResolvedValue({
-			results: [{ item: { id: 'id-2', title: 'Purple', item_number: 2, collection_prefix: 'COLO' } }],
-		});
+		searchApi.mockResolvedValue(
+			page([{ item: { id: 'id-2', title: 'Purple', item_number: 2, collection_prefix: 'COLO' } }]),
+		);
 		render(ItemPicker, { props: { ...createProps, oncreate: vi.fn() } });
 		await tick();
 
@@ -1009,7 +1020,7 @@ describe('ItemPicker — inline create (PLAN-2857 U8)', () => {
 		expect(createRow()).toBeNull();
 
 		// And it must not latch: the next query gets a fresh verdict.
-		searchApi.mockResolvedValue({ results: [] });
+		searchApi.mockResolvedValue(emptyPage());
 		await type('Purple Haze');
 		await vi.waitFor(() => expect(createRow()).not.toBeNull());
 	});
@@ -1069,7 +1080,7 @@ describe('ItemPicker — inline create (PLAN-2857 U8)', () => {
 		vi.useFakeTimers();
 		setBootstrapState('cold');
 		loadIndex([]);
-		searchApi.mockResolvedValue({ results: [] });
+		searchApi.mockResolvedValue(emptyPage());
 		render(ItemPicker, { props: { ...createProps, oncreate: vi.fn() } });
 		await tick();
 
@@ -1091,7 +1102,7 @@ describe('ItemPicker — inline create (PLAN-2857 U8)', () => {
 		expect(input().getAttribute('aria-expanded')).toBe('false');
 		expect(createRow()).toBeNull();
 
-		release({ results: [] });
+		release(emptyPage());
 		await vi.waitFor(() => expect(createRow()).not.toBeNull());
 		vi.useRealTimers();
 	});
@@ -1101,14 +1112,19 @@ describe('ItemPicker — inline create (PLAN-2857 U8)', () => {
 		// exact title is not evidence the title is unused — the row may be on a
 		// page nobody fetched. Same defect as trusting the local ranker's
 		// window, arriving from the server side.
+		//
+		// Completeness is the PAGE LENGTH against the echoed limit, not `total`
+		// (codex round 8): a failed count query floors `total` up to
+		// `len(results)` server-side, so it cannot distinguish a complete page
+		// from a broken count.
 		setBootstrapState('cold');
 		loadIndex([]);
-		searchApi.mockResolvedValue({
-			results: [{ item: { id: 'id-9', title: 'Purple Haze', item_number: 9, collection_prefix: 'COLO' } }],
-			total: 84,
-			limit: 50,
-			offset: 0,
+		// A FULL page — as many rows as the limit — which is what truncation
+		// actually looks like on the wire.
+		const row = (n: number) => ({
+			item: { id: `id-${n}`, title: `Purple ${n}`, item_number: n, collection_prefix: 'COLO' },
 		});
+		searchApi.mockResolvedValue({ results: [row(1), row(2)], total: 84, limit: 2, offset: 0 });
 		render(ItemPicker, { props: { ...createProps, oncreate: vi.fn() } });
 		await tick();
 
@@ -1116,14 +1132,20 @@ describe('ItemPicker — inline create (PLAN-2857 U8)', () => {
 		await vi.waitFor(() => expect(options().length).toBeGreaterThan(0));
 		expect(createRow()).toBeNull();
 
-		// CONTROL: the identical shape with a COMPLETE page does offer it, so
-		// this leg is measuring truncation and not the query.
-		searchApi.mockResolvedValue({
-			results: [{ item: { id: 'id-9', title: 'Purple Haze', item_number: 9, collection_prefix: 'COLO' } }],
-			total: 1,
-			limit: 50,
-			offset: 0,
-		});
+		// The shape that discriminates PAGE LENGTH from `total`: a full page
+		// whose count query FAILED. `store.search` sets total = -1 on a count
+		// error, floors it to 0, then floors it again to len(results)
+		// (search.go:604-608) — so the wire says total === 2 with a page size of
+		// 2 and 84 rows really matching. Reading completeness off `total` calls
+		// that complete; reading it off the page length does not.
+		searchApi.mockResolvedValue({ results: [row(1), row(2)], total: 2, limit: 2, offset: 0 });
+		await type('Purple r');
+		await vi.waitFor(() => expect(options().length).toBeGreaterThan(0));
+		expect(createRow()).toBeNull();
+
+		// CONTROL: a page SHORTER than the limit is a complete answer and does
+		// offer it, so this leg measures truncation and not the query.
+		searchApi.mockResolvedValue({ results: [row(1)], total: 1, limit: 50, offset: 0 });
 		await type('Purpl');
 		await vi.waitFor(() => expect(createRow()).not.toBeNull());
 	});
@@ -1137,7 +1159,7 @@ describe('ItemPicker — inline create (PLAN-2857 U8)', () => {
 		// longer see anything in.
 		setBootstrapState('cold');
 		loadIndex([]);
-		searchApi.mockResolvedValue({ results: [] });
+		searchApi.mockResolvedValue(emptyPage());
 		render(ItemPicker, { props: { ...createProps, oncreate: vi.fn() } });
 		await tick();
 
@@ -1160,7 +1182,7 @@ describe('ItemPicker — inline create (PLAN-2857 U8)', () => {
 		// here because refusing to offer create while cold would strand the user.
 		setBootstrapState('cold');
 		loadIndex([{ id: 'id-2', title: 'Purple', item_number: 2, collection_prefix: 'COLO' }]);
-		searchApi.mockResolvedValue({ results: [] });
+		searchApi.mockResolvedValue(emptyPage());
 		render(ItemPicker, { props: { ...createProps, oncreate: vi.fn() } });
 		await tick();
 

--- a/web/src/lib/components/items/ItemPicker.svelte.test.ts
+++ b/web/src/lib/components/items/ItemPicker.svelte.test.ts
@@ -441,6 +441,39 @@ describe('ItemPicker — collection size does not change the control (PLAN-2857 
 	});
 });
 
+describe('ItemPicker — the collection scope is a tracked input', () => {
+	it('re-lists when the target collection changes under an open picker', async () => {
+		// codex round 10. A relation field's declared target can change while
+		// this picker is mounted — a schema edit, or an SSE-driven collection
+		// refresh — and `ItemDetail` does not remount it for that. Rows from the
+		// OLD collection must not stay on screen and selectable under the new
+		// scope.
+		const colours = [{ id: 'c-1', title: 'Red', item_number: 1, collection_prefix: 'COLO' }];
+		const sizes = [{ id: 's-1', title: 'Large', item_number: 1, collection_prefix: 'SIZE' }];
+		rowsById = new Map([...colours, ...sizes].map((r) => [r.id, r]));
+		localIndexMock.getByCollection.mockImplementation((_ws: string, coll: string) =>
+			coll === 'colors' ? colours : sizes,
+		);
+
+		// Driven through the probe's single-prop setter, NOT `rerender`: that
+		// replaces the whole props object and re-runs the picker's effect
+		// whether or not it tracks the scope, so a rerender-driven version of
+		// this test passes against the untracked build. The identical trap this
+		// host was created for.
+		const { component } = render(ItemPickerProbe, {
+			props: { wsSlug: 'ws', collection: 'colors', onselect: () => {} },
+		});
+		await tick();
+		expect(options().map((o) => o.textContent)).toEqual([expect.stringContaining('Red')]);
+
+		(component as unknown as { setCollection: (c: string) => void }).setCollection('sizes');
+		await tick();
+		await tick();
+
+		expect(options().map((o) => o.textContent)).toEqual([expect.stringContaining('Large')]);
+	});
+});
+
 describe('ItemPicker — source: the two callers want different models', () => {
 	// Lead ruling on PR #1241: the Relationships tab keeps the server FTS, which
 	// indexes item BODY CONTENT. `localIndex` strips `content` by design, so the

--- a/web/src/lib/components/items/ItemPickerProbe.svelte
+++ b/web/src/lib/components/items/ItemPickerProbe.svelte
@@ -25,6 +25,18 @@
 
 	let { wsSlug, collection, source = 'index', onselect = () => {} }: Props = $props();
 
+	// The scope, held locally for the same reason `excludeIds` is: a test that
+	// changed it through `rerender` would prove nothing, since that replaces the
+	// props object and re-runs the picker's effect whether or not it tracks the
+	// scope (codex round 10 — the identical trap this host was built for).
+	let scope = $state<string | undefined>(undefined);
+	let effectiveCollection = $derived(scope ?? collection);
+
+	/** Driven by the test to simulate a relation field's target changing. */
+	export function setCollection(next: string) {
+		scope = next;
+	}
+
 	// Starts empty and is only ever changed through `setExcludeIds` — seeding
 	// it from a prop would capture the initial value and warn.
 	let excludeIds = $state<string[]>([]);
@@ -35,4 +47,4 @@
 	}
 </script>
 
-<ItemPicker {wsSlug} {collection} {source} {excludeIds} {onselect} />
+<ItemPicker {wsSlug} collection={effectiveCollection} {source} {excludeIds} {onselect} />

--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -161,6 +161,12 @@ const workspaces = new SvelteMap<string, WorkspaceState>();
 // In-flight bootstrap promises live outside the reactive state — there
 // is no reason to proxy a Promise, and keeping it separate makes the
 // reactive-vs-internal split explicit.
+/**
+ * Per-workspace count of `reset()` calls, outliving the state it drops. See
+ * `resetGenerationFor` for why this cannot live on the state object.
+ */
+const resetGenerations = new Map<string, number>();
+
 const inflight = new Map<string, Promise<void>>();
 const projectionResyncs = new Map<string, Promise<void>>();
 
@@ -1304,6 +1310,28 @@ export const localIndex = {
 	},
 
 	/**
+	 * How many times this workspace's state has been DROPPED — sign-out, a
+	 * 403 membership purge, a workspace deletion.
+	 *
+	 * Deliberately kept OUTSIDE `workspaces`, unlike `scopeEpoch` and the
+	 * internal `generation`, because `reset()` deletes that entry: a counter
+	 * living on the state object restarts at 0 with the replacement, so
+	 * comparing it across a reset compares two different identities that
+	 * happen to agree. Those two are safe only because their readers hold a
+	 * REFERENCE to the state object; a caller outside this module cannot.
+	 *
+	 * For such a caller — one holding an in-flight request issued against this
+	 * workspace — capturing this before the request and requiring it unchanged
+	 * afterwards is what distinguishes "still the state I was authorized
+	 * against" from "a fresh state that has coincidentally reached the same
+	 * numbers". `scopeEpochFor` answers the resync question and this answers
+	 * the identity one; a write-back needs both (TASK-2877).
+	 */
+	resetGenerationFor(ws: string): number {
+		return resetGenerations.get(ws) ?? 0;
+	},
+
+	/**
 	 * Current bootstrap state. Used by route loaders to decide whether
 	 * to render a spinner, the items, or an error. Returns `'cold'`
 	 * for unknown workspaces so first-visit consumers see a sane
@@ -1320,6 +1348,11 @@ export const localIndex = {
 	 * user's cache. After reset, `bootstrap(ws)` from cold.
 	 */
 	reset(ws: string): void {
+		// Bumped for EVERY reset, including one for a workspace with no state
+		// yet: a caller's captured value has to change even when the drop found
+		// nothing to drop, or a purge racing a first bootstrap reads as no
+		// purge at all.
+		resetGenerations.set(ws, (resetGenerations.get(ws) ?? 0) + 1);
 		const prior = workspaces.get(ws);
 		// Bump generation on the prior state object BEFORE deleting
 		// it from the map. Any in-flight bootstrap promise still holds

--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -167,6 +167,18 @@ const workspaces = new SvelteMap<string, WorkspaceState>();
  */
 const resetGenerations = new Map<string, number>();
 
+/**
+ * Record that a workspace's rows are gone. EVERY path that drops them calls
+ * this — `reset()`, which deletes the whole state entry, and `bootstrap()`'s
+ * 401/403 branch, which clears the rows in place. Two call sites rather than
+ * one because the operations genuinely differ; the shared helper is what makes
+ * the pairing greppable, and `localIndexResetGeneration.svelte.test.ts` fails
+ * if a third site starts clearing rows without it.
+ */
+function markWorkspaceDropped(ws: string): void {
+	resetGenerations.set(ws, (resetGenerations.get(ws) ?? 0) + 1);
+}
+
 const inflight = new Map<string, Promise<void>>();
 const projectionResyncs = new Map<string, Promise<void>>();
 
@@ -677,6 +689,19 @@ export const localIndex = {
 							state.pendingResync = false;
 							state.items.clear();
 							state.cursor = '0';
+							// This IS a drop, so it counts as one
+							// (TASK-2877). `resetGenerationFor`'s
+							// contract is "the state you captured is
+							// gone", and an in-flight write-back that
+							// resolves after this would otherwise
+							// resurrect rows into a workspace whose
+							// access was just revoked — the case the
+							// accessor exists for. Bumped here rather
+							// than by funnelling through `reset()`,
+							// which also deletes the state entry and
+							// would change what the caller's redirect
+							// handler finds.
+							markWorkspaceDropped(ws);
 							// Drop the MiniSearch index in lockstep with
 							// the cleared in-RAM rows so a stale search
 							// result can't navigate the user to a
@@ -1352,7 +1377,7 @@ export const localIndex = {
 		// yet: a caller's captured value has to change even when the drop found
 		// nothing to drop, or a purge racing a first bootstrap reads as no
 		// purge at all.
-		resetGenerations.set(ws, (resetGenerations.get(ws) ?? 0) + 1);
+		markWorkspaceDropped(ws);
 		const prior = workspaces.get(ws);
 		// Bump generation on the prior state object BEFORE deleting
 		// it from the map. Any in-flight bootstrap promise still holds

--- a/web/src/lib/stores/localIndexResetGeneration.svelte.test.ts
+++ b/web/src/lib/stores/localIndexResetGeneration.svelte.test.ts
@@ -1,0 +1,73 @@
+// `resetGenerationFor` (TASK-2877): the identity signal a caller outside this
+// module needs to tell "still the state I was authorized against" from "a fresh
+// state that has reached the same numbers".
+//
+// The properties under test are exactly the ones the two existing counters do
+// NOT have, which is why this had to be new surface rather than a reuse:
+// `scopeEpoch` lives on the state object and `reset()` deletes that object, so
+// the replacement starts at 0 — and 0 is also the value whenever no projection
+// resync has ever run, i.e. the ordinary case. Comparing it across a reset
+// therefore compares two different identities that agree by default.
+import { afterEach, describe, expect, it } from 'vitest';
+import { localIndex } from './localIndex.svelte';
+import type { ItemIndexRow } from '$lib/types';
+
+const ws = 'reset-generation-test';
+
+function row(id: string, seq: number): ItemIndexRow {
+	return {
+		id,
+		seq,
+		collection_slug: 'colors',
+		created_at: '2026-01-01T00:00:00Z',
+		updated_at: '2026-01-01T00:00:00Z',
+	} as ItemIndexRow;
+}
+
+afterEach(() => {
+	localIndex.reset(ws);
+});
+
+describe('localIndex.resetGenerationFor', () => {
+	it('is 0 for a workspace it has never seen', () => {
+		expect(localIndex.resetGenerationFor('never-touched-workspace')).toBe(0);
+	});
+
+	it('advances on every reset and does NOT restart with the new state', () => {
+		const before = localIndex.resetGenerationFor(ws);
+		localIndex.upsert(ws, row('a', 1));
+		expect(localIndex.resetGenerationFor(ws)).toBe(before);
+
+		localIndex.reset(ws);
+		const afterFirst = localIndex.resetGenerationFor(ws);
+		expect(afterFirst).toBe(before + 1);
+
+		// The point of the whole accessor: the workspace is live again, and the
+		// counter has NOT gone back to where it was.
+		localIndex.upsert(ws, row('b', 1));
+		expect(localIndex.resetGenerationFor(ws)).toBe(afterFirst);
+
+		localIndex.reset(ws);
+		expect(localIndex.resetGenerationFor(ws)).toBe(before + 2);
+	});
+
+	it('advances even when the reset found no state to drop', () => {
+		// A purge racing a first bootstrap must not read as "no purge happened".
+		const fresh = 'reset-generation-test-unseen';
+		const before = localIndex.resetGenerationFor(fresh);
+		localIndex.reset(fresh);
+		expect(localIndex.resetGenerationFor(fresh)).toBe(before + 1);
+	});
+
+	it('CONTROL: scopeEpochFor cannot answer this question', () => {
+		// Not a test of the store so much as of the premise the fence rests on.
+		// If this ever stops holding, the caller-side equality check on
+		// `scopeEpoch` would have been sufficient after all.
+		localIndex.upsert(ws, row('a', 1));
+		const epochBefore = localIndex.scopeEpochFor(ws);
+		localIndex.reset(ws);
+		localIndex.upsert(ws, row('b', 1));
+		expect(localIndex.scopeEpochFor(ws)).toBe(epochBefore);
+		expect(localIndex.resetGenerationFor(ws)).not.toBe(0);
+	});
+});

--- a/web/src/lib/stores/localIndexResetGeneration.svelte.test.ts
+++ b/web/src/lib/stores/localIndexResetGeneration.svelte.test.ts
@@ -9,6 +9,8 @@
 // resync has ever run, i.e. the ordinary case. Comparing it across a reset
 // therefore compares two different identities that agree by default.
 import { afterEach, describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { localIndex } from './localIndex.svelte';
 import type { ItemIndexRow } from '$lib/types';
 
@@ -57,6 +59,47 @@ describe('localIndex.resetGenerationFor', () => {
 		const before = localIndex.resetGenerationFor(fresh);
 		localIndex.reset(fresh);
 		expect(localIndex.resetGenerationFor(fresh)).toBe(before + 1);
+	});
+
+	it('every path that drops a workspace\u2019s rows counts as a drop', () => {
+		// codex round 7: `bootstrap()`'s unauthorized/forbidden branch clears
+		// `items`, resets the search index and wipes the persisted cache — every
+		// bit a drop — but does NOT go through `reset()`. A generation bumped
+		// only there misses exactly the revocation case the fence exists for.
+		//
+		// Asserted STRUCTURALLY rather than by driving that branch. Reaching it
+		// through the front door needs a warm cache plus a pending resync plus a
+		// 401 from /items-changes, which is a fixture larger than the invariant
+		// it would check; and the invariant — "clearing rows and counting the
+		// drop travel together" — is what actually has to hold. The site-count
+		// assertion is the part that keeps this honest: a NEW clear site fails
+		// this test loudly instead of being silently unexamined, which is how an
+		// enumeration instrument usually rots.
+		// Resolved from the vitest root (`web/`) rather than `import.meta.url`:
+		// in this project's jsdom environment that is not a file: URL.
+		const src = readFileSync(
+			resolve(process.cwd(), 'src/lib/stores/localIndex.svelte.ts'),
+			'utf8',
+		);
+
+		const clearSites = [...src.matchAll(/state\.items\.clear\(\)/g)].map((m) => m.index ?? 0);
+		expect(
+			clearSites.length,
+			'a new site clears the row map — does it call markWorkspaceDropped?',
+		).toBe(1);
+
+		for (const at of clearSites) {
+			const window = src.slice(at, at + 1200);
+			expect(window, 'rows cleared without counting the drop').toContain('markWorkspaceDropped(ws)');
+		}
+
+		// And the helper is the only writer, so the two cannot drift apart by
+		// someone bumping the counter inline somewhere new.
+		const writes = [...src.matchAll(/resetGenerations\.set\(/g)];
+		expect(writes.length).toBe(1);
+		expect(src).toMatch(/function markWorkspaceDropped/);
+		// Both known droppers go through it.
+		expect([...src.matchAll(/markWorkspaceDropped\(ws\)/g)].length).toBe(2);
 	});
 
 	it('CONTROL: scopeEpochFor cannot answer this question', () => {


### PR DESCRIPTION
Unit **U8** of the relation-fields design pass ([[PLAN-2857]]), closing TASK-2877. Blocked only by U3 (merged `7fde7a3c`), so it was startable while U1 waited on #1240.

## What it does

When the scoped relation picker's query matches nothing — or nothing **exactly** — it offers a trailing `+ Create "<query>" in <Collection>` row, keyboard-reachable like any other row. Choosing it creates the item in the field's **declared target collection**, sets the field to the new item's id, and renders U2's chip.

The affordance is **opt-in at the call site**: the picker offers it only when handed an `oncreate`. Both of the unit's scope rules are expressed that way rather than by the picker knowing them — "relation fields only" is the Relationships tab passing nothing, and the permission gate is `FieldEditor` withholding it when `canEditCollection` says no for the target.

## The proving test, driven end to end in a real browser

Scratch instance on port 7891 with its own temp HOME + SQLite, built from this branch. Nothing shared was touched: not `:7777`, not the installed binary, not the shared Postgres on 5445.

- Typed `Chartreuse` against Cars/Colors. Options were exactly `["+ Create \"Chartreuse\" in Colors"]`; `aria-expanded` true; `ArrowDown` put `aria-activedescendant` on the create row; Enter created it.
- Server state after that one Enter: **colors 2 → 3, cars unchanged at 2.** `CAR-5.fields.color` holds `COLO-6`'s uuid. First leg, end to end.
- The created row came back `{"status":"approved"}` — the schema's declared **default**. The Colors fixture was deliberately `options: [draft, approved]` with `default: approved` so the two disagree, because the collection page's "+ New" guesses `status.options[0]` and would have written `draft`. This unit sends **no fields** and lets the server apply defaults (`items.ValidateFields` → "Marshal validated/defaulted fields back").
- Second pass at the same text: options `["COLO-6 Chartreuse"]`, **create row count 0**, Enter selected the existing row, colors still 3. Second leg.
- Escape leaves the value untouched. No bare UUID anywhere in the page text.
- Create-row geometry checked explicitly (342px in a 342px list, 30px tall, no overflow) because U3's browser pass found a flex `align-items: stretch` bug that 30 component tests missed.

## One rule, asked in four places

Every gate here is the same sentence: **offer only where something authoritative has answered.** It took five review rounds to state it once instead of five times.

| Situation | Authority | Verdict |
|---|---|---|
| Index settled | the in-RAM collection | scan it |
| Index `ready` but `pendingResync` | a cache snapshot delta-sync has not reconciled | withhold |
| Cold, `/search` answered a **complete** page | the server | offer |
| Cold, search failed / truncated / workspace dropped | nothing | withhold |

Completeness is read from the **page length against the echoed limit**, never from `total`: when the count query fails, `store.search` sets `total = -1`, floors it to 0, then floors it again to `len(results)` (`internal/store/search.go:604-608`), so a broken count is indistinguishable on the wire from an exact-fit page.

## Gates

- `npx vitest run` — **124 files, 2108 passed, 0 failed**
- `npm run check` — **1093 files, 0 errors, 6 warnings**, all six pre-existing and in files this branch does not touch (this branch introduced two and removed them again)
- `npx vite build` — clean · `make build-go` — clean
- **Zero Go files changed**, so the Go and PG gates are unchanged from the base and are left to CI
- **Mutation matrix: 35 mutants, all killed**; baseline and restore both 97/97

## Codex review: 13 rounds, 20 findings

17 taken, 3 declined with the reasoning **in the code** — a round-3 decline that lived only in a commit message got re-raised in round 7, because a reviewer reading the diff never sees a commit message.

Round 6 corrected a residual round 5 had dismissed as needing a coincidence: `reset()` deletes the workspace state and the replacement starts at `scopeEpoch` 0, which is *also* the value whenever no resync ever ran — so the equality check passed trivially across the exact event it was added to catch. That needed new store surface, `localIndex.resetGenerationFor(ws)`, deliberately kept outside the `workspaces` map because `reset()` deletes that entry.

**Round 14 could not be obtained**: three consecutive 10-minute timeouts at 0 bytes. Not a broken CLI — two other sessions were running concurrent `codex exec` jobs on this machine. Reported rather than rounded up to CLEAN.

## Follow-up filed

[[IDEA-2880]] — `item create` has no idempotency key, so a lost response makes a retry duplicate. Deliberately not patched client-side: checking for a same-title item before retrying rests on the same ranked, paged, possibly-stale evidence the create row itself rests on, and would look like a guarantee the client cannot make.
