### PR TITLE
IDEA-2886: state the drop-vs-refuse rule once, and route all three sites through it

### DIFF
--- a/internal/store/relation_referents.go
+++ b/internal/store/relation_referents.go
@@ -547,8 +547,22 @@ func (s *Store) MigrateRelationReferentsQ(
 				delete(fieldMap, ri.Key)
 			}
 		}
-		// Carry the canonicalised survivors back.
+		// Carry the canonicalised SURVIVORS back — survivors, not everything
+		// supplied. A key deleted above is absent from fieldMap, and checking
+		// that is what stops the write-back restoring a value the branch just
+		// dropped; the alternative, deleting from both maps, keeps two loops
+		// that have to agree with each other.
+		//
+		// Identical to the destination-default branch below, and that is the
+		// point: the two dispositions differ, the write-back does not. Review
+		// found the first version of this branch reporting a drop while
+		// retaining the dropped value — an unreachable branch that was WRONG,
+		// which is a trap for whoever makes it reachable, and the whole reason
+		// the branch exists is that someone might.
 		for k, v := range suppliedRelations {
+			if _, survived := fieldMap[k]; !survived {
+				continue
+			}
 			fieldMap[k] = v
 		}
 	}

--- a/internal/store/relation_referents.go
+++ b/internal/store/relation_referents.go
@@ -418,6 +418,29 @@ const (
 	RelationOriginDestinationDefault
 )
 
+// Refuses reports whether an unresolvable value of this origin REFUSES the
+// request, or is dropped and reported.
+//
+// THIS IS THE ONE STATEMENT OF THE RULE (IDEA-2886). A relation value the
+// CALLER ASSERTED in this request is a write, and an unresolvable write is
+// their bug, so it is refused. A value asserted by NOBODY — carried from the
+// source item, or injected from the destination schema's `default` — is
+// dropped and reported instead. Refusing those would make a legacy item
+// permanently un-updatable, un-movable and un-copyable, and would let a single
+// bad default in a schema fail every write into that collection, on a defect
+// its author has to fix somewhere else entirely.
+//
+// It was stated three times before this — in the origin split below, in the
+// late-default pass, and in IssuesForCallerInput — each in its own control
+// flow and its own prose. Three statements of one rule is the shape that
+// invites a fourth door to state it slightly differently, which is the drift
+// TASK-2878 existed to remove. The polarity now lives HERE and nowhere else,
+// so a reviewer checking "does this door get the rule right" reads one
+// function, and a mutation of it breaks every site at once.
+func (o RelationOrigin) Refuses() bool {
+	return o == RelationOriginSupplied
+}
+
 // MigrateRelationReferents is the ONE decision the four migrate doors share
 // (PLAN-2857 U1 / TASK-2878). Same-workspace move, bulk move, cross-workspace
 // copy and the copy preflight all call this; none of them reimplements it.
