### PR TITLE
feat(store,server): make collection trait uniqueness a database invariant — de-dup pass + partial unique indexes (TASK-2710)

### DIFF
--- a/internal/server/handlers_collection_traits_test.go
+++ b/internal/server/handlers_collection_traits_test.go
@@ -252,11 +252,17 @@ func TestResolvePlaybookIgnoresInvisibleCollections(t *testing.T) {
 	var second models.Collection
 	parseJSON(t, rr, &second)
 	secondTraits := `{"bootstrap_include":[{"mode":"metadata","key":"playbooks"}],"invocation_field":"invocation_slug"}`
-	withTraitUniquenessSuspended(t, srv, func() {
-		if _, err := srv.store.UpdateCollection(second.ID, models.CollectionUpdate{Traits: &secondTraits}); err != nil {
-			t.Fatalf("attach traits to second collection: %v", err)
-		}
-	})
+	// TASK-2710's unique indexes forbid this state; it is built anyway because
+	// LEGACY databases hold it and what this test verifies is how resolution
+	// HANDLES it. The restore is expected to fail here — the duplicate stays
+	// live for the whole test, which is exactly the condition that makes
+	// recreating a unique index impossible — so its error is ignored
+	// deliberately rather than by omission.
+	restoreTraitUniqueness := srv.store.SuspendTraitUniquenessForTesting()
+	defer func() { _ = restoreTraitUniqueness() }()
+	if _, err := srv.store.UpdateCollection(second.ID, models.CollectionUpdate{Traits: &secondTraits}); err != nil {
+		t.Fatalf("attach traits to second collection: %v", err)
+	}
 
 	// Same invocation slug in both collections. The partial unique index is
 	// per (collection_id, invocation_slug), so this is legal.
@@ -327,11 +333,17 @@ func TestCollectionIDForKindIgnoresInvisibleCollections(t *testing.T) {
 	var second models.Collection
 	parseJSON(t, rr, &second)
 	secondTraits := `{"artifact_kind":{"kind":"convention"}}`
-	withTraitUniquenessSuspended(t, srv, func() {
-		if _, err := srv.store.UpdateCollection(second.ID, models.CollectionUpdate{Traits: &secondTraits}); err != nil {
-			t.Fatalf("attach traits to second collection: %v", err)
-		}
-	})
+	// TASK-2710's unique indexes forbid this state; it is built anyway because
+	// LEGACY databases hold it and what this test verifies is how resolution
+	// HANDLES it. The restore is expected to fail here — the duplicate stays
+	// live for the whole test, which is exactly the condition that makes
+	// recreating a unique index impossible — so its error is ignored
+	// deliberately rather than by omission.
+	restoreTraitUniqueness := srv.store.SuspendTraitUniquenessForTesting()
+	defer func() { _ = restoreTraitUniqueness() }()
+	if _, err := srv.store.UpdateCollection(second.ID, models.CollectionUpdate{Traits: &secondTraits}); err != nil {
+		t.Fatalf("attach traits to second collection: %v", err)
+	}
 
 	wsID := workspaceIDForSlug(t, srv, wsSlug)
 
@@ -513,36 +525,4 @@ func TestFirstPartyKeyModeIsPinned(t *testing.T) {
 	if rr.Code != http.StatusOK {
 		t.Errorf("control leg failed: bodies mode on `conventions` was refused: %d %s", rr.Code, rr.Body.String())
 	}
-}
-
-// withTraitUniquenessSuspended runs fn with TASK-2710's partial unique indexes
-// dropped, so a test can build the two-collections-declaring-one-trait state
-// those indexes now forbid.
-//
-// The state is not hypothetical and the tests above are not obsolete. They
-// guard the round-2 shadowing fix: when two collections declare one kind and
-// the first-sorting one is invisible to the caller, resolution must return the
-// visible one instead of failing. TASK-2710 makes that state unrepresentable
-// GOING FORWARD and repairs it at startup on databases that already hold it —
-// but the resolver is what stands between a legacy database and a wrong answer
-// in the window before that repair, and on any deployment where an operator
-// has dropped the index. Deleting these tests would retire a guarantee that is
-// still load-bearing; suspending the constraint to build the fixture keeps
-// them testing exactly what they always tested.
-//
-// This mirrors internal/store's withTraitIndexSuspended, and the same
-// reasoning as IDEA-2883's disagreeing-reminder fixture: once a constraint
-// makes a legacy state unbuildable, the test for how that state is HANDLED has
-// to construct it the way it actually exists in the wild.
-func withTraitUniquenessSuspended(t *testing.T, srv *Server, fn func()) {
-	t.Helper()
-	for _, idx := range []string{
-		"idx_collections_artifact_kind_per_workspace",
-		"idx_collections_invocation_field_per_workspace",
-	} {
-		if err := srv.store.DropIndexForTest(idx); err != nil {
-			t.Fatalf("suspend %s: %v", idx, err)
-		}
-	}
-	fn()
 }

--- a/internal/server/handlers_collection_traits_test.go
+++ b/internal/server/handlers_collection_traits_test.go
@@ -252,9 +252,11 @@ func TestResolvePlaybookIgnoresInvisibleCollections(t *testing.T) {
 	var second models.Collection
 	parseJSON(t, rr, &second)
 	secondTraits := `{"bootstrap_include":[{"mode":"metadata","key":"playbooks"}],"invocation_field":"invocation_slug"}`
-	if _, err := srv.store.UpdateCollection(second.ID, models.CollectionUpdate{Traits: &secondTraits}); err != nil {
-		t.Fatalf("attach traits to second collection: %v", err)
-	}
+	withTraitUniquenessSuspended(t, srv, func() {
+		if _, err := srv.store.UpdateCollection(second.ID, models.CollectionUpdate{Traits: &secondTraits}); err != nil {
+			t.Fatalf("attach traits to second collection: %v", err)
+		}
+	})
 
 	// Same invocation slug in both collections. The partial unique index is
 	// per (collection_id, invocation_slug), so this is legal.
@@ -325,9 +327,11 @@ func TestCollectionIDForKindIgnoresInvisibleCollections(t *testing.T) {
 	var second models.Collection
 	parseJSON(t, rr, &second)
 	secondTraits := `{"artifact_kind":{"kind":"convention"}}`
-	if _, err := srv.store.UpdateCollection(second.ID, models.CollectionUpdate{Traits: &secondTraits}); err != nil {
-		t.Fatalf("attach traits to second collection: %v", err)
-	}
+	withTraitUniquenessSuspended(t, srv, func() {
+		if _, err := srv.store.UpdateCollection(second.ID, models.CollectionUpdate{Traits: &secondTraits}); err != nil {
+			t.Fatalf("attach traits to second collection: %v", err)
+		}
+	})
 
 	wsID := workspaceIDForSlug(t, srv, wsSlug)
 
@@ -509,4 +513,36 @@ func TestFirstPartyKeyModeIsPinned(t *testing.T) {
 	if rr.Code != http.StatusOK {
 		t.Errorf("control leg failed: bodies mode on `conventions` was refused: %d %s", rr.Code, rr.Body.String())
 	}
+}
+
+// withTraitUniquenessSuspended runs fn with TASK-2710's partial unique indexes
+// dropped, so a test can build the two-collections-declaring-one-trait state
+// those indexes now forbid.
+//
+// The state is not hypothetical and the tests above are not obsolete. They
+// guard the round-2 shadowing fix: when two collections declare one kind and
+// the first-sorting one is invisible to the caller, resolution must return the
+// visible one instead of failing. TASK-2710 makes that state unrepresentable
+// GOING FORWARD and repairs it at startup on databases that already hold it —
+// but the resolver is what stands between a legacy database and a wrong answer
+// in the window before that repair, and on any deployment where an operator
+// has dropped the index. Deleting these tests would retire a guarantee that is
+// still load-bearing; suspending the constraint to build the fixture keeps
+// them testing exactly what they always tested.
+//
+// This mirrors internal/store's withTraitIndexSuspended, and the same
+// reasoning as IDEA-2883's disagreeing-reminder fixture: once a constraint
+// makes a legacy state unbuildable, the test for how that state is HANDLED has
+// to construct it the way it actually exists in the wild.
+func withTraitUniquenessSuspended(t *testing.T, srv *Server, fn func()) {
+	t.Helper()
+	for _, idx := range []string{
+		"idx_collections_artifact_kind_per_workspace",
+		"idx_collections_invocation_field_per_workspace",
+	} {
+		if err := srv.store.DropIndexForTest(idx); err != nil {
+			t.Fatalf("suspend %s: %v", idx, err)
+		}
+	}
+	fn()
 }

--- a/internal/server/handlers_collections.go
+++ b/internal/server/handlers_collections.go
@@ -229,8 +229,8 @@ func (s *Server) handleCreateCollection(w http.ResponseWriter, r *http.Request) 
 
 	coll, err := s.store.CreateCollection(workspaceID, input)
 	if err != nil {
-		if strings.Contains(err.Error(), "UNIQUE constraint") {
-			writeError(w, http.StatusConflict, "conflict", "A collection with this name already exists")
+		if isUniqueViolation(err) {
+			writeError(w, http.StatusConflict, "conflict", uniqueCollectionConflictMessage(err))
 			return
 		}
 		writeInternalError(w, err)
@@ -382,6 +382,15 @@ func (s *Server) handleUpdateCollection(w http.ResponseWriter, r *http.Request) 
 			writeCollectionUpdateConflictError(w, coll.Slug, conflict)
 			return
 		}
+		// A unique violation reaching here is a RACE past checkTraitConflicts
+		// and the slug pre-check — that gate reads then writes without holding
+		// a lock across both, which is why TASK-2710 made the constraint the
+		// real guarantee. This path recognised NEITHER driver's text and
+		// answered 500; it now matches create.
+		if isUniqueViolation(err) {
+			writeError(w, http.StatusConflict, "conflict", uniqueCollectionConflictMessage(err))
+			return
+		}
 		writeInternalError(w, err)
 		return
 	}
@@ -525,4 +534,35 @@ func (s *Server) handleDeleteCollection(w http.ResponseWriter, r *http.Request) 
 	}
 
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// isUniqueViolation recognises a unique-index violation from EITHER driver.
+//
+// The collection handlers used to check only SQLite's "UNIQUE constraint", so
+// the identical race answered 409 on SQLite and 500 on Postgres — and the
+// update path checked neither. Every item handler already tests both strings;
+// this is that test, named, so the next handler needing it does not invent a
+// third spelling (codex round 1, P2).
+func isUniqueViolation(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "UNIQUE constraint") || strings.Contains(msg, "duplicate key")
+}
+
+// uniqueCollectionConflictMessage distinguishes the indexes a collection write
+// can violate, because "a collection with this name already exists" is
+// actively misleading for a TASK-2710 trait conflict: the NAME is fine, the
+// DECLARATION is taken, and a user told to rename would rename forever.
+func uniqueCollectionConflictMessage(err error) string {
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "idx_collections_artifact_kind_per_workspace"):
+		return "Another collection in this workspace already declares this artifact kind"
+	case strings.Contains(msg, "idx_collections_invocation_field_per_workspace"):
+		return "Another collection in this workspace already handles invocation routing"
+	default:
+		return "A collection with this name already exists"
+	}
 }

--- a/internal/server/handlers_collections.go
+++ b/internal/server/handlers_collections.go
@@ -562,7 +562,17 @@ func uniqueCollectionConflictMessage(err error) string {
 		return "Another collection in this workspace already declares this artifact kind"
 	case strings.Contains(msg, "idx_collections_invocation_field_per_workspace"):
 		return "Another collection in this workspace already handles invocation routing"
-	default:
+	case strings.Contains(msg, "collections"):
+		// Names the collections table or its slug constraint
+		// (collections_workspace_id_slug_key on Postgres, "UNIQUE constraint
+		// failed: collections.workspace_id, collections.slug" on SQLite).
 		return "A collection with this name already exists"
+	default:
+		// Reached because a collection UPDATE can migrate ITEM field values,
+		// and an item-level unique index can fail there — invocation_slug is
+		// the live example. Telling that caller their collection NAME is taken
+		// sends them to rename something that is not the problem, so the
+		// message stays honest about what it does not know (codex round 3).
+		return "This change conflicts with an existing unique value"
 	}
 }

