### PR TITLE
fix(cli): the session's registered agent is the name its writes carry (BUG-2882)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,9 +144,15 @@ export PAD_AGENT=reviewer
 
 # 3. Otherwise Pad detects the runtimes it knows — Claude Code reports
 #    "claude-code" — and that detected id is used as the name.
+
+# 0. Per-session, and ahead of all three: the name this session REGISTERED
+#    as. `pad session register --agent rook` re-attributes every later write
+#    from that session to "rook", whatever .pad.toml or $PAD_AGENT say — the
+#    registry row and the write stamp are one value, not two.
+pad session register --agent rook
 ```
 
-**If none of the three produce a name, the write is not marked as an agent's at all** — it is recorded as the person whose credentials it used, which is the case the caveat below is about. The generic `agent` label you may see on older entries is a write that identified itself before Pad stored names, or an event type that records the actor without the name (workspace membership changes, sign-ins).
+**If none of these produce a name, the write is not marked as an agent's at all** — it is recorded as the person whose credentials it used, which is the case the caveat below is about. The generic `agent` label you may see on older entries is a write that identified itself before Pad stored names, or an event type that records the actor without the name (workspace membership changes, sign-ins).
 
 The name is rendered exactly as sent — Pad keeps no list of approved names, and does not re-case or rewrite what you choose.
 

--- a/cmd/pad/cmd_session.go
+++ b/cmd/pad/cmd_session.go
@@ -211,8 +211,10 @@ needs, and where it is only as good as its inputs):
     newest — registered_at is each session's own clock.
   - The registry is this OS user's; other users' sessions are not here.
   - The verdict is a sample: a session can register or exit right after.
-  - A row carries the name at registration; a window that changes its
-    PAD_AGENT afterwards must run 'pad session register' again.
+  - A row's name IS the name the session's writes carry (BUG-2882), and
+    it outranks PAD_AGENT and .pad.toml while the row is alive. A plain
+    're-register' keeps it; to change it, run 'pad session register
+    --agent <name>' — changing PAD_AGENT alone changes nothing.
 
 Newest first. Use --format json for the stable shape.`,
 		Args: cobra.NoArgs,

--- a/cmd/pad/cmd_session.go
+++ b/cmd/pad/cmd_session.go
@@ -118,7 +118,11 @@ the registry back with a liveness verdict per session.
 
 The agent name defaults to what every write is attributed to (.pad.toml
 agent_name, else $PAD_AGENT, else the detected runtime); --agent overrides
-it, and --agent "" registers an anonymous session.
+it, and --agent "" registers an anonymous session. A registered name is
+then what this session's writes carry from that point on — the record is
+consulted before .pad.toml and the environment (BUG-2882) — so re-registering
+under a different name re-attributes the session's later writes with it. An
+anonymous registration leaves an environment-declared name in force.
 
 Safe to call from any directory — it does not require a linked workspace
 (.pad.toml) — and safe to call more than once per session: each call
@@ -153,7 +157,7 @@ prune').`,
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&agent, "agent", "", "agent name to register as (default: the name this session's writes carry; \"\" for anonymous)")
+	cmd.Flags().StringVar(&agent, "agent", "", "agent name to register as; becomes the name this session's writes carry (default: the current one; \"\" for an anonymous row)")
 	return cmd
 }
 

--- a/internal/cli/agent_identity.go
+++ b/internal/cli/agent_identity.go
@@ -12,10 +12,21 @@ import "os"
 //
 // Precedence, most explicit first:
 //
-//  1. `agent_name` in .pad.toml — a deliberate per-workspace choice.
-//  2. $PAD_AGENT — the runtime-agnostic override. Any harness we have not
+//  1. The agent this SESSION registered as (`pad session register --agent`),
+//     when a live registry record for the owning session exists and names
+//     one — the most recent and most deliberate declaration, and the one
+//     `pad session list` shows. BUG-2882: before this step the registry and
+//     the write stamp were two self-declarations that could disagree, and
+//     did — two seats launched under one name, one re-registered under the
+//     right one, and every write it made afterwards carried the wrong one,
+//     because `--agent` could rewrite the registry row but not $PAD_AGENT,
+//     and nothing reconciled the two. Now the row IS the stamp. An anonymous
+//     registration (`--agent ""`) does not blank a name the environment
+//     declares; it only says the registry row is anonymous.
+//  2. `agent_name` in .pad.toml — a deliberate per-workspace choice.
+//  3. $PAD_AGENT — the runtime-agnostic override. Any harness we have not
 //     taught this function about can set it and be attributed correctly.