@@ -511,7 +534,19 @@ func (s *Store) MigrateRelationReferentsQ(
 		if resolveErr != nil {
 			return nil, nil, resolveErr
 		}
-		refusals = issues
+		// Routed through the origin's own rule rather than assigning to
+		// `refusals` because this branch happens to be the supplied one
+		// (IDEA-2886). The `else` is unreachable while Refuses() answers as it
+		// does — and that is the point: if the rule ever changes, this site
+		// follows it instead of contradicting it.
+		if RelationOriginSupplied.Refuses() {
+			refusals = issues
+		} else {
+			dropped = append(dropped, issues...)
+			for _, ri := range issues {
+				delete(fieldMap, ri.Key)
+			}
+		}
 		// Carry the canonicalised survivors back.
 		for k, v := range suppliedRelations {
 			fieldMap[k] = v
@@ -519,7 +554,9 @@ func (s *Store) MigrateRelationReferentsQ(
 	}
 
 	// Destination defaults resolve against the DESTINATION in both modes — the
-	// destination picked the value, so the mode says nothing about it.
+	// destination picked the value, so the mode says nothing about it. They
+	// DROP rather than refuse because RelationOriginDestinationDefault.Refuses()
+	// is false, which is the one place that is decided (IDEA-2886).
 	if defaults := byOrigin[RelationOriginDestinationDefault]; len(defaults) > 0 {
 		// A NON-STRING default is dropped and reported here, exactly as
 		// ResolveLateRelationDefaultsQ drops one, and NOT left for
@@ -755,6 +792,18 @@ func (s *Store) ResolveLateRelationDefaultsQ(
 	fieldMap map[string]any,
 	before map[string]bool,
 ) (dropped []RelationIssue, err error) {
+	// EVERY key this pass looks at is a destination default: the `before`
+	// guard skips anything present before validation ran, so what remains was
+	// injected by `ValidateFields` from the schema. Its return is therefore
+	// named `dropped` and never `refusals` — which is
+	// RelationOriginDestinationDefault.Refuses() being false, not a separate
+	// decision this function makes (IDEA-2886). The assertion below says so in
+	// code rather than in prose, so a future edit that starts refusing here
+	// contradicts the rule instead of quietly forking it.
+	if RelationOriginDestinationDefault.Refuses() {
+		return nil, fmt.Errorf("relation defaults now refuse; this pass reports drops only " +
+			"and its callers treat its return as a drop list — see RelationOrigin.Refuses")
+	}
 	late := map[string]any{}
 	for _, def := range schema.Fields {
 		if def.Type != "relation" || before[def.Key] {
@@ -818,7 +867,16 @@ func (s *Store) ResolveLateRelationDefaultsQ(
 func IssuesForCallerInput(issues []RelationIssue, presentBefore map[string]bool) []RelationIssue {
 	out := make([]RelationIssue, 0, len(issues))
 	for _, ri := range issues {
+		// CLASSIFY, then ask the rule — rather than restating the rule as
+		// "keep it if it was there before" (IDEA-2886). At a write door,
+		// present-before-validation IS the caller's own input and anything
+		// else is a default validation injected, so the two origins below are
+		// the only ones reachable here; there is no source item to carry from.
+		origin := RelationOriginDestinationDefault
 		if presentBefore[ri.Key] {
+			origin = RelationOriginSupplied
+		}
+		if origin.Refuses() {
 			out = append(out, ri)
 		}
 	}


### PR DESCRIPTION
One rule, stated once, with its three sites routed through it. **Behaviour is unchanged at every door — that is the spec, not a caveat.**

## The rule and its three statements

A relation value the **caller asserted** in this request is a write, so an unresolvable one is refused. A value asserted by **nobody** — carried from the source item, or injected from the destination schema's `default` — is dropped and reported instead. Refusing those would make a legacy item permanently un-updatable, un-movable and un-copyable, and would let one bad default in a schema fail every write into that collection.

It was stated three times, each in its own control flow and its own prose:

- the origin split in `MigrateRelationReferentsQ` — supplied → `refusals`, the other two → `dropped`;
- `ResolveLateRelationDefaultsQ`, whose return is named `dropped` because everything it sees is a default;
- `IssuesForCallerInput`, which kept an issue if its key was present before validation.

Three statements of one rule is the shape that invites the fourth door to state it slightly differently — the drift TASK-2878 existed to remove. This was filed out of that unit after a review round stated the rule for the third time.

## What changed

The polarity now lives in `RelationOrigin.Refuses()` and nowhere else. The three sites consult it:

- **the supplied branch asks the rule** instead of assuming its own identity. Its `else` is unreachable while `Refuses()` answers as it does, and that is the point — if the rule changes, this site follows it rather than contradicting it.
- **the late-default pass opens with an assertion** that its origin does not refuse, so an edit that starts refusing there fails loudly instead of quietly forking the rule.
- **`IssuesForCallerInput` classifies to an origin and then asks**, rather than restating the rule as "keep it if it was there before".

## What the mutants can and cannot show

Stated plainly, because a behaviour-preserving refactor is exactly where a mutation matrix lies.

- **Per-site mutants are impossible by construction.** Restoring any one site's old form is behaviour-identical, so no test can distinguish it. Reporting "3/3 survived" would be true and would mean nothing.
- **The master mutant is the real one.** Flipping `Refuses()` to `!=` compiles and kills **116 server subtests and 1 store subtest** — the rule is load-bearing, not decorative.
- **Per-site reachability answers what the mutants cannot:** does each site actually consult the rule, or keep a private copy? Making `Refuses()` panic, one test per site:

| Site | Probe | Result |
|---|---|---|
| origin split (supplied) | `TestRelationDoors_Move` | panics |
| write doors | `TestRelationDoors_Create` | panics |
| destination defaults | `TestRelationDoors_MoveDropsInvisibleDestinationDefault` | panics |
| late defaults | `TestRelationDoors_LateDefaultWrongCollectionDoesNotDiscloseExistence` | panics |
| late defaults, required | `TestRelationDoors_RequiredInvisibleDefaultRefuses` | panics |

**My first run of that probe reported zero panics for the late-default site and I nearly wrote it up as unreached.** The filter I used matched **no tests at all** — the reading was my instrument, not the code. I have that trap in my own notes from a previous unit and walked into it again, so the re-run counts `=== RUN` lines alongside the panics: an instrument that cannot say how many tests it ran cannot tell silence from absence.

## Review found one thing, and it is the one I asked for

The new `else` in the supplied path is **unreachable, and it was wrong.** It deleted each unresolvable key from `fieldMap` and then fell into a write-back loop that copied every entry of `suppliedRelations` back in — restoring the value it had just dropped, so it would report a drop while retaining the dropped value. Reviewer's exhibit: schema `{Key:"r", Type:"relation", Collection:""}`, `fieldMap={"r":"bad"}`, `supplied={"r":"bad"}`.

**Fixed by construction rather than by bookkeeping.** My first fix deleted the key from `suppliedRelations` too — which works, and leaves two loops that have to agree with each other. The write-back is now guarded on survival, `if _, survived := fieldMap[k]; !survived { continue }`, which is character-for-character what the destination-default branch already does. The two branches differ in their disposition; they no longer differ in their write-back. *When I notice I am writing a second loop to compensate for the first, the compensation is usually the sign that the structure is wrong.*

Behaviour is unchanged on the reachable path, and here is the argument rather than the assertion: nothing deletes from `fieldMap` in the refusing path, `suppliedRelations` was built from `fieldMap`'s own keys, and `ResolveRelationReferentsQ` canonicalises the map it is handed without touching `fieldMap` — so every supplied key survives the guard. Round 2 was asked to check each clause of that against the code, including whether the guard could skip a *canonicalised* key and silently keep the caller's raw ref. It came back **CLEAN**.

**There is no test for the branch, and that is named rather than left looking covered:** exercising it requires inverting `Refuses()`, which inverts the rule for every door at once and fails 116 subtests for unrelated reasons. A probe that cannot isolate what it is probing proves nothing, so I did not keep the one I tried. The structural fix means the branch is correct without needing to be run.

## Scope

`internal/store` only. No overlap with the TASK-2710 handoff in `export.go`.

## Gates

| Gate | Result |
|---|---|
| `internal/store` (SQLite) | ok 183.002s |
| `internal/server` (SQLite) | ok 160.804s |
| `go vet` / `gofmt` | clean |
| **Postgres** | ok — 29 packages, EXIT=0 |
| review rounds | round 1: one finding, fixed; round 2, aimed at that fix: **CLEAN** |

https://claude.ai/code/session_01Xk9M5UVPdc84xL5E1mZkm8
