### PR TITLE
fix(store): export soft-deleted collections so their live items survive a round trip (BUG-2884)

### DIFF
--- a/internal/models/export.go
+++ b/internal/models/export.go
@@ -107,6 +107,28 @@ type CollectionExport struct {
 	IsSystem  bool   `json:"is_system"`
 	CreatedAt string `json:"created_at"`
 	UpdatedAt string `json:"updated_at"`
+	// DeletedAt carries a collection's soft-delete mark, empty for a live
+	// collection (BUG-2884).
+	//
+	// The bundle used to skip soft-deleted collections while exporting every
+	// live ITEM, and DeleteCollection soft-deletes only the collection row —
+	// its items keep deleted_at IS NULL and stay reachable by ref, by id, and
+	// through search, because no item-bearing read joins collection liveness.
+	// So the two sections were filtered by different rules and the bundle
+	// named a collection it did not carry; ImportWorkspace then dropped those
+	// items on its orphan gate, silently. Since pad db migrate is
+	// ExportWorkspace piped into ImportWorkspace, that was live data lost on a
+	// SQLite→Postgres migration, not just a lossy backup.
+	//
+	// Filtering the items to live collections instead would have made the
+	// migration DELETE reachable rows, so the bundle carries the archived
+	// collection and the importer reproduces the archive.
+	//
+	// omitempty for the same reason as Traits: an archive from a workspace
+	// with nothing deleted omits the key rather than carrying a noise "" on
+	// every collection. Absent decodes to "" and MUST mean live — that is what
+	// keeps every archive written before this field importable.
+	DeletedAt string `json:"deleted_at,omitempty"`
 }
 
 // ItemExport holds an item's data for export.