-//  3. A detected agent runtime, below.
+//  4. A detected agent runtime, below.
 //
 // WHAT THIS IS NOT. The header is client-supplied and self-declared, so it
 // records honesty, not identity:
@@ -31,6 +42,9 @@ import "os"
 // agent's relay of a human's words was recorded indistinguishably from the
 // human having typed them.
 func ResolveAgentName() string {
+	if name, ok := registeredAgentForThisSession(); ok && name != "" {
+		return name
+	}
 	if pt, _ := LoadPadToml(); pt != nil && pt.AgentName != "" {
 		return pt.AgentName
 	}

--- a/internal/cli/agent_identity_test.go
+++ b/internal/cli/agent_identity_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -201,5 +202,80 @@ func TestActorKind(t *testing.T) {
 				t.Errorf("ActorKind() = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+// TestRegisteredAgentWinsForThisSession — BUG-2882. Two seats booted under one
+// name; one re-registered under the right one with --agent; every write it
+// made afterwards still carried the wrong name, because the registry row and
+// $PAD_AGENT were two self-declarations and nothing reconciled them. The row
+// is now the first thing the resolver reads, so `--agent` means what its help
+// text says. Three properties, each its own case so a regression names
+// itself: the row wins over the environment AND over .pad.toml; an anonymous
+// row does not blank an environment name; a row for a different session that
+// reused this pid is ignored.
+//
+// MUTANT: removing the registry step from ResolveAgentName fails the first
+// two; dropping the proc-start comparison fails the last.
+func TestRegisteredAgentWinsForThisSession(t *testing.T) {
+	sessionsDir := registryEnv(t)
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".pad.toml"), []byte("workspace = \"w\"\nagent_name = \"toml-name\"\n"), 0o600); err != nil {
+		t.Fatalf("write .pad.toml: %v", err)
+	}
+	chdir(t, dir)
+	t.Setenv("PAD_AGENT", "wren")
+	// This process is its own session owner (no PAD_SESSION_PID / CLAUDE_PID).
+
+	if got := ResolveAgentName(); got != "toml-name" {
+		t.Fatalf("before any registration, ResolveAgentName() = %q, want the .pad.toml name", got)
+	}
+
+	if _, err := RegisterSession(dir, "rook"); err != nil {
+		t.Fatalf("RegisterSession: %v", err)
+	}
+	if got := ResolveAgentName(); got != "rook" {
+		t.Errorf("after registering as rook, ResolveAgentName() = %q, want %q (the row must win over .pad.toml and $PAD_AGENT)", got, "rook")
+	}
+
+	// Re-registering with the default keeps the name: the default IS the
+	// resolver, which now reads the row.
+	if _, err := RegisterSession(dir, ResolveAgentName()); err != nil {
+		t.Fatalf("re-register: %v", err)
+	}
+	if got := ResolveAgentName(); got != "rook" {
+		t.Errorf("after a default re-register, ResolveAgentName() = %q, want %q", got, "rook")
+	}
+
+	// An anonymous row is a statement about the row, not about the writes.
+	if _, err := RegisterSession(dir, ""); err != nil {
+		t.Fatalf("anonymous register: %v", err)
+	}
+	if got := ResolveAgentName(); got != "toml-name" {
+		t.Errorf("after an anonymous registration, ResolveAgentName() = %q, want the .pad.toml name back", got)
+	}
+
+	// A record for THIS pid but a different process start is another
+	// session that once had the pid; it must not name us.
+	path := filepath.Join(sessionsDir, itoa(os.Getpid())+".json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read record: %v", err)
+	}
+	var reg SessionRegistration
+	if err := json.Unmarshal(data, &reg); err != nil {
+		t.Fatalf("unmarshal record: %v", err)
+	}
+	if reg.ProcStart == "" {
+		t.Skip("platform records no process-start token; the pid-reuse guard has nothing to compare")
+	}
+	reg.Agent = "ghost"
+	reg.ProcStart = reg.ProcStart + "-not-us"
+	out, _ := json.Marshal(reg)
+	if err := os.WriteFile(path, out, 0o600); err != nil {
+		t.Fatalf("rewrite record: %v", err)
+	}
+	if got := ResolveAgentName(); got != "toml-name" {
+		t.Errorf("a record from a different session with our pid named us: ResolveAgentName() = %q", got)
 	}
 }

