### PR TITLE
feat(store): composite FK making a reminder's workspace agree with its item's (IDEA-2883)

### DIFF
--- a/internal/store/migrations/086_item_reminders_composite_fk.sql
+++ b/internal/store/migrations/086_item_reminders_composite_fk.sql
@@ -1,0 +1,103 @@
+-- IDEA-2883: make the item/workspace agreement a SCHEMA CONSTRAINT rather
+-- than a predicate repeated at every read.
+--
+-- item_reminders.workspace_id is denormalized from the item (see 085 for why:
+-- the scheduler tick claims and scopes work without joining items on every
+-- pass). Denormalization creates a value that CAN disagree with its source,
+-- and IDEA-2641 closed that class one read at a time across codex rounds 13
+-- and 14 — reminderFireable, the Postgres pin, ListPendingReminders, the
+-- export query, then GetReminder and ListRemindersForItem. Five sites now
+-- spell the same identity. The sixth someone adds will not, and the round
+-- that finds it will be the sixteenth.
+--
+-- A composite foreign key makes the disagreeing row unrepresentable. The
+-- read-side predicates STAY — they are also what makes the tests express the
+-- invariant — but they become belt on top of braces rather than the only
+-- thing standing between a denormalized column and its source.
+--
+-- NO ON UPDATE CASCADE, deliberately. items.workspace_id is never updated:
+-- enumerated across internal/ and cmd/ (no `UPDATE items SET workspace_id`
+-- anywhere, and UpdateItem's dynamic set list has no such column), and the
+-- cross-workspace "move" is copy-plus-archive against a NEW item row
+-- (items_cross_workspace_copy.go, PLAN-2357), so no row migrates between
+-- workspaces. If a future feature does move one, this constraint should
+-- REFUSE it rather than quietly rewrite the reminders underneath it — moving
+-- an item's reminders is a decision that feature has to make on purpose.
+--
+-- SQLite cannot ADD a constraint, so the table is rebuilt via the standard
+-- recipe, following migration 055. The runner supports this directly:
+-- applySQLiteMigration pins the migration to ONE connection, treats
+-- `PRAGMA foreign_keys = OFF` as a before-transaction pragma, restores it on
+-- a defer covering every return path, and wraps the body plus its
+-- schema_migrations row in a single transaction (store.go, IDEA-1485).
+--
+-- 084_nul_invariant_triggers.sql does not cover item_reminders, so the
+-- rebuild has three indexes to recreate and no triggers.
+
+PRAGMA foreign_keys = OFF;
+
+-- The parent key. A composite FK needs the referenced columns to carry a
+-- UNIQUE index; items(id) is already the primary key, so this index is
+-- redundant for uniqueness and exists solely to be referenceable. Measured on
+-- both drivers before writing this migration: SQLite (modernc, foreign_keys
+-- on) and Postgres both accept a plain unique INDEX as an FK target, refuse
+-- the disagreeing child row, and cascade through the composite key.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_items_id_workspace ON items(id, workspace_id);
+
+DROP TABLE IF EXISTS item_reminders_new;
+
+CREATE TABLE item_reminders_new (
+    id           TEXT PRIMARY KEY,
+    workspace_id TEXT NOT NULL,
+    item_id      TEXT NOT NULL,
+    remind_at    TEXT NOT NULL,
+    fired_at     TEXT,
+    acked_at     TEXT,
+    created_at   TEXT NOT NULL,
+    updated_at   TEXT NOT NULL,
+
+    -- Replaces 085's single-column `item_id REFERENCES items(id)`. The
+    -- composite form implies it — item_id still has to name a live row — and
+    -- keeps ON DELETE CASCADE, which was verified to fire through the
+    -- composite key rather than being silently dropped with the old FK.
+    FOREIGN KEY (item_id, workspace_id) REFERENCES items(id, workspace_id) ON DELETE CASCADE
+);
+
+-- The copy is JOIN-FILTERED, which is the repair pass. A row that disagrees
+-- with its item — or whose item no longer exists at all — cannot be inserted
+-- into the new table, so it has to be resolved here rather than failing the
+-- migration on live data (055's precedent: backfill before constraining).
+--
+-- DROPPED, not repaired, and that is a choice rather than the easy path. A
+-- disagreeing row is already unreachable: all five read predicates filter it,
+-- so it can never fire, never be listed, and never be acknowledged. Repairing
+-- it to the item's workspace would RESURRECT it — an upgrade would deliver a
+-- notification for an instant long past, which is the one outcome nobody
+-- asked for. Deleting it removes nothing any surface could ever show.
+--
+-- Rows are not expected to exist: CreateReminder derives workspace_id from
+-- the item itself, and the import path writes an id minted in the same
+-- workspace. That is an argument about the write doors, not a census, which
+-- is exactly why this filter is here instead of a bare INSERT ... SELECT *.
+INSERT INTO item_reminders_new (id, workspace_id, item_id, remind_at, fired_at, acked_at, created_at, updated_at)
+SELECT r.id, r.workspace_id, r.item_id, r.remind_at, r.fired_at, r.acked_at, r.created_at, r.updated_at
+FROM item_reminders r
+JOIN items i ON i.id = r.item_id AND i.workspace_id = r.workspace_id;
+
+DROP TABLE item_reminders;
+
+ALTER TABLE item_reminders_new RENAME TO item_reminders;
+
+-- The three indexes from 085, recreated verbatim. Their comments live there.
+CREATE INDEX IF NOT EXISTS idx_item_reminders_armed
+    ON item_reminders(remind_at)
+    WHERE fired_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_item_reminders_unacked
+    ON item_reminders(workspace_id, fired_at)
+    WHERE fired_at IS NOT NULL AND acked_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_item_reminders_item
+    ON item_reminders(item_id, remind_at);
+
+PRAGMA foreign_keys = ON;

--- a/internal/store/pgmigrations/063_item_reminders_composite_fk.sql
+++ b/internal/store/pgmigrations/063_item_reminders_composite_fk.sql
@@ -1,0 +1,51 @@
+-- IDEA-2883, Postgres half. Mirrors
+-- internal/store/migrations/086_item_reminders_composite_fk.sql — see the
+-- SQLite file for why the constraint exists, why there is no ON UPDATE
+-- CASCADE, and why disagreeing rows are dropped rather than repaired.
+--
+-- Postgres CAN add the constraint in place, so there is no table rebuild
+-- here; the two dialects still end in the same shape.
+
+-- The parent key. Measured, not assumed: Postgres accepts a plain unique
+-- INDEX (not only a unique CONSTRAINT) as a composite FK target.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_items_id_workspace ON items(id, workspace_id);
+
+-- The repair pass, matching the SQLite copy's JOIN filter: a reminder whose
+-- workspace disagrees with its item's, or whose item is gone, would fail the
+-- ADD CONSTRAINT below and take a deployment's startup with it.
+DELETE FROM item_reminders r
+WHERE NOT EXISTS (
+    SELECT 1 FROM items i
+    WHERE i.id = r.item_id AND i.workspace_id = r.workspace_id
+);
+
+-- Drop the single-column FK that 062 created inline. Discovered by SHAPE
+-- rather than by name: Postgres auto-names it item_reminders_item_id_fkey,
+-- but auto-names collide-and-suffix, so a deployment could carry a different
+-- one and a name-keyed DROP ... IF EXISTS would silently leave it in place.
+-- Harmless if it stayed — the composite FK is strictly stronger — but then
+-- the two dialects would not actually agree, and the next reader comparing
+-- them would be reading a lie.
+DO $$
+DECLARE
+    conname_found TEXT;
+BEGIN
+    SELECT conname INTO conname_found
+    FROM pg_constraint
+    WHERE conrelid = 'item_reminders'::regclass
+      AND contype = 'f'
+      AND confrelid = 'items'::regclass
+      AND conkey = ARRAY[(SELECT attnum FROM pg_attribute
+                          WHERE attrelid = 'item_reminders'::regclass AND attname = 'item_id')]::smallint[];
+    IF conname_found IS NOT NULL THEN
+        EXECUTE format('ALTER TABLE item_reminders DROP CONSTRAINT %I', conname_found);
+    END IF;
+END
+$$;
+
+-- IF NOT EXISTS is not available for ADD CONSTRAINT, and re-running is not a
+-- concern: schema_migrations makes this file run once, inside the same
+-- transaction as its bookkeeping row.
+ALTER TABLE item_reminders
+    ADD CONSTRAINT item_reminders_item_workspace_fkey
+    FOREIGN KEY (item_id, workspace_id) REFERENCES items(id, workspace_id) ON DELETE CASCADE;

--- a/internal/store/pgmigrations/063_item_reminders_composite_fk.sql
+++ b/internal/store/pgmigrations/063_item_reminders_composite_fk.sql
@@ -26,20 +26,26 @@ WHERE NOT EXISTS (
 -- Harmless if it stayed — the composite FK is strictly stronger — but then
 -- the two dialects would not actually agree, and the next reader comparing
 -- them would be reading a lie.
+-- A LOOP rather than SELECT ... INTO: plpgsql's INTO takes the first row and
+-- does not error on several, so a table carrying two single-column FKs on
+-- item_id would keep one and leave a reader asking which was dropped. Nothing
+-- creates a duplicate today; the loop costs two lines and removes the
+-- question.
 DO $$
 DECLARE
     conname_found TEXT;
 BEGIN
-    SELECT conname INTO conname_found
-    FROM pg_constraint
-    WHERE conrelid = 'item_reminders'::regclass
-      AND contype = 'f'
-      AND confrelid = 'items'::regclass
-      AND conkey = ARRAY[(SELECT attnum FROM pg_attribute
-                          WHERE attrelid = 'item_reminders'::regclass AND attname = 'item_id')]::smallint[];
-    IF conname_found IS NOT NULL THEN
+    FOR conname_found IN
+        SELECT conname
+        FROM pg_constraint
+        WHERE conrelid = 'item_reminders'::regclass
+          AND contype = 'f'
+          AND confrelid = 'items'::regclass
+          AND conkey = ARRAY[(SELECT attnum FROM pg_attribute
+                              WHERE attrelid = 'item_reminders'::regclass AND attname = 'item_id')]::smallint[]
+    LOOP
         EXECUTE format('ALTER TABLE item_reminders DROP CONSTRAINT %I', conname_found);
-    END IF;
+    END LOOP;
 END
 $$;
 

--- a/internal/store/reminder_workspace_constraint_test.go
+++ b/internal/store/reminder_workspace_constraint_test.go
@@ -310,3 +310,79 @@ func TestMigration063DropsPreExistingDisagreeingRows(t *testing.T) {
 		t.Error("after the migration the table still accepts a disagreeing row")
 	}
 }
+
+// TestMigration063DropsEveryLegacyItemIdConstraint exercises the LOOP in 063's
+// DO block, which the repair-pass test above cannot: that fixture carries one
+// legacy foreign key, and one is what a `SELECT ... INTO` handles correctly
+// too. Two is where they differ — plpgsql's INTO takes the first row and does
+// not error, so the second would survive and sit alongside the composite key,
+// leaving the two dialects disagreeing about the table's shape while the
+// migration reported success.
+//
+// Nothing creates a duplicate today. It is tested because the loop exists to
+// handle a case no other test reaches, and an untested branch that only runs
+// on a database nobody has is worse than no branch at all.
+func TestMigration063DropsEveryLegacyItemIdConstraint(t *testing.T) {
+	if os.Getenv("PAD_TEST_POSTGRES_URL") == "" {
+		t.Skip("Postgres-only: the DO block has no SQLite counterpart (the rebuild replaces the FK wholesale)")
+	}
+	const migrationName = "063_item_reminders_composite_fk.sql"
+
+	s := testStore(t)
+
+	legacyCount := func() int {
+		t.Helper()
+		var n int
+		if err := s.db.QueryRow(`
+			SELECT COUNT(*) FROM pg_constraint
+			WHERE conrelid = 'item_reminders'::regclass
+			  AND contype = 'f'
+			  AND confrelid = 'items'::regclass
+			  AND conkey = ARRAY[(SELECT attnum FROM pg_attribute
+			                      WHERE attrelid = 'item_reminders'::regclass AND attname = 'item_id')]::smallint[]
+		`).Scan(&n); err != nil {
+			t.Fatalf("count legacy constraints: %v", err)
+		}
+		return n
+	}
+
+	// Rewind past 063 and put TWO single-column FKs on item_id, the shape the
+	// loop exists for.
+	for _, stmt := range []string{
+		`ALTER TABLE item_reminders DROP CONSTRAINT item_reminders_item_workspace_fkey`,
+		`ALTER TABLE item_reminders ADD CONSTRAINT item_reminders_item_id_fkey FOREIGN KEY (item_id) REFERENCES items(id) ON DELETE CASCADE`,
+		`ALTER TABLE item_reminders ADD CONSTRAINT item_reminders_item_id_fkey1 FOREIGN KEY (item_id) REFERENCES items(id) ON DELETE CASCADE`,
+		`DELETE FROM schema_migrations WHERE version = '` + migrationName + `'`,
+	} {
+		if _, err := s.db.Exec(stmt); err != nil {
+			t.Fatalf("rewind %q: %v", stmt, err)
+		}
+	}
+	if got := legacyCount(); got != 2 {
+		t.Fatalf("control leg failed: seeded %d legacy constraints, want 2 — the loop's case is not set up", got)
+	}
+
+	body, err := pgMigrationsFS.ReadFile("pgmigrations/" + migrationName)
+	if err != nil {
+		t.Fatalf("read embedded migration: %v", err)
+	}
+	if err := applyPostgresMigration(s.db, migrationName, string(body)); err != nil {
+		t.Fatalf("migration failed against two legacy constraints: %v", err)
+	}
+
+	if got := legacyCount(); got != 0 {
+		t.Errorf("legacy single-column constraints remaining = %d, want 0 — the DO block dropped only the first", got)
+	}
+
+	// And the composite key is the one in force.
+	var composite int
+	if err := s.db.QueryRow(`
+		SELECT COUNT(*) FROM pg_constraint
+		WHERE conrelid = 'item_reminders'::regclass AND conname = 'item_reminders_item_workspace_fkey'
+	`).Scan(&composite); err != nil {
+		t.Fatalf("count composite: %v", err)
+	}
+	if composite != 1 {
+		t.Errorf("composite constraints = %d, want 1", composite)
+	}
+}

--- a/internal/store/reminder_workspace_constraint_test.go
+++ b/internal/store/reminder_workspace_constraint_test.go
@@ -1,0 +1,312 @@
+package store
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// IDEA-2883. item_reminders.workspace_id is denormalized from the item, and
+// until migration 086 nothing but a repeated read-side predicate stopped the
+// two from disagreeing. IDEA-2641 closed that class one read at a time across
+// two codex rounds and five call sites; these tests lock the constraint that
+// makes the disagreeing row unrepresentable instead.
+
+// reminderConstraintFixture returns a workspace with one item, plus a SECOND
+// workspace whose id is the wrong one to file that item's reminder under.
+func reminderConstraintFixture(t *testing.T, s *Store) (item *models.Item, ownWorkspace, otherWorkspace string) {
+	t.Helper()
+	own := createTestWorkspace(t, s, "Reminder Constraint Own")
+	other := createTestWorkspace(t, s, "Reminder Constraint Other")
+	coll, err := s.CreateCollection(own.ID, models.CollectionCreate{Name: "Tasks", Prefix: "TSK"})
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	it, err := s.CreateItem(own.ID, coll.ID, models.ItemCreate{Title: "Remind me"})
+	if err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+	return it, own.ID, other.ID
+}
+
+// TestReminderWorkspaceMustMatchItem is the regression instrument: a direct
+// INSERT filing a reminder under a workspace that is not its item's must be
+// refused by the DATABASE.
+//
+// It goes through raw SQL on purpose. CreateReminder derives workspace_id
+// from the item itself, so it cannot produce the row this constraint exists to
+// forbid — testing through it would assert that a correct writer writes
+// correctly, which is the thing already true before the migration.
+func TestReminderWorkspaceMustMatchItem(t *testing.T) {
+	s := testStore(t)
+	item, own, other := reminderConstraintFixture(t, s)
+	ts := now()
+
+	// Control: the AGREEING row is accepted by the same statement shape. Without
+	// this leg a broken INSERT would look like a working constraint.
+	if _, err := s.db.Exec(s.q(`
+		INSERT INTO item_reminders (id, workspace_id, item_id, remind_at, fired_at, acked_at, created_at, updated_at)
+		VALUES (?, ?, ?, ?, NULL, NULL, ?, ?)`),
+		newID(), own, item.ID, time.Now().UTC().Add(time.Hour).Format(time.RFC3339), ts, ts); err != nil {
+		t.Fatalf("control leg failed: the agreeing row was rejected: %v", err)
+	}
+
+	_, err := s.db.Exec(s.q(`
+		INSERT INTO item_reminders (id, workspace_id, item_id, remind_at, fired_at, acked_at, created_at, updated_at)
+		VALUES (?, ?, ?, ?, NULL, NULL, ?, ?)`),
+		newID(), other, item.ID, time.Now().UTC().Add(time.Hour).Format(time.RFC3339), ts, ts)
+	if err == nil {
+		t.Fatal("a reminder filed under a workspace that is not its item's was ACCEPTED; the composite foreign key is not in force")
+	}
+	t.Logf("disagreeing row refused: %v", err)
+}
+
+// TestReminderCascadeSurvivesTheCompositeKey is a PRESERVATION LOCK, not a
+// regression instrument — it passes before and after migration 086. Replacing
+// a single-column foreign key with a composite one is exactly the edit that
+// can drop ON DELETE CASCADE without anything else noticing, and a reminder
+// for a deleted item is a notification nobody can act on (085's rationale).
+func TestReminderCascadeSurvivesTheCompositeKey(t *testing.T) {
+	s := testStore(t)
+	item, own, _ := reminderConstraintFixture(t, s)
+
+	if _, err := s.CreateReminder(own, item.ID, time.Now().UTC().Add(time.Hour).Format(time.RFC3339)); err != nil {
+		t.Fatalf("CreateReminder: %v", err)
+	}
+	var before int
+	if err := s.db.QueryRow(s.q(`SELECT COUNT(*) FROM item_reminders WHERE item_id = ?`), item.ID).Scan(&before); err != nil {
+		t.Fatalf("count before: %v", err)
+	}
+	if before != 1 {
+		t.Fatalf("control leg failed: reminders before delete = %d, want 1", before)
+	}
+
+	// A HARD delete: the product's ordinary delete is a soft one, which by
+	// design leaves reminders alone. The cascade is what protects the row when
+	// the item is really gone (workspace purge).
+	if _, err := s.db.Exec(s.q(`DELETE FROM items WHERE id = ?`), item.ID); err != nil {
+		t.Fatalf("hard delete item: %v", err)
+	}
+	var after int
+	if err := s.db.QueryRow(s.q(`SELECT COUNT(*) FROM item_reminders WHERE item_id = ?`), item.ID).Scan(&after); err != nil {
+		t.Fatalf("count after: %v", err)
+	}
+	if after != 0 {
+		t.Errorf("reminders after the item was deleted = %d, want 0 — the rebuild dropped ON DELETE CASCADE", after)
+	}
+}
+
+// TestMigration086DropsPreExistingDisagreeingRows exercises the migration's
+// repair pass against the shape it was written for: a database that already
+// holds a disagreeing row when 086 runs.
+//
+// The pass matters because the alternative is a deployment incident. Postgres
+// would fail ADD CONSTRAINT on such a row and SQLite would fail the rebuild's
+// INSERT ... SELECT, and a migration that fails takes startup with it.
+//
+// Faithful in the parts that count: the migration text is read from the
+// embedded FS (not retyped), applied through the real applySQLiteMigration,
+// against the real items table. The one hand-written piece is the pre-086
+// item_reminders shape, copied from 085.
+func TestMigration086DropsPreExistingDisagreeingRows(t *testing.T) {
+	if os.Getenv("PAD_TEST_POSTGRES_URL") != "" {
+		t.Skip("SQLite rebuild path; the Postgres half of 086 is a DELETE + ADD CONSTRAINT")
+	}
+	const migrationName = "086_item_reminders_composite_fk.sql"
+
+	dbPath := filepath.Join(t.TempDir(), "migrate086.db")
+	s, err := New(dbPath)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer s.Close()
+
+	item, own, other := reminderConstraintFixture(t, s)
+	ts := now()
+	remindAt := time.Now().UTC().Add(time.Hour).Format(time.RFC3339)
+
+	// Rewind to the pre-086 world: drop the constrained table, rebuild 085's
+	// shape, and forget the bookkeeping row so the migration can run again.
+	for _, stmt := range []string{
+		`DROP TABLE item_reminders`,
+		`CREATE TABLE item_reminders (
+			id           TEXT PRIMARY KEY,
+			workspace_id TEXT NOT NULL,
+			item_id      TEXT NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+			remind_at    TEXT NOT NULL,
+			fired_at     TEXT,
+			acked_at     TEXT,
+			created_at   TEXT NOT NULL,
+			updated_at   TEXT NOT NULL
+		)`,
+		`DELETE FROM schema_migrations WHERE version = '` + migrationName + `'`,
+	} {
+		if _, err := s.db.Exec(stmt); err != nil {
+			t.Fatalf("rewind %q: %v", stmt, err)
+		}
+	}
+
+	goodID, badID := newID(), newID()
+	for _, r := range []struct{ id, ws string }{{goodID, own}, {badID, other}} {
+		if _, err := s.db.Exec(`
+			INSERT INTO item_reminders (id, workspace_id, item_id, remind_at, fired_at, acked_at, created_at, updated_at)
+			VALUES (?, ?, ?, ?, NULL, NULL, ?, ?)`,
+			r.id, r.ws, item.ID, remindAt, ts, ts); err != nil {
+			t.Fatalf("seed pre-migration row (ws=%s): %v", r.ws, err)
+		}
+	}
+	// Control: the pre-086 schema really does admit the disagreeing row. If it
+	// did not, the migration would have nothing to repair and a green below
+	// would mean nothing.
+	var seeded int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM item_reminders`).Scan(&seeded); err != nil {
+		t.Fatalf("count seeded: %v", err)
+	}
+	if seeded != 2 {
+		t.Fatalf("control leg failed: seeded %d rows into the pre-086 table, want 2", seeded)
+	}
+
+	body, err := migrationsFS.ReadFile("migrations/" + migrationName)
+	if err != nil {
+		t.Fatalf("read embedded migration: %v", err)
+	}
+	if !strings.Contains(string(body), "item_reminders_new") {
+		t.Fatalf("control leg failed: the embedded migration is not the rebuild this test targets")
+	}
+	if err := applySQLiteMigration(s.db, migrationName, string(body)); err != nil {
+		t.Fatalf("the migration failed on a database holding a disagreeing row: %v", err)
+	}
+
+	var survivors []string
+	rows, err := s.db.Query(`SELECT id FROM item_reminders ORDER BY id`)
+	if err != nil {
+		t.Fatalf("read survivors: %v", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		survivors = append(survivors, id)
+	}
+	if len(survivors) != 1 || survivors[0] != goodID {
+		t.Fatalf("survivors = %v, want just the agreeing row %s", survivors, goodID)
+	}
+
+	// The rebuilt table is constrained, and its indexes came back.
+	if _, err := s.db.Exec(`
+		INSERT INTO item_reminders (id, workspace_id, item_id, remind_at, fired_at, acked_at, created_at, updated_at)
+		VALUES (?, ?, ?, ?, NULL, NULL, ?, ?)`,
+		newID(), other, item.ID, remindAt, ts, ts); err == nil {
+		t.Error("after the rebuild the table still accepts a disagreeing row")
+	}
+	for _, idx := range []string{"idx_item_reminders_armed", "idx_item_reminders_unacked", "idx_item_reminders_item"} {
+		var n int
+		if err := s.db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name=?`, idx).Scan(&n); err != nil {
+			t.Fatalf("look up %s: %v", idx, err)
+		}
+		if n != 1 {
+			t.Errorf("index %s did not survive the rebuild", idx)
+		}
+	}
+
+	// And foreign_keys came back ON for the pooled connection, which the
+	// runner's defer is responsible for. A rebuild that leaks FKs=OFF would
+	// disable enforcement for whoever checks that connection out next.
+	var fk int
+	if err := s.db.QueryRow(`PRAGMA foreign_keys`).Scan(&fk); err != nil {
+		t.Fatalf("read pragma: %v", err)
+	}
+	if fk != 1 {
+		t.Errorf("PRAGMA foreign_keys = %d after the migration, want 1", fk)
+	}
+	var _ = sql.ErrNoRows
+}
+
+// TestMigration063DropsPreExistingDisagreeingRows is the Postgres counterpart.
+// The two halves repair by different means — SQLite filters the rebuild's
+// copy, Postgres DELETEs before ADD CONSTRAINT — so one test cannot stand for
+// both, and the untested half is the one that would fail a deployment's
+// startup.
+func TestMigration063DropsPreExistingDisagreeingRows(t *testing.T) {
+	if os.Getenv("PAD_TEST_POSTGRES_URL") == "" {
+		t.Skip("Postgres half of IDEA-2883; the SQLite rebuild has its own test")
+	}
+	const migrationName = "063_item_reminders_composite_fk.sql"
+
+	s := testStore(t)
+	item, own, other := reminderConstraintFixture(t, s)
+	ts := now()
+	remindAt := time.Now().UTC().Add(time.Hour).Format(time.RFC3339)
+
+	// Rewind: drop the constraint this migration added and forget its
+	// bookkeeping row, so the table admits the row again and 063 can re-run.
+	for _, stmt := range []string{
+		`ALTER TABLE item_reminders DROP CONSTRAINT item_reminders_item_workspace_fkey`,
+		`DELETE FROM schema_migrations WHERE version = '` + migrationName + `'`,
+	} {
+		if _, err := s.db.Exec(stmt); err != nil {
+			t.Fatalf("rewind %q: %v", stmt, err)
+		}
+	}
+
+	goodID, badID := newID(), newID()
+	for _, r := range []struct{ id, ws string }{{goodID, own}, {badID, other}} {
+		if _, err := s.db.Exec(`
+			INSERT INTO item_reminders (id, workspace_id, item_id, remind_at, fired_at, acked_at, created_at, updated_at)
+			VALUES ($1, $2, $3, $4, NULL, NULL, $5, $6)`,
+			r.id, r.ws, item.ID, remindAt, ts, ts); err != nil {
+			t.Fatalf("seed pre-migration row (ws=%s): %v", r.ws, err)
+		}
+	}
+	// Control: without the constraint the disagreeing row really is admitted,
+	// so the migration below has something to repair.
+	var seeded int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM item_reminders WHERE item_id = $1`, item.ID).Scan(&seeded); err != nil {
+		t.Fatalf("count seeded: %v", err)
+	}
+	if seeded != 2 {
+		t.Fatalf("control leg failed: seeded %d rows, want 2", seeded)
+	}
+
+	body, err := pgMigrationsFS.ReadFile("pgmigrations/" + migrationName)
+	if err != nil {
+		t.Fatalf("read embedded migration: %v", err)
+	}
+	if !strings.Contains(string(body), "ADD CONSTRAINT item_reminders_item_workspace_fkey") {
+		t.Fatal("control leg failed: the embedded migration is not the one this test targets")
+	}
+	if err := applyPostgresMigration(s.db, migrationName, string(body)); err != nil {
+		t.Fatalf("the migration failed on a database holding a disagreeing row: %v", err)
+	}
+
+	var survivors []string
+	rows, err := s.db.Query(`SELECT id FROM item_reminders WHERE item_id = $1 ORDER BY id`, item.ID)
+	if err != nil {
+		t.Fatalf("read survivors: %v", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		survivors = append(survivors, id)
+	}
+	if len(survivors) != 1 || survivors[0] != goodID {
+		t.Fatalf("survivors = %v, want just the agreeing row %s", survivors, goodID)
+	}
+
+	if _, err := s.db.Exec(`
+		INSERT INTO item_reminders (id, workspace_id, item_id, remind_at, fired_at, acked_at, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, NULL, NULL, $5, $6)`,
+		newID(), other, item.ID, remindAt, ts, ts); err == nil {
+		t.Error("after the migration the table still accepts a disagreeing row")
+	}
+}

--- a/internal/store/reminders.go
+++ b/internal/store/reminders.go
@@ -37,14 +37,22 @@ import (
 //
 // THE ROW'S OWN workspace_id MUST AGREE WITH ITS ITEM'S (codex round 13).
 // CreateReminder writes the pair from the item, and import writes it from
-// its own in-workspace mapping, so no door produces a disagreement today —
-// but the table has an FK to the item and no constraint tying the two
-// columns, and every reader scopes by r.workspace_id and then joins the item.
-// A row that ever disagreed (a hand-edited bundle, a future move door, a
-// direct write) would carry one workspace's item into another's dashboard
-// and webhooks. The identity is asserted in the predicate, so the scan, the
-// arbiter, the pin and the reads all refuse the row rather than one of them
-// deciding it is "unreachable" on the others' behalf.
+// its own in-workspace mapping, so no door produces a disagreement today, and
+// since IDEA-2883 the TABLE forbids one: the foreign key is composite,
+// (item_id, workspace_id) REFERENCES items(id, workspace_id), so a
+// disagreeing row is unrepresentable rather than merely unwritten
+// (migrations 086 / 063). The sentence that stood here said the table had "no
+// constraint tying the two columns", which is what this predicate was
+// compensating for.
+//
+// THE PREDICATE STAYS, and not out of habit. Enforcement binds to the
+// connection doing the write, and SQLite's is a per-connection pragma that
+// table-rebuild migrations legitimately turn off — so a row can still arrive
+// from a restored pre-086 backup, from an operator who dropped the
+// constraint, or through a future rebuild's window. When one does, the scan,
+// the arbiter, the pin and the reads all refuse it here rather than one of
+// them deciding it is "unreachable" on the others' behalf. Belt on top of
+// braces, with the braces now actually present.
 const reminderFireable = `EXISTS (
 		SELECT 1 FROM items i
 		JOIN workspaces w ON w.id = i.workspace_id

--- a/internal/store/reminders_test.go
+++ b/internal/store/reminders_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"testing"
@@ -1471,7 +1472,18 @@ func TestImportRefusesAckWithoutFire(t *testing.T) {
 // is asserted in reminderFireable and in the two reads that do not use it,
 // so the row is inert everywhere rather than "unreachable" somewhere.
 //
-// The row is written raw, because that is the only way one can exist.
+// The row is written with the composite foreign key SUSPENDED, because since
+// IDEA-2883 that is the only way one can exist: the table now FORBIDS the
+// disagreement rather than merely failing to forbid it (migrations 086 / 063).
+//
+// This test survives that change on purpose, and the reason is specific rather
+// than a general nod to defence in depth. The constraint protects rows written
+// through a connection that is ENFORCING it, and SQLite's enforcement is a
+// per-connection PRAGMA that table-rebuild migrations legitimately turn off —
+// so a row can still arrive from a restored pre-086 backup, from an operator
+// who dropped the constraint, or through a future rebuild's window. If one
+// ever does, these five reads are what keep it inert, and this is the only
+// test that says so.
 //
 // MUTANT: dropping `i.workspace_id = item_reminders.workspace_id` from
 // reminderFireable makes the row a candidate and fires it; dropping the
@@ -1489,12 +1501,7 @@ func TestAReminderWhoseWorkspaceDisagreesWithItsItemIsInert(t *testing.T) {
 	// so the pending surface would show it if it could.
 	ts := now()
 	id := newID()
-	if _, err := s.db.Exec(s.q(`
-		INSERT INTO item_reminders (id, workspace_id, item_id, remind_at, fired_at, acked_at, created_at, updated_at)
-		VALUES (?, ?, ?, ?, NULL, NULL, ?, ?)
-	`), id, wsB.ID, itemA.ID, past, ts, ts); err != nil {
-		t.Fatalf("raw insert: %v", err)
-	}
+	insertUnconstrainedReminder(t, s, id, wsB.ID, itemA.ID, past, ts)
 
 	// Scan: not a candidate.
 	ids, err := s.dueReminderCandidates(nowTS(), 0)
@@ -1554,5 +1561,57 @@ func TestAReminderWhoseWorkspaceDisagreesWithItsItemIsInert(t *testing.T) {
 	}
 	if n := len(bundle.Reminders); n != 0 {
 		t.Errorf("B's export carries %d reminder(s) about A's item, want 0", n)
+	}
+}
+
+// insertUnconstrainedReminder writes a reminder row that the IDEA-2883
+// composite foreign key would refuse, by suspending enforcement for exactly
+// that one INSERT. It exists so the read-side identity predicates keep a test
+// after the constraint made their fixture unbuildable.
+//
+// The two drivers suspend differently and neither is a shortcut worth hiding:
+//
+//   - SQLite enforcement is a PER-CONNECTION pragma, so the pragma and the
+//     INSERT have to ride the SAME pinned connection — on the pool they could
+//     land on different ones and the INSERT would be refused (the hazard
+//     applySQLiteMigration documents). It is restored on a defer, so the
+//     connection never returns to the pool with foreign keys off.
+//   - Postgres has no per-session equivalent short of superuser tricks, so the
+//     constraint is DROPPED. It is not re-added: the row now in the table
+//     violates it, so the ADD would fail. That is fine here — the subject of
+//     this test is the READ predicates, and the constraint has its own tests —
+//     but it means this fixture must stay the last thing that needs the
+//     constraint in its store.
+func insertUnconstrainedReminder(t *testing.T, s *Store, id, workspaceID, itemID, remindAt, ts string) {
+	t.Helper()
+	const ins = `INSERT INTO item_reminders (id, workspace_id, item_id, remind_at, fired_at, acked_at, created_at, updated_at)
+		VALUES (?, ?, ?, ?, NULL, NULL, ?, ?)`
+
+	if s.dialect.Driver() == DriverPostgres {
+		if _, err := s.db.Exec(`ALTER TABLE item_reminders DROP CONSTRAINT item_reminders_item_workspace_fkey`); err != nil {
+			t.Fatalf("suspend composite fk: %v", err)
+		}
+		if _, err := s.db.Exec(s.q(ins), id, workspaceID, itemID, remindAt, ts, ts); err != nil {
+			t.Fatalf("raw insert: %v", err)
+		}
+		return
+	}
+
+	ctx := context.Background()
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("pin connection: %v", err)
+	}
+	defer conn.Close()
+	if _, err := conn.ExecContext(ctx, "PRAGMA foreign_keys = OFF"); err != nil {
+		t.Fatalf("suspend foreign keys: %v", err)
+	}
+	defer func() {
+		if _, err := conn.ExecContext(ctx, "PRAGMA foreign_keys = ON"); err != nil {
+			t.Fatalf("restore foreign keys: %v", err)
+		}
+	}()
+	if _, err := conn.ExecContext(ctx, s.q(ins), id, workspaceID, itemID, remindAt, ts, ts); err != nil {
+		t.Fatalf("raw insert: %v", err)
 	}
 }


### PR DESCRIPTION
Implements IDEA-2883.

## Why

`item_reminders.workspace_id` is denormalized from the item so the scheduler tick can claim and scope work without joining `items` on every pass. Denormalization creates a value that CAN disagree with its source, and nothing in the schema said it must not.

IDEA-2641 closed that class one read at a time across codex rounds 13 and 14: `reminderFireable`, the Postgres pin, `ListPendingReminders`, the export query, then `GetReminder` and `ListRemindersForItem`. Five sites now spell the same identity. The sixth someone adds will not, and the round that finds it will be the sixteenth.

A composite foreign key — `(item_id, workspace_id) REFERENCES items(id, workspace_id)` — makes the disagreeing row unrepresentable. The read-side predicates stay; they become belt on top of braces rather than the only thing standing between a denormalized column and its source.

## The two migrations

SQLite cannot `ADD` a constraint, so `086` rebuilds the table (following `055`'s recipe; the runner already supports it — `applySQLiteMigration` pins the migration to one connection, treats `PRAGMA foreign_keys = OFF` as a before-transaction pragma, restores it on a defer covering every return, and wraps body plus bookkeeping in one transaction). `063` alters in place. Both add `UNIQUE INDEX idx_items_id_workspace ON items(id, workspace_id)` as the referenceable parent key.

**Measured before writing either file**, not recalled: both drivers accept a plain unique INDEX (not only a unique CONSTRAINT) as a composite FK target, refuse the disagreeing child row, and cascade through the composite key. The cascade leg matters — replacing a single-column FK with a composite one is exactly the edit that drops `ON DELETE CASCADE` unnoticed, and a reminder for a deleted item is a notification nobody can act on.

The Postgres half drops `062`'s inline single-column FK **by shape rather than by name**. Postgres auto-names it `item_reminders_item_id_fkey`, but auto-names collide-and-suffix, so a name-keyed `DROP ... IF EXISTS` could silently leave a differently-named one in place — harmless in itself, since the composite FK is strictly stronger, but then the two dialects would not agree while claiming to.

**No `ON UPDATE CASCADE`, deliberately.** `items.workspace_id` is never updated: enumerated across `internal/` and `cmd/`, and `UpdateItem`'s dynamic set list has no such column; the cross-workspace "move" is copy-plus-archive against a new item row. If a future feature does move an item between workspaces, this constraint should REFUSE it rather than quietly rewrite the reminders underneath — moving them is a decision that feature has to make on purpose.

## Disagreeing rows are dropped, not repaired

Both halves repair before constraining, because a migration that fails on live data is a deployment incident: Postgres would fail `ADD CONSTRAINT`, SQLite would fail the rebuild's copy, and either takes startup down.

Dropping rather than repairing is a choice. A disagreeing row is **already unreachable** — all five read predicates filter it, so it can never fire, be listed, or be acknowledged. Pointing it back at its item would RESURRECT it: an upgrade would deliver a notification for an instant long past. Deleting removes nothing any surface could ever show.

No such rows are expected — `CreateReminder` derives `workspace_id` from the item itself, and the import path writes an id minted in the same workspace — but that is an argument about the write doors, not a census. The dev database holds zero reminder rows, so a census there answers nothing about anyone else's deployment, which is exactly why the repair pass exists rather than a bare copy.

## An existing test had to change, and was kept rather than deleted

`TestAReminderWhoseWorkspaceDisagreesWithItsItemIsInert` (IDEA-2641, codex round 13) could no longer construct its fixture: the constraint refuses the row on both drivers. Its comment said "the table has nothing that forbids one", which is now false and says so.

It is kept, for a specific reason rather than a general nod to defence in depth. The constraint protects rows written through a connection that is ENFORCING it, and SQLite's enforcement is a per-connection pragma that table-rebuild migrations legitimately turn off — so a row can still arrive from a restored pre-086 backup, from an operator who dropped the constraint, or through a future rebuild's window. Those five reads are what keep it inert, and this is the only test that says so. The fixture now suspends enforcement for exactly one INSERT, differently per driver, and the helper explains both.

## Evidence

**Counterfactual matrix, six mutants, both drivers:**

| mutant | SQLite | Postgres |
|---|---|---|
| C1 both migrations absent | DETECTED (repair + constraint) | DETECTED (repair + constraint) |
| C2 sqlite copy loses the JOIN repair filter | DETECTED | survived |
| C3 pg migration loses the DELETE repair pass | survived | DETECTED |
| C4 sqlite FK drops the workspace column | DETECTED (2 tests) | survived |
| C5 pg FK drops the workspace column | survived | DETECTED (2 tests) |
| C6 sqlite rebuild drops `ON DELETE CASCADE` | DETECTED | survived |

Every survivor is a mutant editing the OTHER driver's file — the only correct outcome, since a SQLite migration edit is invisible to a Postgres run. Union across both columns: all six detected, no unexplained cell.

**Instruments.** The constraint test writes raw SQL on purpose: `CreateReminder` derives the workspace from the item, so it cannot produce the row the constraint forbids, and testing through it would assert that a correct writer writes correctly. Both migration tests read the migration text from the embedded FS and apply it through the real `applySQLiteMigration` / `applyPostgresMigration` against the real `items` table, so they exercise the shipped SQL rather than a retyped copy; the halves repair by different means, so one test cannot stand for both. The SQLite test also asserts the three indexes came back and that `PRAGMA foreign_keys` is 1 afterwards — a rebuild that leaked FKs=OFF would disable enforcement for whichever caller next checks that connection out. `TestReminderCascadeSurvivesTheCompositeKey` is labelled in its own comment as a preservation lock that passes on both sides of the change; C6 is what makes it worth having.

**Prose swept** (CONVE-23): `reminderFireable`'s note said the table has "no constraint tying the two columns" — that was the predicate's premise and it is now false. Migration `085` is left as written: it is a historical record of what it did, and `086`'s header states that it supersedes that FK.

## Post-review addition

Codex round 1 came back CLEAN, and re-reading the diff as its reviewer rather than its author then found a defect the round had missed: the Postgres `DO` block dropped only the FIRST legacy `item_id` constraint, because plpgsql's `SELECT ... INTO` takes one row and does not error on several. A table carrying two would keep one alongside the composite key while the migration reported success, leaving the two dialects disagreeing about the table's shape. It is now a loop, with its own test — nothing creates a duplicate today, which is exactly why the branch needed one rather than a comment. Round 2 (focused on whether the tests can fail for the reasons they claim) then came back CLEAN on the gated tip.

`id TEXT PRIMARY KEY` is carried over from 085 without adding `NOT NULL`, though migration 077 records that SQLite does not imply it there. Deliberate: changing a column definition inside a constraint migration is the kind of silent addition that makes a migration hard to review, and no door can write a NULL id.

https://claude.ai/code/session_01HeChkgZVYb3NTgTcckF5KR