--- a/internal/store/collections.go
+++ b/internal/store/collections.go
@@ -144,9 +144,12 @@ func (s *Store) CreateCollection(workspaceID string, input models.CollectionCrea
 // edits, not the only one. The others are ListCollections (above), and
 // ExportWorkspace / ImportWorkspace in export.go, which carry their own
 // projection over models.CollectionExport — a portability format, deliberately
-// not this model: it omits workspace_id and deleted_at because an import
-// assigns a fresh workspace and an export skips deleted rows. A column added
-// here but not there hydrates everywhere and still vanishes on export/import.
+// not this model: it omits workspace_id because an import assigns a fresh
+// workspace. It DOES carry deleted_at (BUG-2884): the export used to skip
+// deleted collections while exporting their still-live items, so the bundle
+// named a collection it did not contain and the importer dropped those items
+// silently. A column added here but not there hydrates everywhere and still
+// vanishes on export/import.
 const collectionColumns = `id, workspace_id, name, slug, prefix, icon, description, schema, settings, traits, sort_order, is_default, is_system, created_at, updated_at, deleted_at`
 
 // collectionSelect is the shared prefix each single-row accessor completes

--- a/internal/store/export.go
+++ b/internal/store/export.go
@@ -734,7 +734,16 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 	for _, lk := range data.ItemLinks {
 		newSourceID := itemMap[lk.SourceID]
 		newTargetID := itemMap[lk.TargetID]
-		if newSourceID == "" || newTargetID == "" {
+		// insertedItems on BOTH endpoints, not just a non-empty mapping
+		// (BUG-2884). An orphaned item still gets a map entry — written before
+		// the skip, because parent resolution needs it — so `!= ""` is
+		// satisfied by an id naming no row, and the INSERT below hits the
+		// foreign key. `continue` on that error is not a recovery on
+		// POSTGRES: a failed statement aborts the surrounding transaction, so
+		// every later statement fails and COMMIT reports "commit unexpectedly
+		// resulted in rollback". One skippable link took the whole restore
+		// down. The row has to be refused before the database sees it.
+		if !insertedItems[newSourceID] || !insertedItems[newTargetID] {
 			continue
 		}
 		_, err := tx.Exec(s.q(`
@@ -743,7 +752,12 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 			newID(), ws.ID, newSourceID, newTargetID, lk.LinkType, lk.CreatedBy,
 			lk.CreatedAt)
 		if err != nil {
-			// Ignore duplicate links
+			// Defence in depth for a duplicate, nothing more — and on Postgres
+			// it is thin: the transaction is already poisoned by the time this
+			// runs, so the guard above is what actually keeps the import
+			// alive. A duplicate is not expected here anyway, since the source
+			// enforces UNIQUE(source_id, target_id, link_type) and the ids are
+			// freshly minted.
 			continue
 		}
 	}
@@ -753,11 +767,18 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 	// string would make a never-fired reminder read as fired at "".
 	for _, rm := range data.Reminders {
 		newItemID := itemMap[rm.ItemID]
-		// TWO GUARDS, AND NEITHER ALONE IS OBSERVABLE — measured, not assumed.
-		// Reverting either one on its own leaves the test green: with the map
-		// gate restored, the skip-on-error below survives the FK failure; with
-		// the fatal return restored, this gate means the insert never fails.
-		// Removing BOTH is what fails it. They are kept as a pair because they
+		// TWO GUARDS, AND NEITHER ALONE IS OBSERVABLE ON SQLITE — measured,
+		// not assumed. Reverting either one on its own leaves the test green
+		// there: with the map gate restored, the skip-on-error below survives
+		// the FK failure; with the fatal return restored, this gate means the
+		// insert never fails. Removing BOTH is what fails it.
+		//
+		// The driver qualifier is not decoration (BUG-2884): on POSTGRES a
+		// failed statement aborts the transaction, so "the skip-on-error
+		// survives the FK failure" is false there — COMMIT reports "commit
+		// unexpectedly resulted in rollback" and the whole import is lost.
+		// This gate, which refuses the row before the database sees it, is the
+		// one that carries both drivers. They are kept as a pair because they
 		// defend the same failure at different depths — this one prevents the
 		// bad write, the one below survives a bad write that arrives some
 		// other way — and the pair is recorded here so a future reader does
@@ -833,7 +854,13 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 	// Import item versions
 	for _, ver := range data.ItemVersions {
 		newItemID := itemMap[ver.ItemID]
-		if newItemID == "" {
+		// insertedItems, not just a non-empty mapping — same reason as the
+		// links loop above, and the same Postgres consequence (BUG-2884). The
+		// skip-on-error below is a log-and-continue for the unexpected, not a
+		// substitute for this gate: on Postgres the FK failure it used to
+		// "skip" had already aborted the transaction, so a single orphaned
+		// item's version history failed the entire workspace restore.
+		if !insertedItems[newItemID] {
 			continue
 		}
 		// version_seq (BUG-2270): re-derive a per-item monotonic seq at

--- a/internal/store/export.go
+++ b/internal/store/export.go
@@ -147,10 +147,26 @@ func (s *Store) ExportWorkspace(slug string) (*models.WorkspaceExport, error) {
 		},
 	}
 
-	// Collections
+	// Collections — including SOFT-DELETED ones, which carry their deleted_at
+	// so the importer can reproduce the archive (BUG-2884).
+	//
+	// This section used to filter `deleted_at IS NULL` while the items section
+	// below filtered only on the ITEM's own deleted_at. DeleteCollection
+	// soft-deletes the collection row alone, so its items stay live and stay
+	// reachable — by ref, by id, and through search, since no item-bearing
+	// read in this package joins collection liveness. Two sections, two rules,
+	// and the bundle named a collection it did not contain: ImportWorkspace
+	// then dropped every such item on its orphan gate, with no log line for
+	// the item itself.
+	//
+	// The other repair — filtering items to live collections — was rejected on
+	// measurement rather than taste. `pad db migrate` is ExportWorkspace piped
+	// into ImportWorkspace (cmd/pad/cmd_db.go), so dropping those items would
+	// silently DELETE live, addressable rows during a SQLite→Postgres
+	// migration: a worse defect than the lossy backup it would fix.
 	rows, err := s.db.Query(s.q(`
-		SELECT id, name, slug, icon, description, schema, settings, traits, prefix, sort_order, is_default, is_system, created_at, updated_at
-		FROM collections WHERE workspace_id = ? AND deleted_at IS NULL
+		SELECT id, name, slug, icon, description, schema, settings, traits, prefix, sort_order, is_default, is_system, created_at, updated_at, COALESCE(deleted_at, '')
+		FROM collections WHERE workspace_id = ?
 		ORDER BY sort_order, name`), ws.ID)
 	if err != nil {
 		return nil, fmt.Errorf("export collections: %w", err)
@@ -159,7 +175,7 @@ func (s *Store) ExportWorkspace(slug string) (*models.WorkspaceExport, error) {
 	for rows.Next() {
 		var c models.CollectionExport
 		var isDefault, isSystem bool
-		if err := rows.Scan(&c.ID, &c.Name, &c.Slug, &c.Icon, &c.Description, &c.Schema, &c.Settings, &c.Traits, &c.Prefix, &c.SortOrder, &isDefault, &isSystem, &c.CreatedAt, &c.UpdatedAt); err != nil {
+		if err := rows.Scan(&c.ID, &c.Name, &c.Slug, &c.Icon, &c.Description, &c.Schema, &c.Settings, &c.Traits, &c.Prefix, &c.SortOrder, &isDefault, &isSystem, &c.CreatedAt, &c.UpdatedAt, &c.DeletedAt); err != nil {
 			return nil, fmt.Errorf("scan collection: %w", err)
 		}
 		c.IsDefault = isDefault
@@ -353,9 +369,21 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 	// declarations live, which collection receives an imported artifact or
 	// answers an invocation slug depends on collection order. Warn so the
 	// operator can fix it. Codex round 8.
+	//
+	// ARCHIVED collections are excluded from this scan (BUG-2884). Since the
+	// bundle started carrying soft-deleted collections, a workspace whose
+	// archived collection still declares the kind its live replacement
+	// declares would warn on every import about an ambiguity that does not
+	// exist: routing is live-only (ListTraitedCollections filters
+	// deleted_at IS NULL), so an archived declaration resolves nothing. Worse
+	// than the noise, the archived slug could win `seenKinds` and the warning
+	// would name the LIVE collection as the duplicate.
 	seenKinds := map[string]string{}
 	invocationCollection := ""
 	for _, c := range data.Collections {
+		if c.DeletedAt != "" {
+			continue
+		}
 		if t, err := models.ParseCollectionTraits(c.Traits); err == nil {
 			if t.ArtifactKind != nil && t.ArtifactKind.Kind != "" {
 				if prev, dup := seenKinds[t.ArtifactKind.Kind]; dup {
@@ -449,7 +477,14 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 		// that only round-trips through an export. Slug-keyed for the same
 		// reason the migration is: on a row with no declarations, the slug is
 		// the only evidence of intent that exists. Codex round 4.
-		if inferred := collections.CanonicalTraitsForSlug(c.Slug); !inferred.IsZero() {
+		//
+		// Not applied to an ARCHIVED collection (BUG-2884): inference exists so
+		// a restored workspace comes up ROUTING, and an archived collection
+		// never routes. Stamping it would only add a log line about a
+		// declaration nothing reads — and, where the archived collection is a
+		// renamed predecessor of the live one, would put the canonical set on
+		// two rows.
+		if inferred := collections.CanonicalTraitsForSlug(c.Slug); !inferred.IsZero() && c.DeletedAt == "" {
 			if current, err := models.ParseCollectionTraits(traits); err == nil && current.IsZero() {
 				if encoded, err := inferred.JSON(); err == nil {
 					// Two different situations reach here and the log must
@@ -470,11 +505,15 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 			}
 		}
 
+		// NULLIF so an ABSENT deleted_at — every archive written before
+		// BUG-2884, which decodes the missing key as "" — imports the
+		// collection LIVE. That direction is what keeps old bundles working;
+		// only a non-empty mark reproduces an archive.
 		_, err := tx.Exec(s.q(`
-			INSERT INTO collections (id, workspace_id, name, slug, icon, description, schema, settings, traits, prefix, sort_order, is_default, is_system, created_at, updated_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`),
+			INSERT INTO collections (id, workspace_id, name, slug, icon, description, schema, settings, traits, prefix, sort_order, is_default, is_system, created_at, updated_at, deleted_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULLIF(?, ''))`),
 			newCollID, ws.ID, c.Name, c.Slug, c.Icon, c.Description, c.Schema, settings, traits, c.Prefix, c.SortOrder, s.dialect.BoolToInt(c.IsDefault), s.dialect.BoolToInt(c.IsSystem),
-			c.CreatedAt, c.UpdatedAt)
+			c.CreatedAt, c.UpdatedAt, c.DeletedAt)
 		if err != nil {
 			return nil, fmt.Errorf("import collection %s: %w", c.Name, err)
 		}
@@ -631,7 +670,11 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 	_ = coercedTags // tags don't carry ID relations; second-pass only touches fields
 	for _, it := range data.Items {
 		newItemID := itemMap[it.ID]
-		if newItemID == "" {
+		// Same correction as the comment loop, though this one was INERT
+		// rather than wrong: an orphan's UPDATE matched no row and returned no
+		// error. Left as `== ""` it reads like an orphan guard that works,
+		// which is the reading that let the comment loop ship unguarded.
+		if !insertedItems[newItemID] {
 			continue
 		}
 		fieldsInput, ok := coercedFields[it.ID]
@@ -656,7 +699,21 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 	// Import comments
 	for _, cm := range data.Comments {
 		newItemID := itemMap[cm.ItemID]
-		if newItemID == "" {
+		// insertedItems, NOT `newItemID == ""` (BUG-2884). That test cannot
+		// fire for an item the bundle CONTAINS: itemMap is written for every
+		// item before the orphan skip above, deliberately, because parent
+		// resolution reads it for items the loop has not reached yet. So an
+		// orphaned item's comment used to reach this INSERT with an item_id
+		// naming no row, and the foreign key aborted the ENTIRE workspace
+		// import — one skippable row taking the whole restore down.
+		//
+		// The reminder loop below carries a long note about being fixed for
+		// exactly this; the comment loop was left standing. Fixing the export
+		// half removes pad's own route here (a bundle this build writes has no
+		// orphans), but a hand-edited, foreign, or pre-fix archive can still
+		// carry one, and that is precisely the population that needs to
+		// import.
+		if !insertedItems[newItemID] {
 			continue
 		}
 		// Stamp BEFORE the INSERT (BUG-2415).

--- a/internal/store/export.go
+++ b/internal/store/export.go
@@ -320,6 +320,36 @@ func (s *Store) ExportWorkspace(slug string) (*models.WorkspaceExport, error) {
 	return export, nil
 }
 
+// resolveImportParent maps an exported parent_id onto the id its item received
+// in this import, and returns "" — meaning no parent — unless that item
+// actually landed.
+//
+// itemMap alone is not enough (BUG-2884, codex round 3). It holds an entry for
+// every item in the bundle INCLUDING orphans, written before the orphan skip
+// because parent resolution reads it for items the loop has not reached yet.
+// So `mapped != ""` was satisfied by an id naming no row, and a live child of
+// an archived-collection parent wrote that id into items.parent_id — a foreign
+// key. It fails on both drivers (SQLite runs with foreign_keys ON), fatally on
+// the first pass and by aborting the transaction on Postgres.
+//
+// Dropping the edge is the only thing the bundle can express: the parent is
+// not in it, so there is nothing to point at. item_links already drops a link
+// whose endpoint is missing, for the same reason.
+//
+// Both passes call this, and both need it: the first because an orphan earlier
+// in the bundle's order is already mapped by the time a later child is
+// inserted, the second because by then every item is mapped.
+func resolveImportParent(exportedParentID string, itemMap map[string]string, insertedItems map[string]bool) string {
+	if exportedParentID == "" {
+		return ""
+	}
+	mapped, ok := itemMap[exportedParentID]
+	if !ok || !insertedItems[mapped] {
+		return ""
+	}
+	return mapped
+}
+
 // ImportWorkspace imports a workspace from an exported data structure.
 // It creates a new workspace with regenerated IDs, remapping all references.
 // If newName is non-empty, it overrides the workspace name and slug.
@@ -545,10 +575,18 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 	// So a later section resolving an id through itemMap alone can get one
 	// that names no row, and inserting a foreign key to it fails (SQLite
 	// enforces FKs here — `_pragma=foreign_keys(on)` in the DSN — and Postgres
-	// always does). item_links and item_versions survive that by skipping on
-	// error; the reminder loop below checks this set instead, which refuses
-	// the row for the right reason rather than letting the database refuse it
-	// for an incidental one.
+	// always does).
+	//
+	// EVERY consumer therefore checks this set, not just a non-empty mapping
+	// (BUG-2884): the two parent-resolution sites via resolveImportParent, and
+	// the comment, link, version and reminder loops directly. The earlier
+	// design let links and versions "survive by skipping on error", which is
+	// true only on SQLite — on Postgres a failed statement aborts the
+	// transaction, so the skip never runs and COMMIT reports "commit
+	// unexpectedly resulted in rollback". A row that cannot be written has to
+	// be refused before the database sees it, which also refuses it for the
+	// right reason rather than letting the database refuse it for an
+	// incidental one.
 	insertedItems := make(map[string]bool, len(data.Items))
 	var nextItemNumber int
 	for _, it := range data.Items {
@@ -560,12 +598,7 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 		}
 
 		// On first pass, parent_id may refer to an item not yet created, so use empty
-		parentID := ""
-		if it.ParentID != "" {
-			if mapped, ok := itemMap[it.ParentID]; ok {
-				parentID = mapped
-			}
-		}
+		parentID := resolveImportParent(it.ParentID, itemMap, insertedItems)
 
 		nextItemNumber++
 		// IDEA-1486 + IDEA-1488: coerce empty-string / malformed
@@ -683,12 +716,7 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 		}
 		// Remap relation fields now that ALL items are mapped
 		fields := remapFieldIDs(fieldsInput, itemMap, collMap)
-		parentID := ""
-		if it.ParentID != "" {
-			if mapped, ok := itemMap[it.ParentID]; ok {
-				parentID = mapped
-			}
-		}
+		parentID := resolveImportParent(it.ParentID, itemMap, insertedItems)
 		_, err := tx.Exec(s.q(`UPDATE items SET fields = ?, parent_id = NULLIF(?, '') WHERE id = ?`),
 			fields, parentID, newItemID)
 		if err != nil {
@@ -731,6 +759,7 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 	}
 
 	// Import item links
+	seenLinks := make(map[string]bool, len(data.ItemLinks))
 	for _, lk := range data.ItemLinks {
 		newSourceID := itemMap[lk.SourceID]
 		newTargetID := itemMap[lk.TargetID]
@@ -746,6 +775,19 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 		if !insertedItems[newSourceID] || !insertedItems[newTargetID] {
 			continue
 		}
+		// DEDUPE BEFORE THE WRITE, not after the error. The source enforces
+		// UNIQUE(source_id, target_id, link_type), but that bounds what pad
+		// WROTE, not what ARRIVES: a hand-edited, merged, or concatenated
+		// bundle can carry the same edge twice. On Postgres the unique
+		// violation aborts the transaction, so the `continue` below could
+		// never ignore it — COMMIT failed and the whole restore was lost over
+		// a row the loop meant to drop (codex round 3). Keyed on the remapped
+		// triple because that is what the index sees.
+		edge := newSourceID + "\x00" + newTargetID + "\x00" + lk.LinkType
+		if seenLinks[edge] {
+			continue
+		}
+		seenLinks[edge] = true
 		_, err := tx.Exec(s.q(`
 			INSERT INTO item_links (id, workspace_id, source_id, target_id, link_type, created_by, created_at)
 			VALUES (?, ?, ?, ?, ?, ?, ?)`),

--- a/internal/store/export_soft_deleted_collection_test.go
+++ b/internal/store/export_soft_deleted_collection_test.go
@@ -383,77 +383,203 @@ func TestLegacyBundleWithoutDeletedAtImportsLive(t *testing.T) {
 	}
 }
 
-// TestImportSurvivesOrphanedItemWithComment covers a SECOND defect, found by
-// the dependents test above while the export half was still unfixed: an
-// orphaned item — one whose collection the bundle does not carry — aborted the
-// ENTIRE workspace import if it had a comment.
+// TestImportSurvivesOrphanedItemDependents covers a SECOND defect, found by
+// the dependents test above while the export half was still unfixed, and
+// widened by the Postgres gate: a dependent row hanging off an ORPHANED item —
+// one whose collection the bundle does not carry — took the ENTIRE workspace
+// import down.
 //
-// The comment loop guards on `itemMap[cm.ItemID] == ""`, and that guard cannot
-// fire for an item the bundle contains: itemMap is populated for EVERY item
-// before the orphan skip, deliberately, because parent resolution reads it for
-// items the loop has not reached. So the loop INSERTed a comment whose item_id
-// names no row and the FK refused it, failing the whole restore. This is the
-// same defect the reminder loop already carries a long comment about ("ONE
-// orphaned item with a reminder aborted the entire workspace import"); it was
-// fixed there and left standing here.
+// Two mechanisms, and the second is why the SQLite suite was not enough.
 //
-// Fixing the export half removes pad's own route to it — a bundle this build
+//  1. THE GUARD CANNOT FIRE. Every dependent loop tested
+//     `itemMap[...] == ""`, and itemMap is populated for EVERY item before the
+//     orphan skip — deliberately, because parent resolution reads it for items
+//     the loop has not reached. So the INSERT went ahead with an id naming no
+//     row and the foreign key refused it.
+//
+//  2. "SKIP ON ERROR" IS NOT A SKIP ON POSTGRES. The links and versions loops
+//     answered the FK failure by continuing, which works on SQLite. On
+//     Postgres a failed statement aborts the surrounding transaction, so every
+//     later statement fails and COMMIT reports `commit unexpectedly resulted in
+//     rollback`. Catching the error cannot recover it; the row has to be
+//     refused BEFORE the database sees it. That is exactly what the reminder
+//     loop's insertedItems check already did, and it is now what all four do.
+//
+// One dependent kind per subtest, deliberately: a fixture carrying all three
+// would fail whichever loop is checked first and prove nothing about the other
+// two.
+//
+// Fixing the export half removes pad's own route here — a bundle this build
 // writes has no orphans — but not a hand-edited, foreign, or pre-fix archive,
 // which is exactly the population that needs to import.
-func TestImportSurvivesOrphanedItemWithComment(t *testing.T) {
-	s := testStore(t)
-	owner := createTestUser(t, s, "orphan2884@test.com", "Owner", "password123")
-	ws, archived, it := archivedCollectionFixture(t, s, "Orphan Comment 2884")
+func TestImportSurvivesOrphanedItemDependents(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		// seed hangs exactly ONE kind of dependent row off the orphaned item.
+		seed func(t *testing.T, s *Store, ws *models.Workspace, orphan, live *models.Item)
+		// present asserts the bundle actually carries it, so a green cannot
+		// come from the fixture never reaching the loop under test.
+		present func(exp *models.WorkspaceExport, orphanID string) bool
+	}{
+		{
+			name: "comment",
+			seed: func(t *testing.T, s *Store, ws *models.Workspace, orphan, live *models.Item) {
+				if _, err := s.CreateComment(ws.ID, orphan.ID, "", models.CommentCreate{Author: "Rook", Body: "on an orphan"}); err != nil {
+					t.Fatalf("CreateComment: %v", err)
+				}
+			},
+			present: func(exp *models.WorkspaceExport, orphanID string) bool {
+				for _, cm := range exp.Comments {
+					if cm.ItemID == orphanID {
+						return true
+					}
+				}
+				return false
+			},
+		},
+		{
+			name: "version",
+			seed: func(t *testing.T, s *Store, ws *models.Workspace, orphan, live *models.Item) {
+				body := "edited, which mints a version"
+				if _, err := s.UpdateItem(orphan.ID, models.ItemUpdate{Content: &body}); err != nil {
+					t.Fatalf("UpdateItem: %v", err)
+				}
+			},
+			present: func(exp *models.WorkspaceExport, orphanID string) bool {
+				for _, v := range exp.ItemVersions {
+					if v.ItemID == orphanID {
+						return true
+					}
+				}
+				return false
+			},
+		},
+		{
+			name: "link",
+			seed: func(t *testing.T, s *Store, ws *models.Workspace, orphan, live *models.Item) {
+				if _, err := s.CreateItemLink(ws.ID, models.ItemLinkCreate{TargetID: orphan.ID, LinkType: "blocks"}, live.ID); err != nil {
+					t.Fatalf("CreateItemLink: %v", err)
+				}
+			},
+			present: func(exp *models.WorkspaceExport, orphanID string) bool {
+				for _, lk := range exp.ItemLinks {
+					if lk.TargetID == orphanID || lk.SourceID == orphanID {
+						return true
+					}
+				}
+				return false
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := testStore(t)
+			owner := createTestUser(t, s, "orphan-"+tc.name+"-2884@test.com", "Owner", "password123")
+			ws, archived, orphan := archivedCollectionFixture(t, s, "Orphan "+tc.name+" 2884")
 
-	if _, err := s.CreateComment(ws.ID, it.ID, "", models.CommentCreate{Author: "Rook", Body: "on an orphan"}); err != nil {
-		t.Fatalf("CreateComment: %v", err)
-	}
+			var live *models.Item
+			items, err := s.ListItems(ws.ID, models.ItemListParams{})
+			if err != nil {
+				t.Fatalf("ListItems: %v", err)
+			}
+			for i := range items {
+				if items[i].Title == "Live item" {
+					live = &items[i]
+				}
+			}
+			if live == nil {
+				t.Fatal("control leg failed: the fixture has no live item to link from")
+			}
+			tc.seed(t, s, ws, orphan, live)
 
-	exp, err := s.ExportWorkspace(ws.Slug)
-	if err != nil {
-		t.Fatalf("ExportWorkspace: %v", err)
-	}
+			exp, err := s.ExportWorkspace(ws.Slug)
+			if err != nil {
+				t.Fatalf("ExportWorkspace: %v", err)
+			}
 
-	// Hand-edit the bundle into the pre-fix shape: the item stays, its
-	// collection is removed. This is what every archive written before this
-	// change looks like, and what a foreign bundle may look like at any time.
-	kept := exp.Collections[:0]
-	for _, c := range exp.Collections {
-		if c.ID != archived.ID {
-			kept = append(kept, c)
-		}
-	}
-	if len(kept) == len(exp.Collections) {
-		t.Fatal("control leg failed: the archived collection was not in the bundle to remove")
-	}
-	exp.Collections = kept
-	var orphanHasComment bool
-	for _, cm := range exp.Comments {
-		if cm.ItemID == it.ID {
-			orphanHasComment = true
-		}
-	}
-	if !orphanHasComment {
-		t.Fatal("control leg failed: the bundle carries no comment on the orphaned item")
-	}
+			// Hand-edit the bundle into the pre-fix shape: the item stays, its
+			// collection is removed. This is what every archive written before
+			// this change looks like, and what a foreign bundle may look like
+			// at any time.
+			kept := exp.Collections[:0]
+			for _, c := range exp.Collections {
+				if c.ID != archived.ID {
+					kept = append(kept, c)
+				}
+			}
+			if len(kept) == len(exp.Collections) {
+				t.Fatal("control leg failed: the archived collection was not in the bundle to remove")
+			}
+			exp.Collections = kept
 
-	imported, err := s.ImportWorkspace(exp, "orphan-comment-2884-target", owner.ID)
-	if err != nil {
-		t.Fatalf("a bundle with one orphaned item aborted the whole import: %v", err)
-	}
+			// ISOLATE. Creating and editing an item mints rows of its own, so
+			// a bundle assembled for the "comment" case also carries a version
+			// for the orphan — and then the fixture would fail at whichever
+			// loop runs first no matter which loop is broken. Strip every
+			// orphan-attached dependent except the one under test, so each
+			// subtest can fail for exactly one reason.
+			exp.Comments = keepUnless(exp.Comments, tc.name == "comment", func(cm models.CommentExport) bool { return cm.ItemID == orphan.ID })
+			exp.ItemVersions = keepUnless(exp.ItemVersions, tc.name == "version", func(v models.ItemVersionExport) bool { return v.ItemID == orphan.ID })
+			exp.ItemLinks = keepUnless(exp.ItemLinks, tc.name == "link", func(lk models.ItemLinkExport) bool {
+				return lk.SourceID == orphan.ID || lk.TargetID == orphan.ID
+			})
 
-	// The orphan is skipped — that part is correct and unchanged — but the
-	// rest of the workspace must land.
-	items, err := s.ListItems(imported.ID, models.ItemListParams{})
-	if err != nil {
-		t.Fatalf("ListItems: %v", err)
-	}
-	if len(items) != 1 || items[0].Title != "Live item" {
-		got := make([]string, 0, len(items))
-		for _, i := range items {
-			got = append(got, i.Title)
-		}
-		t.Errorf("imported items = %v, want just [Live item]", got)
+			if !tc.present(exp, orphan.ID) {
+				t.Fatalf("control leg failed: the bundle carries no %s on the orphaned item, so the loop under test is never reached", tc.name)
+			}
+			// ...and nothing else attached to the orphan survived the strip.
+			for _, other := range []struct {
+				kind    string
+				present func(*models.WorkspaceExport, string) bool
+			}{
+				{"comment", func(e *models.WorkspaceExport, id string) bool {
+					for _, cm := range e.Comments {
+						if cm.ItemID == id {
+							return true
+						}
+					}
+					return false
+				}},
+				{"version", func(e *models.WorkspaceExport, id string) bool {
+					for _, v := range e.ItemVersions {
+						if v.ItemID == id {
+							return true
+						}
+					}
+					return false
+				}},
+				{"link", func(e *models.WorkspaceExport, id string) bool {
+					for _, lk := range e.ItemLinks {
+						if lk.SourceID == id || lk.TargetID == id {
+							return true
+						}
+					}
+					return false
+				}},
+			} {
+				if other.kind != tc.name && other.present(exp, orphan.ID) {
+					t.Fatalf("fixture is not single-reason: it also carries a %s on the orphaned item", other.kind)
+				}
+			}
+
+			imported, err := s.ImportWorkspace(exp, "orphan-"+tc.name+"-2884-target", owner.ID)
+			if err != nil {
+				t.Fatalf("a bundle with one orphaned item carrying a %s aborted the whole import: %v", tc.name, err)
+			}
+
+			// The orphan is skipped — that part is correct and unchanged — but
+			// the rest of the workspace must land.
+			got, err := s.ListItems(imported.ID, models.ItemListParams{})
+			if err != nil {
+				t.Fatalf("ListItems: %v", err)
+			}
+			if len(got) != 1 || got[0].Title != "Live item" {
+				titles := make([]string, 0, len(got))
+				for _, i := range got {
+					titles = append(titles, i.Title)
+				}
+				t.Errorf("imported items = %v, want just [Live item]", titles)
+			}
+		})
 	}
 }
 
@@ -533,4 +659,20 @@ func TestImportDoesNotInferTraitsForArchivedCollections(t *testing.T) {
 	if !parsed.IsZero() {
 		t.Errorf("inference stamped the canonical set onto an ARCHIVED collection; stored traits = %s", stored)
 	}
+}
+
+// keepUnless drops the entries matching drop, unless keep is true, in which
+// case the slice is returned untouched. Used to reduce an exported bundle to
+// exactly one kind of orphan-attached dependent.
+func keepUnless[T any](in []T, keep bool, drop func(T) bool) []T {
+	if keep {
+		return in
+	}
+	out := in[:0]
+	for _, v := range in {
+		if !drop(v) {
+			out = append(out, v)
+		}
+	}
+	return out
 }

--- a/internal/store/export_soft_deleted_collection_test.go
+++ b/internal/store/export_soft_deleted_collection_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"log/slog"
 	"strings"
 	"testing"
 	"time"
@@ -282,9 +283,43 @@ func TestImportRoutingIgnoresSoftDeletedCollections(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ExportWorkspace: %v", err)
 	}
+
+	var captured []slog.Record
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	slog.SetDefault(slog.New(&recordCapturingHandler{records: &captured}))
+
 	imported, err := s.ImportWorkspace(exp, "routing-2884-target", owner.ID)
 	if err != nil {
 		t.Fatalf("ImportWorkspace: %v", err)
+	}
+	slog.SetDefault(prev)
+
+	// DISCRIMINATION. The two assertions below are the ones that die when the
+	// scan skip and the inference skip are reverted; the ListTraitedCollections
+	// check further down does NOT discriminate them, because that query filters
+	// deleted rows anyway and would pass either way. Kept as the end-to-end leg,
+	// labelled so nobody reads it as coverage for the skips.
+	//
+	// (1) The duplicate-declaration scan must not fire on the archived
+	// collection: it declares the same artifact kind as the live conventions
+	// collection, and without the skip the import warns about an ambiguity
+	// that cannot exist — routing is live-only.
+	for _, r := range captured {
+		if r.Level != slog.LevelWarn {
+			continue
+		}
+		if strings.Contains(r.Message, "declares one artifact kind on two collections") ||
+			strings.Contains(r.Message, "declares invocation routing on two collections") {
+			var colls string
+			r.Attrs(func(a slog.Attr) bool {
+				if a.Key == "collections" {
+					colls = a.Value.String()
+				}
+				return true
+			})
+			t.Errorf("import warned about a duplicate declaration that only exists because an ARCHIVED collection joined the scan: %q (collections=%s)", r.Message, colls)
+		}
 	}
 
 	traited, err := s.ListTraitedCollections(imported.ID)
@@ -419,5 +454,83 @@ func TestImportSurvivesOrphanedItemWithComment(t *testing.T) {
 			got = append(got, i.Title)
 		}
 		t.Errorf("imported items = %v, want just [Live item]", got)
+	}
+}
+
+// TestImportDoesNotInferTraitsForArchivedCollections discriminates the SECOND
+// archived-collection skip: canonical-trait inference.
+//
+// Inference exists so a pre-traits archive comes up ROUTING (BUG-2702). An
+// archived collection never routes — ListTraitedCollections filters
+// deleted_at IS NULL — so stamping it writes a declaration nothing reads, and
+// where the archived row is a renamed predecessor of a live one, puts the
+// canonical set on two rows in the same workspace.
+//
+// The fixture is a workspace whose conventions collection was DELETED with no
+// live replacement, which is the only shape that reaches inference: the slug
+// is what inference keys on, and slug uniqueness spans deleted rows, so an
+// archived "conventions" and a live one cannot coexist.
+func TestImportDoesNotInferTraitsForArchivedCollections(t *testing.T) {
+	s := testStore(t)
+	owner := createTestUser(t, s, "inference2884@test.com", "Owner", "password123")
+	ws := createTestWorkspace(t, s, "Inference 2884")
+
+	conv, err := s.CreateCollection(ws.ID, models.CollectionCreate{Name: "Conventions", Prefix: "CONV"})
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	if conv.Slug != "conventions" {
+		t.Fatalf("fixture assumed slug %q, got %q — inference keys on the slug", "conventions", conv.Slug)
+	}
+	// A pre-traits archive's shape: the column holds no declarations. Written
+	// directly because the create path may stamp them.
+	if _, err := s.db.Exec(s.q(`UPDATE collections SET traits = '{}' WHERE id = ?`), conv.ID); err != nil {
+		t.Fatalf("blank traits: %v", err)
+	}
+	if _, err := s.CreateItem(ws.ID, conv.ID, models.ItemCreate{Title: "A rule"}); err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+	if err := s.DeleteCollection(conv.ID, ""); err != nil {
+		t.Fatalf("DeleteCollection: %v", err)
+	}
+
+	exp, err := s.ExportWorkspace(ws.Slug)
+	if err != nil {
+		t.Fatalf("ExportWorkspace: %v", err)
+	}
+	// Control: the bundle carries the archived collection, blank, and it is
+	// the slug inference would act on. Without this the assertion below could
+	// pass because nothing reached inference at all.
+	var carried bool
+	for _, c := range exp.Collections {
+		if c.Slug == "conventions" {
+			carried = true
+			if c.DeletedAt == "" {
+				t.Fatal("control leg failed: the archived collection exported without its mark")
+			}
+			if parsed, perr := models.ParseCollectionTraits(c.Traits); perr != nil || !parsed.IsZero() {
+				t.Fatalf("control leg failed: exported traits are not blank (err=%v), so inference would not have fired either way", perr)
+			}
+		}
+	}
+	if !carried {
+		t.Fatal("control leg failed: the bundle carries no conventions collection")
+	}
+
+	imported, err := s.ImportWorkspace(exp, "inference-2884-target", owner.ID)
+	if err != nil {
+		t.Fatalf("ImportWorkspace: %v", err)
+	}
+
+	var stored string
+	if err := s.db.QueryRow(s.q(`SELECT traits FROM collections WHERE workspace_id = ? AND slug = ?`), imported.ID, "conventions").Scan(&stored); err != nil {
+		t.Fatalf("read imported traits: %v", err)
+	}
+	parsed, perr := models.ParseCollectionTraits(stored)
+	if perr != nil {
+		t.Fatalf("ParseCollectionTraits(%q): %v", stored, perr)
+	}
+	if !parsed.IsZero() {
+		t.Errorf("inference stamped the canonical set onto an ARCHIVED collection; stored traits = %s", stored)
 	}
 }

--- a/internal/store/export_soft_deleted_collection_test.go
+++ b/internal/store/export_soft_deleted_collection_test.go
@@ -1,0 +1,349 @@
+package store
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// BUG-2884. DeleteCollection soft-deletes the collection row only; its items
+// keep deleted_at IS NULL and stay fully reachable (GetItemByRef, GetItem,
+// SearchItems all return them — no item-bearing read in this package filters
+// joined collection liveness). Export dropped the collection and kept the
+// items, so the bundle carried items naming a collection it did not contain,
+// and ImportWorkspace's orphan gate discarded them without a log line.
+//
+// pad db migrate is ExportWorkspace piped into ImportWorkspace
+// (cmd/pad/cmd_db.go:450,459), so this is the SQLite→Postgres migration path
+// losing live rows, not only a backup being lossy.
+
+// archivedCollectionFixture builds a workspace holding one live collection
+// with an item, and one collection that is soft-deleted AFTER an item was
+// created in it. Returns the workspace and the archived collection's item.
+func archivedCollectionFixture(t *testing.T, s *Store, name string) (*models.Workspace, *models.Collection, *models.Item) {
+	t.Helper()
+	ws := createTestWorkspace(t, s, name)
+
+	live, err := s.CreateCollection(ws.ID, models.CollectionCreate{Name: "Live", Prefix: "LIVE"})
+	if err != nil {
+		t.Fatalf("CreateCollection(live): %v", err)
+	}
+	if _, err := s.CreateItem(ws.ID, live.ID, models.ItemCreate{Title: "Live item"}); err != nil {
+		t.Fatalf("CreateItem(live): %v", err)
+	}
+
+	archived, err := s.CreateCollection(ws.ID, models.CollectionCreate{Name: "Archived", Prefix: "ARCH"})
+	if err != nil {
+		t.Fatalf("CreateCollection(archived): %v", err)
+	}
+	it, err := s.CreateItem(ws.ID, archived.ID, models.ItemCreate{
+		Title:   "Survivor",
+		Content: "body that must round-trip",
+	})
+	if err != nil {
+		t.Fatalf("CreateItem(archived): %v", err)
+	}
+	if err := s.DeleteCollection(archived.ID, ""); err != nil {
+		t.Fatalf("DeleteCollection: %v", err)
+	}
+	return ws, archived, it
+}
+
+// TestExportCarriesSoftDeletedCollections locks the bundle SHAPE: a
+// soft-deleted collection is exported, carrying its deleted_at, so the items
+// section is no longer filtered by a different rule than the collections
+// section.
+func TestExportCarriesSoftDeletedCollections(t *testing.T) {
+	s := testStore(t)
+	ws, archived, it := archivedCollectionFixture(t, s, "Export Shape 2884")
+
+	exp, err := s.ExportWorkspace(ws.Slug)
+	if err != nil {
+		t.Fatalf("ExportWorkspace: %v", err)
+	}
+
+	var gotArchived, gotLive *models.CollectionExport
+	for i := range exp.Collections {
+		switch exp.Collections[i].ID {
+		case archived.ID:
+			gotArchived = &exp.Collections[i]
+		default:
+			if exp.Collections[i].Slug == "live" {
+				gotLive = &exp.Collections[i]
+			}
+		}
+	}
+	if gotArchived == nil {
+		t.Fatal("export dropped the soft-deleted collection; its items are exported, so the bundle names a collection it does not carry")
+	}
+	if gotArchived.DeletedAt == "" {
+		t.Error("soft-deleted collection exported with an empty deleted_at — the importer cannot tell it was archived")
+	}
+	if gotLive == nil {
+		t.Fatal("control leg failed: export dropped the LIVE collection too")
+	}
+	if gotLive.DeletedAt != "" {
+		t.Errorf("live collection exported with deleted_at %q, want empty", gotLive.DeletedAt)
+	}
+
+	// Every exported item's collection must be present in the same bundle.
+	inBundle := map[string]bool{}
+	for _, c := range exp.Collections {
+		inBundle[c.ID] = true
+	}
+	var sawSurvivor bool
+	for _, i := range exp.Items {
+		if !inBundle[i.CollectionID] {
+			t.Errorf("item %q names collection %s, absent from the bundle", i.Title, i.CollectionID)
+		}
+		if i.ID == it.ID {
+			sawSurvivor = true
+		}
+	}
+	if !sawSurvivor {
+		t.Fatal("control leg failed: the archived collection's item was not exported at all")
+	}
+}
+
+// TestRoundTripPreservesItemsUnderSoftDeletedCollection is the headline: the
+// item is live in the source (reachable by ref) and must be live in the
+// target, under a collection that is still archived there.
+func TestRoundTripPreservesItemsUnderSoftDeletedCollection(t *testing.T) {
+	s := testStore(t)
+	owner := createTestUser(t, s, "roundtrip2884@test.com", "Owner", "password123")
+	ws, _, it := archivedCollectionFixture(t, s, "Round Trip 2884")
+
+	// Control: the item is live and ref-reachable in the SOURCE. If this ever
+	// stops holding, the premise of the whole fix is gone and the test says so
+	// here rather than by silently passing below.
+	if src, err := s.GetItemByRef(ws.ID, "ARCH", *it.ItemNumber); err != nil || src == nil {
+		t.Fatalf("control leg failed: item under a soft-deleted collection is not reachable in the source (item=%v err=%v)", src != nil, err)
+	}
+
+	exp, err := s.ExportWorkspace(ws.Slug)
+	if err != nil {
+		t.Fatalf("ExportWorkspace: %v", err)
+	}
+	imported, err := s.ImportWorkspace(exp, "round-trip-2884-target", owner.ID)
+	if err != nil {
+		t.Fatalf("ImportWorkspace: %v", err)
+	}
+
+	items, err := s.ListItems(imported.ID, models.ItemListParams{})
+	if err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+	titles := make([]string, 0, len(items))
+	for _, i := range items {
+		titles = append(titles, i.Title)
+	}
+	var survivor *models.Item
+	for i := range items {
+		if items[i].Title == "Survivor" {
+			survivor = &items[i]
+		}
+	}
+	if survivor == nil {
+		t.Fatalf("the archived collection's item vanished on import; imported items = %v", titles)
+	}
+	if survivor.Content != "body that must round-trip" {
+		t.Errorf("survivor content = %q, want the source body", survivor.Content)
+	}
+
+	// The collection came back, and came back ARCHIVED — importing it live
+	// would resurrect a collection the user deleted.
+	coll, err := s.GetCollectionAnyState(survivor.CollectionID)
+	if err != nil {
+		t.Fatalf("GetCollectionAnyState: %v", err)
+	}
+	if coll == nil {
+		t.Fatal("imported item names a collection row that does not exist")
+	}
+	if coll.DeletedAt == nil || coll.DeletedAt.IsZero() {
+		t.Error("the archived collection imported LIVE — a deleted collection reappears in the target's collection list")
+	}
+	// ...and it is absent from the live listing, exactly as in the source.
+	live, err := s.ListCollections(imported.ID)
+	if err != nil {
+		t.Fatalf("ListCollections: %v", err)
+	}
+	for _, c := range live {
+		if c.Slug == coll.Slug {
+			t.Errorf("archived collection %q appears in the imported workspace's live collection list", c.Slug)
+		}
+	}
+}
+
+// TestRoundTripPreservesDependentsUnderSoftDeletedCollection covers the four
+// sections that inherit the item set. Losing the item lost all of them, each
+// for a different reason (comments/versions/reminders resolve through the item
+// map), so they are asserted together rather than trusted to follow.
+func TestRoundTripPreservesDependentsUnderSoftDeletedCollection(t *testing.T) {
+	s := testStore(t)
+	owner := createTestUser(t, s, "deps2884@test.com", "Owner", "password123")
+	ws, _, it := archivedCollectionFixture(t, s, "Dependents 2884")
+
+	if _, err := s.CreateComment(ws.ID, it.ID, "", models.CommentCreate{Author: "Rook", Body: "comment on an archived-collection item"}); err != nil {
+		t.Fatalf("CreateComment: %v", err)
+	}
+	newBody := "edited, which mints a version"
+	if _, err := s.UpdateItem(it.ID, models.ItemUpdate{Content: &newBody}); err != nil {
+		t.Fatalf("UpdateItem: %v", err)
+	}
+	remindAt := time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339)
+	if _, err := s.CreateReminder(ws.ID, it.ID, remindAt); err != nil {
+		t.Fatalf("CreateReminder: %v", err)
+	}
+
+	exp, err := s.ExportWorkspace(ws.Slug)
+	if err != nil {
+		t.Fatalf("ExportWorkspace: %v", err)
+	}
+	if len(exp.Comments) == 0 || len(exp.ItemVersions) == 0 || len(exp.Reminders) == 0 {
+		t.Fatalf("control leg failed: export carried comments=%d versions=%d reminders=%d, want all non-zero",
+			len(exp.Comments), len(exp.ItemVersions), len(exp.Reminders))
+	}
+
+	imported, err := s.ImportWorkspace(exp, "dependents-2884-target", owner.ID)
+	if err != nil {
+		t.Fatalf("ImportWorkspace: %v", err)
+	}
+	items, err := s.ListItems(imported.ID, models.ItemListParams{})
+	if err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+	var survivorID string
+	for _, i := range items {
+		if i.Title == "Survivor" {
+			survivorID = i.ID
+		}
+	}
+	if survivorID == "" {
+		t.Fatal("the archived collection's item vanished on import; its dependents cannot be checked")
+	}
+
+	comments, err := s.ListComments(survivorID)
+	if err != nil {
+		t.Fatalf("ListComments: %v", err)
+	}
+	if len(comments) != 1 {
+		t.Errorf("imported comments = %d, want 1", len(comments))
+	}
+	reminders, err := s.ListRemindersForItem(imported.ID, survivorID)
+	if err != nil {
+		t.Fatalf("ListRemindersForItem: %v", err)
+	}
+	if len(reminders) != 1 {
+		t.Errorf("imported reminders = %d, want 1", len(reminders))
+	}
+	versions, err := s.ListItemVersions(survivorID)
+	if err != nil {
+		t.Fatalf("ListItemVersions: %v", err)
+	}
+	if len(versions) == 0 {
+		t.Error("imported item carries no version history; the source had some")
+	}
+}
+
+// TestImportRoutingIgnoresSoftDeletedCollections guards the seam this fix
+// OPENS. Trait routing is live-only (ListTraitedCollections filters
+// deleted_at IS NULL), so an archived collection now travelling in the bundle
+// must not participate in the import's duplicate-declaration scan, and must
+// not be mistaken for the workspace's conventions collection.
+func TestImportRoutingIgnoresSoftDeletedCollections(t *testing.T) {
+	s := testStore(t)
+	owner := createTestUser(t, s, "routing2884@test.com", "Owner", "password123")
+	ws := createTestWorkspace(t, s, "Routing 2884")
+	if err := s.SeedCollectionsFromTemplate(ws.ID, "startup"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// An archived collection carrying the conventions declaration, alongside
+	// the live seeded conventions collection.
+	convs, err := s.GetCollectionBySlug(ws.ID, "conventions")
+	if err != nil || convs == nil {
+		t.Fatalf("GetCollectionBySlug(conventions): %v (nil=%v)", err, convs == nil)
+	}
+	ghost, err := s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name:   "Old Conventions",
+		Prefix: "OCONV",
+		Traits: convs.Traits,
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection(ghost): %v", err)
+	}
+	if err := s.DeleteCollection(ghost.ID, ""); err != nil {
+		t.Fatalf("DeleteCollection(ghost): %v", err)
+	}
+
+	exp, err := s.ExportWorkspace(ws.Slug)
+	if err != nil {
+		t.Fatalf("ExportWorkspace: %v", err)
+	}
+	imported, err := s.ImportWorkspace(exp, "routing-2884-target", owner.ID)
+	if err != nil {
+		t.Fatalf("ImportWorkspace: %v", err)
+	}
+
+	traited, err := s.ListTraitedCollections(imported.ID)
+	if err != nil {
+		t.Fatalf("ListTraitedCollections: %v", err)
+	}
+	var declaring []string
+	for _, tc := range traited {
+		if tc.Traits.ArtifactKind != nil && tc.Traits.ArtifactKind.Kind != "" {
+			declaring = append(declaring, tc.Slug+":"+tc.Traits.ArtifactKind.Kind)
+		}
+	}
+	for _, d := range declaring {
+		if strings.HasPrefix(d, "old-conventions:") {
+			t.Errorf("the archived collection is routing in the imported workspace: %v", declaring)
+		}
+	}
+}
+
+// TestLegacyBundleWithoutDeletedAtImportsLive is a COMPATIBILITY LOCK, not a
+// regression instrument: it passes before and after this change. A bundle
+// written before deleted_at existed on CollectionExport decodes it as "", and
+// "" must mean live — the absent→live direction is what keeps every archive
+// ever written importable.
+func TestLegacyBundleWithoutDeletedAtImportsLive(t *testing.T) {
+	s := testStore(t)
+	owner := createTestUser(t, s, "legacy2884@test.com", "Owner", "password123")
+	ws := createTestWorkspace(t, s, "Legacy 2884")
+	coll, err := s.CreateCollection(ws.ID, models.CollectionCreate{Name: "Widgets", Prefix: "WID"})
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	if _, err := s.CreateItem(ws.ID, coll.ID, models.ItemCreate{Title: "Legacy item"}); err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+
+	exp, err := s.ExportWorkspace(ws.Slug)
+	if err != nil {
+		t.Fatalf("ExportWorkspace: %v", err)
+	}
+	for i := range exp.Collections {
+		exp.Collections[i].DeletedAt = "" // as a pre-BUG-2884 archive decodes
+	}
+
+	imported, err := s.ImportWorkspace(exp, "legacy-2884-target", owner.ID)
+	if err != nil {
+		t.Fatalf("ImportWorkspace: %v", err)
+	}
+	live, err := s.ListCollections(imported.ID)
+	if err != nil {
+		t.Fatalf("ListCollections: %v", err)
+	}
+	var found bool
+	for _, c := range live {
+		if c.Slug == "widgets" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("a legacy bundle's collection did not import LIVE; live collections = %d", len(live))
+	}
+}

--- a/internal/store/export_soft_deleted_collection_test.go
+++ b/internal/store/export_soft_deleted_collection_test.go
@@ -347,3 +347,77 @@ func TestLegacyBundleWithoutDeletedAtImportsLive(t *testing.T) {
 		t.Errorf("a legacy bundle's collection did not import LIVE; live collections = %d", len(live))
 	}
 }
+
+// TestImportSurvivesOrphanedItemWithComment covers a SECOND defect, found by
+// the dependents test above while the export half was still unfixed: an
+// orphaned item — one whose collection the bundle does not carry — aborted the
+// ENTIRE workspace import if it had a comment.
+//
+// The comment loop guards on `itemMap[cm.ItemID] == ""`, and that guard cannot
+// fire for an item the bundle contains: itemMap is populated for EVERY item
+// before the orphan skip, deliberately, because parent resolution reads it for
+// items the loop has not reached. So the loop INSERTed a comment whose item_id
+// names no row and the FK refused it, failing the whole restore. This is the
+// same defect the reminder loop already carries a long comment about ("ONE
+// orphaned item with a reminder aborted the entire workspace import"); it was
+// fixed there and left standing here.
+//
+// Fixing the export half removes pad's own route to it — a bundle this build
+// writes has no orphans — but not a hand-edited, foreign, or pre-fix archive,
+// which is exactly the population that needs to import.
+func TestImportSurvivesOrphanedItemWithComment(t *testing.T) {
+	s := testStore(t)
+	owner := createTestUser(t, s, "orphan2884@test.com", "Owner", "password123")
+	ws, archived, it := archivedCollectionFixture(t, s, "Orphan Comment 2884")
+
+	if _, err := s.CreateComment(ws.ID, it.ID, "", models.CommentCreate{Author: "Rook", Body: "on an orphan"}); err != nil {
+		t.Fatalf("CreateComment: %v", err)
+	}
+
+	exp, err := s.ExportWorkspace(ws.Slug)
+	if err != nil {
+		t.Fatalf("ExportWorkspace: %v", err)
+	}
+
+	// Hand-edit the bundle into the pre-fix shape: the item stays, its
+	// collection is removed. This is what every archive written before this
+	// change looks like, and what a foreign bundle may look like at any time.
+	kept := exp.Collections[:0]
+	for _, c := range exp.Collections {
+		if c.ID != archived.ID {
+			kept = append(kept, c)
+		}
+	}
+	if len(kept) == len(exp.Collections) {
+		t.Fatal("control leg failed: the archived collection was not in the bundle to remove")
+	}
+	exp.Collections = kept
+	var orphanHasComment bool
+	for _, cm := range exp.Comments {
+		if cm.ItemID == it.ID {
+			orphanHasComment = true
+		}
+	}
+	if !orphanHasComment {
+		t.Fatal("control leg failed: the bundle carries no comment on the orphaned item")
+	}
+
+	imported, err := s.ImportWorkspace(exp, "orphan-comment-2884-target", owner.ID)
+	if err != nil {
+		t.Fatalf("a bundle with one orphaned item aborted the whole import: %v", err)
+	}
+
+	// The orphan is skipped — that part is correct and unchanged — but the
+	// rest of the workspace must land.
+	items, err := s.ListItems(imported.ID, models.ItemListParams{})
+	if err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+	if len(items) != 1 || items[0].Title != "Live item" {
+		got := make([]string, 0, len(items))
+		for _, i := range items {
+			got = append(got, i.Title)
+		}
+		t.Errorf("imported items = %v, want just [Live item]", got)
+	}
+}

--- a/internal/store/export_soft_deleted_collection_test.go
+++ b/internal/store/export_soft_deleted_collection_test.go
@@ -676,3 +676,174 @@ func keepUnless[T any](in []T, keep bool, drop func(T) bool) []T {
 	}
 	return out
 }
+
+// TestImportSurvivesOrphanedParent covers the parent_id half of the same
+// class, which my own sweep of the itemMap consumers missed and codex round 3
+// caught: the guard I added to the second pass protects the item BEING
+// updated, not the parent VALUE it writes.
+//
+// Both passes resolve a parent through itemMap, which holds an entry for an
+// orphaned item, so a live child of an archived-collection parent had a
+// nonexistent parent_id written into a foreign key. On Postgres that aborts
+// the transaction and the whole import is lost; the child is created before
+// the orphan is skipped, so this is reachable on the first pass too.
+//
+// Correct behaviour is the one the bundle can express: import the child with
+// NO parent. The parent is not in the bundle, so there is nothing to point at,
+// and dropping the edge is what item_links already does for a missing
+// endpoint.
+func TestImportSurvivesOrphanedParent(t *testing.T) {
+	s := testStore(t)
+	owner := createTestUser(t, s, "orphanparent2884@test.com", "Owner", "password123")
+	ws := createTestWorkspace(t, s, "Orphan Parent 2884")
+
+	// The parent is created FIRST so it sorts ahead of the child in the
+	// export's created_at ordering — that is what makes the first pass, not
+	// only the second, resolve the parent through itemMap.
+	archived, err := s.CreateCollection(ws.ID, models.CollectionCreate{Name: "Archived", Prefix: "ARCH"})
+	if err != nil {
+		t.Fatalf("CreateCollection(archived): %v", err)
+	}
+	parent, err := s.CreateItem(ws.ID, archived.ID, models.ItemCreate{Title: "Archived parent"})
+	if err != nil {
+		t.Fatalf("CreateItem(parent): %v", err)
+	}
+	live, err := s.CreateCollection(ws.ID, models.CollectionCreate{Name: "Live", Prefix: "LIVE"})
+	if err != nil {
+		t.Fatalf("CreateCollection(live): %v", err)
+	}
+	child, err := s.CreateItem(ws.ID, live.ID, models.ItemCreate{Title: "Live child", ParentID: &parent.ID})
+	if err != nil {
+		t.Fatalf("CreateItem(child): %v", err)
+	}
+	if err := s.DeleteCollection(archived.ID, ""); err != nil {
+		t.Fatalf("DeleteCollection: %v", err)
+	}
+
+	exp, err := s.ExportWorkspace(ws.Slug)
+	if err != nil {
+		t.Fatalf("ExportWorkspace: %v", err)
+	}
+	kept := exp.Collections[:0]
+	for _, c := range exp.Collections {
+		if c.ID != archived.ID {
+			kept = append(kept, c)
+		}
+	}
+	exp.Collections = kept
+
+	// Order the bundle parent-first. The export sorts by created_at then id,
+	// and both rows land in the same second, so the id tie-break decides —
+	// leaving the first-pass path exercised only about half the time. A bundle
+	// may legitimately arrive in any order, and this is the order that reaches
+	// BOTH passes, so the test pins it rather than rolling for it.
+	ordered := make([]models.ItemExport, 0, len(exp.Items))
+	for _, it := range exp.Items {
+		if it.ID == parent.ID {
+			ordered = append(ordered, it)
+		}
+	}
+	for _, it := range exp.Items {
+		if it.ID != parent.ID {
+			ordered = append(ordered, it)
+		}
+	}
+	exp.Items = ordered
+
+	// Controls: the bundle carries the child pointing at an item it does not
+	// carry, and the parent now sorts first. Without both, the write under
+	// test is never attempted.
+	var sawChild, sawParent bool
+	var parentIdx, childIdx = -1, -1
+	for i, it := range exp.Items {
+		if it.ID == child.ID {
+			sawChild, childIdx = true, i
+			if it.ParentID != parent.ID {
+				t.Fatalf("control leg failed: exported child's parent_id = %q, want the archived parent", it.ParentID)
+			}
+		}
+		if it.ID == parent.ID {
+			sawParent, parentIdx = true, i
+		}
+	}
+	if !sawChild || !sawParent {
+		t.Fatalf("control leg failed: bundle carries child=%v parent=%v", sawChild, sawParent)
+	}
+	if parentIdx > childIdx {
+		t.Fatalf("control leg failed: parent sorts after child (%d > %d), so the first pass never resolves it", parentIdx, childIdx)
+	}
+
+	imported, err := s.ImportWorkspace(exp, "orphan-parent-2884-target", owner.ID)
+	if err != nil {
+		t.Fatalf("a live item whose parent is orphaned aborted the whole import: %v", err)
+	}
+
+	items, err := s.ListItems(imported.ID, models.ItemListParams{})
+	if err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+	if len(items) != 1 || items[0].Title != "Live child" {
+		titles := make([]string, 0, len(items))
+		for _, i := range items {
+			titles = append(titles, i.Title)
+		}
+		t.Fatalf("imported items = %v, want just [Live child]", titles)
+	}
+	if items[0].ParentID != nil && *items[0].ParentID != "" {
+		t.Errorf("imported child kept a parent_id (%q) naming an item the bundle never carried", *items[0].ParentID)
+	}
+}
+
+// TestImportSurvivesDuplicateLinks covers the residual half of the links loop.
+// The insertedItems guard removes the foreign-key route, but a hand-edited or
+// foreign bundle can still carry the same (source, target, link_type) twice —
+// the source's UNIQUE constraint bounds what pad writes, not what arrives. The
+// loop answered that with `continue`, which is not a recovery on Postgres: the
+// unique violation has already aborted the transaction, so COMMIT fails and
+// the entire restore is lost over a row the loop meant to ignore.
+func TestImportSurvivesDuplicateLinks(t *testing.T) {
+	s := testStore(t)
+	owner := createTestUser(t, s, "duplinks2884@test.com", "Owner", "password123")
+	ws := createTestWorkspace(t, s, "Duplicate Links 2884")
+	coll, err := s.CreateCollection(ws.ID, models.CollectionCreate{Name: "Widgets", Prefix: "WID"})
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	a, err := s.CreateItem(ws.ID, coll.ID, models.ItemCreate{Title: "A"})
+	if err != nil {
+		t.Fatalf("CreateItem(a): %v", err)
+	}
+	b, err := s.CreateItem(ws.ID, coll.ID, models.ItemCreate{Title: "B"})
+	if err != nil {
+		t.Fatalf("CreateItem(b): %v", err)
+	}
+	if _, err := s.CreateItemLink(ws.ID, models.ItemLinkCreate{TargetID: b.ID, LinkType: "blocks"}, a.ID); err != nil {
+		t.Fatalf("CreateItemLink: %v", err)
+	}
+
+	exp, err := s.ExportWorkspace(ws.Slug)
+	if err != nil {
+		t.Fatalf("ExportWorkspace: %v", err)
+	}
+	if len(exp.ItemLinks) != 1 {
+		t.Fatalf("control leg failed: exported links = %d, want 1", len(exp.ItemLinks))
+	}
+	// The hand-edit: the same edge twice, with distinct ids, exactly as a
+	// merged or concatenated bundle would carry it.
+	dup := exp.ItemLinks[0]
+	dup.ID = dup.ID + "-dup"
+	exp.ItemLinks = append(exp.ItemLinks, dup)
+
+	imported, err := s.ImportWorkspace(exp, "duplicate-links-2884-target", owner.ID)
+	if err != nil {
+		t.Fatalf("a bundle carrying one duplicated link aborted the whole import: %v", err)
+	}
+
+	items, err := s.ListItems(imported.ID, models.ItemListParams{})
+	if err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+	if len(items) != 2 {
+		t.Errorf("imported items = %d, want 2", len(items))
+	}
+}


### PR DESCRIPTION
Fixes BUG-2884.

## The reported defect

`DeleteCollection` soft-deletes the collection row only. Its items keep `deleted_at IS NULL` and stay fully reachable — by ref, by id, and through search — because no item-bearing read in `internal/store` joins collection liveness.

`ExportWorkspace` filtered collections on `deleted_at IS NULL` but items only on the item's own mark. Two sections, two rules: the bundle named a collection it did not carry, and `ImportWorkspace` discarded those items on its orphan gate with **no log line for the item itself** (the bug body says `slog.Warn`; that is true of the dependents, not the item).

Because `pad db migrate` is `ExportWorkspace` piped into `ImportWorkspace` (`cmd/pad/cmd_db.go:450,459`), this lost live rows on a SQLite→Postgres migration, not only in backups.

**Fix shape.** BUG-2884 offered two. Option 1 — filter items to live collections at export — is disqualified by measurement rather than taste: it would make the migration silently DELETE reachable rows, a worse defect than the lossy backup it fixes. So the bundle carries soft-deleted collections with their `deleted_at`, and the importer reproduces the archive. (The bug's stated motivation for option 2, "preserves the restore window", is false and is corrected on its trail — **nothing in the product ever clears `collections.deleted_at`**; collection soft-delete is one-way. The real justification is that the items are live.)

`CollectionExport.DeletedAt` is `omitempty`, and an absent value decodes to `""` and means LIVE — that direction is what keeps every archive written before this change importable, and it has its own test.

## A second defect, on the same door

Found by the regression tests, then widened by the Postgres gate. **A dependent row hanging off an orphaned item took the entire import down** — not a lossy restore, no restore.

Two mechanisms:

1. **The guard could not fire.** Every dependent loop tested `itemMap[...] == ""`, and `itemMap` holds an entry for every item in the bundle *including orphans* — written before the orphan skip, because parent resolution reads it for items the loop has not reached. So the INSERT went ahead with an id naming no row.
2. **"Skip on error" is not a skip on Postgres.** The links and versions loops answered the foreign-key failure by continuing. That recovers on SQLite. On Postgres a failed statement aborts the transaction, so every later statement fails and COMMIT reports `commit unexpectedly resulted in rollback`. The row has to be refused *before* the database sees it.

This is the same defect the reminder loop carries a long note about having fixed (IDEA-2641 round 10), left standing in three sibling loops. All four now check `insertedItems`. The reminder loop's own claim that "the skip-on-error below survives the FK failure" is now qualified with the driver it holds on — it is the sentence that would talk the next reader out of this fix.

It stays load-bearing after the export fix: a bundle *this* build writes has no orphans, but a hand-edited, foreign, or pre-fix archive does — and that is exactly the population that needs to import.

## Two more, from adversarial review

Rounds 1 and 2 (lean prompt) returned CLEAN. Round 3, with one focus sentence about Postgres transaction semantics, returned three findings. Each was verified in the code before being accepted.

- **Parent resolution trusted `itemMap`.** My own sweep of the itemMap consumers guarded the item being *updated* and missed the parent *value* the same loop writes. A live child of an archived-collection parent wrote a nonexistent id into `items.parent_id`. This one is not Postgres-specific and not deferred to COMMIT — SQLite runs with `foreign_keys` ON, and it fails fatally on the first pass. Both sites now go through one helper that drops the edge, which is the only thing a bundle missing the parent can express.
- **Duplicate links.** The `insertedItems` guard removed the FK route, but the source's UNIQUE constraint bounds what pad *wrote*, not what *arrives*; a merged or hand-edited bundle can carry the same edge twice, and on Postgres that unique violation aborts the transaction. Links are now deduped on the remapped triple before the write.
- **P2, filed not fixed → BUG-2892.** `CreateWorkspace` commits before the import transaction opens, so a failed import leaves an empty workspace behind and a retrying caller accumulates husks. Pre-existing, different mechanism; folding it in would put workspace-creation transactionality inside an export/import correctness PR.

## The seam this opens

Trait routing is live-only (`ListTraitedCollections` filters `deleted_at IS NULL`), so an archived collection now travelling in the bundle must not join the import's duplicate-declaration scan or the canonical-trait inference. Both skip it, and both skips have a test that dies without them.

## Evidence

**Regression tests, measured failing before the fix**, each for its designed reason. The export-shape and round-trip tests were compiled against `5c4fa229` plus the model field alone (no behaviour change) so their failures describe the unfixed logic. The orphan-dependent tests were measured *with* the export fix in place, since they defend an independent path.

The orphan-dependent test is one subtest per dependent kind, with the bundle stripped to exactly that kind and asserted in both directions. Its first version failed all three subtests for one reason: creating and editing an item mints rows of its own, so the "comment" bundle also carried a version, and the fixture failed at whichever loop ran first — discriminating nothing.

**Mutation matrix, both drivers.** Ten mutants; the four survivors are explained rather than papered over:

| mutant | SQLite | Postgres |
|---|---|---|
| M1 export query keeps `deleted_at IS NULL` | DETECTED (8 tests) | DETECTED (8) |
| M2 import writes the collection LIVE | DETECTED (2) | DETECTED (2) |
| M3 archived collections rejoin the duplicate scan | DETECTED | DETECTED |
| M4 inference stamps archived collections | DETECTED | DETECTED |
| M5 comment loop back to the inert guard | DETECTED | DETECTED |
| M6 second pass back to the inert guard | SURVIVED | SURVIVED |
| M7 links loop back to the inert guard | SURVIVED | DETECTED |
| M8 versions loop back to the inert guard | SURVIVED | DETECTED |
| M9 parent resolution trusts itemMap alone | DETECTED | DETECTED |
| M10 links loop drops the dedupe | SURVIVED | DETECTED |

- **M7 / M8 / M10 surviving on SQLite is the finding, not a hole** — those are Postgres-only defects, and a matrix run on SQLite alone would have reported three holes that are not holes while never surfacing the defects at all.
- **M6 surviving on both was predicted before the run.** It is a readability fix over an *inert* guard — an orphan's UPDATE matched no row and returned no error — so no test can die for it, and none was written to fill the cell.
- M10's first attempt scored BUILD-FAIL, a distinct outcome; scored as SURVIVED it would have invented a hole.


## Rebased onto `14cb9759`, and what that turned up

Five commits replayed with no conflicts. A clean rebase is a textual result, not a semantic one, and TASK-2878 touched this same file, so its changes were read rather than trusted: `remapFieldIDs` now substitutes the QUOTED JSON token instead of the raw id, which is correct and orthogonal to this unit. Its `TestImportWorkspace_CarriesUnresolvableRelationValues` now runs in this suite — including the control leg that a resolvable relation on a live-collection item still remaps, which is the leg the second-pass guard here could have broken — and passes alongside all twelve tests of this unit.

Checking that seam produced **BUG-2895**, filed rather than fixed here. `remapFieldIDs` maps through `itemMap`, which holds orphans, so a relation value pointing at an orphaned item is rewritten to the id that item WOULD have received:

```
source orphan id : 89affc62-163a-4077-8649-06d0ca6e2ee7
imported fields  : {"related":"37b09d3f-19c7-409d-ab36-d3efbc51713b"}
```

That is worse than dangling: TASK-2878's carry rule imports an unresolvable value verbatim precisely so nothing is invented, and this asserts a reference to an id that never identified anything anywhere. It is the JSON-blob twin of the `parent_id` bug fixed above — same cause, orphan ids escaping `itemMap` into written values — except a foreign key refused the parent version and nothing refuses this one. Filed because it changes relation-carry semantics TASK-2878 owns.

One process note worth recording: this branch's Postgres leg failed once with `database schema is newer than this pad binary (064_…)`. Not a flake and not a product bug — the schema-ahead guard did its job. Two branches' suites were sharing one hand-rolled Postgres container, and the other branch had migrated it past what this one ships. The re-run went through `make test-pg`, which since TASK-2708 gives each worktree its own container, and passed clean.

https://claude.ai/code/session_01HeChkgZVYb3NTgTcckF5KR