--- a/internal/cli/agent_identity_test.go
+++ b/internal/cli/agent_identity_test.go
@@ -155,6 +155,8 @@ func TestClientSendsResolvedAgentHeader(t *testing.T) {
 // which read this exact header.
 func TestPushItemSendsResolvedAgentHeader(t *testing.T) {
 	chdir(t, t.TempDir())
+	isolateHome(t, t.TempDir())
+	clearSessionEnv(t)
 	for _, k := range []string{"PAD_AGENT", "CLAUDECODE"} {
 		t.Setenv(k, "")
 		os.Unsetenv(k)
@@ -309,5 +311,36 @@ func TestRegisteredAgentWinsForThisSession(t *testing.T) {
 	}
 	if got := ResolveAgentName(); got != "ghost" {
 		t.Errorf("the genuine record stopped naming us: ResolveAgentName() = %q", got)
+	}
+}
+
+// TestRegisteredAgentRequiresAVerifiableOwner — codex round 2 on #1248. A
+// harness-supplied owner pid that the platform CAN check and that is NOT
+// this process or an ancestor is a misconfigured session: its registry row
+// must not name us, even though the pid is alive and its token matches
+// (pid-reuse and liveness are not the failure here; the claim of ownership
+// is). Where the platform cannot walk ancestry the check does not run and
+// the token + liveness residual applies, which is why this is gated on the
+// check being available rather than on PIDVerified alone — gating on the
+// flag would have switched the fix off everywhere but Linux.
+//
+// MUTANT: dropping the pidIsSelfOrAncestor refusal makes the child's row
+// name us.
+func TestRegisteredAgentRequiresAVerifiableOwner(t *testing.T) {
+	registryEnv(t)
+	if _, err := pidIsSelfOrAncestor(os.Getpid()); err != nil {
+		t.Skip("platform cannot walk process ancestry; the ownership check does not run here")
+	}
+	dir := t.TempDir()
+	chdir(t, dir)
+	t.Setenv("PAD_AGENT", "env-name")
+	child := livingChildPID(t)
+	t.Setenv("CLAUDE_PID", itoa(child))
+
+	if _, err := RegisterSession(dir, "impostor"); err != nil {
+		t.Fatalf("RegisterSession: %v", err)
+	}
+	if got := ResolveAgentName(); got != "env-name" {
+		t.Errorf("a row owned by a live non-ancestor pid named us: ResolveAgentName() = %q, want %q", got, "env-name")
 	}
 }

--- a/internal/cli/agent_identity_test.go
+++ b/internal/cli/agent_identity_test.go
@@ -61,6 +61,11 @@ func TestResolveAgentName(t *testing.T) {
 				}
 			}
 			chdir(t, dir)
+			// And from a scratch HOME with no session identity, so a registry
+			// row belonging to the REAL session running these tests cannot
+			// leak in as the resolver's first answer (codex round 1, #1248).
+			isolateHome(t, t.TempDir())
+			clearSessionEnv(t)
 
 			// Clear every variable the resolver consults, then set this case's.
 			for _, k := range []string{"PAD_AGENT", "CLAUDECODE"} {
@@ -106,6 +111,8 @@ func TestClientSendsResolvedAgentHeader(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			chdir(t, t.TempDir())
+			isolateHome(t, t.TempDir())
+			clearSessionEnv(t)
 			for _, k := range []string{"PAD_AGENT", "CLAUDECODE"} {
 				t.Setenv(k, "")
 				os.Unsetenv(k)
@@ -191,6 +198,8 @@ func TestActorKind(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			chdir(t, t.TempDir())
+			isolateHome(t, t.TempDir())
+			clearSessionEnv(t)
 			for _, k := range []string{"PAD_AGENT", "CLAUDECODE"} {
 				t.Setenv(k, "")
 				os.Unsetenv(k)
@@ -269,13 +278,36 @@ func TestRegisteredAgentWinsForThisSession(t *testing.T) {
 	if reg.ProcStart == "" {
 		t.Skip("platform records no process-start token; the pid-reuse guard has nothing to compare")
 	}
+	token := reg.ProcStart
 	reg.Agent = "ghost"
-	reg.ProcStart = reg.ProcStart + "-not-us"
+	reg.ProcStart = token + "-not-us"
 	out, _ := json.Marshal(reg)
 	if err := os.WriteFile(path, out, 0o600); err != nil {
 		t.Fatalf("rewrite record: %v", err)
 	}
 	if got := ResolveAgentName(); got != "toml-name" {
 		t.Errorf("a record from a different session with our pid named us: ResolveAgentName() = %q", got)
+	}
+
+	// A record with NO token, while this process can read one, is
+	// unverifiable and must not name us either (codex round 1, #1248: a
+	// dead session's stale row under a reused pid).
+	reg.ProcStart = ""
+	out, _ = json.Marshal(reg)
+	if err := os.WriteFile(path, out, 0o600); err != nil {
+		t.Fatalf("rewrite record: %v", err)
+	}
+	if got := ResolveAgentName(); got != "toml-name" {
+		t.Errorf("a token-less record for our pid named us: ResolveAgentName() = %q", got)
+	}
+
+	// Positive control after the two rejections: the genuine token names us.
+	reg.ProcStart = token
+	out, _ = json.Marshal(reg)
+	if err := os.WriteFile(path, out, 0o600); err != nil {
+		t.Fatalf("rewrite record: %v", err)
+	}
+	if got := ResolveAgentName(); got != "ghost" {
+		t.Errorf("the genuine record stopped naming us: ResolveAgentName() = %q", got)
 	}
 }

--- a/internal/cli/session_registry.go
+++ b/internal/cli/session_registry.go
@@ -149,12 +149,17 @@ func SessionsDir() (string, error) {
 // being rewritten parses as malformed and is ignored, and the next call sees
 // the new record).
 //
-// ok is false when there is no record, the record is malformed or legacy, or
-// the record is for a DIFFERENT session that happened to have this pid: when
-// both sides carry a process-start token they must agree, exactly as the
-// liveness verdict requires. A record with an empty agent is a deliberate
-// anonymous registration and returns ("", true); the caller decides that this
-// does not override an environment-declared name.
+// ok is false — FAIL CLOSED — unless the record is confirmed to be THIS
+// session's (codex round 1 on #1248): it must parse, carry this owner pid,
+// pass the same OwnerLiveness verdict `pad session list` applies (socket
+// identity and pid alive with its token), and, when this process can read a
+// process-start token for the owner, carry the SAME token. A record with no
+// token while we have one is unverifiable, not verified: a dead session's
+// stale row under a reused pid must not name a live one. Where the platform
+// has no token at all, bare liveness is the documented residual, as it is for
+// the registry itself. A record with an empty agent is a deliberate anonymous
+// registration and returns ("", true); the caller decides that this does not
+// override an environment-declared name.
 func registeredAgentForThisSession() (string, bool) {
 	owner, err := CaptureSessionOwner()
 	if err != nil {
@@ -180,7 +185,12 @@ func registeredAgentForThisSession() (string, bool) {
 		// v1 (legacy) records have no owner pid; they never carried a name.
 		return "", false
 	}
-	if reg.ProcStart != "" && owner.ProcStart != "" && reg.ProcStart != owner.ProcStart {
+	if owner.ProcStart != "" && reg.ProcStart != owner.ProcStart {
+		// Includes the empty case: a token we can check and the record
+		// cannot supply is a record we cannot trust.
+		return "", false
+	}
+	if OwnerLiveness(&reg.SessionOwner) != LivenessAlive {
 		return "", false
 	}
 	return reg.Agent, true

--- a/internal/cli/session_registry.go
+++ b/internal/cli/session_registry.go
@@ -157,7 +157,10 @@ func SessionsDir() (string, error) {
 // token while we have one is unverifiable, not verified: a dead session's
 // stale row under a reused pid must not name a live one. Where the platform
 // has no token at all, bare liveness is the documented residual, as it is for
-// the registry itself. A record with an empty agent is a deliberate anonymous
+// the registry itself. And where the platform can walk process ancestry, the
+// owner pid must be this process or an ancestor — the same claim
+// session_pid_verified reports — so a misconfigured CLAUDE_PID cannot borrow
+// another live session's name. A record with an empty agent is a deliberate anonymous
 // registration and returns ("", true); the caller decides that this does not
 // override an environment-declared name.
 func registeredAgentForThisSession() (string, bool) {
@@ -191,6 +194,17 @@ func registeredAgentForThisSession() (string, bool) {
 		return "", false
 	}
 	if OwnerLiveness(&reg.SessionOwner) != LivenessAlive {
+		return "", false
+	}
+	// The owner must be THIS process or an ancestor, where the platform can
+	// say (codex round 2): a harness-supplied pid that is alive, token-matched
+	// and yet not above us is a misconfigured session, and its row is not
+	// ours to speak for. CaptureSessionOwner records that outcome as
+	// PIDVerified=false but does not distinguish "checked and wrong" from
+	// "cannot check"; gating on the flag would disable this step on every
+	// platform without ancestry (see proc_ancestry_other.go), so the check is
+	// re-run here and only a checked-and-wrong answer refuses.
+	if ok, err := pidIsSelfOrAncestor(owner.PID); err == nil && !ok {
 		return "", false
 	}
 	return reg.Agent, true

--- a/internal/cli/session_registry.go
+++ b/internal/cli/session_registry.go
@@ -58,10 +58,14 @@ type SessionRegistration struct {
 	// sessions by id (transcript paths, session measurement). Opaque to
 	// pad.
 	SessionID string `json:"session_id,omitempty"`
-	// Agent is the name the session declared for itself — the same
-	// self-declared value ResolveAgentName stamps on every write, recorded
-	// so a reader can tell two sessions in one checkout apart by what they
-	// are working AS. Empty is an anonymous session.
+	// Agent is the name the session declared for itself, recorded so a
+	// reader can tell two sessions in one checkout apart by what they are
+	// working AS. When non-empty it is ALSO the value ResolveAgentName
+	// stamps on every write from this session — by construction since
+	// BUG-2882, which found the two disagreeing on both live seats: the
+	// resolver now reads this record first (registeredAgentForThisSession).
+	// Empty is an anonymous session; it does not blank an environment-
+	// declared name on writes.
 	Agent string `json:"agent,omitempty"`
 	// RegistrarPID is the pid of the process that wrote the file (the
 	// `pad` command). Its JSON key is v1's "pid", kept for compatibility;
@@ -135,6 +139,51 @@ func SessionsDir() (string, error) {
 		_ = os.Chmod(dir, 0700)
 	}
 	return dir, nil
+}
+
+// registeredAgentForThisSession reads the registry record for the session
+// that owns this process — the same owner CaptureSessionOwner would record —
+// and returns its agent name. It is the first thing ResolveAgentName consults
+// (BUG-2882), so it must be cheap and must never create anything: a plain
+// stat-and-read of one file, no MkdirAll, no lock (a torn read of a record
+// being rewritten parses as malformed and is ignored, and the next call sees
+// the new record).
+//
+// ok is false when there is no record, the record is malformed or legacy, or
+// the record is for a DIFFERENT session that happened to have this pid: when
+// both sides carry a process-start token they must agree, exactly as the
+// liveness verdict requires. A record with an empty agent is a deliberate
+// anonymous registration and returns ("", true); the caller decides that this
+// does not override an environment-declared name.
+func registeredAgentForThisSession() (string, bool) {
+	owner, err := CaptureSessionOwner()
+	if err != nil {
+		return "", false
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", false
+	}
+	path := filepath.Join(home, ".pad", "sessions", fmt.Sprintf("%d.json", owner.PID))
+	data, err := readRegistryBytes(path)
+	if err != nil {
+		return "", false
+	}
+	if !utf8.Valid(data) {
+		return "", false
+	}
+	var reg SessionRegistration
+	if err := json.Unmarshal(data, &reg); err != nil || !registrationWellFormed(&reg) {
+		return "", false
+	}
+	if reg.PID != owner.PID {
+		// v1 (legacy) records have no owner pid; they never carried a name.
+		return "", false
+	}
+	if reg.ProcStart != "" && owner.ProcStart != "" && reg.ProcStart != owner.ProcStart {
+		return "", false
+	}
+	return reg.Agent, true
 }
 
 // registryFileName matches registry records — and ONLY them. The same


### PR DESCRIPTION
## Summary

`pad session register --agent <name>` rewrote the registry row and nothing else. `ResolveAgentName()` — the one source of `X-Pad-Agent`, and so of every `agent_name` stamp on every write — read `.pad.toml`, then `$PAD_AGENT`, then the detected runtime, never the registry. So the moment an operator used `--agent` to correct a mis-launched seat, pad held two self-declarations of "the same value" that disagreed, and nothing reconciled or warned. Night 10 (2026-09-04) read both live docapp seats inverted: the registry said `rook`/`wren`, the environment said `wren`/`rook`, and every checkpoint on TASK-2878 was stamped with the other seat's name.

## The change

**Registry first.** `ResolveAgentName` consults the registry record for the session that owns this process before anything else. `registeredAgentForThisSession` is a stat-and-read of `~/.pad/sessions/<owner pid>.json`: no `MkdirAll`, no lock (a torn read parses as malformed and is ignored; the next call sees the new record), and the record is ignored when malformed, legacy (no owner pid), or carrying a different process-start token — the pid-reuse guard, matching the liveness verdict's rule.

Precedence is now: registered name → `.pad.toml` `agent_name` → `$PAD_AGENT` → detected runtime. A **non-empty** registered name wins; an anonymous row (`--agent ""`) is a statement about the row and leaves an environment-declared name in force.

`pad session register` without `--agent` keeps the current name, as before — its default is the resolver, which now reads the row.

**Words made true.** The record's `Agent` doc comment claimed it was "the same self-declared value ResolveAgentName stamps on every write"; it is now, by construction. `--agent`'s help text, the register command's long text, and README's precedence list say so.

## Codex rounds 1–3 changed this PR

Two findings, both taken. **Fail closed on an unverifiable record**: the first cut compared process-start tokens only when both sides had one, so a stale row with no token under a reused pid — a dead session's — would have named a live one. Now, when this process can read a token, the record must carry the same one, and the record must pass the same `OwnerLiveness` verdict `pad session list` applies. **Hermetic tests**: the pre-existing resolver and header tests cleared `PAD_AGENT`/`CLAUDECODE` but not `HOME` or the session-pid variables, so run inside a registered seat they would have read that seat's row as the resolver's first answer. They now run from a scratch `HOME` with no session identity.

Round 2: one identity test had been missed by that fix (now isolated), and the registry step accepted a row whose owner pid was alive and token-matched but **not this process or an ancestor** — a misconfigured `CLAUDE_PID` naming a sibling session could borrow its name. Refused where the platform can walk ancestry. Deliberately not gated on `PIDVerified`: `CaptureSessionOwner` records "cannot check" and "checked and wrong" as the same `false`, and the flag alone would have disabled the step on every non-Linux platform; the check is re-run and only a checked-and-wrong answer refuses.

Round 3 (blast radius): `pad session list`'s help still said a window that changes its `PAD_AGENT` should re-run `pad session register` to pick the new name up. With the row outranking the environment, a plain re-register keeps the row's name (its default is the resolver, which now reads the row); only `--agent <name>` changes it. The text now says so.

## Not changed

- Fix shape 3 from the bug (a mismatch marker in `pad session list`) is moot: with the row being the stamp, pad's own writes cannot diverge from the row. What remains self-declared is still self-declared (see the resolver's "WHAT THIS IS NOT").
- Existing mis-stamped comments cannot be restamped; the trails carry correction lines.

## Verification

`TestRegisteredAgentWinsForThisSession`: under `PAD_AGENT=wren` and a `.pad.toml` naming `toml-name`, register as `rook` → resolver says `rook`; default re-register → `rook`; anonymous → `toml-name`; a record for this pid with another process's start token → `toml-name`; a record for this pid with NO token → `toml-name`; the genuine record again → its name. The registry-step mutant fails the first two assertions; the empty-token-skips-the-check mutant fails the token-less row. A second test claims a live non-ancestor child as the session owner and asserts its row does not name us; the refusal-dropped mutant lets it. `internal/cli`, `internal/mcp` drift tests and `cmd/pad` green; gofmt/vet clean.

Fixes docapp BUG-2882.

