### PR TITLE
fix(store): collection slug races — allocate under the row lock, serialize CreateCollection with rename (TASK-2885)

### DIFF
--- a/internal/store/collections.go
+++ b/internal/store/collections.go
@@ -76,17 +76,51 @@ func (s *Store) CreateCollection(workspaceID string, input models.CollectionCrea
 	if isReservedCollectionSlug(baseSlug) {
 		baseSlug = baseSlug + "-collection"
 	}
-	slug, err := s.uniqueSlug("collections", "workspace_id", workspaceID, baseSlug)
+	tx, err := s.db.Begin()
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	// LOCK ORDER: workspace advisory lock FIRST, then the INSERT (whose only
+	// row lock is the FK key-share on the workspaces row). That is the same
+	// first step item-create (tryCreateItem) and rename (UpdateCollection)
+	// take, so this path adds no new edge to the ordering those two already
+	// keep. No collection row is locked here — a create has none of its own
+	// yet — which is exactly why the lock is needed (BUG-2875): a rename's
+	// relation-repoint scan holds every EXISTING sibling row FOR UPDATE, and a
+	// row that does not exist yet cannot be held. Without this lock a create
+	// naming the old slug lands between that scan and the rename's commit,
+	// invisible to the scan and unrepointed. With it the create queues behind
+	// the rename, so whatever validates its relation targets (TASK-2878) sees
+	// committed state rather than a snapshot from before the rename.
+	//
+	// The slug is allocated UNDER the same lock, in the same transaction as
+	// the INSERT, exactly as createItemTx does (IDEA-2874's create-side half):
+	// the collision scan is serialized against every other collection slug
+	// writer in the workspace, so two creates (or a create racing a rename)
+	// deriving the same base get `x` and `x-2` rather than one of them
+	// failing on the UNIQUE index. On SQLite both the lock and the ordering
+	// come free from the single BEGIN IMMEDIATE write lock; the advisory lock
+	// is a no-op there.
+	if err := s.acquireWorkspaceSeqLock(tx, workspaceID); err != nil {
+		return nil, err
+	}
+
+	slug, err := s.uniqueSlugQ(tx, "collections", "workspace_id", workspaceID, baseSlug)
 	if err != nil {
 		return nil, fmt.Errorf("unique slug: %w", err)
 	}
 
-	_, err = s.db.Exec(s.q(`
+	_, err = tx.Exec(s.q(`
 		INSERT INTO collections (id, workspace_id, name, slug, prefix, icon, description, schema, settings, traits, sort_order, is_default, is_system, created_at, updated_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`), id, workspaceID, input.Name, slug, prefix, icon, description, schema, settings, traits, 0, s.dialect.BoolToInt(input.IsDefault), s.dialect.BoolToInt(input.IsSystem), ts, ts)
 	if err != nil {
 		return nil, fmt.Errorf("insert collection: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit collection create: %w", err)
 	}
 
 	return s.GetCollection(id)
@@ -407,31 +441,31 @@ func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*mod
 	sets := []string{"updated_at = ?"}
 	args := []interface{}{ts}
 
-	// Set when this update actually changes the slug, which is what strands
-	// relation fields (BUG-2873): `models.FieldDef.Collection` holds the
-	// target's SLUG and is the only pointer a relation has — there is no id
-	// beside it — so a rename leaves every field aimed here pointing at a name
-	// that no longer resolves.
-	var renamedTo string
-
-	if input.Name != nil {
+	// A rename re-slugifies, and the new slug is what strands relation fields
+	// (BUG-2873): `models.FieldDef.Collection` holds the target's SLUG and is
+	// the only pointer a relation has — there is no id beside it — so a rename
+	// leaves every field aimed here pointing at a name that no longer resolves.
+	//
+	// Only the BASE is derived here. The unique slug is ALLOCATED inside the
+	// transaction below, after the workspace lock and the row lock are held
+	// (IDEA-2874): allocating on the pool up front let two renames deriving
+	// the same base both scan an unlocked snapshot, both choose `gamma`, and
+	// the loser fail on the UNIQUE index — on Postgres after first BLOCKING on
+	// that index until the winner committed. Under the lock the second scan
+	// sees the first's slug and steps to `gamma-2`, matching documents.go and
+	// items.go, which have always allocated under their transactions.
+	renaming := input.Name != nil
+	var renameBase string
+	if renaming {
 		sets = append(sets, "name = ?")
 		args = append(args, *input.Name)
-		// Update slug too
-		baseSlug := slugify(*input.Name)
-		if baseSlug == "" {
-			baseSlug = "collection"
+		renameBase = slugify(*input.Name)
+		if renameBase == "" {
+			renameBase = "collection"
 		}
-		if isReservedCollectionSlug(baseSlug) {
-			baseSlug = baseSlug + "-collection"
+		if isReservedCollectionSlug(renameBase) {
+			renameBase = renameBase + "-collection"
 		}
-		newSlug, err := s.uniqueSlugExcluding(s.db, "collections", "workspace_id", existing.WorkspaceID, baseSlug, id)
-		if err != nil {
-			return nil, fmt.Errorf("unique slug: %w", err)
-		}
-		sets = append(sets, "slug = ?")
-		args = append(args, newSlug)
-		renamedTo = newSlug
 	}
 	if input.Prefix != nil {
 		sets = append(sets, "prefix = ?")
@@ -482,8 +516,9 @@ func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*mod
 		args = append(args, *input.SortOrder)
 	}
 
-	args = append(args, id)
-	query := fmt.Sprintf("UPDATE collections SET %s WHERE id = ?", strings.Join(sets, ", "))
+	// `args` is not closed with the row id here — the slug (if renaming) is
+	// still to be appended under the lock below, and the statement is built
+	// after that.
 
 	// BUG-2265: collections.updated_at doubles as the optimistic-concurrency
 	// token (no schema migration — it's the existing column). For that to be
@@ -521,10 +556,11 @@ func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*mod
 	// creation locks the same pair in the order [workspace advisory lock
 	// (tryCreateItem) → collection-row FK key-share lock (on INSERT)], so we
 	// MUST take the workspace lock FIRST here too — grabbing the row lock first
-	// would ABBA-deadlock against a concurrent item-create. Acquired only on the
-	// migration path (the only path that touches the workspace seq lock); a
-	// plain update just takes the row lock and can't deadlock. On SQLite both
-	// are no-ops under the single BEGIN IMMEDIATE write lock.
+	// would ABBA-deadlock against a concurrent item-create. Acquired on the
+	// migration path and on renames (below); a plain update just takes the row
+	// lock and can't deadlock. On SQLite both are no-ops under the single
+	// BEGIN IMMEDIATE write lock. CreateCollection takes this same lock as ITS
+	// first step (BUG-2875), so creates serialize with renames too.
 	// The comment above orders the workspace lock against ONE collection row
 	// lock, because until BUG-2873 nothing took more than one. Migrating relation
 	// targets writes SIBLING collection rows, so two concurrent renames of
@@ -534,7 +570,7 @@ func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*mod
 	// without inventing a second ordering rule to keep in sync with the first,
 	// and it is taken BEFORE the row lock, preserving the order this comment
 	// exists to protect.
-	if len(input.Migrations) > 0 || renamedTo != "" {
+	if len(input.Migrations) > 0 || renaming {
 		if err := s.acquireWorkspaceSeqLock(tx, existing.WorkspaceID); err != nil {
 			return nil, err
 		}
@@ -548,8 +584,8 @@ func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*mod
 	// value under the lock is the only one that describes what the relations
 	// currently point at.
 	//
-	// This is the READ of the old slug. ALLOCATION of the new one is still
-	// outside the transaction and deliberately left alone here — IDEA-2874.
+	// This is the READ of the old slug; the ALLOCATION of the new one follows
+	// it, under the same locks (IDEA-2874, below).
 	reread := "SELECT updated_at, slug FROM collections WHERE id = ? AND deleted_at IS NULL"
 	if s.dialect.Driver() == DriverPostgres {
 		reread += " FOR UPDATE"
@@ -565,6 +601,29 @@ func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*mod
 		return nil, fmt.Errorf("re-read collection under lock: %w", rerr)
 	}
 	current := parseTime(currentUpdatedAt)
+
+	// Allocate the new slug UNDER the workspace lock and this row's lock
+	// (IDEA-2874). The scan runs on `tx`, not the pool — a pool read from
+	// inside a lock-holding transaction needs a second connection and can
+	// deadlock in the application when the pool is saturated by callers
+	// waiting on the very lock this transaction holds (see
+	// uniqueSlugExcluding). Serialized by the workspace lock against every
+	// other rename and every create in this workspace (CreateCollection takes
+	// the same lock first, BUG-2875), so the count it reads is the count that
+	// will hold at commit.
+	var renamedTo string
+	if renaming {
+		newSlug, err := s.uniqueSlugExcluding(tx, "collections", "workspace_id", existing.WorkspaceID, renameBase, id)
+		if err != nil {
+			return nil, fmt.Errorf("unique slug: %w", err)
+		}
+		sets = append(sets, "slug = ?")
+		args = append(args, newSlug)
+		renamedTo = newSlug
+	}
+
+	args = append(args, id)
+	query := fmt.Sprintf("UPDATE collections SET %s WHERE id = ?", strings.Join(sets, ", "))
 
 	// Optimistic-concurrency guard — only when the caller opted in by sending
 	// the token it last read. Compared with time.Equal (format-agnostic).
@@ -1126,8 +1185,9 @@ func isReservedCollectionSlug(slug string) bool {
 // fall back on. `UpdateCollection` re-slugifies on rename, so without this every
 // relation field aimed at the renamed collection is stranded: the picker filters
 // on a slug that resolves to nothing, and the field silently stops being
-// fillable. See IDEA-2874 for the related, deliberately SEPARATE question of the
-// new slug being ALLOCATED outside this transaction.
+// fillable. The new slug is allocated inside this same transaction, under the
+// same locks (IDEA-2874) — it used to be allocated on the pool before the
+// transaction opened.
 //
 // THREE THINGS IT DOES THAT AN OBVIOUS VERSION DOES NOT, each from codex review:
 //

--- a/internal/store/collections_slug_race_pg_test.go
+++ b/internal/store/collections_slug_race_pg_test.go
@@ -1,0 +1,251 @@
+package store
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// TASK-2885 (IDEA-2874 + BUG-2875). A collection's slug is an identifier and a
+// mutable name at once, and two writers used to allocate it with no ordering
+// between them:
+//
+//   - UpdateCollection scanned for a free slug on the POOL before its
+//     transaction opened, so two renames deriving the same base both picked the
+//     same slug and the loser's UPDATE failed on the UNIQUE index (IDEA-2874).
+//   - CreateCollection took no lock at all, so a create could land between the
+//     rename's FOR UPDATE scan of EXISTING sibling rows (which cannot see a row
+//     that does not exist yet) and its commit (BUG-2875).
+//
+// Both are closed the same way: allocation moves under the transaction, and
+// both paths take the workspace advisory lock FIRST — the order item-create and
+// rename already share. These tests were written BEFORE the fix (team CONVE-29)
+// and measured failing against it; see the trail for the run.
+//
+// "Blocked" is verified in the database via pg_stat_activity (waitForLockWait,
+// attachments_live_item_test.go), never by elapsed time. The needle is the
+// advisory-lock call itself: on the unfixed tree the create does NOT wait
+// there — it has already chosen `gamma` and blocks on the UNIQUE index inside
+// its INSERT — so a needle on `INSERT INTO collections` would pass on both
+// sides and measure nothing.
+//
+// SQLite is excluded rather than skipped for convenience: its DSN sets
+// _txlock=immediate, so the second writer cannot even open its transaction
+// while the first is live — the interleaving these tests construct is
+// unrepresentable there. The dialect-agnostic instrument for the same defects
+// is TestConcurrentSlugWritersNeverCollide below.
+
+func slugRacePGStore(t *testing.T) (*Store, string, *models.Collection) {
+	t.Helper()
+	pgURL := os.Getenv("PAD_TEST_POSTGRES_URL")
+	if pgURL == "" {
+		t.Skip("PAD_TEST_POSTGRES_URL not set — the advisory lock only exists on Postgres")
+	}
+	s := testStorePostgres(t, pgURL)
+	ws := createTestWorkspace(t, s, "SlugRace")
+	alpha, err := s.CreateCollection(ws.ID, models.CollectionCreate{Name: "Alpha", Slug: "alpha"})
+	if err != nil {
+		t.Fatalf("create alpha: %v", err)
+	}
+	return s, ws.ID, alpha
+}
+
+// holdUncommittedRename opens a transaction that looks exactly like a rename
+// in flight: workspace lock held, the row's slug already rewritten, nothing
+// committed. The caller commits (or rolls back) it.
+func holdUncommittedRename(t *testing.T, s *Store, wsID, collID, newSlug string) *sql.Tx {
+	t.Helper()
+	tx, err := s.db.Begin()
+	if err != nil {
+		t.Fatalf("begin rename tx: %v", err)
+	}
+	if err := s.acquireWorkspaceSeqLock(tx, wsID); err != nil {
+		tx.Rollback()
+		t.Fatalf("acquire workspace lock: %v", err)
+	}
+	if _, err := tx.Exec(s.q(`UPDATE collections SET slug = ?, updated_at = ? WHERE id = ?`), newSlug, nowNano(), collID); err != nil {
+		tx.Rollback()
+		t.Fatalf("rename in tx: %v", err)
+	}
+	return tx
+}
+
+// BUG-2875: a create must queue behind an in-flight rename, not slip between
+// its scan and its commit.
+func TestCreateCollectionWaitsForAnUncommittedRename(t *testing.T) {
+	s, wsID, alpha := slugRacePGStore(t)
+
+	tx := holdUncommittedRename(t, s, wsID, alpha.ID, "gamma")
+	defer tx.Rollback() // no-op after Commit
+
+	type result struct {
+		coll *models.Collection
+		err  error
+	}
+	done := make(chan error, 1)
+	results := make(chan result, 1)
+	go func() {
+		// The relation names the slug the rename is moving AWAY from. On this
+		// tree it lands dangling — refusing a relation target that names no
+		// collection is TASK-2878's (U1), not this unit's. What this unit owes
+		// is the ORDER: the create runs after the rename is committed, so that
+		// refusal, once it exists, sees the committed state and not a
+		// snapshot from before it.
+		c, err := s.CreateCollection(wsID, models.CollectionCreate{
+			Name: "Gamma", Schema: relationSchema(t, "alpha_ref", "alpha"),
+		})
+		results <- result{coll: c, err: err}
+		done <- err
+	}()
+
+	waitForLockWait(t, s, "pg_advisory_xact_lock", done)
+
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit rename: %v", err)
+	}
+	r := <-results
+	if r.err != nil {
+		t.Fatalf("create after the rename committed: %v", r.err)
+	}
+	// Allocated AFTER the rename's `gamma` became visible, so the create
+	// stepped around it. Unfixed, the pool scan ran before the commit, chose
+	// `gamma`, and the INSERT failed on the UNIQUE index once the rename landed.
+	if r.coll.Slug != "gamma-2" {
+		t.Fatalf("created slug = %q, want gamma-2 (allocated after the rename committed)", r.coll.Slug)
+	}
+	if got := relationTargetOf(t, s, r.coll.ID, "alpha_ref"); got != "alpha" {
+		t.Fatalf("relation target = %q, want the literal alpha the caller supplied (repointing a create's own schema is not this unit's)", got)
+	}
+}
+
+// IDEA-2874: a rename must allocate its new slug under the lock, so two
+// renames deriving the same slug serialize into `gamma` and `gamma-2` rather
+// than one of them failing on the UNIQUE index.
+func TestRenameAllocatesItsSlugUnderTheWorkspaceLock(t *testing.T) {
+	s, wsID, alpha := slugRacePGStore(t)
+	beta, err := s.CreateCollection(wsID, models.CollectionCreate{Name: "Beta", Slug: "beta"})
+	if err != nil {
+		t.Fatalf("create beta: %v", err)
+	}
+
+	tx := holdUncommittedRename(t, s, wsID, alpha.ID, "gamma")
+	defer tx.Rollback() // no-op after Commit
+
+	type result struct {
+		coll *models.Collection
+		err  error
+	}
+	done := make(chan error, 1)
+	results := make(chan result, 1)
+	go func() {
+		name := "Gamma"
+		c, err := s.UpdateCollection(beta.ID, models.CollectionUpdate{Name: &name})
+		results <- result{coll: c, err: err}
+		done <- err
+	}()
+
+	// Both trees block here — the unfixed rename ALSO takes the workspace lock,
+	// it just allocated before reaching it. The discriminating assertion is
+	// the slug it ends up with.
+	waitForLockWait(t, s, "pg_advisory_xact_lock", done)
+
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit rename: %v", err)
+	}
+	r := <-results
+	if r.err != nil {
+		t.Fatalf("second rename after the first committed: %v", r.err)
+	}
+	if r.coll.Slug != "gamma-2" {
+		t.Fatalf("renamed slug = %q, want gamma-2 (allocated under the lock, after the first rename's gamma was visible)", r.coll.Slug)
+	}
+}
+
+// TestConcurrentSlugWritersNeverCollide is the dialect-agnostic instrument for
+// the same two defects. Each round releases THREE writers at a barrier — two
+// renames and one create — all deriving the same base slug, and asserts every
+// writer succeeded and the three slugs are distinct. Unfixed, the scans run
+// outside any lock on both dialects (SQLite's BEGIN IMMEDIATE serializes the
+// WRITE, not a pool read issued before it), so two writers pick the same slug
+// and one fails on the UNIQUE index.
+//
+// Repeated and barrier-released for the reason the deadlock test states: a
+// single unsynchronised trio almost never interleaves at the point that
+// matters. Measured failing on the unfixed tree before the fix landed — the
+// count is on the trail, not recalled here.
+func TestConcurrentSlugWritersNeverCollide(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "SlugCollide")
+
+	a, err := s.CreateCollection(ws.ID, models.CollectionCreate{Name: "Alpha", Slug: "alpha"})
+	if err != nil {
+		t.Fatalf("create alpha: %v", err)
+	}
+	b, err := s.CreateCollection(ws.ID, models.CollectionCreate{Name: "Beta", Slug: "beta"})
+	if err != nil {
+		t.Fatalf("create beta: %v", err)
+	}
+
+	const rounds = 40
+	for round := 0; round < rounds; round++ {
+		name := fmt.Sprintf("Same R%d", round)
+		start := make(chan struct{})
+		slugs := make(chan string, 3)
+		errs := make(chan error, 3)
+		var wg sync.WaitGroup
+
+		rename := func(id string) {
+			defer wg.Done()
+			<-start
+			n := name
+			c, err := s.UpdateCollection(id, models.CollectionUpdate{Name: &n})
+			if err != nil {
+				errs <- err
+				return
+			}
+			slugs <- c.Slug
+		}
+		wg.Add(3)
+		go rename(a.ID)
+		go rename(b.ID)
+		go func() {
+			defer wg.Done()
+			<-start
+			c, err := s.CreateCollection(ws.ID, models.CollectionCreate{Name: name})
+			if err != nil {
+				errs <- err
+				return
+			}
+			slugs <- c.Slug
+		}()
+		close(start)
+
+		finished := make(chan struct{})
+		go func() { wg.Wait(); close(finished) }()
+		select {
+		case <-finished:
+		case <-time.After(20 * time.Second):
+			t.Fatalf("round %d: writers did not complete within 20s", round)
+		}
+		close(errs)
+		for err := range errs {
+			t.Fatalf("round %d: a slug writer failed: %v", round, err)
+		}
+		close(slugs)
+		seen := map[string]bool{}
+		for sl := range slugs {
+			if seen[sl] {
+				t.Fatalf("round %d: two writers were handed the same slug %q", round, sl)
+			}
+			seen[sl] = true
+		}
+		if len(seen) != 3 {
+			t.Fatalf("round %d: %d distinct slugs, want 3", round, len(seen))
+		}
+	}
+}

--- a/internal/store/collections_slug_race_pg_test.go
+++ b/internal/store/collections_slug_race_pg_test.go
@@ -249,3 +249,96 @@ func TestConcurrentSlugWritersNeverCollide(t *testing.T) {
 		}
 	}
 }
+
+// TestCollectionSlugWritersDoNoPoolIOUnderTheLock is the guard for the
+// invariant the fix introduces: everything CreateCollection and a renaming
+// UpdateCollection read while holding the workspace lock goes through the
+// transaction, never the pool. A pool read from inside a lock-holding
+// transaction needs a SECOND connection, and when the pool is saturated by
+// callers waiting on that very lock the second connection never arrives — a
+// deadlock in the application that no SQLSTATE names (BUG-2409's class). With
+// MaxOpenConns(1) the transaction owns the only connection, so ANY pool read
+// inside the critical section deadlocks deterministically here instead of
+// only under load. Works identically on both dialects.
+//
+// This one passes on the unfixed tree too (the pre-fix scans ran BEFORE the
+// transaction opened, which is the ordering defect, not this one). Its
+// negative control is the mutation matrix on the trail: handing `s.db` to
+// either allocation, or issuing the INSERT on the pool, hangs it.
+//
+// Every optional leg of the rename is armed: a relation sibling so
+// retargetRelationFieldsTx runs, and a field migration so
+// applyFieldMigrationsTx runs — an unarmed branch is invisible to the sweep.
+func TestCollectionSlugWritersDoNoPoolIOUnderTheLock(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "NoPoolIO")
+
+	alpha, err := s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Alpha", Slug: "alpha",
+		Schema: `{"fields":[{"key":"status","type":"select","options":["open","done"]}]}`,
+	})
+	if err != nil {
+		t.Fatalf("create alpha: %v", err)
+	}
+	if _, err := s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Beta", Slug: "beta", Schema: relationSchema(t, "alpha_ref", "alpha"),
+	}); err != nil {
+		t.Fatalf("create beta: %v", err)
+	}
+	if _, err := s.CreateItem(ws.ID, alpha.ID, models.ItemCreate{Title: "Migrate me", Fields: `{"status":"open"}`}); err != nil {
+		t.Fatalf("seed field value: %v", err)
+	}
+
+	// From here on the pool has exactly one connection: the transaction's.
+	s.db.SetMaxOpenConns(1)
+
+	run := func(label string, op func() error) {
+		t.Helper()
+		done := make(chan error, 1)
+		go func() { done <- op() }()
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("%s: %v", label, err)
+			}
+		case <-time.After(30 * time.Second):
+			t.Fatalf("%s did not complete under MaxOpenConns(1): a read inside the "+
+				"lock-holding transaction went to the pool and is waiting for a "+
+				"connection the transaction itself holds", label)
+		}
+	}
+
+	run("CreateCollection", func() error {
+		_, err := s.CreateCollection(ws.ID, models.CollectionCreate{Name: "Gamma"})
+		return err
+	})
+	run("UpdateCollection(rename + migration + relation sibling)", func() error {
+		name := "Alpha Prime"
+		schema := `{"fields":[{"key":"status","type":"select","options":["todo","done"]}]}`
+		_, err := s.UpdateCollection(alpha.ID, models.CollectionUpdate{
+			Name:   &name,
+			Schema: &schema,
+			Migrations: []models.FieldMigration{
+				{Field: "status", RenameOptions: map[string]string{"open": "todo"}},
+			},
+		})
+		return err
+	})
+
+	// The rename's sibling repoint ran under the same single connection.
+	if got := relationTargetOf(t, s, mustCollectionBySlug(t, s, ws.ID, "beta").ID, "alpha_ref"); got != "alpha-prime" {
+		t.Fatalf("relation target = %q, want alpha-prime", got)
+	}
+}
+
+func mustCollectionBySlug(t *testing.T, s *Store, wsID, slug string) *models.Collection {
+	t.Helper()
+	c, err := s.GetCollectionBySlug(wsID, slug)
+	if err != nil {
+		t.Fatalf("GetCollectionBySlug(%s): %v", slug, err)
+	}
+	if c == nil {
+		t.Fatalf("collection %q missing", slug)
+	}
+	return c
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1007,18 +1007,20 @@ func findStatementEnd(sql string) int {
 
 // uniqueSlugExcluding generates a unique slug, excluding a specific document ID
 // from the collision check. Used during title renames.
-// It takes the executor rather than reaching for s.db, because TWO of its
-// three callers run inside a transaction that already holds locks — the item
-// update (items.go, under the workspace seq and parent-children locks) and
-// the document rename (documents.go, under the rename lock this bug added).
-// A read issued against the POOL from inside such a transaction needs a
-// SECOND connection while the first is held, and if the pool is saturated by
-// callers waiting on the very lock this transaction holds, that second
-// connection never arrives: the deadlock is then in the application rather
-// than in the database, where no SQLSTATE names it and no lock timeout breaks
-// it. The third caller (UpdateCollection) runs BEFORE its transaction opens
-// and correctly passes the pool — checked rather than assumed, after an
-// earlier version of this comment claimed all three were in-transaction.
+// It takes the executor rather than reaching for s.db, because all three of
+// its callers run inside a transaction that already holds locks — the item
+// update (items.go, under the workspace seq and parent-children locks), the
+// document rename (documents.go, under the rename lock this bug added), and
+// since IDEA-2874 the collection rename (collections.go, under the workspace
+// seq lock and the row's FOR UPDATE). A read issued against the POOL from
+// inside such a transaction needs a SECOND connection while the first is
+// held, and if the pool is saturated by callers waiting on the very lock this
+// transaction holds, that second connection never arrives: the deadlock is
+// then in the application rather than in the database, where no SQLSTATE
+// names it and no lock timeout breaks it. (An earlier version of this comment
+// claimed all three were in-transaction when UpdateCollection still ran its
+// scan BEFORE opening one; it is true now because the scan moved, not
+// because the comment was re-read.)
 func (s *Store) uniqueSlugExcluding(q rowQueryer, table, scopeCol, scopeVal, baseSlug, excludeID string) (string, error) {
 	slug := baseSlug
 	for i := 2; ; i++ {


### PR DESCRIPTION
Closes TASK-2885 (IDEA-2874 + BUG-2875), two sibling findings from the BUG-2873 review. Both are consequences of a collection's slug being an identifier and a mutable name at once.

## Affected populations

- **Every collection rename** (`UpdateCollection` with a `name`), not only renames that touch relation fields.
- **Every collection creation** (`CreateCollection`): the HTTP handler, the CLI, and `SeedCollectionsFromTemplate`.

`ImportWorkspace` also inserts collection rows, but into a workspace it created moments earlier inside the same call — nothing else holds that workspace id until the import returns, so no rename can race it. Out of the population by construction, not by omission.

## Observable change per finding

**IDEA-2874 — allocation under the lock.** `UpdateCollection` allocated its new slug with a pool read *before* its transaction opened. Two renames deriving the same base both scanned an unlocked snapshot, both chose `gamma`, and the loser failed on the UNIQUE index (on Postgres after first blocking on that index until the winner committed). Allocation now runs on the transaction after the workspace advisory lock and the `FOR UPDATE` re-read, matching `documents.go` and `items.go`, which have always allocated under theirs. Before: one rename gets a constraint error. After: it waits and gets `gamma-2`.

**BUG-2875 — creates serialize with renames.** `CreateCollection` took no lock at all, so a create could land between a rename's `FOR UPDATE` scan of *existing* sibling rows (which cannot hold a row that does not exist yet) and the rename's commit — invisible to the repoint. It now opens a transaction, takes the workspace advisory lock **first** (the same first step item-create and rename take; the order is stated in a comment at each acquisition site), allocates its slug under it, and inserts on the transaction. Before: an unseen create. After: it queues behind the rename, so whatever validates its relation targets sees committed state. Refusing a relation target that names no collection is TASK-2878's (U1) and is not duplicated here.

## Lock order

Workspace advisory lock → own collection row (`FOR UPDATE`) → sibling rows (`FOR UPDATE`, ordered by id). `CreateCollection` takes only the first, plus the INSERT's FK key-share on the workspaces row — no new edge. On SQLite both the lock and the ordering come from the single `BEGIN IMMEDIATE` write lock.

## Tests — `internal/store/collections_slug_race_pg_test.go`

Written before the fix and measured failing on `02846a67`:

```
--- SQLite unfixed
--- FAIL: TestConcurrentSlugWritersNeverCollide (0.48s)   round 0: UNIQUE constraint failed: collections.workspace_id, collections.slug
--- PG unfixed
--- FAIL: TestCreateCollectionWaitsForAnUncommittedRename (11.41s)   no backend reported waiting on a lock for a statement containing "pg_advisory_xact_lock"
--- FAIL: TestRenameAllocatesItsSlugUnderTheWorkspaceLock (1.27s)   duplicate key value violates unique constraint "collections_workspace_id_slug_key" (23505)
--- FAIL: TestConcurrentSlugWritersNeverCollide (1.25s)   duplicate key value violates unique constraint (23505)
```

- Two Postgres-only interleavings in the `attachments_live_item_test.go` shape: "blocked" is observed in `pg_stat_activity`, never by elapsed time. The needle is the advisory-lock call itself — on the unfixed tree the create blocks on the UNIQUE index inside its INSERT, so a needle on the INSERT would pass on both sides. SQLite is excluded with the `_txlock=immediate` reason stated.
- One dialect-agnostic barrier-released trio (two renames + one create per round, 40 rounds) that collided on round 0 on both dialects unfixed.
- One pool-I/O guard (`MaxOpenConns(1)`, BUG-2409's instrument) with the rename's optional legs armed (relation sibling + field migration). Passes unfixed by design — it guards the invariant the fix introduces.

## Mutation matrix — 6 designed / 6 killed, build-checked per mutant

```
M1 create: drop workspace lock            KILLED  TestCreateCollectionWaits…, TestConcurrentSlugWriters…
M2 create: allocate on the pool           KILLED  …NoPoolIOUnderTheLock
M3 create: INSERT on the pool             KILLED  …NoPoolIOUnderTheLock
M4 rename: allocate on the pool           KILLED  …NoPoolIOUnderTheLock
M5 rename: no workspace lock for a rename KILLED  DoNotDeadlock, TestRenameAllocates…, TestConcurrentSlugWriters…
M7 create: never commit                   KILLED  DoNotDeadlock
```
M6 (allocation moved back before the transaction) is the unfixed tree; its run is the block above.

## Review

Codex round 1 CLEAN (lean, naming `internal/store/collections.go`); round 2 CLEAN, enumeration-shaped — its writer population matches the one above.

## Prose sweep

`uniqueSlugExcluding`'s doc comment claimed one of its three callers ran before its transaction; the retarget doc pointed at IDEA-2874 as open; the rename path carried an "allocation still outside — IDEA-2874" note. All three now describe the tree.

Not in scope: storing the collection id on `FieldDef` instead of the slug.
