### PR TITLE
TASK-2869 (U2b): the preflight names a relation's target collection, and the copy dialog scopes its picker to the destination

### DIFF
--- a/cmd/pad/cmd_item.go
+++ b/cmd/pad/cmd_item.go
@@ -2191,6 +2191,14 @@ func renderItemCopyNeedsValue(out io.Writer, p *cli.ItemCopyPreflight, overrides
 		if len(f.Options) > 0 {
 			fmt.Fprintf(w, "  %-20s   options: %s\n", "", itemCopyList(f.Options))
 		}
+		// The relation analogue of `options` (TASK-2869). A row reading
+		// `owner_ref (relation) required — no value` tells a CLI user nothing
+		// about what a valid value would be; the target collection is what
+		// makes `--field owner_ref=<ref>` answerable. Same reason the dialog
+		// needs it, on the surface that has no picker at all.
+		if f.Collection != "" {
+			fmt.Fprintf(w, "  %-20s   target collection: %s\n", "", itemCopyLine(f.Collection))
+		}
 		if f.Message != "" {
 			fmt.Fprintf(w, "  %-20s   %s\n", "", itemCopyLine(f.Message))
 		}

--- a/cmd/pad/item_copy_test.go
+++ b/cmd/pad/item_copy_test.go
@@ -1656,3 +1656,56 @@ func TestItemCopyCmd_IsRegisteredWithEveryFlag(t *testing.T) {
 		t.Fatal("pad item copy is not registered in the item group")
 	}
 }