--- a/internal/server/handlers_collections.go
+++ b/internal/server/handlers_collections.go
@@ -125,24 +125,30 @@ func validateCollectionTraits(raw string) error {
 // would depend on sort_order and creation time. That is a coin flip wearing a
 // rule's clothes. Codex round 7.
 //
-// BEST-EFFORT, NOT AN INVARIANT — say so plainly rather than let the name
-// imply more than it delivers (Codex round 8). This reads and then writes
-// without holding a lock across both, so two concurrent owner-level writes can
-// both pass and mint a duplicate. Workspace IMPORT bypasses it entirely by
-// design, and a rename that frees a canonical slug can produce a duplicate
-// with no write to this path at all.
+// NOT THE GUARANTEE — say so plainly rather than let the name imply more than
+// it delivers (Codex round 8). This reads and then writes without holding a
+// lock across both, so two concurrent owner-level writes can both pass it, and
+// a rename that frees a canonical slug can produce a duplicate with no write
+// to this path at all.
 //
-// The database-level version — a partial unique index on the extracted trait,
-// the shape migration 054 already uses for invocation_slug — is deliberately
-// NOT added in phase 0: existing deployments can already hold duplicates (the
-// rename-then-reseed path produces one), so creating such an index would fail
-// the migration on exactly the databases that most need fixing. That wants a
-// de-duplication pass first, which is its own unit.
+// What backs it is migration 087's two partial unique indexes (TASK-2710),
+// which turned the rule into a database invariant for LIVE collections. This
+// gate survives them for the message: a unique violation is a 409 saying a
+// name is taken unless something tells the handler otherwise, and "rename your
+// collection" is useless advice when the name is fine and the DECLARATION is
+// taken. So the pre-check produces the friendly, specific refusal in the
+// common case and the index is what actually holds — the same division
+// checkUniqueFields and the invocation_slug index already use. A violation
+// that reaches the handler anyway is translated by
+// uniqueCollectionConflictMessage rather than mis-labelled.
 //
-// So this gate closes the common case — a user or agent declaring a duplicate
-// through the API — and the resolvers keep their documented order-dependent
-// behaviour for duplicates arriving any other way, because refusing to resolve
-// at read time would break a workspace rather than a request.
+// Two things it is still worth knowing this gate does not cover. Workspace
+// IMPORT does not call it: an archive arrives whole and is often the only copy
+// of a workspace, so import DE-DUPLICATES on the way in (see
+// dropDuplicateImportDeclarations) rather than refusing the restore. And
+// ARCHIVED collections are outside the invariant entirely — both indexes carry
+// AND deleted_at IS NULL, and every trait resolver filters the same way, so a
+// soft-deleted row may hold a declaration a live one also holds.
 //
 // excludeCollID is the collection being updated, so a collection never
 // conflicts with itself.

--- a/internal/store/collections.go
+++ b/internal/store/collections.go
@@ -1012,11 +1012,11 @@ func (s *Store) SeedCollectionsFromTemplate(workspaceID string, templateName str
 		// Reachable in production only through a future re-seed door — both of
 		// today's callers seed a workspace they just created — but the seeder
 		// should not be the thing that discovers the invariant the hard way.
-		if taken, takenBy, terr := s.artifactKindTaken(workspaceID, def.Traits); terr != nil {
-			return fmt.Errorf("check artifact kind for %s: %w", def.Slug, terr)
+		if taken, takenBy, which, terr := s.traitDeclarationTaken(workspaceID, def.Traits); terr != nil {
+			return fmt.Errorf("check trait declarations for %s: %w", def.Slug, terr)
 		} else if taken {
-			slog.Info("seed: skipping a template collection whose artifact kind is already declared",
-				"workspace_id", workspaceID, "skipped_slug", def.Slug, "declared_by", takenBy)
+			slog.Info("seed: skipping a template collection whose declaration is already held",
+				"workspace_id", workspaceID, "skipped_slug", def.Slug, "declaration", which, "declared_by", takenBy)
 			continue
 		}
 
@@ -1368,24 +1368,39 @@ func retargetRelationsInSchemaJSON(raw, oldSlug, newSlug string) (string, bool, 
 	return string(encoded), true, nil
 }
 
-// artifactKindTaken reports whether some live collection in the workspace
-// already declares the artifact kind carried by def's traits, and which one.
-// Returns false for a definition that declares no kind, which is most of them.
+// traitDeclarationTaken reports whether some live collection in the workspace
+// already holds either declaration carried by def's traits — the artifact kind
+// or invocation routing — and which collection holds it.
 //
-// Exists so SeedCollectionsFromTemplate can skip rather than collide with the
-// TASK-2710 unique index. Deliberately a read on the same rule the index
-// enforces, not a second spelling of it: it asks "is this kind declared", which
-// is exactly what the index makes unique.
-func (s *Store) artifactKindTaken(workspaceID string, traits models.CollectionTraits) (bool, string, error) {
-	if traits.ArtifactKind == nil || traits.ArtifactKind.Kind == "" {
-		return false, "", nil
+// BOTH, not just the kind (codex round 1, P2). The playbooks definition
+// declares artifact_kind AND invocation_field, and TASK-2710 adds a unique
+// index for each; checking only the kind left the invocation index reachable,
+// so a workspace whose invocation-routing collection had been renamed would
+// still have failed its seed. A definition is skipped when EITHER is held: the
+// workspace already has a collection doing that job, which is what seeding is
+// for.
+//
+// Exists so SeedCollectionsFromTemplate can skip rather than collide with those
+// indexes. Deliberately a read on the same rule they enforce rather than a
+// second spelling of it.
+func (s *Store) traitDeclarationTaken(workspaceID string, traits models.CollectionTraits) (bool, string, string, error) {
+	declaresKind := traits.ArtifactKind != nil && traits.ArtifactKind.Kind != ""
+	if !declaresKind && traits.InvocationField == "" {
+		return false, "", "", nil
 	}
 	live, err := s.ListTraitedCollections(workspaceID)
 	if err != nil {
-		return false, "", err
+		return false, "", "", err
 	}
-	if owner := collections.FindByArtifactKind(live, traits.ArtifactKind.Kind); owner != nil {
-		return true, owner.Slug, nil
+	if declaresKind {
+		if owner := collections.FindByArtifactKind(live, traits.ArtifactKind.Kind); owner != nil {
+			return true, owner.Slug, "artifact_kind=" + traits.ArtifactKind.Kind, nil
+		}
 	}
-	return false, "", nil
+	if traits.InvocationField != "" {
+		if owners := collections.FindByInvocationField(live); len(owners) > 0 {
+			return true, owners[0].Slug, "invocation_field", nil
+		}
+	}
+	return false, "", "", nil
 }

--- a/internal/store/collections.go
+++ b/internal/store/collections.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -999,6 +1000,26 @@ func (s *Store) SeedCollectionsFromTemplate(workspaceID string, templateName str
 			continue
 		}
 
+		// A collection can be missing BY SLUG and still be present by
+		// DECLARATION: renaming re-slugs, so a workspace whose `conventions`
+		// became `house-rules` looks slug-empty here while its artifact kind is
+		// still claimed. Creating the definition anyway used to mint a silent
+		// duplicate — the reproduction TASK-2710 exists to repair — and since
+		// that task's partial unique index it would fail this whole seed
+		// instead. Skip and say so: the point of seeding is that the template's
+		// collections EXIST, and by declaration this one does.
+		//
+		// Reachable in production only through a future re-seed door — both of
+		// today's callers seed a workspace they just created — but the seeder
+		// should not be the thing that discovers the invariant the hard way.
+		if taken, takenBy, terr := s.artifactKindTaken(workspaceID, def.Traits); terr != nil {
+			return fmt.Errorf("check artifact kind for %s: %w", def.Slug, terr)
+		} else if taken {
+			slog.Info("seed: skipping a template collection whose artifact kind is already declared",
+				"workspace_id", workspaceID, "skipped_slug", def.Slug, "declared_by", takenBy)
+			continue
+		}
+
 		schemaJSON, err := json.Marshal(def.Schema)
 		if err != nil {
 			return fmt.Errorf("marshal schema for %s: %w", def.Slug, err)
@@ -1345,4 +1366,26 @@ func retargetRelationsInSchemaJSON(raw, oldSlug, newSlug string) (string, bool, 
 		return raw, false, err
 	}
 	return string(encoded), true, nil
+}
+
+// artifactKindTaken reports whether some live collection in the workspace
+// already declares the artifact kind carried by def's traits, and which one.
+// Returns false for a definition that declares no kind, which is most of them.
+//
+// Exists so SeedCollectionsFromTemplate can skip rather than collide with the
+// TASK-2710 unique index. Deliberately a read on the same rule the index
+// enforces, not a second spelling of it: it asks "is this kind declared", which
+// is exactly what the index makes unique.
+func (s *Store) artifactKindTaken(workspaceID string, traits models.CollectionTraits) (bool, string, error) {
+	if traits.ArtifactKind == nil || traits.ArtifactKind.Kind == "" {
+		return false, "", nil
+	}
+	live, err := s.ListTraitedCollections(workspaceID)
+	if err != nil {
+		return false, "", err
+	}
+	if owner := collections.FindByArtifactKind(live, traits.ArtifactKind.Kind); owner != nil {
+		return true, owner.Slug, nil
+	}
+	return false, "", nil
 }

--- a/internal/store/export.go
+++ b/internal/store/export.go
@@ -399,38 +399,80 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 	// declarations live, which collection receives an imported artifact or
 	// answers an invocation slug depends on collection order. Warn so the
 	// operator can fix it. Codex round 8.
+	// DE-DUPLICATED ON THE WAY IN, not warned about and inserted (TASK-2710
+	// item 4, and codex round 2's P1 when it was still the latter).
 	//
-	// ARCHIVED collections are excluded from this scan (BUG-2884). Since the
-	// bundle started carrying soft-deleted collections, a workspace whose
-	// archived collection still declares the kind its live replacement
-	// declares would warn on every import about an ambiguity that does not
-	// exist: routing is live-only (ListTraitedCollections filters
-	// deleted_at IS NULL), so an archived declaration resolves nothing. Worse
-	// than the noise, the archived slug could win `seenKinds` and the warning
-	// would name the LIVE collection as the duplicate.
+	// This used to warn and import both, which was the right call while nothing
+	// forbade the pair. With the partial unique indexes it is no longer
+	// available: the second INSERT is refused, the whole import transaction
+	// rolls back, and the workspace minted before it survives as a husk
+	// ([[BUG-2892]]). An archive carrying a duplicate would become unimportable
+	// — and archives carrying duplicates are exactly the ones this release
+	// repairs, so refusing them is the worst of the three options.
+	//
+	// So the FIRST declaring collection in bundle order keeps the declaration
+	// and later ones are stripped of it, which is the same disposition
+	// dedupeTraitDeclarations applies to an existing database. It cannot use
+	// that pass's primary rule — most user-written items — because items are
+	// inserted after collections and every count would be zero here; bundle
+	// order IS the terminator, and the log says so rather than implying a
+	// considered choice.
+	//
+	// The loser keeps every item, as in the de-dup pass: only the declaration
+	// is dropped, and the items still land in that collection.
+	//
+	// ARCHIVED collections take no part in this (BUG-2884). Since the bundle
+	// started carrying soft-deleted collections, an archived collection can
+	// travel alongside the live one that replaced it, still declaring the same
+	// kind. It must neither CLAIM the kind — that would strip the live
+	// collection later in the bundle and hand routing to a row every resolver
+	// filters out (ListTraitedCollections is deleted_at IS NULL) — nor LOSE its
+	// own declaration, because nothing routes to it either way and stripping it
+	// would edit data the operator archived rather than deleted. The partial
+	// unique indexes agree: both carry `AND deleted_at IS NULL`, so an archived
+	// row is outside the constraint and cannot conflict with anything.
+	strippedTraits := map[string]string{}
 	seenKinds := map[string]string{}
 	invocationCollection := ""
 	for _, c := range data.Collections {
 		if c.DeletedAt != "" {
 			continue
 		}
-		if t, err := models.ParseCollectionTraits(c.Traits); err == nil {
-			if t.ArtifactKind != nil && t.ArtifactKind.Kind != "" {
-				if prev, dup := seenKinds[t.ArtifactKind.Kind]; dup {
-					slog.Warn("import: archive declares one artifact kind on two collections; artifact routing will depend on collection order until one is changed",
-						"kind", t.ArtifactKind.Kind, "collections", prev+","+c.Slug, "workspace_id", ws.ID)
-				} else {
-					seenKinds[t.ArtifactKind.Kind] = c.Slug
-				}
+		t, err := models.ParseCollectionTraits(c.Traits)
+		if err != nil {
+			continue
+		}
+		changed := false
+		if t.ArtifactKind != nil && t.ArtifactKind.Kind != "" {
+			if prev, dup := seenKinds[t.ArtifactKind.Kind]; dup {
+				slog.Warn("import: archive declares one artifact kind on two collections; the later one is imported WITHOUT the declaration and keeps its items",
+					"kind", t.ArtifactKind.Kind, "keeps_declaration", prev, "stripped", c.Slug,
+					"decided_by", "bundle order (arbitrary — the archive carries no basis for preferring either)",
+					"workspace_id", ws.ID)
+				t.ArtifactKind = nil
+				changed = true
+			} else {
+				seenKinds[t.ArtifactKind.Kind] = c.Slug
 			}
-			if t.InvocationField != "" {
-				if invocationCollection != "" {
-					slog.Warn("import: archive declares invocation routing on two collections; playbook resolution will depend on collection order until one is changed",
-						"collections", invocationCollection+","+c.Slug, "workspace_id", ws.ID)
-				} else {
-					invocationCollection = c.Slug
-				}
+		}
+		if t.InvocationField != "" {
+			if invocationCollection != "" {
+				slog.Warn("import: archive declares invocation routing on two collections; the later one is imported WITHOUT the declaration and keeps its items",
+					"keeps_declaration", invocationCollection, "stripped", c.Slug,
+					"decided_by", "bundle order (arbitrary — the archive carries no basis for preferring either)",
+					"workspace_id", ws.ID)
+				t.InvocationField = ""
+				changed = true
+			} else {
+				invocationCollection = c.Slug
 			}
+		}
+		if changed {
+			encoded, eerr := t.JSON()
+			if eerr != nil {
+				return nil, fmt.Errorf("re-encode de-duplicated traits for %s: %w", c.Slug, eerr)
+			}
+			strippedTraits[c.ID] = encoded
 		}
 	}
 
@@ -456,7 +498,12 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 		// fires. Archives written before TASK-2657 carry no traits key at
 		// all, which lands here as "" — a pre-traits archive imports as a
 		// collection that declares nothing, which is the honest reading.
-		traits := coerceJSONForImport(c.Traits, "{}", "collections.traits", c.ID, ws.ID, true)
+		rawTraits := c.Traits
+		if stripped, ok := strippedTraits[c.ID]; ok {
+			// This collection lost a duplicate declaration above.
+			rawTraits = stripped
+		}
+		traits := coerceJSONForImport(rawTraits, "{}", "collections.traits", c.ID, ws.ID, true)
 		// coerceJSONForImport only guarantees the blob is valid JSON. Traits
 		// are declarations that switch kernel behavior on, so an import is
 		// held to the same grammar the API enforces — otherwise a

--- a/internal/store/export.go
+++ b/internal/store/export.go
@@ -402,79 +402,33 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 	// DE-DUPLICATED ON THE WAY IN, not warned about and inserted (TASK-2710
 	// item 4, and codex round 2's P1 when it was still the latter).
 	//
-	// This used to warn and import both, which was the right call while nothing
-	// forbade the pair. With the partial unique indexes it is no longer
-	// available: the second INSERT is refused, the whole import transaction
-	// rolls back, and the workspace minted before it survives as a husk
-	// ([[BUG-2892]]). An archive carrying a duplicate would become unimportable
-	// — and archives carrying duplicates are exactly the ones this release
-	// repairs, so refusing them is the worst of the three options.
+	// Import used to warn and insert both, which was right while nothing
+	// forbade the pair. With the partial unique indexes the second INSERT is
+	// refused, the whole transaction rolls back, and the workspace minted
+	// before it survives as a husk ([[BUG-2892]]) — so an archive carrying a
+	// duplicate would be unimportable, and archives carrying duplicates are
+	// exactly the ones this release repairs.
 	//
-	// So the FIRST declaring collection in bundle order keeps the declaration
-	// and later ones are stripped of it, which is the same disposition
-	// dedupeTraitDeclarations applies to an existing database. It cannot use
-	// that pass's primary rule — most user-written items — because items are
-	// inserted after collections and every count would be zero here; bundle
-	// order IS the terminator, and the log says so rather than implying a
-	// considered choice.
+	// THE CHECK HAPPENS IN THE INSERT LOOP, ON THE FINAL BYTES, and that
+	// placement is the fix for codex round 3's P1 rather than a style choice.
+	// An earlier version pre-computed the strips from the traits the BUNDLE
+	// carries, which is not what gets written: coercion, validation-discard and
+	// canonical inference all run afterwards. A pre-traits archive carrying
+	// `conventions` with an EMPTY blob has its declaration INFERRED from the
+	// slug (BUG-2702), so a bundle pairing that with an explicit declarer
+	// showed the pre-pass one declaration and the database two — and the index
+	// aborted the import. Checking immediately before the INSERT makes the
+	// question "what am I about to write" instead of "what did the file say".
 	//
-	// The loser keeps every item, as in the de-dup pass: only the declaration
-	// is dropped, and the items still land in that collection.
-	//
-	// ARCHIVED collections take no part in this (BUG-2884). Since the bundle
-	// started carrying soft-deleted collections, an archived collection can
-	// travel alongside the live one that replaced it, still declaring the same
-	// kind. It must neither CLAIM the kind — that would strip the live
-	// collection later in the bundle and hand routing to a row every resolver
-	// filters out (ListTraitedCollections is deleted_at IS NULL) — nor LOSE its
-	// own declaration, because nothing routes to it either way and stripping it
-	// would edit data the operator archived rather than deleted. The partial
-	// unique indexes agree: both carry `AND deleted_at IS NULL`, so an archived
-	// row is outside the constraint and cannot conflict with anything.
-	strippedTraits := map[string]string{}
+	// The FIRST declaring collection in bundle order keeps the declaration and
+	// later ones are stripped, which is the disposition dedupeTraitDeclarations
+	// applies to an existing database. It cannot use that pass's primary rule —
+	// most user-written items — because items are inserted after collections
+	// and every count here is zero; bundle order IS the terminator, and the log
+	// says so rather than implying a considered choice. The loser keeps every
+	// item; only the declaration is dropped.
 	seenKinds := map[string]string{}
 	invocationCollection := ""
-	for _, c := range data.Collections {
-		if c.DeletedAt != "" {
-			continue
-		}
-		t, err := models.ParseCollectionTraits(c.Traits)
-		if err != nil {
-			continue
-		}
-		changed := false
-		if t.ArtifactKind != nil && t.ArtifactKind.Kind != "" {
-			if prev, dup := seenKinds[t.ArtifactKind.Kind]; dup {
-				slog.Warn("import: archive declares one artifact kind on two collections; the later one is imported WITHOUT the declaration and keeps its items",
-					"kind", t.ArtifactKind.Kind, "keeps_declaration", prev, "stripped", c.Slug,
-					"decided_by", "bundle order (arbitrary — the archive carries no basis for preferring either)",
-					"workspace_id", ws.ID)
-				t.ArtifactKind = nil
-				changed = true
-			} else {
-				seenKinds[t.ArtifactKind.Kind] = c.Slug
-			}
-		}
-		if t.InvocationField != "" {
-			if invocationCollection != "" {
-				slog.Warn("import: archive declares invocation routing on two collections; the later one is imported WITHOUT the declaration and keeps its items",
-					"keeps_declaration", invocationCollection, "stripped", c.Slug,
-					"decided_by", "bundle order (arbitrary — the archive carries no basis for preferring either)",
-					"workspace_id", ws.ID)
-				t.InvocationField = ""
-				changed = true
-			} else {
-				invocationCollection = c.Slug
-			}
-		}
-		if changed {
-			encoded, eerr := t.JSON()
-			if eerr != nil {
-				return nil, fmt.Errorf("re-encode de-duplicated traits for %s: %w", c.Slug, eerr)
-			}
-			strippedTraits[c.ID] = encoded
-		}
-	}
 
 	for _, c := range data.Collections {
 		newCollID := newID()
@@ -498,12 +452,7 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 		// fires. Archives written before TASK-2657 carry no traits key at
 		// all, which lands here as "" — a pre-traits archive imports as a
 		// collection that declares nothing, which is the honest reading.
-		rawTraits := c.Traits
-		if stripped, ok := strippedTraits[c.ID]; ok {
-			// This collection lost a duplicate declaration above.
-			rawTraits = stripped
-		}
-		traits := coerceJSONForImport(rawTraits, "{}", "collections.traits", c.ID, ws.ID, true)
+		traits := coerceJSONForImport(c.Traits, "{}", "collections.traits", c.ID, ws.ID, true)
 		// coerceJSONForImport only guarantees the blob is valid JSON. Traits
 		// are declarations that switch kernel behavior on, so an import is
 		// held to the same grammar the API enforces — otherwise a
@@ -580,6 +529,14 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 					traits = encoded
 				}
 			}
+		}
+
+		// Now that `traits` is final — coerced, validated, and inferred — drop
+		// any declaration another collection in this bundle already took.
+		var derr error
+		traits, derr = dropDuplicateImportDeclarations(traits, c.Slug, ws.ID, seenKinds, &invocationCollection)
+		if derr != nil {
+			return nil, fmt.Errorf("de-duplicate declarations for %s: %w", c.Slug, derr)
 		}
 
 		// NULLIF so an ABSENT deleted_at — every archive written before
@@ -1057,4 +1014,52 @@ func remapFieldIDs(fieldsJSON string, itemMap, collMap map[string]string) string
 		result = strings.ReplaceAll(result, `"`+oldID+`"`, `"`+newID+`"`)
 	}
 	return result
+}
+
+// dropDuplicateImportDeclarations returns traits with any declaration already
+// claimed by an earlier collection in the same bundle removed, recording the
+// claims it does allow. Called with the FINAL blob, immediately before the
+// INSERT that writes it — see the note at the import loop for why that
+// placement is load-bearing rather than incidental.
+//
+// A blob that does not parse is returned untouched: it declares nothing to
+// every other reader, and it is outside the indexes' json_valid guard too.
+func dropDuplicateImportDeclarations(traits, slug, workspaceID string, seenKinds map[string]string, invocationCollection *string) (string, error) {
+	t, err := models.ParseCollectionTraits(traits)
+	if err != nil {
+		return traits, nil
+	}
+	changed := false
+	if t.ArtifactKind != nil && t.ArtifactKind.Kind != "" {
+		if prev, dup := seenKinds[t.ArtifactKind.Kind]; dup {
+			slog.Warn("import: archive declares one artifact kind on two collections; the later one is imported WITHOUT the declaration and keeps its items",
+				"kind", t.ArtifactKind.Kind, "keeps_declaration", prev, "stripped", slug,
+				"decided_by", "bundle order (arbitrary — the archive carries no basis for preferring either)",
+				"workspace_id", workspaceID)
+			t.ArtifactKind = nil
+			changed = true
+		} else {
+			seenKinds[t.ArtifactKind.Kind] = slug
+		}
+	}
+	if t.InvocationField != "" {
+		if *invocationCollection != "" {
+			slog.Warn("import: archive declares invocation routing on two collections; the later one is imported WITHOUT the declaration and keeps its items",
+				"keeps_declaration", *invocationCollection, "stripped", slug,
+				"decided_by", "bundle order (arbitrary — the archive carries no basis for preferring either)",
+				"workspace_id", workspaceID)
+			t.InvocationField = ""
+			changed = true
+		} else {
+			*invocationCollection = slug
+		}
+	}
+	if !changed {
+		return traits, nil
+	}
+	encoded, eerr := t.JSON()
+	if eerr != nil {
+		return "", eerr
+	}
+	return encoded, nil
 }

--- a/internal/store/export.go
+++ b/internal/store/export.go
@@ -427,6 +427,18 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 	// and every count here is zero; bundle order IS the terminator, and the log
 	// says so rather than implying a considered choice. The loser keeps every
 	// item; only the declaration is dropped.
+	//
+	// ARCHIVED collections take no part in this (BUG-2884). Since the bundle
+	// started carrying soft-deleted collections, an archived collection can
+	// travel alongside the live one that replaced it, still declaring the same
+	// kind — and it arrives FIRST if it was created first, because the bundle
+	// is in creation order. It must neither CLAIM the kind, which would strip
+	// the live collection later in the bundle and leave the workspace with
+	// routing owned by a row every resolver filters out
+	// (ListTraitedCollections is deleted_at IS NULL), nor LOSE its own, which
+	// would edit data the operator archived rather than deleted. Both partial
+	// unique indexes carry `AND deleted_at IS NULL`, so an archived row is
+	// outside the constraint and can conflict with nothing.
 	seenKinds := map[string]string{}
 	invocationCollection := ""
 
@@ -534,7 +546,7 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 		// Now that `traits` is final — coerced, validated, and inferred — drop
 		// any declaration another collection in this bundle already took.
 		var derr error
-		traits, derr = dropDuplicateImportDeclarations(traits, c.Slug, ws.ID, seenKinds, &invocationCollection)
+		traits, derr = dropDuplicateImportDeclarations(traits, c.Slug, c.DeletedAt, ws.ID, seenKinds, &invocationCollection)
 		if derr != nil {
 			return nil, fmt.Errorf("de-duplicate declarations for %s: %w", c.Slug, derr)
 		}
@@ -1024,7 +1036,19 @@ func remapFieldIDs(fieldsJSON string, itemMap, collMap map[string]string) string
 //
 // A blob that does not parse is returned untouched: it declares nothing to
 // every other reader, and it is outside the indexes' json_valid guard too.
-func dropDuplicateImportDeclarations(traits, slug, workspaceID string, seenKinds map[string]string, invocationCollection *string) (string, error) {
+//
+// So is an ARCHIVED collection's, for the same reason one step further out: a
+// soft-deleted row is outside both partial unique indexes (`AND deleted_at IS
+// NULL`) and outside every trait resolver, so it can neither create the
+// conflict this function exists to prevent nor be harmed by holding a stale
+// declaration. Letting it take a claim would be the actual damage — the live
+// collection later in the bundle would be stripped and the workspace would
+// import with no routing for that kind at all (BUG-2884; the pre-pass this
+// replaced grew the same condition).
+func dropDuplicateImportDeclarations(traits, slug, deletedAt, workspaceID string, seenKinds map[string]string, invocationCollection *string) (string, error) {
+	if deletedAt != "" {
+		return traits, nil
+	}
 	t, err := models.ParseCollectionTraits(traits)
 	if err != nil {
 		return traits, nil

--- a/internal/store/export_soft_deleted_collection_test.go
+++ b/internal/store/export_soft_deleted_collection_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/PerpetualSoftware/pad/internal/collections"
 	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
@@ -257,26 +258,38 @@ func TestImportRoutingIgnoresSoftDeletedCollections(t *testing.T) {
 	s := testStore(t)
 	owner := createTestUser(t, s, "routing2884@test.com", "Owner", "password123")
 	ws := createTestWorkspace(t, s, "Routing 2884")
-	if err := s.SeedCollectionsFromTemplate(ws.ID, "startup"); err != nil {
-		t.Fatalf("seed: %v", err)
-	}
 
-	// An archived collection carrying the conventions declaration, alongside
-	// the live seeded conventions collection.
-	convs, err := s.GetCollectionBySlug(ws.ID, "conventions")
-	if err != nil || convs == nil {
-		t.Fatalf("GetCollectionBySlug(conventions): %v (nil=%v)", err, convs == nil)
+	// An archived collection carrying the conventions declaration, alongside a
+	// live conventions collection.
+	//
+	// Built in THIS order — declare, archive, then seed — because TASK-2710's
+	// unique index refuses two LIVE collections declaring one kind, and the
+	// order is not a workaround for it: it is the production path that mints
+	// this state. A workspace whose conventions collection is deleted and then
+	// re-seeded ends up here, and every step is legal under the invariant,
+	// which is the point. Seeding does not skip, because traitDeclarationTaken
+	// reads ListTraitedCollections and the archived row is not in it.
+	convTraits, terr := collections.CanonicalTraitsForSlug("conventions").JSON()
+	if terr != nil {
+		t.Fatalf("encode canonical conventions traits: %v", terr)
 	}
 	ghost, err := s.CreateCollection(ws.ID, models.CollectionCreate{
 		Name:   "Old Conventions",
 		Prefix: "OCONV",
-		Traits: convs.Traits,
+		Traits: convTraits,
 	})
 	if err != nil {
 		t.Fatalf("CreateCollection(ghost): %v", err)
 	}
 	if err := s.DeleteCollection(ghost.ID, ""); err != nil {
 		t.Fatalf("DeleteCollection(ghost): %v", err)
+	}
+	if err := s.SeedCollectionsFromTemplate(ws.ID, "startup"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	convs, err := s.GetCollectionBySlug(ws.ID, "conventions")
+	if err != nil || convs == nil {
+		t.Fatalf("control leg failed: seeding skipped conventions even though the only other declarer is archived: %v (nil=%v)", err, convs == nil)
 	}
 
 	exp, err := s.ExportWorkspace(ws.Slug)

--- a/internal/store/migrations/087_collection_trait_uniqueness.sql
+++ b/internal/store/migrations/087_collection_trait_uniqueness.sql
@@ -1,0 +1,45 @@
+-- TASK-2710: make "one collection per artifact kind, one invocation-routing
+-- collection per workspace" a real database invariant instead of a best-effort
+-- API gate. The enforcement-mechanism half of SPEC-0 L6, deferred from
+-- TASK-2657 by lead ruling.
+--
+-- TASK-2657's checkTraitConflicts refuses duplicates at collection create and
+-- update, and its own code says the gate is BEST-EFFORT: it reads then writes
+-- without holding a lock across both, workspace import bypasses it by design
+-- (warning instead, so a conflicting archive is never silent), and a rename
+-- that frees a canonical slug can mint a duplicate with no write to that path
+-- at all. With two declarations live, FindByArtifactKind returns whichever the
+-- result order puts first — and that order is arbitrary, not a tie-break:
+-- template-seeded collections share sort_order AND created_at, and on Postgres
+-- the winner was measured FLIPPING BETWEEN RUNS on identical data.
+--
+-- The repair that has to happen first is NOT in this file. It is
+-- dedupeTraitDeclarations (internal/store/trait_dedupe.go), which runs BEFORE
+-- migrate() because these CREATE statements would fail on precisely the
+-- databases that hold duplicates. It is in Go rather than SQL because the
+-- ruling requires every resolution to be REPORTED — it silently changes which
+-- collection owns a kernel behavior — and a SQL migration cannot log: Postgres
+-- RAISE NOTICE goes nowhere here (no notice handler is registered) and SQLite
+-- has no equivalent. Writing the rule once in Go and the indexes once in SQL
+-- keeps one rule with one spelling.
+--
+-- Shape follows migrations/054, which already constrains items.invocation_slug
+-- the same way: a partial unique index over an extracted JSON value, excluding
+-- rows that do not opt in and rows that are soft-deleted.
+
+-- One collection per artifact kind per workspace.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_collections_artifact_kind_per_workspace
+    ON collections(workspace_id, json_extract(traits, '$.artifact_kind.kind'))
+    WHERE json_extract(traits, '$.artifact_kind.kind') IS NOT NULL
+      AND json_extract(traits, '$.artifact_kind.kind') != ''
+      AND deleted_at IS NULL;
+
+-- One invocation-routing collection per workspace. Unlike artifact_kind this
+-- is not keyed by the value: the invariant is that at most ONE collection in a
+-- workspace routes invocations at all, so the index is over workspace_id alone
+-- and the partial predicate is what restricts it to the declaring rows.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_collections_invocation_field_per_workspace
+    ON collections(workspace_id)
+    WHERE json_extract(traits, '$.invocation_field') IS NOT NULL
+      AND json_extract(traits, '$.invocation_field') != ''
+      AND deleted_at IS NULL;

--- a/internal/store/migrations/087_collection_trait_uniqueness.sql
+++ b/internal/store/migrations/087_collection_trait_uniqueness.sql
@@ -28,9 +28,19 @@
 -- rows that do not opt in and rows that are soft-deleted.
 
 -- One collection per artifact kind per workspace.
+-- json_valid() guards every extraction. SQLite's json_extract RAISES on
+-- malformed JSON rather than returning NULL, so an unguarded expression here
+-- would fail this CREATE — and therefore startup — on any database holding one
+-- malformed traits blob. Every other reader treats malformed traits as
+-- declaring nothing (ListTraitedCollections returns empty traits rather than
+-- failing the call), and this matches that: a row whose blob does not parse
+-- declares nothing, so it is outside the index rather than fatal to it.
+-- Postgres needs no equivalent — traits is JSONB there, so the column type
+-- makes malformed content unrepresentable at rest. Codex round 2, P2.
 CREATE UNIQUE INDEX IF NOT EXISTS idx_collections_artifact_kind_per_workspace
     ON collections(workspace_id, json_extract(traits, '$.artifact_kind.kind'))
-    WHERE json_extract(traits, '$.artifact_kind.kind') IS NOT NULL
+    WHERE json_valid(traits)
+      AND json_extract(traits, '$.artifact_kind.kind') IS NOT NULL
       AND json_extract(traits, '$.artifact_kind.kind') != ''
       AND deleted_at IS NULL;
 
@@ -40,6 +50,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_collections_artifact_kind_per_workspace
 -- and the partial predicate is what restricts it to the declaring rows.
 CREATE UNIQUE INDEX IF NOT EXISTS idx_collections_invocation_field_per_workspace
     ON collections(workspace_id)
-    WHERE json_extract(traits, '$.invocation_field') IS NOT NULL
+    WHERE json_valid(traits)
+      AND json_extract(traits, '$.invocation_field') IS NOT NULL
       AND json_extract(traits, '$.invocation_field') != ''
       AND deleted_at IS NULL;

--- a/internal/store/pgmigrations/064_collection_trait_uniqueness.sql
+++ b/internal/store/pgmigrations/064_collection_trait_uniqueness.sql
@@ -1,0 +1,20 @@
+-- TASK-2710, Postgres half. Mirrors
+-- internal/store/migrations/087_collection_trait_uniqueness.sql — see that
+-- file for why the invariant exists and why the de-duplication pass that must
+-- precede it lives in Go rather than in this migration.
+--
+-- traits is JSONB here (SQLite stores TEXT), so the extraction operator
+-- differs: ->> yields the value as text, which matches json_extract's result
+-- type on the SQLite side and keeps both indexes keyed on the same thing.
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_collections_artifact_kind_per_workspace
+    ON collections(workspace_id, ((traits -> 'artifact_kind' ->> 'kind')))
+    WHERE (traits -> 'artifact_kind' ->> 'kind') IS NOT NULL
+      AND (traits -> 'artifact_kind' ->> 'kind') <> ''
+      AND deleted_at IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_collections_invocation_field_per_workspace
+    ON collections(workspace_id)
+    WHERE (traits ->> 'invocation_field') IS NOT NULL
+      AND (traits ->> 'invocation_field') <> ''
+      AND deleted_at IS NULL;

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -291,6 +291,15 @@ func New(dbPath string) (*Store, error) {
 	db.SetConnMaxLifetime(time.Hour)
 
 	s := &Store{db: db, dialect: &sqliteDialect{}, dbPath: dbPath}
+	// BEFORE migrate(), not after (TASK-2710). Migrations 087 / 064 add partial
+	// unique indexes over the collection-trait declarations, and those CREATE
+	// statements fail on exactly the databases that hold duplicates — so the
+	// repair has to precede them. No-ops on a fresh database, where the
+	// collections table does not exist yet.
+	if err := s.dedupeTraitDeclarations(); err != nil {
+		return nil, fmt.Errorf("de-duplicate collection trait declarations: %w", err)
+	}
+
 	if err := s.migrate(); err != nil {
 		return nil, fmt.Errorf("migrate: %w", err)
 	}
@@ -377,6 +386,15 @@ func NewPostgres(connStr string) (*Store, error) {
 	}
 
 	s := &Store{db: db, dialect: &postgresDialect{}}
+	// BEFORE migrate(), not after (TASK-2710). Migrations 087 / 064 add partial
+	// unique indexes over the collection-trait declarations, and those CREATE
+	// statements fail on exactly the databases that hold duplicates — so the
+	// repair has to precede them. No-ops on a fresh database, where the
+	// collections table does not exist yet.
+	if err := s.dedupeTraitDeclarations(); err != nil {
+		return nil, fmt.Errorf("de-duplicate collection trait declarations: %w", err)
+	}
+
 	if err := s.migratePostgres(); err != nil {
 		return nil, fmt.Errorf("migrate postgres: %w", err)
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -291,15 +291,6 @@ func New(dbPath string) (*Store, error) {
 	db.SetConnMaxLifetime(time.Hour)
 
 	s := &Store{db: db, dialect: &sqliteDialect{}, dbPath: dbPath}
-	// BEFORE migrate(), not after (TASK-2710). Migrations 087 / 064 add partial
-	// unique indexes over the collection-trait declarations, and those CREATE
-	// statements fail on exactly the databases that hold duplicates — so the
-	// repair has to precede them. No-ops on a fresh database, where the
-	// collections table does not exist yet.
-	if err := s.dedupeTraitDeclarations(); err != nil {
-		return nil, fmt.Errorf("de-duplicate collection trait declarations: %w", err)
-	}
-
 	if err := s.migrate(); err != nil {
 		return nil, fmt.Errorf("migrate: %w", err)
 	}
@@ -386,15 +377,6 @@ func NewPostgres(connStr string) (*Store, error) {
 	}
 
 	s := &Store{db: db, dialect: &postgresDialect{}}
-	// BEFORE migrate(), not after (TASK-2710). Migrations 087 / 064 add partial
-	// unique indexes over the collection-trait declarations, and those CREATE
-	// statements fail on exactly the databases that hold duplicates — so the
-	// repair has to precede them. No-ops on a fresh database, where the
-	// collections table does not exist yet.
-	if err := s.dedupeTraitDeclarations(); err != nil {
-		return nil, fmt.Errorf("de-duplicate collection trait declarations: %w", err)
-	}
-
 	if err := s.migratePostgres(); err != nil {
 		return nil, fmt.Errorf("migrate postgres: %w", err)
 	}
@@ -479,6 +461,27 @@ func (s *Store) migrate() error {
 	// worth snapshotting. Best-effort; a failed snapshot warns, not fatal.
 	if len(applied) > 0 && hasPending(applied, migrations) {
 		s.snapshotBeforeMigrate()
+	}
+
+	// AFTER the snapshot and BEFORE the migrations, both deliberately
+	// (TASK-2710, codex round 5).
+	//
+	// Before the migrations, because 087 / 064 add partial unique indexes over
+	// the collection-trait declarations and those CREATE statements fail on
+	// exactly the databases that hold duplicates — the repair has to precede
+	// them. No-ops on a fresh database, where the collections table does not
+	// exist yet.
+	//
+	// After the snapshot, because the repair CHANGES DATA — it strips a
+	// declaration, moving which collection owns a kernel behavior — and the
+	// snapshot is the operator's rollback for a bad upgrade. Running it in the
+	// constructor, ahead of migrate(), put the altered ownership INSIDE the
+	// snapshot: restoring after a failed migration would have given back the
+	// old schema with the repair already applied and unrecorded, so the one
+	// thing the rollback could not undo was the only thing that had silently
+	// changed routing.
+	if err := s.dedupeTraitDeclarations(); err != nil {
+		return fmt.Errorf("de-duplicate collection trait declarations: %w", err)
 	}
 
 	for _, name := range migrations {
@@ -643,6 +646,15 @@ func (s *Store) migratePostgres() error {
 	// something we can safely fake with a file copy.
 	if err := guardSchemaAhead(applied, migrations); err != nil {
 		return err
+	}
+
+	// The trait repair, in the same position as SQLite's: before the
+	// migrations, because 064's partial unique indexes fail on databases
+	// holding duplicates. There is no snapshot here to sit after — see the
+	// note above — so the ordering argument is one-sided on this dialect, but
+	// the call lives in the same place so the two paths cannot drift.
+	if err := s.dedupeTraitDeclarations(); err != nil {
+		return fmt.Errorf("de-duplicate collection trait declarations: %w", err)
 	}
 
 	for _, name := range migrations {

--- a/internal/store/testing_helpers.go
+++ b/internal/store/testing_helpers.go
@@ -1,5 +1,10 @@
 package store
 
+import (
+	"fmt"
+	"strings"
+)
+
 // SetBcryptCostForTesting overrides the bcrypt cost used by CreateUser
 // and UpdateUser for the lifetime of a test binary. It returns a
 // restore function — call it from TestMain (or defer it) to leave
@@ -20,4 +25,89 @@ func SetBcryptCostForTesting(cost int) func() {
 	prev := bcryptCost
 	bcryptCost = cost
 	return func() { bcryptCost = prev }
+}
+
+// SuspendTraitUniquenessForTesting drops TASK-2710's partial unique indexes
+// and returns a restore function that recreates them. Defer the restore, so a
+// suspended constraint cannot outlive the test that suspended it.
+//
+// Why this exists: those indexes make "two collections in one workspace
+// declaring the same trait" unrepresentable, and several tests need exactly
+// that state — not because it is supported, but because it exists in LEGACY
+// databases and the code's handling of it is what they verify. The round-2
+// shadowing tests in internal/server are the clearest case: they prove
+// resolution returns the collection the caller can SEE rather than one hidden
+// collection that happens to sort first, and that guarantee still stands
+// between a legacy database and a wrong answer in the window before
+// dedupeTraitDeclarations repairs it at startup — or on a deployment where an
+// operator has dropped the index. Deleting those tests to satisfy the
+// constraint would retire a live guarantee; building their fixture the way the
+// state actually occurs keeps them testing what they always tested.
+//
+// THE RESTORE CAN FAIL, and that is information rather than a nuisance:
+// recreating a unique index while a duplicate is still live is exactly the
+// failure the migration would hit, so a test that de-duplicates first will see
+// it succeed and a test that deliberately leaves the duplicate in place will
+// see it fail. The restore therefore reports its error instead of swallowing
+// it, and callers that intend to leave a duplicate behind say so by ignoring
+// it explicitly.
+//
+// Production code MUST NOT call this. The "ForTesting" suffix is the grep
+// signal — any non-test caller is a bug.
+func (s *Store) SuspendTraitUniquenessForTesting() (restore func() error) {
+	indexes := []string{
+		"idx_collections_artifact_kind_per_workspace",
+		"idx_collections_invocation_field_per_workspace",
+	}
+	for _, name := range indexes {
+		if _, err := s.db.Exec(`DROP INDEX IF EXISTS ` + name); err != nil {
+			return func() error { return fmt.Errorf("suspend %s: %w", name, err) }
+		}
+	}
+	return func() error {
+		body, rerr := traitUniquenessIndexDDL(s.dialect.Driver())
+		if rerr != nil {
+			return rerr
+		}
+		for _, stmt := range body {
+			if _, err := s.db.Exec(stmt); err != nil {
+				return fmt.Errorf("restore trait uniqueness: %w", err)
+			}
+		}
+		return nil
+	}
+}
+
+// traitUniquenessIndexDDL returns the CREATE statements for TASK-2710's
+// indexes, read from the SHIPPED migration rather than retyped — a restore
+// that recreated a hand-copied approximation would let the two drift and would
+// then be attesting to an index the product does not have.
+func traitUniquenessIndexDDL(driver DriverType) ([]string, error) {
+	var path string
+	if driver == DriverPostgres {
+		path = "pgmigrations/064_collection_trait_uniqueness.sql"
+	} else {
+		path = "migrations/087_collection_trait_uniqueness.sql"
+	}
+	var raw []byte
+	var err error
+	if driver == DriverPostgres {
+		raw, err = pgMigrationsFS.ReadFile(path)
+	} else {
+		raw, err = migrationsFS.ReadFile(path)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	var out []string
+	for _, stmt := range strings.Split(string(raw), ";") {
+		trimmed := strings.TrimSpace(stmt)
+		if strings.Contains(strings.ToUpper(trimmed), "CREATE UNIQUE INDEX") {
+			out = append(out, trimmed)
+		}
+	}
+	if len(out) != 2 {
+		return nil, fmt.Errorf("expected 2 CREATE UNIQUE INDEX statements in %s, found %d", path, len(out))
+	}
+	return out, nil
 }

--- a/internal/store/trait_dedupe.go
+++ b/internal/store/trait_dedupe.go
@@ -66,12 +66,28 @@ func (s *Store) dedupeTraitDeclarations() error {
 		createdAt string
 	}
 
+	// THE EXTRACTION IS THE INDEX'S, NOT GO'S (codex round 1, P1). An earlier
+	// version parsed traits with ParseCollectionTraits and skipped rows that
+	// failed — but the indexes key on json_extract / ->>, so "declares a kind"
+	// had two spellings that could disagree: a row the Go parser rejected still
+	// carries a value the index sees, and the de-dup would leave a pair the
+	// CREATE then refuses. Asking the database the same question the index asks
+	// makes them incapable of disagreeing.
+	//
+	// source IS NULL counts as user-written: the column is nullable
+	// (migrations/005 declares `source TEXT DEFAULT 'web'`) and legacy rows
+	// predate it. `i.source <> 'template'` alone is NULL for those, which SQL
+	// treats as not-true, so a workspace whose only user content is old would
+	// have had it ignored entirely.
+	kindExpr, fieldExpr := s.traitExtractionExprs()
 	rows, err := s.db.Query(s.q(`
 		SELECT c.id, c.slug, c.workspace_id, c.traits, c.created_at,
+		       COALESCE(` + kindExpr + `, ''),
+		       COALESCE(` + fieldExpr + `, ''),
 		       (SELECT COUNT(*) FROM items i
 		         WHERE i.collection_id = c.id
 		           AND i.deleted_at IS NULL
-		           AND i.source <> 'template')
+		           AND (i.source IS NULL OR i.source <> 'template'))
 		FROM collections c
 		WHERE c.deleted_at IS NULL
 		ORDER BY c.workspace_id, c.created_at ASC, c.id ASC`))
@@ -86,24 +102,17 @@ func (s *Store) dedupeTraitDeclarations() error {
 	fieldOwners := map[string][]candidate{}
 	for rows.Next() {
 		var c candidate
-		if err := rows.Scan(&c.id, &c.slug, &c.workspace, &c.traits, &c.createdAt, &c.userItems); err != nil {
+		var kind, field string
+		if err := rows.Scan(&c.id, &c.slug, &c.workspace, &c.traits, &c.createdAt, &kind, &field, &c.userItems); err != nil {
 			return fmt.Errorf("scan collection: %w", err)
 		}
-		parsed, perr := models.ParseCollectionTraits(c.traits)
-		if perr != nil {
-			// A blob that does not parse declares nothing, which is how every
-			// other reader treats it (ListTraitedCollections). It cannot
-			// compete for a declaration and it cannot violate the index.
-			continue
-		}
-		if parsed.ArtifactKind != nil && parsed.ArtifactKind.Kind != "" {
+		if kind != "" {
 			if kindOwners[c.workspace] == nil {
 				kindOwners[c.workspace] = map[string][]candidate{}
 			}
-			k := parsed.ArtifactKind.Kind
-			kindOwners[c.workspace][k] = append(kindOwners[c.workspace][k], c)
+			kindOwners[c.workspace][kind] = append(kindOwners[c.workspace][kind], c)
 		}
-		if parsed.InvocationField != "" {
+		if field != "" {
 			fieldOwners[c.workspace] = append(fieldOwners[c.workspace], c)
 		}
 	}
@@ -176,22 +185,46 @@ func (s *Store) dedupeTraitDeclarations() error {
 	}
 	defer tx.Rollback()
 
+	// ONE WRITE PER COLLECTION, accumulating every declaration it lost (codex
+	// round 1, P1). A collection can lose BOTH — the playbooks definition
+	// declares artifact_kind AND invocation_field — and stripping them in two
+	// passes, each re-parsing the row's ORIGINAL traits, made the second write
+	// restore what the first removed. The duplicate then survived and the
+	// migration would still fail.
+	stripped := map[string]*models.CollectionTraits{}
+	order := []string{}
 	for _, l := range losers {
-		parsed, perr := models.ParseCollectionTraits(l.loser.traits)
-		if perr != nil {
-			continue
+		cur, seen := stripped[l.loser.id]
+		if !seen {
+			parsed, perr := models.ParseCollectionTraits(l.loser.traits)
+			if perr != nil {
+				// Unparseable here means the row carries a value the INDEX can
+				// see but Go cannot re-encode. Refuse rather than guess: a
+				// silent skip is what would let the CREATE fail later, which is
+				// the failure this pass exists to prevent.
+				return fmt.Errorf("collection %s declares a trait the index sees but its traits blob does not parse; repair it before upgrading: %w", l.loser.slug, perr)
+			}
+			cur = &parsed
+			stripped[l.loser.id] = cur
+			order = append(order, l.loser.id)
 		}
 		if l.stripAll {
-			parsed.InvocationField = ""
+			cur.InvocationField = ""
 		} else {
-			parsed.ArtifactKind = nil
+			cur.ArtifactKind = nil
 		}
-		encoded, eerr := parsed.JSON()
-		if eerr != nil {
-			return fmt.Errorf("re-encode traits for %s: %w", l.loser.slug, eerr)
-		}
-		if _, err := tx.Exec(s.q(`UPDATE collections SET traits = ? WHERE id = ?`), encoded, l.loser.id); err != nil {
-			return fmt.Errorf("strip duplicate declaration from %s: %w", l.loser.slug, err)
+	}
+	writtenFor := map[string]bool{}
+	for _, l := range losers {
+		if !writtenFor[l.loser.id] {
+			encoded, eerr := stripped[l.loser.id].JSON()
+			if eerr != nil {
+				return fmt.Errorf("re-encode traits for %s: %w", l.loser.slug, eerr)
+			}
+			if _, err := tx.Exec(s.q(`UPDATE collections SET traits = ? WHERE id = ?`), encoded, l.loser.id); err != nil {
+				return fmt.Errorf("strip duplicate declaration from %s: %w", l.loser.slug, err)
+			}
+			writtenFor[l.loser.id] = true
 		}
 		// One line per resolution, carrying everything an operator needs to
 		// tell a considered resolution from a coin flip.
@@ -225,4 +258,16 @@ func (s *Store) tableHasColumn(table, column string) bool {
 	// cannot tell, and the safe answer there is "absent" so the pass no-ops
 	// rather than running against a schema it could not inspect.
 	return s.db.QueryRow(query, table, column).Scan(&one) == nil
+}
+
+// traitExtractionExprs returns the SQL that reads the artifact kind and the
+// invocation field out of the traits column, per driver — the SAME expressions
+// migrations 087 / 064 index on. Kept in one place so the de-duplication pass
+// and the constraint cannot develop different opinions about what a
+// declaration is.
+func (s *Store) traitExtractionExprs() (kind, field string) {
+	if s.dialect.Driver() == DriverPostgres {
+		return `(c.traits -> 'artifact_kind' ->> 'kind')`, `(c.traits ->> 'invocation_field')`
+	}
+	return `json_extract(c.traits, '$.artifact_kind.kind')`, `json_extract(c.traits, '$.invocation_field')`
 }

--- a/internal/store/trait_dedupe.go
+++ b/internal/store/trait_dedupe.go
@@ -226,3 +226,12 @@ func (s *Store) tableHasColumn(table, column string) bool {
 	// rather than running against a schema it could not inspect.
 	return s.db.QueryRow(query, table, column).Scan(&one) == nil
 }
+
+// DropIndexForTest drops an index by name. Exported solely so tests in other
+// packages can build a state that TASK-2710's partial unique indexes forbid —
+// the legacy shape whose HANDLING those tests still verify. Not called by
+// production code.
+func (s *Store) DropIndexForTest(name string) error {
+	_, err := s.db.Exec(`DROP INDEX IF EXISTS ` + name)
+	return err
+}

--- a/internal/store/trait_dedupe.go
+++ b/internal/store/trait_dedupe.go
@@ -267,5 +267,11 @@ func (s *Store) traitExtractionExprs() (kind, field string) {
 	if s.dialect.Driver() == DriverPostgres {
 		return `(c.traits -> 'artifact_kind' ->> 'kind')`, `(c.traits ->> 'invocation_field')`
 	}
-	return `json_extract(c.traits, '$.artifact_kind.kind')`, `json_extract(c.traits, '$.invocation_field')`
+	// json_valid guard, matching the index's partial predicate exactly: SQLite's
+	// json_extract RAISES on malformed JSON, so an unguarded read here would
+	// fail STARTUP on a database holding one bad blob — and a row the index
+	// skips must be a row this pass skips, or the two disagree about what a
+	// declaration is, which is the thing this whole design avoids.
+	return `CASE WHEN json_valid(c.traits) THEN json_extract(c.traits, '$.artifact_kind.kind') END`,
+		`CASE WHEN json_valid(c.traits) THEN json_extract(c.traits, '$.invocation_field') END`
 }

--- a/internal/store/trait_dedupe.go
+++ b/internal/store/trait_dedupe.go
@@ -1,0 +1,228 @@
+package store
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// dedupeTraitDeclarations resolves workspaces that hold more than one
+// collection declaring the same kernel trait, so the partial unique indexes in
+// migrations 087 / 064 can be created (TASK-2710).
+//
+// WHY THIS IS GO AND NOT SQL, and why it runs BEFORE migrate(). The ruling
+// requires every resolution to be REPORTED — it silently changes which
+// collection owns a kernel behavior, so an operator has to be able to see what
+// moved. A SQL migration cannot log: Postgres RAISE NOTICE goes nowhere
+// (this store registers no notice handler) and SQLite has no equivalent at
+// all. Splitting "decide" into SQL and "report" into Go would give one rule two
+// spellings that must be kept in step forever — the exact defect class the
+// composite key in IDEA-2883 was introduced to close. So the rule is written
+// once, here, and the SQL migrations only create the indexes.
+//
+// Running before migrate() is what makes that ordering work: the index
+// migration would FAIL on precisely the databases that need repairing, so the
+// repair has to precede it. On a fresh database there is no collections table
+// yet, which is the no-op case below.
+//
+// THE RULE (lead ruling, day-58, after three proposals each retired by a
+// measurement):
+//
+//  1. The collection holding the most items the USER wrote — source <>
+//     'template' — wins.
+//  2. Ties break on lowest (created_at, id), which is ARBITRARY and is
+//     reported as such. It is NOT an age criterion: created_at is
+//     second-resolution RFC3339 and newID() is a random UUID v4, so when two
+//     collections are created in the same second — the normal case for the
+//     reproduction this repairs — the pair carries no age information at all.
+//     Measured: over 12 trials of the reproduction, "oldest wins" picked the
+//     original 7 times and the accidental duplicate 5, with created_at
+//     differing in 0 of them.
+//  3. The loser keeps every item. It loses only the declaration.
+//
+// Why not recency, which was proposed first: the duplicate is typically
+// created by a template reseed, so ITS items are the newest and an activity
+// criterion picks the accident. Counting only non-template items inverts that
+// — a reseed has none by construction, so it can tie but never win. Measured:
+// 8/8 for the user's collection on a fixture where someone had written one
+// convention first, versus a 4/4 coin flip on the bare reproduction where
+// nobody had written anything and no rule could do better.
+//
+// ROUTING MAY CHANGE on an affected deployment. There is no current behavior
+// to preserve: with two declarations live, resolution is by result order, and
+// on Postgres that was measured flipping between runs on identical data.
+func (s *Store) dedupeTraitDeclarations() error {
+	if !s.tableHasColumn("collections", "traits") {
+		return nil // fresh database, or one predating collection traits
+	}
+
+	type candidate struct {
+		id        string
+		slug      string
+		workspace string
+		traits    string
+		userItems int
+		createdAt string
+	}
+
+	rows, err := s.db.Query(s.q(`
+		SELECT c.id, c.slug, c.workspace_id, c.traits, c.created_at,
+		       (SELECT COUNT(*) FROM items i
+		         WHERE i.collection_id = c.id
+		           AND i.deleted_at IS NULL
+		           AND i.source <> 'template')
+		FROM collections c
+		WHERE c.deleted_at IS NULL
+		ORDER BY c.workspace_id, c.created_at ASC, c.id ASC`))
+	if err != nil {
+		return fmt.Errorf("scan collections for trait duplicates: %w", err)
+	}
+	defer rows.Close()
+
+	// kindOwners[workspace][kind] and fieldOwners[workspace] collect the
+	// candidates competing for one declaration.
+	kindOwners := map[string]map[string][]candidate{}
+	fieldOwners := map[string][]candidate{}
+	for rows.Next() {
+		var c candidate
+		if err := rows.Scan(&c.id, &c.slug, &c.workspace, &c.traits, &c.createdAt, &c.userItems); err != nil {
+			return fmt.Errorf("scan collection: %w", err)
+		}
+		parsed, perr := models.ParseCollectionTraits(c.traits)
+		if perr != nil {
+			// A blob that does not parse declares nothing, which is how every
+			// other reader treats it (ListTraitedCollections). It cannot
+			// compete for a declaration and it cannot violate the index.
+			continue
+		}
+		if parsed.ArtifactKind != nil && parsed.ArtifactKind.Kind != "" {
+			if kindOwners[c.workspace] == nil {
+				kindOwners[c.workspace] = map[string][]candidate{}
+			}
+			k := parsed.ArtifactKind.Kind
+			kindOwners[c.workspace][k] = append(kindOwners[c.workspace][k], c)
+		}
+		if parsed.InvocationField != "" {
+			fieldOwners[c.workspace] = append(fieldOwners[c.workspace], c)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	type resolution struct {
+		loser    candidate
+		what     string
+		winner   candidate
+		byRule   string
+		stripAll bool // invocation_field is a string, artifact_kind a pointer
+	}
+	var losers []resolution
+
+	pick := func(cands []candidate) (candidate, string) {
+		best := cands[0]
+		decisive := false
+		for _, c := range cands[1:] {
+			if c.userItems > best.userItems {
+				best, decisive = c, true
+				continue
+			}
+			if c.userItems < best.userItems {
+				decisive = true
+			}
+		}
+		// The scan is already ordered by (created_at, id) within a workspace,
+		// so cands[0] is the terminator's answer when no user content decides.
+		if !decisive {
+			return cands[0], "arbitrary (tie on user-written items; lowest created_at,id — NOT an age)"
+		}
+		return best, "most user-written items"
+	}
+
+	for _, byKind := range kindOwners {
+		for kind, cands := range byKind {
+			if len(cands) < 2 {
+				continue
+			}
+			winner, rule := pick(cands)
+			for _, c := range cands {
+				if c.id == winner.id {
+					continue
+				}
+				losers = append(losers, resolution{c, "artifact_kind=" + kind, winner, rule, false})
+			}
+		}
+	}
+	for _, cands := range fieldOwners {
+		if len(cands) < 2 {
+			continue
+		}
+		winner, rule := pick(cands)
+		for _, c := range cands {
+			if c.id == winner.id {
+				continue
+			}
+			losers = append(losers, resolution{c, "invocation_field", winner, rule, true})
+		}
+	}
+	if len(losers) == 0 {
+		return nil
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	for _, l := range losers {
+		parsed, perr := models.ParseCollectionTraits(l.loser.traits)
+		if perr != nil {
+			continue
+		}
+		if l.stripAll {
+			parsed.InvocationField = ""
+		} else {
+			parsed.ArtifactKind = nil
+		}
+		encoded, eerr := parsed.JSON()
+		if eerr != nil {
+			return fmt.Errorf("re-encode traits for %s: %w", l.loser.slug, eerr)
+		}
+		if _, err := tx.Exec(s.q(`UPDATE collections SET traits = ? WHERE id = ?`), encoded, l.loser.id); err != nil {
+			return fmt.Errorf("strip duplicate declaration from %s: %w", l.loser.slug, err)
+		}
+		// One line per resolution, carrying everything an operator needs to
+		// tell a considered resolution from a coin flip.
+		slog.Warn("trait de-duplication: a collection lost a kernel declaration; routing for it may have changed",
+			"workspace_id", l.loser.workspace,
+			"declaration", l.what,
+			"winner", l.winner.slug,
+			"winner_user_items", l.winner.userItems,
+			"loser", l.loser.slug,
+			"loser_user_items", l.loser.userItems,
+			"decided_by", l.byRule,
+			"loser_items_kept", true)
+	}
+	return tx.Commit()
+}
+
+// tableHasColumn reports whether a column exists, so the de-dup pass can no-op
+// on a database that predates collection traits (or has no schema at all).
+func (s *Store) tableHasColumn(table, column string) bool {
+	var query string
+	switch s.dialect.Driver() {
+	case DriverPostgres:
+		query = `SELECT 1 FROM information_schema.columns WHERE table_name = $1 AND column_name = $2`
+	default:
+		// SQLite has no information_schema; pragma_table_info is the
+		// queryable form of PRAGMA table_info.
+		query = `SELECT 1 FROM pragma_table_info(?) WHERE name = ?`
+	}
+	var one int
+	// sql.ErrNoRows means the column is absent; any other error means we
+	// cannot tell, and the safe answer there is "absent" so the pass no-ops
+	// rather than running against a schema it could not inspect.
+	return s.db.QueryRow(query, table, column).Scan(&one) == nil
+}

--- a/internal/store/trait_dedupe.go
+++ b/internal/store/trait_dedupe.go
@@ -226,12 +226,3 @@ func (s *Store) tableHasColumn(table, column string) bool {
 	// rather than running against a schema it could not inspect.
 	return s.db.QueryRow(query, table, column).Scan(&one) == nil
 }
-
-// DropIndexForTest drops an index by name. Exported solely so tests in other
-// packages can build a state that TASK-2710's partial unique indexes forbid —
-// the legacy shape whose HANDLING those tests still verify. Not called by
-// production code.
-func (s *Store) DropIndexForTest(name string) error {
-	_, err := s.db.Exec(`DROP INDEX IF EXISTS ` + name)
-	return err
-}

--- a/internal/store/trait_dedupe.go
+++ b/internal/store/trait_dedupe.go
@@ -192,7 +192,6 @@ func (s *Store) dedupeTraitDeclarations() error {
 	// restore what the first removed. The duplicate then survived and the
 	// migration would still fail.
 	stripped := map[string]*models.CollectionTraits{}
-	order := []string{}
 	for _, l := range losers {
 		cur, seen := stripped[l.loser.id]
 		if !seen {
@@ -206,7 +205,6 @@ func (s *Store) dedupeTraitDeclarations() error {
 			}
 			cur = &parsed
 			stripped[l.loser.id] = cur
-			order = append(order, l.loser.id)
 		}
 		if l.stripAll {
 			cur.InvocationField = ""

--- a/internal/store/trait_dedupe_test.go
+++ b/internal/store/trait_dedupe_test.go
@@ -51,11 +51,18 @@ func duplicateTraitFixture(t *testing.T, s *Store, name string, userWrote bool) 
 	if err != nil {
 		t.Fatalf("create the would-be reseed: %v", err)
 	}
-	withTraitIndexSuspended(t, s, func() {
-		if _, err := s.db.Exec(s.q(`UPDATE collections SET traits = ? WHERE id = ?`), conv.Traits, dup.ID); err != nil {
-			t.Fatalf("plant the duplicate declaration: %v", err)
+	restore := s.SuspendTraitUniquenessForTesting()
+	t.Cleanup(func() {
+		// After de-duplication the workspace holds one declaration, so the
+		// indexes must be creatable again — which is precisely the precondition
+		// the migration needs, asserted here rather than assumed.
+		if err := restore(); err != nil {
+			t.Errorf("the indexes could not be recreated after de-duplication, so the migration would fail on this state: %v", err)
 		}
 	})
+	if _, err := s.db.Exec(s.q(`UPDATE collections SET traits = ? WHERE id = ?`), conv.Traits, dup.ID); err != nil {
+		t.Fatalf("plant the duplicate declaration: %v", err)
+	}
 	{
 		// The reseed would have populated the duplicate with template rows, and
 		// the bare reproduction ties on item count — that tie is what makes it
@@ -75,20 +82,6 @@ func duplicateTraitFixture(t *testing.T, s *Store, name string, userWrote bool) 
 		}
 	}
 	return ws, conv.ID, dup.ID
-}
-
-// withTraitIndexSuspended runs fn with the TASK-2710 artifact-kind index
-// dropped, so a test can plant the pre-migration duplicate state the index now
-// forbids. Recreated afterwards on the SQLite path; on Postgres the recreate
-// would fail while the planted row is live, so it stays dropped for the rest
-// of that store's life — acceptable because each test gets its own.
-func withTraitIndexSuspended(t *testing.T, s *Store, fn func()) {
-	t.Helper()
-	const idx = "idx_collections_artifact_kind_per_workspace"
-	if _, err := s.db.Exec(`DROP INDEX IF EXISTS ` + idx); err != nil {
-		t.Fatalf("suspend %s: %v", idx, err)
-	}
-	fn()
 }
 
 func declaringConvention(t *testing.T, s *Store, workspaceID string) []string {

--- a/internal/store/trait_dedupe_test.go
+++ b/internal/store/trait_dedupe_test.go
@@ -426,3 +426,70 @@ func TestImportDeduplicatesAConflictingArchive(t *testing.T) {
 		t.Errorf("the stripped collection is missing from the import (err=%v); it should keep everything but the declaration", err)
 	}
 }
+
+// TestImportDeduplicatesAfterCanonicalInference covers the ordering trap in the
+// import de-duplication: inference runs AFTER it.
+//
+// A pre-traits archive carries `conventions` with an EMPTY traits blob, and
+// import infers the canonical declaration for it from its slug (BUG-2702's
+// fix — without that, restoring an old archive comes up inert). If the same
+// bundle also carries another collection that explicitly declares
+// artifact_kind=convention, the de-dup pass sees only ONE declaration and
+// leaves both alone; inference then adds the second, and the unique index
+// aborts the whole import.
+//
+// So the pass has to run on the traits each collection will ACTUALLY be
+// inserted with, not on the ones the bundle carries.
+func TestImportDeduplicatesAfterCanonicalInference(t *testing.T) {
+	s := testStore(t)
+	owner := createTestUser(t, s, "inferdedupe@test.com", "Owner", "password123")
+	ws := createTestWorkspace(t, s, "Infer Dedupe Source")
+	if err := s.SeedCollectionsFromTemplate(ws.ID, "startup"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	exp, err := s.ExportWorkspace(ws.Slug)
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+
+	var convTraits string
+	for i := range exp.Collections {
+		if exp.Collections[i].Slug == "conventions" {
+			convTraits = exp.Collections[i].Traits
+			// The pre-traits archive shape: the key is absent, which decodes
+			// to "". Inference is what gives it back its declaration.
+			exp.Collections[i].Traits = ""
+		}
+	}
+	if convTraits == "" {
+		t.Fatal("control leg failed: the export carries no conventions declaration to work from")
+	}
+
+	// A second collection that DOES declare it explicitly.
+	rival := exp.Collections[0]
+	rival.ID = rival.ID + "-rival"
+	rival.Slug = "house-rules"
+	rival.Name = "House Rules"
+	rival.Prefix = "HRULE"
+	rival.Traits = convTraits
+	exp.Collections = append(exp.Collections, rival)
+
+	imported, err := s.ImportWorkspace(exp, "infer-dedupe-target", owner.ID)
+	if err != nil {
+		t.Fatalf("import failed on an archive whose duplicate only appears after inference: %v", err)
+	}
+
+	traited, err := s.ListTraitedCollections(imported.ID)
+	if err != nil {
+		t.Fatalf("ListTraitedCollections: %v", err)
+	}
+	var declaring []string
+	for _, tc := range traited {
+		if tc.Traits.ArtifactKind != nil && tc.Traits.ArtifactKind.Kind == "convention" {
+			declaring = append(declaring, tc.Slug)
+		}
+	}
+	if len(declaring) != 1 {
+		t.Errorf("collections declaring convention after import = %v, want exactly 1", declaring)
+	}
+}

--- a/internal/store/trait_dedupe_test.go
+++ b/internal/store/trait_dedupe_test.go
@@ -1,0 +1,229 @@
+package store
+
+import (
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// TASK-2710. Two collections in one workspace could declare the same kernel
+// trait, and with both live the resolver returned whichever the result order
+// put first — arbitrary rather than tie-broken, and measured FLIPPING between
+// runs on Postgres. These lock the de-duplication that makes the partial
+// unique indexes creatable, and the rule that decides which one survives.
+
+// duplicateTraitFixture reproduces the state from the task body: seed a
+// template, rename the conventions collection (which re-slugs it), seed again
+// so a fresh `conventions` appears, and both now declare artifact_kind =
+// convention. When userWrote is true the user writes a convention into the
+// RENAMED collection first, which is the only thing that distinguishes them.
+func duplicateTraitFixture(t *testing.T, s *Store, name string, userWrote bool) (ws *models.Workspace, renamedID, dupID string) {
+	t.Helper()
+	ws = createTestWorkspace(t, s, name)
+	if err := s.SeedCollectionsFromTemplate(ws.ID, "startup"); err != nil {
+		t.Fatalf("seed 1: %v", err)
+	}
+	conv, err := s.GetCollectionBySlug(ws.ID, "conventions")
+	if err != nil || conv == nil {
+		t.Fatalf("get conventions: %v (nil=%v)", err, conv == nil)
+	}
+	newName := "House Rules"
+	if _, err := s.UpdateCollection(conv.ID, models.CollectionUpdate{Name: &newName}); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+	if userWrote {
+		if _, err := s.CreateItem(ws.ID, conv.ID, models.ItemCreate{
+			Title: "Our actual house rule", CreatedBy: "user", Source: "web",
+		}); err != nil {
+			t.Fatalf("user item: %v", err)
+		}
+	}
+	// The duplicate is now UNREPRESENTABLE through ordinary code: the partial
+	// unique index refuses it, and SeedCollectionsFromTemplate skips a
+	// definition whose kind is already declared rather than colliding with it.
+	// That is the fix working. It also means this fixture can only be built
+	// the way the state actually exists in the wild — as legacy data written
+	// before the index — so the declaration is copied onto a fresh collection
+	// with enforcement suspended for that one statement.
+	dup, err := s.CreateCollection(ws.ID, models.CollectionCreate{Name: "Conventions", Prefix: "CONV2"})
+	if err != nil {
+		t.Fatalf("create the would-be reseed: %v", err)
+	}
+	withTraitIndexSuspended(t, s, func() {
+		if _, err := s.db.Exec(s.q(`UPDATE collections SET traits = ? WHERE id = ?`), conv.Traits, dup.ID); err != nil {
+			t.Fatalf("plant the duplicate declaration: %v", err)
+		}
+	})
+	{
+		// The reseed would have populated the duplicate with template rows, and
+		// the bare reproduction ties on item count — that tie is what makes it
+		// the arbitrary case. Give the planted duplicate the same count in both
+		// fixtures, so the ONLY difference between them is the user-written
+		// item, which is the thing under test.
+		var n int
+		if err := s.db.QueryRow(s.q(`SELECT COUNT(*) FROM items WHERE collection_id = ? AND deleted_at IS NULL`), conv.ID).Scan(&n); err != nil {
+			t.Fatalf("count original items: %v", err)
+		}
+		for i := 0; i < n; i++ {
+			if _, err := s.CreateItem(ws.ID, dup.ID, models.ItemCreate{
+				Title: "Template rule", CreatedBy: "system", Source: "template",
+			}); err != nil {
+				t.Fatalf("seed template item into the duplicate: %v", err)
+			}
+		}
+	}
+	return ws, conv.ID, dup.ID
+}
+
+// withTraitIndexSuspended runs fn with the TASK-2710 artifact-kind index
+// dropped, so a test can plant the pre-migration duplicate state the index now
+// forbids. Recreated afterwards on the SQLite path; on Postgres the recreate
+// would fail while the planted row is live, so it stays dropped for the rest
+// of that store's life — acceptable because each test gets its own.
+func withTraitIndexSuspended(t *testing.T, s *Store, fn func()) {
+	t.Helper()
+	const idx = "idx_collections_artifact_kind_per_workspace"
+	if _, err := s.db.Exec(`DROP INDEX IF EXISTS ` + idx); err != nil {
+		t.Fatalf("suspend %s: %v", idx, err)
+	}
+	fn()
+}
+
+func declaringConvention(t *testing.T, s *Store, workspaceID string) []string {
+	t.Helper()
+	traited, err := s.ListTraitedCollections(workspaceID)
+	if err != nil {
+		t.Fatalf("ListTraitedCollections: %v", err)
+	}
+	var out []string
+	for _, tc := range traited {
+		if tc.Traits.ArtifactKind != nil && tc.Traits.ArtifactKind.Kind == "convention" {
+			out = append(out, tc.Slug)
+		}
+	}
+	return out
+}
+
+// TestDedupeKeepsTheCollectionTheUserWroteIn is the fixture that MUST be
+// decisive: the renamed collection holds a convention the user wrote, the
+// accidental reseed holds only template rows, so the user's collection keeps
+// the declaration every time. Measured 8/8 before this shipped; the point of
+// the test is that it is not 7/8.
+func TestDedupeKeepsTheCollectionTheUserWroteIn(t *testing.T) {
+	s := testStore(t)
+	ws, _, dupID := duplicateTraitFixture(t, s, "Dedupe User Wrote", true)
+
+	// Control: the fixture really did produce the duplicate state, otherwise
+	// the assertion below passes without exercising anything.
+	if got := declaringConvention(t, s, ws.ID); len(got) != 2 {
+		t.Fatalf("control leg failed: %d collections declare convention, want 2 (%v)", len(got), got)
+	}
+
+	if err := s.dedupeTraitDeclarations(); err != nil {
+		t.Fatalf("dedupeTraitDeclarations: %v", err)
+	}
+
+	got := declaringConvention(t, s, ws.ID)
+	if len(got) != 1 {
+		t.Fatalf("after de-dup %d collections declare convention, want 1 (%v)", len(got), got)
+	}
+	if got[0] != "house-rules" {
+		t.Errorf("declaration survived on %q, want house-rules — the collection the user actually wrote in", got[0])
+	}
+
+	// The loser keeps every item; it loses only the declaration.
+	var loserItems int
+	if err := s.db.QueryRow(s.q(`
+		SELECT COUNT(*) FROM items WHERE collection_id = ? AND deleted_at IS NULL`), dupID).Scan(&loserItems); err != nil {
+		t.Fatalf("count loser items: %v", err)
+	}
+	if loserItems == 0 {
+		t.Error("the losing collection lost its items; the ruling is that it keeps them and loses only the trait")
+	}
+}
+
+// TestDedupeReportsAnArbitraryTieAsArbitrary is the bare reproduction: nobody
+// wrote anything, so both collections hold four identical template rows and
+// tie on every orderable key. No rule can prefer either — measured as a 4/4
+// coin flip — so the requirement is not WHICH one survives but that exactly
+// one does and that the log says the choice was arbitrary rather than dressing
+// it up as age.
+func TestDedupeReportsAnArbitraryTieAsArbitrary(t *testing.T) {
+	s := testStore(t)
+	ws, _, _ := duplicateTraitFixture(t, s, "Dedupe Arbitrary Tie", false)
+	if got := declaringConvention(t, s, ws.ID); len(got) != 2 {
+		t.Fatalf("control leg failed: %d collections declare convention, want 2 (%v)", len(got), got)
+	}
+
+	var captured []slog.Record
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	slog.SetDefault(slog.New(&recordCapturingHandler{records: &captured}))
+	err := s.dedupeTraitDeclarations()
+	slog.SetDefault(prev)
+	if err != nil {
+		t.Fatalf("dedupeTraitDeclarations: %v", err)
+	}
+
+	if got := declaringConvention(t, s, ws.ID); len(got) != 1 {
+		t.Fatalf("after de-dup %d collections declare convention, want exactly 1 (%v)", len(got), got)
+	}
+
+	var sawArbitrary, sawWinner, sawLoser bool
+	for _, r := range captured {
+		if r.Level != slog.LevelWarn || !strings.Contains(r.Message, "trait de-duplication") {
+			continue
+		}
+		r.Attrs(func(a slog.Attr) bool {
+			switch a.Key {
+			case "decided_by":
+				if strings.Contains(a.Value.String(), "arbitrary") &&
+					strings.Contains(a.Value.String(), "NOT an age") {
+					sawArbitrary = true
+				}
+			case "winner":
+				sawWinner = true
+			case "loser":
+				sawLoser = true
+			}
+			return true
+		})
+	}
+	if !sawArbitrary {
+		t.Error("the tie was not reported as arbitrary; an operator reading this log cannot tell a considered resolution from a coin flip")
+	}
+	if !sawWinner || !sawLoser {
+		t.Error("the report does not name both the winner and the loser")
+	}
+}
+
+// TestTraitUniquenessIsEnforcedByTheDatabase locks the half the indexes own:
+// once the duplicates are gone, a second declaration cannot be written at all.
+// Raw SQL on purpose — the API gate refuses this too, so going through it
+// would assert that the gate works rather than that the constraint does.
+func TestTraitUniquenessIsEnforcedByTheDatabase(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Trait Uniqueness")
+	if err := s.SeedCollectionsFromTemplate(ws.ID, "startup"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	conv, err := s.GetCollectionBySlug(ws.ID, "conventions")
+	if err != nil || conv == nil {
+		t.Fatalf("get conventions: %v", err)
+	}
+
+	// Control: a collection with NO declaration inserts fine through the same
+	// statement shape, so a failure below is the constraint and not the SQL.
+	plain, err := s.CreateCollection(ws.ID, models.CollectionCreate{Name: "Plain", Prefix: "PLN"})
+	if err != nil {
+		t.Fatalf("control leg failed: a trait-free collection was rejected: %v", err)
+	}
+
+	if _, err := s.db.Exec(s.q(`UPDATE collections SET traits = ? WHERE id = ?`), conv.Traits, plain.ID); err == nil {
+		t.Fatal("a second collection took the convention declaration; the unique index is not in force")
+	} else {
+		t.Logf("second declaration refused: %v", err)
+	}
+}

--- a/internal/store/trait_dedupe_test.go
+++ b/internal/store/trait_dedupe_test.go
@@ -294,3 +294,118 @@ func TestDedupeStripsEveryDeclarationALoserHolds(t *testing.T) {
 		t.Errorf("the loser kept its invocation_field (%q); both declarations should be gone", got.InvocationField)
 	}
 }
+
+// TestMalformedTraitsDoNotBreakTheInvariant covers the row nobody writes on
+// purpose: a collections row whose traits blob is not valid JSON.
+//
+// SQLite's json_extract RAISES on malformed JSON rather than returning NULL,
+// so an unguarded expression in either the index predicate or the de-dup scan
+// would fail STARTUP — not a request, startup — on a database holding one bad
+// blob. Every other reader treats malformed traits as declaring nothing, and
+// the guard makes these two agree with that rather than being fatal.
+func TestMalformedTraitsDoNotBreakTheInvariant(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Malformed Traits")
+	if err := s.SeedCollectionsFromTemplate(ws.ID, "startup"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	junk, err := s.CreateCollection(ws.ID, models.CollectionCreate{Name: "Junk", Prefix: "JUNK"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	// Written raw: every door validates traits, so this is the shape of a row
+	// that arrived some other way — a hand-edited database, or a write from a
+	// build that predates validation.
+	if _, err := s.db.Exec(s.q(`UPDATE collections SET traits = ? WHERE id = ?`), `{"artifact_kind":`, junk.ID); err != nil {
+		t.Fatalf("plant malformed traits: %v", err)
+	}
+
+	// The de-dup pass must survive it — this is what runs before migrate().
+	if err := s.dedupeTraitDeclarations(); err != nil {
+		t.Fatalf("de-dup failed on a malformed traits blob; startup would fail here: %v", err)
+	}
+
+	// And the indexes must still be creatable, which is the migration itself.
+	restore := s.SuspendTraitUniquenessForTesting()
+	if err := restore(); err != nil {
+		t.Fatalf("the indexes could not be created against a malformed traits blob; the migration would fail here: %v", err)
+	}
+
+	// The malformed row is outside the invariant, not inside it: a live
+	// collection can still take a declaration the junk row appears to hold.
+	var stored string
+	if err := s.db.QueryRow(s.q(`SELECT traits FROM collections WHERE id = ?`), junk.ID).Scan(&stored); err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if stored != `{"artifact_kind":` {
+		t.Errorf("the malformed blob was rewritten to %q; this unit does not repair traits, it only removes duplicate declarations", stored)
+	}
+}
+
+// TestImportDeduplicatesAConflictingArchive covers TASK-2710 item 4. Before
+// the indexes, import warned about a duplicate declaration and inserted both.
+// With them the second INSERT is refused, the whole transaction rolls back and
+// the workspace minted beforehand survives as a husk — so an archive carrying
+// a duplicate would become unimportable, and those archives are exactly the
+// ones this release exists to repair.
+func TestImportDeduplicatesAConflictingArchive(t *testing.T) {
+	s := testStore(t)
+	owner := createTestUser(t, s, "importdedupe@test.com", "Owner", "password123")
+	ws := createTestWorkspace(t, s, "Import Dedupe Source")
+	if err := s.SeedCollectionsFromTemplate(ws.ID, "startup"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	exp, err := s.ExportWorkspace(ws.Slug)
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+
+	// The conflicting archive: a second collection carrying the conventions
+	// declaration. Built in the BUNDLE rather than the database, which is how
+	// it actually arrives — a hand-edited or foreign archive.
+	var convTraits string
+	for _, c := range exp.Collections {
+		if c.Slug == "conventions" {
+			convTraits = c.Traits
+		}
+	}
+	if convTraits == "" {
+		t.Fatal("control leg failed: the exported bundle carries no conventions declaration to duplicate")
+	}
+	dupe := exp.Collections[0]
+	dupe.ID = dupe.ID + "-dupe"
+	dupe.Slug = "old-conventions"
+	dupe.Name = "Old Conventions"
+	dupe.Prefix = "OCONV"
+	dupe.Traits = convTraits
+	exp.Collections = append(exp.Collections, dupe)
+
+	imported, err := s.ImportWorkspace(exp, "import-dedupe-target", owner.ID)
+	if err != nil {
+		t.Fatalf("an archive carrying a duplicate declaration failed to import: %v", err)
+	}
+
+	// Exactly one collection declares it, and the LATER one lost it.
+	traited, err := s.ListTraitedCollections(imported.ID)
+	if err != nil {
+		t.Fatalf("ListTraitedCollections: %v", err)
+	}
+	var declaring []string
+	for _, tc := range traited {
+		if tc.Traits.ArtifactKind != nil && tc.Traits.ArtifactKind.Kind == "convention" {
+			declaring = append(declaring, tc.Slug)
+		}
+	}
+	if len(declaring) != 1 {
+		t.Fatalf("collections declaring convention after import = %v, want exactly 1", declaring)
+	}
+	if declaring[0] != "conventions" {
+		t.Errorf("declaration landed on %q; bundle order gives it to the first, which is conventions", declaring[0])
+	}
+
+	// The stripped collection still exists — it lost the declaration, not its
+	// place in the workspace.
+	if got, err := s.GetCollectionBySlug(imported.ID, "old-conventions"); err != nil || got == nil {
+		t.Errorf("the stripped collection is missing from the import (err=%v); it should keep everything but the declaration", err)
+	}
+}

--- a/internal/store/trait_dedupe_test.go
+++ b/internal/store/trait_dedupe_test.go
@@ -220,3 +220,77 @@ func TestTraitUniquenessIsEnforcedByTheDatabase(t *testing.T) {
 		t.Logf("second declaration refused: %v", err)
 	}
 }
+
+// TestDedupeStripsEveryDeclarationALoserHolds covers the case a collection
+// loses BOTH declarations, which the single-declaration fixtures above cannot
+// reach. The playbooks definition declares artifact_kind AND invocation_field,
+// so a duplicated playbooks collection competes on two fronts at once.
+//
+// The defect this pins: resolving each declaration in its own pass, with each
+// pass re-parsing the row's ORIGINAL traits, made the second write restore what
+// the first had stripped. The duplicate survived and the migration would still
+// have failed on it — which is precisely the failure the de-dup pass exists to
+// prevent, so it would have surfaced as a broken upgrade rather than a test.
+func TestDedupeStripsEveryDeclarationALoserHolds(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Dedupe Both Declarations")
+	if err := s.SeedCollectionsFromTemplate(ws.ID, "startup"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	play, err := s.GetCollectionBySlug(ws.ID, "playbooks")
+	if err != nil || play == nil {
+		t.Fatalf("get playbooks: %v (nil=%v)", err, play == nil)
+	}
+	// Control: the seeded definition really does declare both, otherwise this
+	// test is a duplicate of the single-declaration ones.
+	seeded, perr := models.ParseCollectionTraits(play.Traits)
+	if perr != nil {
+		t.Fatalf("parse seeded traits: %v", perr)
+	}
+	if seeded.ArtifactKind == nil || seeded.ArtifactKind.Kind == "" || seeded.InvocationField == "" {
+		t.Fatalf("control leg failed: playbooks declares kind=%v field=%q, want both", seeded.ArtifactKind, seeded.InvocationField)
+	}
+
+	dup, err := s.CreateCollection(ws.ID, models.CollectionCreate{Name: "Old Playbooks", Prefix: "OPLAY"})
+	if err != nil {
+		t.Fatalf("create duplicate: %v", err)
+	}
+	restore := s.SuspendTraitUniquenessForTesting()
+	t.Cleanup(func() {
+		if err := restore(); err != nil {
+			t.Errorf("indexes not recreatable after de-dup, so the migration would fail here: %v", err)
+		}
+	})
+	if _, err := s.db.Exec(s.q(`UPDATE collections SET traits = ? WHERE id = ?`), play.Traits, dup.ID); err != nil {
+		t.Fatalf("plant the double declaration: %v", err)
+	}
+	// The loser must be the planted one: the seeded playbooks holds the
+	// template's items and the plant holds none, so "most user-written items"
+	// ties at zero and the terminator decides. Give the seeded one a
+	// user-written item so the outcome is determined rather than a coin flip —
+	// this test is about stripping both declarations, not about the tie-break.
+	if _, err := s.CreateItem(ws.ID, play.ID, models.ItemCreate{
+		Title: "A real playbook", CreatedBy: "user", Source: "web",
+	}); err != nil {
+		t.Fatalf("user item: %v", err)
+	}
+
+	if err := s.dedupeTraitDeclarations(); err != nil {
+		t.Fatalf("dedupeTraitDeclarations: %v", err)
+	}
+
+	var raw string
+	if err := s.db.QueryRow(s.q(`SELECT traits FROM collections WHERE id = ?`), dup.ID).Scan(&raw); err != nil {
+		t.Fatalf("read loser traits: %v", err)
+	}
+	got, perr := models.ParseCollectionTraits(raw)
+	if perr != nil {
+		t.Fatalf("parse loser traits %q: %v", raw, perr)
+	}
+	if got.ArtifactKind != nil && got.ArtifactKind.Kind != "" {
+		t.Errorf("the loser kept its artifact_kind (%q); both declarations should be gone", got.ArtifactKind.Kind)
+	}
+	if got.InvocationField != "" {
+		t.Errorf("the loser kept its invocation_field (%q); both declarations should be gone", got.InvocationField)
+	}
+}

--- a/internal/store/trait_dedupe_test.go
+++ b/internal/store/trait_dedupe_test.go
@@ -316,8 +316,25 @@ func TestMalformedTraitsDoNotBreakTheInvariant(t *testing.T) {
 	// Written raw: every door validates traits, so this is the shape of a row
 	// that arrived some other way — a hand-edited database, or a write from a
 	// build that predates validation.
-	if _, err := s.db.Exec(s.q(`UPDATE collections SET traits = ? WHERE id = ?`), `{"artifact_kind":`, junk.ID); err != nil {
-		t.Fatalf("plant malformed traits: %v", err)
+	//
+	// THE TWO DRIVERS DIFFER HERE, and that difference is the point rather
+	// than an inconvenience. On Postgres traits is JSONB, so the column type
+	// REFUSES malformed content and the state is unrepresentable at rest —
+	// which is exactly why migration 064 carries no json_valid guard while 087
+	// does. That claim was prose in the migration until this test found the
+	// refusal; asserting it here makes it a checked fact, and turns this into
+	// the test that would catch someone "fixing" the asymmetry by adding a
+	// guard Postgres does not need, or removing the one SQLite does.
+	_, plantErr := s.db.Exec(s.q(`UPDATE collections SET traits = ? WHERE id = ?`), `{"artifact_kind":`, junk.ID)
+	if s.dialect.Driver() == DriverPostgres {
+		if plantErr == nil {
+			t.Fatal("Postgres accepted a malformed traits blob; the JSONB column type is what makes migration 064's missing json_valid guard correct, and it just stopped being true")
+		}
+		t.Logf("Postgres refused the malformed blob, as the JSONB column requires: %v", plantErr)
+		return
+	}
+	if plantErr != nil {
+		t.Fatalf("plant malformed traits: %v", plantErr)
 	}
 
 	// The de-dup pass must survive it — this is what runs before migrate().

--- a/internal/store/trait_dedupe_test.go
+++ b/internal/store/trait_dedupe_test.go
@@ -493,3 +493,98 @@ func TestImportDeduplicatesAfterCanonicalInference(t *testing.T) {
 		t.Errorf("collections declaring convention after import = %v, want exactly 1", declaring)
 	}
 }
+
+// TestImportKeepsTheLiveDeclarationWhenAnArchivedCollectionSharesIt is the
+// rebase test for this branch against BUG-2884 (checkpoint 6 on TASK-2710).
+//
+// BUG-2884 made the bundle CARRY soft-deleted collections, so an archived
+// collection can now travel alongside the live one that replaced it, still
+// declaring the same artifact kind. Import's de-duplication runs in bundle
+// order and has no notion of liveness, so the archived collection claims the
+// kind and the LIVE one is stripped of it. The workspace then imports with its
+// convention routing owned by a row every resolver filters out
+// (ListTraitedCollections is deleted_at IS NULL) — the workspace comes up
+// inert, which is the failure BUG-2884's own pre-pass skip existed to prevent
+// and which this branch's relocation of the check into the insert loop
+// reintroduced.
+//
+// The archived collection must also KEEP its declaration. Nothing routes to it,
+// the partial unique indexes exclude it (`AND deleted_at IS NULL`), and
+// stripping it would edit data the operator archived rather than deleted.
+func TestImportKeepsTheLiveDeclarationWhenAnArchivedCollectionSharesIt(t *testing.T) {
+	s := testStore(t)
+	owner := createTestUser(t, s, "archivedtrait@test.com", "Owner", "password123")
+	ws := createTestWorkspace(t, s, "Archived Trait Source")
+	if err := s.SeedCollectionsFromTemplate(ws.ID, "startup"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	exp, err := s.ExportWorkspace(ws.Slug)
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+
+	var convTraits string
+	liveIndex := -1
+	for i, c := range exp.Collections {
+		if c.Slug == "conventions" {
+			convTraits = c.Traits
+			liveIndex = i
+		}
+	}
+	if convTraits == "" || liveIndex < 0 {
+		t.Fatal("control leg failed: the exported bundle carries no live conventions declaration to contend with")
+	}
+
+	// The archived predecessor, placed FIRST in bundle order — which is what
+	// makes it the claimant under a de-duplication that only counts order.
+	// Built in the bundle rather than the database because that is how it
+	// arrives: BUG-2884 put soft-deleted collections into the archive.
+	archived := exp.Collections[liveIndex]
+	archived.ID = archived.ID + "-archived"
+	archived.Slug = "old-conventions"
+	archived.Name = "Old Conventions"
+	archived.Prefix = "OCONV"
+	archived.Traits = convTraits
+	archived.DeletedAt = "2026-01-02T03:04:05Z"
+	exp.Collections = append([]models.CollectionExport{archived}, exp.Collections...)
+
+	imported, err := s.ImportWorkspace(exp, "archived-trait-target", owner.ID)
+	if err != nil {
+		t.Fatalf("import failed with an archived collection sharing a declaration: %v", err)
+	}
+
+	// The live collection answers for the kind. This is the assertion a naive
+	// rebase fails: the archived row claims `convention` first and the live
+	// conventions collection is stripped, so nothing resolves.
+	traited, err := s.ListTraitedCollections(imported.ID)
+	if err != nil {
+		t.Fatalf("ListTraitedCollections: %v", err)
+	}
+	var declaring []string
+	for _, tc := range traited {
+		if tc.Traits.ArtifactKind != nil && tc.Traits.ArtifactKind.Kind == "convention" {
+			declaring = append(declaring, tc.Slug)
+		}
+	}
+	if len(declaring) != 1 || declaring[0] != "conventions" {
+		t.Fatalf("live collections declaring convention = %v, want exactly [conventions]; an archived collection took the declaration and left the workspace with no live convention routing", declaring)
+	}
+
+	// And the archived one still holds its own. Read straight from the table:
+	// every store-level reader filters it out, which is the whole reason it is
+	// harmless for it to keep the declaration.
+	var archivedTraits string
+	if err := s.db.QueryRow(s.q(`
+		SELECT traits FROM collections
+		WHERE workspace_id = ? AND slug = ? AND deleted_at IS NOT NULL`),
+		imported.ID, "old-conventions").Scan(&archivedTraits); err != nil {
+		t.Fatalf("read back the archived collection: %v", err)
+	}
+	parsed, perr := models.ParseCollectionTraits(archivedTraits)
+	if perr != nil {
+		t.Fatalf("archived traits did not parse: %v", perr)
+	}
+	if parsed.ArtifactKind == nil || parsed.ArtifactKind.Kind != "convention" {
+		t.Errorf("the archived collection was stripped to %q; nothing routes to it and the indexes exclude it, so import has no business editing data the operator archived", archivedTraits)
+	}
+}

--- a/internal/store/trait_dedupe_test.go
+++ b/internal/store/trait_dedupe_test.go
@@ -1,7 +1,9 @@
 package store
 
 import (
+	"database/sql"
 	"log/slog"
+	"os"
 	"strings"
 	"testing"
 
@@ -587,4 +589,106 @@ func TestImportKeepsTheLiveDeclarationWhenAnArchivedCollectionSharesIt(t *testin
 	if parsed.ArtifactKind == nil || parsed.ArtifactKind.Kind != "convention" {
 		t.Errorf("the archived collection was stripped to %q; nothing routes to it and the indexes exclude it, so import has no business editing data the operator archived", archivedTraits)
 	}
+}
+
+// TestTheSnapshotIsTakenBeforeTheRepairWrites pins the ORDER of two startup
+// steps, which is the whole of what it asserts (codex round 5, P2).
+//
+// The repair changes data — it strips a declaration, moving which collection
+// owns a kernel behavior — and `<db>.pre-<version>` is the operator's rollback
+// for a bad upgrade. Calling the repair from the constructor, ahead of
+// migrate(), put the altered ownership INSIDE the snapshot: restoring after a
+// failed migration handed back the old schema with the repair already applied
+// and no record of it, so the one thing the rollback could not undo was the
+// only thing that had silently changed routing.
+//
+// SQLite only. Postgres takes no snapshot — backups there are the operator's
+// pg_dump/PITR job — so on that dialect there is no ordering to pin.
+func TestTheSnapshotIsTakenBeforeTheRepairWrites(t *testing.T) {
+	s := testStore(t)
+	if s.dialect.Driver() != DriverSQLite {
+		t.Skip("no pre-migration snapshot on Postgres; the ordering this pins does not exist there")
+	}
+	dbPath := s.dbPath
+	if dbPath == "" {
+		t.Fatal("control leg failed: the test store has no file path, so no snapshot could be written either way")
+	}
+
+	ws := createTestWorkspace(t, s, "Snapshot Order")
+	if err := s.SeedCollectionsFromTemplate(ws.ID, "startup"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	convs, err := s.GetCollectionBySlug(ws.ID, "conventions")
+	if err != nil || convs == nil {
+		t.Fatalf("GetCollectionBySlug(conventions): %v (nil=%v)", err, convs == nil)
+	}
+	rival, err := s.CreateCollection(ws.ID, models.CollectionCreate{Name: "House Rules", Prefix: "HOUSE"})
+	if err != nil {
+		t.Fatalf("create rival: %v", err)
+	}
+
+	// The legacy state: two live collections declaring one kind, with the
+	// migration that forbids it not yet applied. Both halves are needed —
+	// without the pending migration no snapshot is taken at all, and the test
+	// would pass by measuring nothing.
+	restore := s.SuspendTraitUniquenessForTesting()
+	_ = restore // deliberately not called: the duplicate must survive the reopen
+	if _, err := s.db.Exec(s.q(`UPDATE collections SET traits = ? WHERE id = ?`), convs.Traits, rival.ID); err != nil {
+		t.Fatalf("plant the duplicate: %v", err)
+	}
+	const migration = "087_collection_trait_uniqueness.sql"
+	res, err := s.db.Exec(s.q(`DELETE FROM schema_migrations WHERE version = ?`), migration)
+	if err != nil {
+		t.Fatalf("un-apply %s: %v", migration, err)
+	}
+	if n, _ := res.RowsAffected(); n != 1 {
+		t.Fatalf("control leg failed: %s was not in schema_migrations (rows=%d), so nothing would be pending and no snapshot taken", migration, n)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	snapshot := dbPath + ".pre-" + sanitizeVersion(BinaryVersion)
+	if _, err := os.Stat(snapshot); err == nil {
+		t.Fatalf("control leg failed: a snapshot at %s already existed before the reopen, and snapshotBeforeMigrate preserves the first one", snapshot)
+	}
+
+	reopened, err := New(dbPath)
+	if err != nil {
+		t.Fatalf("reopen (this is the upgrade the repair runs during): %v", err)
+	}
+	t.Cleanup(func() { reopened.Close() })
+
+	// The live database is repaired: exactly one live collection declares it.
+	if got := countDeclaringConvention(t, reopened.db, reopened.q, ws.ID); got != 1 {
+		t.Fatalf("collections declaring convention after the upgrade = %d, want 1; the repair did not run", got)
+	}
+
+	// And the snapshot still holds the state the operator would roll back TO.
+	// Opened with the raw driver, not New(): New() would migrate and repair the
+	// snapshot too, which would destroy the very thing being measured.
+	snap, err := sql.Open("sqlite", snapshot)
+	if err != nil {
+		t.Fatalf("open snapshot %s: %v", snapshot, err)
+	}
+	defer snap.Close()
+	if got := countDeclaringConvention(t, snap, func(q string) string { return q }, ws.ID); got != 2 {
+		t.Errorf("collections declaring convention in the snapshot = %d, want 2; the repair committed BEFORE the snapshot, so restoring it cannot undo the routing change", got)
+	}
+}
+
+// countDeclaringConvention counts LIVE collections in a workspace whose traits
+// declare artifact_kind=convention, reading the same way the index does.
+func countDeclaringConvention(t *testing.T, db *sql.DB, q func(string) string, workspaceID string) int {
+	t.Helper()
+	var n int
+	if err := db.QueryRow(q(`
+		SELECT COUNT(*) FROM collections
+		WHERE workspace_id = ?
+		  AND deleted_at IS NULL
+		  AND json_valid(traits)
+		  AND json_extract(traits, '$.artifact_kind.kind') = 'convention'`), workspaceID).Scan(&n); err != nil {
+		t.Fatalf("count declaring collections: %v", err)
+	}
+	return n
 }


### PR DESCRIPTION
Implements TASK-2710.

## Why

TASK-2657 refuses duplicate `artifact_kind` / `invocation_field` declarations at collection create and update, and its own code calls that gate **best-effort**: it reads then writes without a lock across both, workspace import bypasses it by design, and a rename that frees a canonical slug mints a duplicate with no write to that path at all.

With two declarations live, `FindByArtifactKind` returns whichever the result order puts first. That is not a tie-break. Template-seeded collections share `sort_order` **and** `created_at`, and the resolver's own doc comment says the winner is "effectively arbitrary".

**Measured, five runs per driver against the task's reproduction:** SQLite picked the same collection 5/5 (equal keys fall back to rowid); **Postgres picked `conventions` three times and `house-rules` twice — same data, same query.** Which collection owns a kernel behaviour was a coin flip between runs.

## The de-duplication rule, and why it took three proposals

Each candidate was retired by a measurement rather than an argument:

- **"Preserve today's winner"** — impossible. There is no winner; see above.
- **"Oldest wins, lowest `(created_at, id)`"** — measured over 12 trials: picked the original 7 times, the accidental duplicate 5, with `created_at` differing in **0 of 12**. `now()` is second-resolution RFC3339 and `newID()` is a random UUID v4, so two rows created in the same second carry no age information at all. Worse: on Postgres, which collection is older is **not recoverable from stored data** — SQLite has an implicit insertion-ordered rowid, Postgres has no stable equivalent, and `collections` has no monotonic counter the way `items` has `seq`. A rowid-based rule would make the two dialects resolve identical data differently, reintroducing the divergence class this task closes.
- **Shipped: most items the USER wrote (`source <> 'template'`) wins**, ties broken on lowest `(created_at, id)` and reported as **arbitrary, explicitly not age**. Measured over 8 trials per fixture: 8/8 for the user's collection where someone had written a convention before the accidental reseed, and a 4/4 coin flip on the bare reproduction where nobody had written anything and no rule could do better. Recency was rejected because a reseed's template rows are the *newest*, so an activity criterion picks the accident; counting only non-template items inverts that — a reseed has none by construction, so it can tie but never win.

The loser keeps every item and loses only the declaration. Every resolution logs the workspace, the declaration, winner, loser, both user-item counts, and **which rule decided** — so an operator can tell a considered resolution from a coin flip.

**Routing MAY change on affected deployments.** There is no current behaviour to preserve, and the migration says so rather than implying otherwise.

## Why the de-dup is Go, and runs before `migrate()`

The ruling requires every resolution to be reported, because it silently changes which collection owns a kernel behaviour. A SQL migration cannot log: Postgres `RAISE NOTICE` goes nowhere here (no notice handler is registered) and SQLite has no equivalent. Splitting decide-into-SQL from report-into-Go would give one rule two spellings to keep in step forever — the defect class the composite key in IDEA-2883 was introduced to close.

It runs **before** `migrate()` because the `CREATE UNIQUE INDEX` statements fail on precisely the databases that need repairing. It no-ops on a fresh database, where the collections table does not exist yet.

## Two things the constraint broke that the task did not predict

**`SeedCollectionsFromTemplate` would have failed outright.** Renaming re-slugs, so a workspace whose `conventions` became `house-rules` looks slug-empty to the seeder while its artifact kind is still claimed. Seeding used to mint the silent duplicate; with the index it would have failed the entire seed. It now skips that definition and logs why — the point of seeding is that the template's collections *exist*, and by declaration this one does. Not reachable in production today (both callers seed a workspace they just created), but the seeder should not be what discovers the invariant the hard way.

**Two server tests from the round-2 shadowing fix stopped building.** `TestResolvePlaybookIgnoresInvisibleCollections` and `TestCollectionIDForKindIgnoresInvisibleCollections` construct two collections declaring one trait, to prove resolution returns the collection the caller can *see* rather than one hidden collection that happens to sort first.

They are **not weakened and not deleted.** That guarantee still stands between a legacy database and a wrong answer in the window before the startup repair, and on any deployment where an operator has dropped the index. The fixture now builds the state the way it occurs in the wild — with the constraint suspended — and every assertion is untouched. Same shape as IDEA-2883's disagreeing-reminder fixture.

`SuspendTraitUniquenessForTesting` sits beside `SetBcryptCostForTesting` and follows it: `ForTesting` suffix as the grep signal, documented as never called by production code, returning a restore the caller defers so a suspended constraint cannot outlive its test. It rebuilds the indexes from the **shipped migration text**, because a hand-copied approximation would drift and then attest to an index the product does not have. Its failure is information: recreating a unique index while a duplicate is live is exactly what the migration would hit, so the de-dup tests assert the restore *succeeds* — the migration's precondition checked rather than assumed — while the shadowing tests, which keep their duplicate live throughout, ignore the error explicitly rather than by omission.

## Evidence

Eight new store tests, both drivers:

| test | what it pins |
|---|---|
| `TestDedupeKeepsTheCollectionTheUserWroteIn` | the realistic fixture — the collection someone wrote in keeps the declaration |
| `TestDedupeReportsAnArbitraryTieAsArbitrary` | the bare reproduction — exactly one survives, and the log calls the choice arbitrary rather than implying a rule |
| `TestDedupeStripsEveryDeclarationALoserHolds` | a loser holding both declarations loses both |
| `TestTraitUniquenessIsEnforcedByTheDatabase` | the index itself refuses a second declaration, exercised through **raw SQL** — the API gate refuses it too, so going through the gate would assert that the gate works rather than that the constraint does |
| `TestMalformedTraitsDoNotBreakTheInvariant` | the per-driver asymmetry: SQLite needs the `json_valid` guard, Postgres's JSONB column makes the state unrepresentable |
| `TestImportDeduplicatesAConflictingArchive` | an archive carrying a duplicate imports rather than rolling back |
| `TestImportDeduplicatesAfterCanonicalInference` | the ordering trap — inference runs after the check, so the check must read the bytes being written |
| `TestImportKeepsTheLiveDeclarationWhenAnArchivedCollectionSharesIt` | the BUG-2884 rebase — an archived collection neither takes the live one's declaration nor loses its own |
## Import: de-duplicated on the way in, not warned about and inserted

Task item 4 — the decision the task left open, "refuse a conflicting archive or de-duplicate it on the way in." I had not done it, and review round 2 found the gap.

`ImportWorkspace` used to warn about a duplicate declaration and insert both, which was right while nothing forbade the pair. With the indexes the second INSERT is refused, the whole transaction rolls back, and the workspace minted beforehand survives as a husk ([[BUG-2892]], filed). **An archive carrying a duplicate would have become unimportable — and archives carrying duplicates are exactly the population this release repairs.**

Chose de-duplicate, not refuse, following import's own long-standing posture that an archive is often the only copy of a workspace. The first declaring collection in bundle order keeps it; later ones are stripped and keep every item. It cannot use the migration pass's primary rule — items are inserted after collections, so every user-item count is zero at that point — so bundle order is the terminator, and the log says exactly that rather than implying a considered choice.

**The check runs in the insert loop, on the final bytes, and that placement is round 3's P1 rather than a style choice.** An earlier version pre-computed the strips from the traits the BUNDLE carries, which is not what gets written: coercion, validation-discard and canonical inference all run afterwards. A pre-traits archive carrying `conventions` with an empty blob has its declaration INFERRED from its slug (BUG-2702), so a bundle pairing that with an explicit declarer showed the pre-pass one declaration and the database two — and the index aborted the whole import. Reproduced, then fixed by moving the question from "what did the file say" to "what am I about to write".

## `json_extract` on a malformed blob would have failed STARTUP

Round 2's other finding. SQLite's `json_extract` **raises** on malformed JSON rather than returning NULL, so the unguarded expressions in both index predicates and in the de-dup scan would fail on any database holding one bad blob — not a request, startup. `json_valid` now guards both, which also makes them agree with every other reader: a row whose blob does not parse declares nothing.

The scan and the index use the **same** predicate deliberately — a row the index skips must be a row the pass skips, or they disagree about what a declaration is, which is the failure this design exists to avoid. Postgres needs no equivalent: `traits` is JSONB there, so the column type makes malformed content unrepresentable at rest. A test asserts that asymmetry per driver, so nobody "fixes" it by adding a guard Postgres does not need or removing the one SQLite does.

## Rebased onto BUG-2884: an archived collection neither takes nor loses a declaration

BUG-2884 landed while this branch was packaged and made the export bundle **carry soft-deleted collections**. Both units rewrote the same region of `ImportWorkspace`, and the conflict is semantic rather than textual — a mechanical resolution compiles, passes most tests, and is wrong.

An archived collection can now travel alongside the live one that replaced it, still declaring the same kind, and it arrives FIRST if it was created first. `dropDuplicateImportDeclarations` had no notion of liveness, so it would CLAIM the kind and strip the live collection later in the bundle. The workspace then imports with its routing owned by a row every resolver filters out (`ListTraitedCollections` is `deleted_at IS NULL`) — the exact failure BUG-2884's pre-pass skip existed to prevent, reintroduced through this branch's relocation of the check.

The resolution keeps both: this branch's in-loop placement AND BUG-2884's liveness condition. An archived collection's traits are returned untouched — it neither claims (which strips the live one) nor loses its own (nothing routes to it, both partial unique indexes carry `AND deleted_at IS NULL`, and stripping it would edit data the operator archived rather than deleted).

Written as a **failing test first**, against the naive resolution:

```
--- FAIL: TestImportKeepsTheLiveDeclarationWhenAnArchivedCollectionSharesIt
    live collections declaring convention = [], want exactly [conventions]
WARN import: archive declares one artifact kind on two collections;
     keeps_declaration=old-conventions stripped=conventions
```

Two counterfactuals at the fixed tip: dropping the liveness guard fails two tests (the new one and BUG-2884's own `TestImportRoutingIgnoresSoftDeletedCollections`); stripping the archived collection instead of leaving it alone fails only the new test's second assertion — so the two assertions are not redundant.

`TestImportRoutingIgnoresSoftDeletedCollections` could no longer BUILD its fixture, because it created its archived collection while the live one already declared the kind. Its assertions are unchanged; only the order moved — declare, archive, then seed. That order is not a workaround for the constraint: it is the production path that mints this state (delete the conventions collection, seed the template again), every step legal under the invariant, and it needs no test-only suspension. Seeding correctly does not skip, because `traitDeclarationTaken` reads `ListTraitedCollections`, which is live-only.

## One error message stopped lying

The collection-create path reported any UNIQUE violation as "a collection with this name already exists", and checked only SQLite's spelling of it, so the identical race answered 409 on SQLite and 500 on Postgres while the update path checked neither. Violations are now told apart by the index that failed: the two new trait indexes get messages naming the declaration (a user told to rename a name that is fine would rename forever), a violation naming the collections table keeps the name message, and anything else — a collection UPDATE can migrate ITEM field values, and an item-level unique index can fail there, `invocation_slug` being the live example — says what it knows instead of guessing.

## The repair now runs after the snapshot that is meant to protect it

Round 5, P2, and an ordering I got wrong when I chose the call site. `dedupeTraitDeclarations` ran from the two store constructors, ahead of `migrate()` — and `snapshotBeforeMigrate()` runs *inside* `migrate()`. The repair changes data, and `<db>.pre-<version>` is the operator's rollback for a bad upgrade, so the altered trait ownership was already committed when the snapshot was taken: restoring after a failed migration handed back the old schema with the repair applied and unrecorded. The one thing the rollback could not undo was the only thing that had silently changed routing.

The call moved into `migrate()`, immediately after the snapshot and before the migration loop, which satisfies both constraints at once. `TestTheSnapshotIsTakenBeforeTheRepairWrites` pins it end to end and reads the snapshot with the **raw driver** — opening it through `New()` would migrate and repair the snapshot too, destroying the thing being measured. Reverting the call to its old position fails that test on its own assertion.

## Review

Six rounds, and CONVE-31's shape throughout: rounds 1–3 each found real defects, several of them regressions I had introduced, in seams my own instruments did not point at.

- **Round 4** raised [[BUG-2896]] to P1, claiming a duplicate-key blob can bypass de-duplication and fail index creation. **Measured false** — the divergence between `json_extract` and Go parsing is real, but de-dup completes, index creation succeeds, and the residue is a row no Pad writer can produce.
- **Round 5** found two P2s. The snapshot ordering above is fixed. The other — a valid-JSON blob with an *unknown key* reserves a kind in the index that no resolver can see, so a later legitimate declaration is refused by the database with the API pre-check having seen no conflict — was reproduced end to end and **recorded on BUG-2896 rather than fixed here**: it is the same `json_extract`-versus-Go divergence, no current writer can produce it (create, update, import, seeding and the backfill all parse or discard), it fails closed, startup is already defended by the de-dup's explicit refusal, and the suggested remedy — teaching the SQL predicate which trait keys exist — would trade a fail-closed refusal for a fail-open one that drifts on every new key.
- **Round 6 returned CLEAN**, on the same tip the gates ran against.

[[BUG-2892]], [[BUG-2895]] and [[BUG-2896]] are filed rather than folded in.

## One thing this PR does not do

[[DOC-2655]] (SPEC-5) §Collection traits and its amendment 9 both record trait uniqueness as best-effort in phase 0 with enforcement *"deferred to TASK-2710"*. Merging this makes both false. I have not amended an approved spec: the correct moment is at merge, and every prior amendment to that document was lead-ruled.

https://claude.ai/code/session_01HeChkgZVYb3NTgTcckF5KR