+
+// A relation row tells the CLI user what to point at (TASK-2869).
+//
+// The dialog gets a picker; the CLI has no picker at all, so the target
+// collection is the only thing that makes `--field owner_ref=<ref>`
+// answerable. Without it the row reads "owner_ref (relation) required — no
+// value" and the user is told a value is needed but not what kind of value
+// exists.
+//
+// The `options:` line for a select is the exact analogue, and is asserted a
+// few tests above; this is that line for relations.
+func TestRenderItemCopyNeedsValue_RelationNamesItsTargetCollection(t *testing.T) {
+	pre := &cli.ItemCopyPreflight{
+		Destination: cli.ItemCopyPreflightDestination{
+			WorkspaceSlug: "dest-ws", CollectionSlug: "tasks",
+		},
+		Fields: cli.ItemCopyPreflightFields{
+			NeedsValue: []cli.ItemCopyPreflightNeedsValue{
+				{
+					Key: "owner_ref", Label: "Owner", Type: "relation",
+					Collection: "people", Required: true, Reason: "missing_required",
+				},
+				// A NON-relation row in the same render, so the assertion
+				// below cannot pass by printing the line unconditionally.
+				{
+					Key: "priority", Label: "Priority", Type: "select",
+					Options: []string{"low", "high"}, Required: true,
+					Reason: "missing_required",
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := renderItemCopyNeedsValue(&buf, pre, nil); err != nil {
+		t.Fatalf("renderItemCopyNeedsValue: %v", err)
+	}
+	got := buf.String()
+
+	if !strings.Contains(got, "target collection: people") {
+		t.Fatalf("the relation row does not name its target collection, so a CLI user is told a "+
+			"value is needed and not what kind exists:\n%s", got)
+	}
+	// Exactly once: the select row must NOT produce one.
+	if n := strings.Count(got, "target collection:"); n != 1 {
+		t.Fatalf("target collection printed %d times, want 1 — only the relation row has a "+
+			"target:\n%s", n, got)
+	}
+	// The select's own line still renders, so this change did not displace it.
+	if !strings.Contains(got, `options: "low", "high"`) {
+		t.Fatalf("the select row lost its options line:\n%s", got)
+	}
+}

--- a/internal/cli/client_items_copy.go
+++ b/internal/cli/client_items_copy.go
@@ -144,11 +144,17 @@ type ItemCopyPreflightDropped struct {
 // ItemCopyPreflightNeedsValue is one destination field the caller must
 // resolve with an override before the copy can proceed.
 type ItemCopyPreflightNeedsValue struct {
-	Key      string   `json:"key"`
-	Label    string   `json:"label,omitempty"`
-	Type     string   `json:"type,omitempty"`
-	Options  []string `json:"options,omitempty"`
-	Required bool     `json:"required"`
+	Key     string   `json:"key"`
+	Label   string   `json:"label,omitempty"`
+	Type    string   `json:"type,omitempty"`
+	Options []string `json:"options,omitempty"`
+	// Collection is the target collection SLUG for a `relation` field, empty
+	// otherwise (TASK-2869). Mirrored here because
+	// TestItemCopyMirrorsMatchServerShapes requires this struct to match the
+	// server's field for field — a mirror that silently lags is a mirror that
+	// lies, and the CLI renders these rows.
+	Collection string `json:"collection,omitempty"`
+	Required   bool   `json:"required"`
 	// Reason is "missing_required" or "invalid_value".
 	Reason  string `json:"reason"`
 	Message string `json:"message,omitempty"`

--- a/internal/server/handlers_items_copy_preflight.go
+++ b/internal/server/handlers_items_copy_preflight.go
@@ -335,11 +335,26 @@ type ItemCopyPreflightDropped struct {
 // ItemCopyPreflightNeedsValue is one destination field the caller must
 // resolve with an override before the copy can proceed.
 type ItemCopyPreflightNeedsValue struct {
-	Key      string   `json:"key"`
-	Label    string   `json:"label,omitempty"`
-	Type     string   `json:"type,omitempty"`
-	Options  []string `json:"options,omitempty"`
-	Required bool     `json:"required"`
+	Key     string   `json:"key"`
+	Label   string   `json:"label,omitempty"`
+	Type    string   `json:"type,omitempty"`
+	Options []string `json:"options,omitempty"`
+	// Collection is the target collection SLUG for a `relation` field, and
+	// empty for every other type (TASK-2869).
+	//
+	// Without it the dialog receives `type: "relation"` and no target, so its
+	// field editor has nothing to scope a picker to. The old fallback was a
+	// free-text box, which let a user type anything and — before U1's referent
+	// validation — the copy stored it. The picker needs the DESTINATION's
+	// collection, which is the only place this is known: the row is built from
+	// the destination schema.
+	//
+	// Additive and `omitempty`, so a client that does not read it is
+	// unaffected and a response for a non-relation field is byte-identical to
+	// before. Not a wire-version question for the same reason
+	// `models.ItemWriteWarnings` was not.
+	Collection string `json:"collection,omitempty"`
+	Required   bool   `json:"required"`
 	// Reason is "missing_required" (no value and no default) or
 	// "invalid_value" (a value carried across that the destination schema
 	// rejects — only reachable for non-override values; an INVALID
@@ -943,13 +958,14 @@ func (s *Server) handleCopyItemPreflight(w http.ResponseWriter, r *http.Request)
 				reason = "missing_required"
 			}
 			resp.Fields.NeedsValue = append(resp.Fields.NeedsValue, ItemCopyPreflightNeedsValue{
-				Key:      def.Key,
-				Label:    def.Label,
-				Type:     def.Type,
-				Options:  def.Options,
-				Required: def.Required,
-				Reason:   reason,
-				Message:  iss.Message,
+				Key:        def.Key,
+				Label:      def.Label,
+				Type:       def.Type,
+				Options:    def.Options,
+				Collection: def.Collection,
+				Required:   def.Required,
+				Reason:     reason,
+				Message:    iss.Message,
 			})
 			continue
 		}

--- a/internal/server/handlers_items_copy_relation_test.go
+++ b/internal/server/handlers_items_copy_relation_test.go
@@ -1122,3 +1122,64 @@ func TestCopyEndpoint_PreflightAndCopyAgreeOnOverridePrecedence(t *testing.T) {
 		})
 	}
 }
+
+// A required RELATION in the destination reaches the dialog with its target
+// collection, so the picker can be scoped to it (TASK-2869 / U2b).
+//
+// `ItemCopyPreflightNeedsValue` carried `type: "relation"` and no target, so
+// the dialog had a field it knew was a relation and no idea what to point at.
+// Its editor gates the relation branch on `wsSlug` AND `field.collection`, so
+// the row rendered as free text — and before U1's referent validation, a copy
+// with anything typed into it was STORED.
+//
+// The proving test from the task, both legs. The negative leg is the one that
+// matters: with `collection` absent the row must be treated as uncollectable,
+// which is what makes the dialog show an honest blocked state rather than an
+// unscoped picker offering SOURCE-workspace items.
+func TestCopyPreflight_RequiredRelationNeedsValueCarriesItsCollection(t *testing.T) {
+	f := newCopyRelationFixtureWith(t, noDestDefault, nil, true)
+
+	pre := f.ok(f.baseBody())
+	var row *ItemCopyPreflightNeedsValue
+	for i := range pre.Fields.NeedsValue {
+		if pre.Fields.NeedsValue[i].Key == "owner_ref" {
+			row = &pre.Fields.NeedsValue[i]
+		}
+	}
+	if row == nil {
+		t.Fatalf("a REQUIRED relation with no value produced no needs_value row: %+v", pre.Fields)
+	}
+	if row.Type != "relation" {
+		t.Fatalf("needs_value row type = %q, want relation", row.Type)
+	}
+	if row.Collection != f.targetsB.Slug {
+		t.Fatalf("needs_value row carries collection %q, want the DESTINATION's target %q — "+
+			"without it the dialog knows the field is a relation and not what it may point at",
+			row.Collection, f.targetsB.Slug)
+	}
+	if !row.Required {
+		t.Fatalf("the row does not report the field as required: %+v", row)
+	}
+
+	// The collection named is the DESTINATION's, not the source's. Those are
+	// different collections in this fixture, which is what makes the assertion
+	// above discriminate rather than pass on a coincidence of naming.
+	if f.targetsB.Slug == f.targetsA.Slug {
+		t.Fatalf("fixture defect: source and destination relation targets share the slug %q, "+
+			"so this test cannot tell which one the row names", f.targetsA.Slug)
+	}
+
+	// NEGATIVE LEG: a NON-relation needs-value row carries no collection, so
+	// the field is omitted rather than sent empty — `omitempty` is what keeps
+	// a response for an ordinary field byte-identical to before this change.
+	f2 := newCopyRelationFixtureWith(t, noDestDefault, nil, false)
+	body := f2.baseBody()
+	body["field_overrides"] = map[string]any{"status": ""}
+	pre2 := f2.ok(body)
+	for _, r := range pre2.Fields.NeedsValue {
+		if r.Type != "relation" && r.Collection != "" {
+			t.Fatalf("a %s row carries collection %q; only relation rows name a target",
+				r.Type, r.Collection)
+		}
+	}
+}

--- a/web/src/lib/components/fields/fieldEditorRelationCallers.test.ts
+++ b/web/src/lib/components/fields/fieldEditorRelationCallers.test.ts
@@ -55,8 +55,13 @@ describe('CopyItemDialog is now on the EDITABLE side of the gate (TASK-2869 / U2
 	it('passes the DESTINATION workspace slug, not the source', () => {
 		// destWs, never sourceWsSlug: a relation resolves at the destination,
 		// so the picker must list items the copy can actually point at.
-		expect(tag).toMatch(/wsSlug=\{destWs\}/);
+		// The PREFLIGHT'S canonical destination slug, not the raw `destWs`
+		// route value: an item opened through a workspace-UUID URL puts that
+		// UUID in destWs, and /search resolves by slug only, so the picker
+		// would silently search nothing (codex review, TASK-2869).
+		expect(tag).toMatch(/wsSlug=\{pickerWsSlug\}/);
 		expect(tag).not.toMatch(/wsSlug=\{sourceWsSlug\}/);
+		expect(copyDialog).toMatch(/preflight\?\.destination\.workspace_slug \|\| destWs/);
 	});
 
 	it('carries the row\'s target collection into the FieldDef', () => {

--- a/web/src/lib/components/fields/fieldEditorRelationCallers.test.ts
+++ b/web/src/lib/components/fields/fieldEditorRelationCallers.test.ts
@@ -38,26 +38,41 @@ describe('ItemDetail gives FieldEditor the relation link context', () => {
 	});
 });
 
-describe('CopyItemDialog stays on the read-only side of the gate', () => {
-	// Not an oversight to fix later — the assertion IS the behaviour. Its
-	// FieldDef comes from a preflight row that carries no `collection`
-	// (`ItemCopyPreflightNeedsValue`), so a picker mounted here would be
-	// unscoped, and this dialog copies ACROSS workspaces: it would offer
-	// source-workspace items as the value for a destination-workspace field and
-	// look authoritative doing it. TASK-2869 (U2b) fixes the contract end;
-	// until then, no wsSlug here is what keeps the picker out.
+describe('CopyItemDialog is now on the EDITABLE side of the gate (TASK-2869 / U2b)', () => {
+	// THIS BLOCK USED TO ASSERT THE OPPOSITE, and that was correct at the time:
+	// the preflight row carried no `collection`, so a picker mounted here would
+	// have been unscoped — and this dialog copies ACROSS workspaces, so it would
+	// have offered SOURCE-workspace items as the value for a DESTINATION field
+	// and looked authoritative doing it. Withholding `wsSlug` is what kept the
+	// picker out.
+	//
+	// U2b closed the contract end the old block named by ref: the row now
+	// carries its target collection, so both halves of FieldEditor's gate can
+	// be satisfied honestly. The old version told its successor to revisit the
+	// gate WITH that change rather than let it drift, which is this block.
 	const tag = mountTag(copyDialog);
 
-	it('does not pass a workspace slug', () => {
-		expect(tag).not.toMatch(/\bwsSlug\b/);
+	it('passes the DESTINATION workspace slug, not the source', () => {
+		// destWs, never sourceWsSlug: a relation resolves at the destination,
+		// so the picker must list items the copy can actually point at.
+		expect(tag).toMatch(/wsSlug=\{destWs\}/);
+		expect(tag).not.toMatch(/wsSlug=\{sourceWsSlug\}/);
 	});
 
-	it('still builds its FieldDef from a shape with no target collection', () => {
-		// If this ever fails, the preflight row grew `collection` — which is
-		// exactly U2b's change, and the gate above should be revisited WITH it
-		// rather than left to drift.
+	it('carries the row\'s target collection into the FieldDef', () => {
 		const toFieldDef = copyDialog.match(/function toFieldDef\([\s\S]*?\n\t\}/);
 		expect(toFieldDef).not.toBeNull();
-		expect(toFieldDef![0]).not.toMatch(/\bcollection\b/);
+		expect(toFieldDef![0]).toMatch(/collection: row\.collection/);
+	});
+
+	it('still refuses to mount a picker for a relation row with NO collection', () => {
+		// The other half of the gate, and the half that is easy to lose: the
+		// dialog delegates that decision to isCollectable, which is unit-tested
+		// in copyNeedsValue.test.ts. Asserting the DELEGATION here means the
+		// two cannot drift apart — a dialog that inlined its own predicate
+		// again would pass those unit tests and fail this.
+		expect(copyDialog).toMatch(/from '\$lib\/items\/copyNeedsValue'/);
+		expect(copyDialog).toMatch(/\{#if isCollectable\(row\)\}/);
 	});
 });
+

--- a/web/src/lib/components/items/CopyItemDialog.svelte
+++ b/web/src/lib/components/items/CopyItemDialog.svelte
@@ -660,6 +660,24 @@ user hunting for an item that provably does not exist.
 		return applied;
 	}
 
+	/**
+	 * The workspace slug the relation picker searches in.
+	 *
+	 * The PREFLIGHT'S OWN destination slug, not `destWs`, and the difference
+	 * is not cosmetic: an item can be opened through a workspace-UUID URL, the
+	 * route parameter is passed through as `sourceWsSlug`, and a same-workspace
+	 * copy then puts that UUID in `destWs`. `/search` resolves a workspace by
+	 * SLUG only, so a picker handed a UUID searches nothing and silently
+	 * returns no results — a control that looks usable and cannot be used.
+	 *
+	 * The preflight response is the canonicalising round-trip: the server
+	 * resolved whatever it was given and answered with the real slug. Falls
+	 * back to `destWs` only before the first preflight has returned, at which
+	 * point no needs-value row is being rendered anyway (codex review,
+	 * TASK-2869).
+	 */
+	let pickerWsSlug = $derived(preflight?.destination.workspace_slug || destWs);
+
 	function toFieldDef(row: ItemCopyPreflightNeedsValue): FieldDef {
 		return {
 			key: row.key,
@@ -1154,7 +1172,7 @@ user hunting for an item that provably does not exist.
 												<div class="needs-control">
 													<FieldEditor
 														field={toFieldDef(row)}
-														wsSlug={destWs}
+														wsSlug={pickerWsSlug}
 														ariaLabel={row.label || row.key}
 														value={overrides[row.key]}
 														readonly={submitting || preparing}

--- a/web/src/lib/components/items/CopyItemDialog.svelte
+++ b/web/src/lib/components/items/CopyItemDialog.svelte
@@ -48,6 +48,7 @@ user hunting for an item that provably does not exist.
 	import FieldEditor from '$lib/components/fields/FieldEditor.svelte';
 	import { api, PadApiError } from '$lib/api/client';
 	import { copyDropReasonMessage } from '$lib/items/copyDropReasons';
+	import { isCollectable } from '$lib/items/copyNeedsValue';
 	import { canEditCollection } from '$lib/utils/permissions';
 	import { parseSchema } from '$lib/types';
 	import type {
@@ -133,7 +134,11 @@ user hunting for an item that provably does not exist.
 	 * any uncollectable type renders an explicit blocked state naming the field
 	 * and its type, rather than a dead Confirm or a lying input.
 	 */
-	const COLLECTABLE_TYPES = new Set(['text', 'number', 'select', 'date', 'checkbox', 'url']);
+	// COLLECTABLE_TYPES and isCollectable now live in `$lib/items/copyNeedsValue`
+	// so they can be tested (TASK-2869, following IDEA-2894): the mutant that
+	// made `relation` unconditionally collectable survived every suite in the
+	// repo while this logic was inline here.
+
 
 	// ── Destination selection ─────────────────────────────────────────────
 	let workspaces = $state<Workspace[]>([]);
@@ -245,9 +250,7 @@ user hunting for an item that provably does not exist.
 
 	/** Required destination fields the dialog cannot safely collect a value for. */
 	let blockedFields = $derived(
-		(preflight?.fields.needs_value ?? []).filter(
-			(f) => !COLLECTABLE_TYPES.has(f.type ?? 'text')
-		)
+		(preflight?.fields.needs_value ?? []).filter((f) => !isCollectable(f))
 	);
 
 	let warnings = $derived(preflight?.warnings ?? null);
@@ -663,6 +666,13 @@ user hunting for an item that provably does not exist.
 			label: row.label || row.key,
 			type: (row.type ?? 'text') as FieldDef['type'],
 			options: row.options,
+			// The DESTINATION's target collection for a relation row, which is
+			// what FieldEditor scopes its picker to. The call site pairs it
+			// with wsSlug={destWs} — the DESTINATION workspace, never the
+			// source: the picker must list items the copy can actually point
+			// at, and a relation resolves at the destination (TASK-2869,
+			// day-55 ruling).
+			collection: row.collection,
 			required: row.required
 		};
 	}
@@ -1135,7 +1145,7 @@ user hunting for an item that provably does not exist.
 								{/if}
 								<div class="needs-list">
 									{#each overrideRows as row (row.key)}
-										{#if COLLECTABLE_TYPES.has(row.type ?? 'text')}
+										{#if isCollectable(row)}
 											<div class="needs-row">
 												<span class="k">
 													{row.label || row.key}
@@ -1144,6 +1154,7 @@ user hunting for an item that provably does not exist.
 												<div class="needs-control">
 													<FieldEditor
 														field={toFieldDef(row)}
+														wsSlug={destWs}
 														ariaLabel={row.label || row.key}
 														value={overrides[row.key]}
 														readonly={submitting || preparing}

--- a/web/src/lib/items/copyNeedsValue.test.ts
+++ b/web/src/lib/items/copyNeedsValue.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { isCollectable, COLLECTABLE_TYPES } from './copyNeedsValue';
+import type { ItemCopyPreflightNeedsValue } from '$lib/types';
+
+const row = (over: Partial<ItemCopyPreflightNeedsValue>): ItemCopyPreflightNeedsValue => ({
+	key: 'owner_ref',
+	required: true,
+	reason: 'missing_required',
+	...over,
+});
+
+describe('isCollectable', () => {
+	it('accepts a relation that names its target collection', () => {
+		expect(isCollectable(row({ type: 'relation', collection: 'people-b' }))).toBe(true);
+	});
+
+	// THE NEGATIVE LEG of TASK-2869's proving test, and the reason this module
+	// exists. FieldEditor gates its relation branch on wsSlug AND
+	// field.collection, so a relation row with no collection cannot be filled
+	// in — offering it would render a dead control, or an unscoped picker
+	// listing SOURCE-workspace items the copy cannot point at.
+	it('refuses a relation with no target collection', () => {
+		expect(isCollectable(row({ type: 'relation' }))).toBe(false);
+		expect(isCollectable(row({ type: 'relation', collection: '' }))).toBe(false);
+	});
+
+	it('is unaffected for every other type', () => {
+		for (const type of COLLECTABLE_TYPES) {
+			expect(isCollectable(row({ type })), `${type} should stay collectable`).toBe(true);
+		}
+		// The two FieldEditor cannot safely collect, named individually rather
+		// than as "everything else" so a new dangerous type does not join them
+		// silently.
+		expect(isCollectable(row({ type: 'multi_select' }))).toBe(false);
+		expect(isCollectable(row({ type: 'json' }))).toBe(false);
+	});
+
+	it('treats a missing type as text, which is collectable', () => {
+		expect(isCollectable(row({}))).toBe(true);
+	});
+});

--- a/web/src/lib/items/copyNeedsValue.ts
+++ b/web/src/lib/items/copyNeedsValue.ts
@@ -1,0 +1,45 @@
+import type { ItemCopyPreflightNeedsValue } from '$lib/types';
+
+/**
+ * Types the copy dialog can safely collect a value for — the set `FieldEditor`
+ * implements as real typed controls.
+ *
+ * Everything else is NOT rendered as a text box. `json` is deliberately
+ * read-only in FieldEditor (a plain text input would store the string "[]"
+ * where an array belongs), and `multi_select` falls through FieldEditor's TEXT
+ * fallback, which yields a string where the server requires `[]any`. That last
+ * one is the dangerous case: enterable and silently invalid.
+ */
+export const COLLECTABLE_TYPES = new Set([
+	'text',
+	'number',
+	'select',
+	'date',
+	'checkbox',
+	'url',
+]);
+
+/**
+ * Whether a `needs_value` row can be given a value in the copy dialog.
+ *
+ * `relation` is collectable ONLY IF THE ROW NAMES ITS TARGET COLLECTION
+ * (TASK-2869). FieldEditor's relation branch is gated on `wsSlug` AND
+ * `field.collection`; with either missing it renders the non-editable state, so
+ * offering the row without a collection produces a control that cannot be
+ * filled and a Confirm that cannot be satisfied.
+ *
+ * A row missing `collection` is therefore treated exactly as an uncollectable
+ * TYPE — it lands in the blocked list and the user is told which field and why,
+ * instead of meeting a dead input, or worse an unscoped picker offering
+ * SOURCE-workspace items the copy cannot use.
+ *
+ * EXTRACTED RATHER THAN LEFT INLINE, for the reason IDEA-2894 established one
+ * unit earlier: logic living unexported inside `CopyItemDialog.svelte` cannot
+ * be tested, and the mutant that made `relation` unconditionally collectable
+ * survived every suite in the repo while it lived there.
+ */
+export function isCollectable(row: ItemCopyPreflightNeedsValue): boolean {
+	const type = row.type ?? 'text';
+	if (type === 'relation') return Boolean(row.collection);
+	return COLLECTABLE_TYPES.has(type);
+}

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -843,6 +843,17 @@ export interface ItemCopyPreflightNeedsValue {
 	label?: string;
 	type?: string;
 	options?: string[];
+	/**
+	 * Target collection SLUG for a `relation` field; absent for every other
+	 * type (TASK-2869).
+	 *
+	 * It names a collection in the DESTINATION workspace, which is what the
+	 * field editor scopes its picker to. Absent on a relation row means the
+	 * server could not say what to point at — render the non-editable state
+	 * rather than an unscoped picker, which would otherwise offer SOURCE
+	 * workspace items the copy cannot use.
+	 */
+	collection?: string;
 	required: boolean;
 	reason: 'missing_required' | 'invalid_value';
 	message?: string;


### PR DESCRIPTION
U2b, per the day-55 ruling. Both blockers are in: U1 (referent validation) and U2 (the FieldEditor relation branch + picker).

## The defect

`ItemCopyPreflightNeedsValue` carried `type: "relation"` and **no target**. `FieldEditor` gates its relation branch on `wsSlug` **and** `field.collection`, so a required relation in the destination reached the copy dialog as a field it knew was a relation with no idea what to point at — and rendered as **free text**. Before U1 landed, the copy stored whatever was typed.

## The change

**Server.** `collection` on the needs-value row, from the destination schema's `def.Collection` — the only place it is known, since the row is built from that schema. Additive and `omitempty`: a client that ignores it is unaffected and a non-relation row is byte-identical to before.

**Client.** `toFieldDef` carries it through; the picker is scoped to the destination workspace. `relation` becomes collectable **only if the row names its target** — without one, FieldEditor's gate renders the non-editable state, so offering the row would produce a control that cannot be filled and a Confirm that cannot be satisfied. Such a row joins the blocked list and the user is told which field and why: the same disposition `multi_select` gets, and for the same reason.

**CLI.** The surface with no picker at all now prints the relation analogue of the `options:` line a select already gets — `target collection: people` — because that is what makes `--field owner_ref=<ref>` answerable.

## Three things this unit taught me

**1. The web mutant survived, and that is why `isCollectable` moved.** My first version left the predicate inline in `CopyItemDialog.svelte`. Making `relation` unconditionally collectable — the exact defect the negative leg of the proving test is about — **passed every suite in the repo.** That is IDEA-2894's lesson arriving one unit later in the same file. The predicate now lives in `$lib/items/copyNeedsValue` with tests, and two mutants die there: relation-always-collectable, and `multi_select` slipped into the collectable set.

**2. A U2-era test asserted the absence this unit closes — correctly.** `fieldEditorRelationCallers.test.ts` required the dialog to pass no `wsSlug` and build its FieldDef from a shape with no `collection`. That *was* the behaviour, and withholding `wsSlug` is what kept an unscoped picker out. It also named this task by ref and told its successor to revisit the gate *with* the change rather than let it drift. Inverted here — and it now also asserts the dialog **delegates** the collectability decision, so a future inlined predicate would pass the unit tests and fail this. *A test that pins a temporary absence should name what would make it wrong.*

**3. I swept two consumers of three.** The first commit said "both sides" — server and TypeScript. `internal/cli` keeps a mirror of the preflight shape, and `TestItemCopyMirrorsMatchServerShapes` caught it in the Postgres gate, in a package the change did not touch. `ItemCopyPreflightNeedsValue` appears in exactly three files and I looked at two. The instrument is not "run more tests" but *grep for the type's name before calling the sweep done.*

## Review: three findings, one fixed here, two filed

**Fixed — the picker searched a value that is not always a slug.** `wsSlug={destWs}` could be a workspace **UUID**: an item opened through a UUID URL passes the route parameter through as `sourceWsSlug`, and a same-workspace copy puts it in `destWs`. `/search` resolves by slug only, so the picker searched nothing and returned no results — usable-looking and not usable. Now the preflight's own `destination.workspace_slug`, which is the canonicalising round-trip. The caller test asserts the prop **and** the derivation, since asserting only the prop would pass against `destWs` renamed.

**IDEA-2898 — `ItemPicker` serves warm local-index results without re-authorising them**, so a collection whose access was revoked can still be listed. The cold `/search` path is visibility-filtered and correct; the warm path is not. **Pre-existing, and it applies to every caller** including `ItemDetail` — last touched by TASK-2877. This unit widened exposure by adding a caller; it did not create the defect, and the fix needs a decision about where the client learns its access set from, which no current signal provides.

**IDEA-2899 — a relation row can name a target that is deleted or unreadable**, so `isCollectable` says yes on a non-empty string and the user meets a picker with nothing in it. **I could not fix this correctly here, and the reason is measured:** the obvious test is to check the target against `destCollections`, and that list is filtered by `canEditCollection` — it is what the user may copy *into*. A relation target needs only *read* access, so a usable target routinely is not in it. Using it would **over-block**, refusing rows the user could have filled — a worse failure than the one being fixed, and invisible to whoever hits it. The right shape is probably the server reporting availability on the row it already builds.

## Gates

| Gate | Result |
|---|---|
| `internal/server` | ok 153.645s |
| `internal/cli` · `cmd/pad` | ok |
| `go vet` / `gofmt` | clean |
| `npm run check` | 0 errors (6 pre-existing warnings) |
| `make web-test` | 127 files, 2123 tests |
| **Postgres** | ok — 29 packages, EXIT=0 |

Rebased onto `47d2b15e` and re-gated there — a gate on a pre-rebase tip is not a gate on what merges.

https://claude.ai/code/session_01Xk9M5UVPdc84xL5E1mZkm8
