### PR TITLE
feat(server,web): detect a revocation that writes no item, and evict the cache it left stale (IDEA-2898)

### DIFF
--- a/internal/server/access_epoch.go
+++ b/internal/server/access_epoch.go
@@ -1,0 +1,74 @@
+package server
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"sort"
+)
+
+// accessEpochUnrestricted is the epoch for a caller with no collection
+// filtering at all (owner, editor with "all" access, cookie-session admin).
+//
+// It is a SENTINEL rather than a hash of the empty set, because the empty set
+// is a real and opposite state: a restricted member with zero visible
+// collections. Hashing both to the same value would make the widest and the
+// narrowest access indistinguishable — a caller whose access was revoked down
+// to nothing would carry the same epoch as an owner, and a promotion from
+// nothing to everything would signal no change at all.
+const accessEpochUnrestricted = "all"
+
+// computeAccessEpoch fingerprints the caller's EFFECTIVE visible resource set
+// so a client can tell that the set changed without being told what it is.
+//
+// IDEA-2898. The delta stream (/items-changes) can only express changes to
+// ROWS. A revocation that writes no item — the ordinary shape of revocation —
+// therefore produces no signal at all, and a client's warm local index goes on
+// serving rows for a collection the caller can no longer see. This value is
+// that missing signal: the client compares it against the one it stored and,
+// on a change, runs the authoritative resync it already implements.
+//
+// Inputs are the two lists the item doors already resolve before writing their
+// response, so this costs no additional query:
+//
+//   - visibleCollectionIDs: nil means "no filtering" (see the sentinel above);
+//     a non-nil slice, possibly empty, is the caller's collection-level set.
+//   - grantedItemIDs: the caller's item-level grants, empty for most callers.
+//
+// The hash is over a CANONICAL form — both lists sorted, and the two lists
+// separated by a byte that cannot occur in an ID — so a set that has not
+// changed cannot produce a different epoch just because the store returned its
+// rows in a different order. An epoch that flapped on ordering alone would
+// trigger a full resync per poll, which is the one failure mode that would
+// make this worse than the defect it closes.
+//
+// The value is derived only from the caller's OWN access and is opaque: it
+// names no collection and no item, and two callers with different access
+// cannot learn anything about each other from it.
+func computeAccessEpoch(visibleCollectionIDs, grantedItemIDs []string) string {
+	if visibleCollectionIDs == nil {
+		// Grants only narrow within a filtered set; an unrestricted caller
+		// cannot also be item-filtered, and the doors never pass both.
+		return accessEpochUnrestricted
+	}
+	h := sha256.New()
+	writeSortedIDs(h, visibleCollectionIDs)
+	// Separator: a newline cannot appear in a UUID, so ["a","b"]+[] and
+	// ["a"]+["b"] cannot collide.
+	_, _ = h.Write([]byte("\n--\n"))
+	writeSortedIDs(h, grantedItemIDs)
+	return hex.EncodeToString(h.Sum(nil))[:16]
+}
+
+// writeSortedIDs feeds ids to h in sorted order, one per line. The input slice
+// is COPIED before sorting: the callers pass slices they go on to use for the
+// query itself, and reordering those under them would be an invisible
+// side effect of computing a fingerprint.
+func writeSortedIDs(h interface{ Write([]byte) (int, error) }, ids []string) {
+	sorted := make([]string, len(ids))
+	copy(sorted, ids)
+	sort.Strings(sorted)
+	for _, id := range sorted {
+		_, _ = h.Write([]byte(id))
+		_, _ = h.Write([]byte("\n"))
+	}
+}

--- a/internal/server/access_epoch_test.go
+++ b/internal/server/access_epoch_test.go
@@ -1,0 +1,68 @@
+package server
+
+import "testing"
+
+// The properties the two item doors depend on. Each case names what a
+// FAILURE would mean for the client, because that is what decides whether
+// the property is worth a test (CONVE-12: assert what the wrong behaviour
+// would do, not what the right behaviour leaves looking unchanged).
+func TestComputeAccessEpoch(t *testing.T) {
+	t.Run("stable across input ordering", func(t *testing.T) {
+		// A different row order out of the store must not read as a changed
+		// access set. If it did, every poll would trigger a full authoritative
+		// resync — strictly worse than the defect this closes.
+		a := computeAccessEpoch([]string{"c1", "c2", "c3"}, []string{"i2", "i1"})
+		b := computeAccessEpoch([]string{"c3", "c1", "c2"}, []string{"i1", "i2"})
+		if a != b {
+			t.Errorf("epoch flapped on ordering alone: %q vs %q", a, b)
+		}
+	})
+
+	t.Run("does not reorder its inputs", func(t *testing.T) {
+		// The callers pass the same slices to the query that produced them.
+		// Sorting in place would be an invisible side effect of computing a
+		// fingerprint, and the door would then query a differently-ordered set.
+		ids := []string{"c3", "c1", "c2"}
+		computeAccessEpoch(ids, nil)
+		if ids[0] != "c3" || ids[1] != "c1" || ids[2] != "c2" {
+			t.Errorf("input slice was reordered: %v", ids)
+		}
+	})
+
+	t.Run("unrestricted is distinct from empty", func(t *testing.T) {
+		// nil = no filtering (owner). Empty = a restricted member who can see
+		// nothing. Collapsing them would make a revocation-to-nothing carry an
+		// owner's epoch, which is the exact silence this whole change removes.
+		if computeAccessEpoch(nil, nil) == computeAccessEpoch([]string{}, nil) {
+			t.Error("unrestricted and empty-restricted share an epoch")
+		}
+	})
+
+	t.Run("narrowing changes the epoch", func(t *testing.T) {
+		before := computeAccessEpoch([]string{"c1", "c2"}, nil)
+		after := computeAccessEpoch([]string{"c1"}, nil)
+		if before == after {
+			t.Error("dropping a collection left the epoch unchanged")
+		}
+	})
+
+	t.Run("item grants are part of the set", func(t *testing.T) {
+		// A guest keeps collection-level visibility while an item grant is
+		// revoked. Hashing only the collections would miss it entirely.
+		before := computeAccessEpoch([]string{"c1"}, []string{"i1", "i2"})
+		after := computeAccessEpoch([]string{"c1"}, []string{"i1"})
+		if before == after {
+			t.Error("revoking an item grant left the epoch unchanged")
+		}
+	})
+
+	t.Run("the two lists cannot be confused", func(t *testing.T) {
+		// Without a separator, ["a","b"]+[] and ["a"]+["b"] hash the same, so
+		// moving a resource between the collection and item dimensions would
+		// be invisible. The value is opaque, so nothing downstream would catch
+		// this — only here.
+		if computeAccessEpoch([]string{"a", "b"}, nil) == computeAccessEpoch([]string{"a"}, []string{"b"}) {
+			t.Error("collection and item lists collide")
+		}
+	})
+}

--- a/internal/server/handlers_events.go
+++ b/internal/server/handlers_events.go
@@ -563,7 +563,36 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 			// access tightened to "specific", item grants revoked). Rebuild
 			// the filter set so the next event dispatched respects the
 			// current grants rather than the ones captured at connect time.
+			epochBefore := vis.accessEpoch()
 			vis = s.computeSSEVisibility(r, ws.ID)
+			// IDEA-2898. Rebuilding the filter set stops the LEAK — no further
+			// event for a revoked collection is dispatched — but it says
+			// nothing to the client, whose local index is still holding the
+			// rows it was sent before the revocation. A revocation writes no
+			// item, so no delta will ever carry an eviction for them.
+			//
+			// The existing sync_required is exactly the right signal: it means
+			// "your view may be behind, go reconcile", and reconciling is what
+			// evicts. No new event type, and no extra query — both epochs come
+			// from visibility sets this tick already computed.
+			//
+			// Deliberately NOT writeSSEResetCursorEvent: that form blanks the
+			// client's Last-Event-ID because the STREAM has a hole. This stream
+			// has none. The caller's scope changed, which is a different fact,
+			// and clearing a healthy resume cursor would cost a full replay on
+			// the next reconnect for nothing.
+			if vis.accessEpoch() != epochBefore {
+				slog.Info("SSE: subscriber access scope changed mid-stream, sending sync_required",
+					"workspace", ws.Slug, "user_id", sseUserID)
+				if err := writeSSEEvent(w, "sync_required", 0, map[string]string{
+					"reason": "Your access to this workspace changed. Full sync required.",
+				}); err != nil {
+					slog.Debug("SSE: access-change sync_required write failed, closing",
+						"workspace", ws.Slug, "error", err)
+					return
+				}
+				flusher.Flush()
+			}
 			// Re-arm the timer at the regular cadence. The first fire was
 			// jittered; subsequent fires can be evenly spaced without
 			// introducing a stampede because connect-time variance has
@@ -657,6 +686,33 @@ func sseEventVisibleFor(vis sseVisibility, sseUserID string, event events.Event)
 		return false
 	}
 	return true
+}
+
+// accessEpoch fingerprints this snapshot's effective visible set, so two
+// revalidation ticks can be compared without re-querying anything (IDEA-2898).
+//
+// It reuses the same function the item doors use, for one reason worth stating:
+// the client compares the epoch it got from /items-changes against the one it
+// stored, and this signal only tells it to go and do that. If the two sides
+// disagreed about what "the same set" means, this tick would announce changes
+// that the delta then declared unchanged, or stay silent on ones it did not.
+// They are separate values on separate wires; they must be one definition.
+func (v sseVisibility) accessEpoch() string {
+	if v.visibleSlugSet == nil {
+		// Mirrors computeAccessEpoch's nil case: no filtering at all.
+		return computeAccessEpoch(nil, nil)
+	}
+	collIDs := make([]string, 0, len(v.visibleCollIDSet))
+	for id := range v.visibleCollIDSet {
+		collIDs = append(collIDs, id)
+	}
+	itemIDs := make([]string, 0, len(v.grantedItemSet))
+	for id := range v.grantedItemSet {
+		itemIDs = append(itemIDs, id)
+	}
+	// Map iteration order is randomized; computeAccessEpoch sorts, which is
+	// what makes this comparable across ticks at all.
+	return computeAccessEpoch(collIDs, itemIDs)
 }
 
 type sseVisibility struct {

--- a/internal/server/handlers_events_access_epoch_stream_test.go
+++ b/internal/server/handlers_events_access_epoch_stream_test.go
@@ -1,0 +1,157 @@
+package server
+
+import (
+	"bufio"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// TestSSEStream_AnnouncesAnAccessChangeButStaysQuietOtherwise is the WIRING
+// half of IDEA-2898's server signal (CONVE-19): the epoch's correctness is
+// pinned by the unit test next door, and that test says nothing about whether
+// the revalidation tick ever WRITES anything. A version of this change that
+// computed the epoch perfectly and never emitted would pass every other test.
+//
+// Both legs are load-bearing, and the quiet one is the sharper:
+//
+//   - QUIET: a tick that emitted unconditionally would send a client into a
+//     full authoritative resync once a minute, forever, on every open tab.
+//     That is worse than the defect being closed, and it is indistinguishable
+//     from correct behaviour if you only assert that the signal arrives.
+//   - ANNOUNCED: without it the client's warm index holds the revoked
+//     collection's rows until it next bootstraps.
+//
+// Through the router on a live server, not by calling the handler.
+func TestSSEStream_AnnouncesAnAccessChangeButStaysQuietOtherwise(t *testing.T) {
+	// A real minute is not a test. The var exists to be shrunk; restore it so
+	// a parallel-package run isn't left with a 25ms cadence.
+	prev := sseMembershipRevalInterval
+	sseMembershipRevalInterval = 25 * time.Millisecond
+	t.Cleanup(func() { sseMembershipRevalInterval = prev })
+
+	srv := testServerWithEvents(t)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	owner, err := srv.store.CreateUser(models.UserCreate{
+		Email: "owner@example.com", Name: "Owner", Password: "correct-horse-battery-staple", Role: "admin",
+	})
+	if err != nil {
+		t.Fatalf("create owner: %v", err)
+	}
+	member, err := srv.store.CreateUser(models.UserCreate{
+		Email: "member@example.com", Name: "Member", Password: "correct-horse-battery-staple", Role: "member",
+	})
+	if err != nil {
+		t.Fatalf("create member: %v", err)
+	}
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "EpochStream", OwnerID: owner.ID})
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, owner.ID, "owner"); err != nil {
+		t.Fatalf("add owner: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, member.ID, "editor"); err != nil {
+		t.Fatalf("add member: %v", err)
+	}
+	schema := `{"fields":[{"key":"status","type":"select","options":["open","done"],"default":"open"}]}`
+	kept, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{Name: "Kept", Slug: "kept", Prefix: "KEP", Schema: schema})
+	if err != nil {
+		t.Fatalf("create kept: %v", err)
+	}
+	revoked, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{Name: "Revoked", Slug: "revoked", Prefix: "REV", Schema: schema})
+	if err != nil {
+		t.Fatalf("create revoked: %v", err)
+	}
+	if err := srv.store.SetMemberCollectionAccess(ws.ID, member.ID, "specific", []string{kept.ID, revoked.ID}); err != nil {
+		t.Fatalf("grant both: %v", err)
+	}
+	// The session is IP- and UA-bound; over a live server the request really
+	// does arrive from loopback, so bind it there rather than at the
+	// 192.0.2.1 the ResponseRecorder helpers can fake.
+	token, err := srv.store.CreateSession(member.ID, "test", "127.0.0.1", testSessionUA, webSessionTTL)
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/api/v1/events?workspace="+ws.Slug, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("User-Agent", testSessionUA)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName(srv.secureCookies), Value: token})
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("open stream: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("stream status = %d, want 200", resp.StatusCode)
+	}
+
+	var mu sync.Mutex
+	var syncRequired int
+	connected := make(chan struct{})
+	go func() {
+		sc := bufio.NewScanner(resp.Body)
+		closedConnected := false
+		for sc.Scan() {
+			line := strings.TrimSpace(sc.Text())
+			if line == "event: connected" && !closedConnected {
+				closedConnected = true
+				close(connected)
+			}
+			if line == "event: sync_required" {
+				mu.Lock()
+				syncRequired++
+				mu.Unlock()
+			}
+		}
+	}()
+
+	select {
+	case <-connected:
+	case <-time.After(5 * time.Second):
+		t.Fatal("stream never announced `connected`")
+	}
+
+	// QUIET LEG. Several revalidation ticks with nothing changing.
+	time.Sleep(300 * time.Millisecond)
+	mu.Lock()
+	quiet := syncRequired
+	mu.Unlock()
+	if quiet != 0 {
+		t.Fatalf("tick emitted %d sync_required with no access change; a per-tick resync is worse than the defect", quiet)
+	}
+
+	// ANNOUNCED LEG. A revocation that writes no item — the case the delta
+	// stream cannot carry.
+	if err := srv.store.SetMemberCollectionAccess(ws.ID, member.ID, "specific", []string{kept.ID}); err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+
+	deadline := time.After(5 * time.Second)
+	for {
+		mu.Lock()
+		got := syncRequired
+		mu.Unlock()
+		if got > 0 {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatal("no sync_required after the caller's collection access was narrowed")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}

--- a/internal/server/handlers_events_access_epoch_test.go
+++ b/internal/server/handlers_events_access_epoch_test.go
@@ -1,0 +1,113 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// TestSSEVisibilityAccessEpoch_TracksNarrowingAndMatchesTheItemDoors covers the
+// two things the 60s revalidation tick's sync_required emission rests on
+// (IDEA-2898).
+//
+//  1. The epoch MOVES when the caller's collection access narrows. Without that
+//     the tick is silent and the client's warm index keeps the revoked rows
+//     until it next bootstraps.
+//  2. The epoch AGREES with what the item doors send for the same caller. These
+//     are two values on two wires — one from an SSE tick, one from
+//     /items-changes — and the client compares the second against what it
+//     stored. If the two sides could disagree about what "the same set" means,
+//     the tick would announce a change the delta then denied, or stay silent on
+//     one it made. The tick tells the client to go and reconcile; the delta is
+//     what decides. They have to be one definition, and this is the only place
+//     that can catch them drifting apart.
+func TestSSEVisibilityAccessEpoch_TracksNarrowingAndMatchesTheItemDoors(t *testing.T) {
+	srv := testServer(t)
+
+	owner, err := srv.store.CreateUser(models.UserCreate{
+		Email: "owner@example.com", Name: "Owner", Password: "correct-horse-battery-staple", Role: "admin",
+	})
+	if err != nil {
+		t.Fatalf("create owner: %v", err)
+	}
+	user, err := srv.store.CreateUser(models.UserCreate{
+		Email: "member@example.com", Name: "Member", Password: "correct-horse-battery-staple", Role: "member",
+	})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "EpochVis", OwnerID: owner.ID})
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, owner.ID, "owner"); err != nil {
+		t.Fatalf("add owner: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, user.ID, "editor"); err != nil {
+		t.Fatalf("add member: %v", err)
+	}
+	schema := `{"fields":[{"key":"status","type":"select","options":["open","done"],"default":"open"}]}`
+	kept, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{Name: "Kept", Slug: "kept", Prefix: "KEP", Schema: schema})
+	if err != nil {
+		t.Fatalf("create kept: %v", err)
+	}
+	revoked, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{Name: "Revoked", Slug: "revoked", Prefix: "REV", Schema: schema})
+	if err != nil {
+		t.Fatalf("create revoked: %v", err)
+	}
+
+	mkReq := func() *http.Request {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/events?workspace="+ws.Slug, nil)
+		return req.WithContext(context.WithValue(req.Context(), ctxCurrentUser, user))
+	}
+	// The item doors' own view of the same caller, through the same helper
+	// they use — not a re-derivation, which would let this test agree with a
+	// wrong answer.
+	doorEpoch := func() string {
+		visibleIDs, err := srv.visibleCollectionIDs(mkReq(), ws.ID)
+		if err != nil {
+			t.Fatalf("visibleCollectionIDs: %v", err)
+		}
+		_, grantedItemIDs, err := srv.guestResourceFilter(mkReq(), ws.ID)
+		if err != nil {
+			t.Fatalf("guestResourceFilter: %v", err)
+		}
+		return computeAccessEpoch(visibleIDs, grantedItemIDs)
+	}
+
+	if err := srv.store.SetMemberCollectionAccess(ws.ID, user.ID, "specific", []string{kept.ID, revoked.ID}); err != nil {
+		t.Fatalf("grant both collections: %v", err)
+	}
+	before := srv.computeSSEVisibility(mkReq(), ws.ID).accessEpoch()
+	if before != doorEpoch() {
+		t.Errorf("SSE tick and item doors disagree before revocation: %q vs %q", before, doorEpoch())
+	}
+
+	if err := srv.store.SetMemberCollectionAccess(ws.ID, user.ID, "specific", []string{kept.ID}); err != nil {
+		t.Fatalf("revoke one collection: %v", err)
+	}
+	after := srv.computeSSEVisibility(mkReq(), ws.ID).accessEpoch()
+	if after == before {
+		t.Errorf("epoch unchanged across a narrowing (%q) — the tick would stay silent", after)
+	}
+	if after != doorEpoch() {
+		t.Errorf("SSE tick and item doors disagree after revocation: %q vs %q", after, doorEpoch())
+	}
+
+	// Widening back is a change too, and the tick should announce it: the
+	// client's cache is missing rows it may now see, and the same resync is
+	// what fetches them.
+	if err := srv.store.SetMemberCollectionAccess(ws.ID, user.ID, "all", nil); err != nil {
+		t.Fatalf("restore full access: %v", err)
+	}
+	widened := srv.computeSSEVisibility(mkReq(), ws.ID).accessEpoch()
+	if widened == after {
+		t.Errorf("epoch unchanged across a widening (%q)", widened)
+	}
+	if widened != doorEpoch() {
+		t.Errorf("SSE tick and item doors disagree after widening: %q vs %q", widened, doorEpoch())
+	}
+}

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -139,6 +139,12 @@ type itemsIndexResponse struct {
 	Total                      int           `json:"total"`
 	Cursor                     string        `json:"cursor"`
 	IncludesUnparentedMetadata bool          `json:"includes_unparented_metadata"`
+	// AccessEpoch fingerprints the caller's effective visible set so the
+	// client can detect a revocation that wrote no row (IDEA-2898). See
+	// computeAccessEpoch. Carried on BOTH doors, and they must agree: a
+	// cold bootstrap and a delta poll that disagreed about the caller's
+	// scope would resync each other in a loop.
+	AccessEpoch string `json:"access_epoch"`
 }
 
 // handleListItemsIndex returns the skinny-projection of every item in a
@@ -258,6 +264,7 @@ func (s *Server) handleListItemsIndex(w http.ResponseWriter, r *http.Request) {
 		Total:                      len(result),
 		Cursor:                     cursor,
 		IncludesUnparentedMetadata: params.IncludeUnparentedMetadata,
+		AccessEpoch:                computeAccessEpoch(visibleIDs, grantedItemIDs),
 	})
 }
 
@@ -293,6 +300,10 @@ type itemsChangesResponse struct {
 	Changes                    []itemChangeRow `json:"changes"`
 	Cursor                     string          `json:"cursor"`
 	IncludesUnparentedMetadata bool            `json:"includes_unparented_metadata"`
+	// AccessEpoch — see itemsIndexResponse.AccessEpoch. This is the door
+	// that matters most for IDEA-2898: it is the one a warm client polls,
+	// and the one a revocation is otherwise invisible on.
+	AccessEpoch string `json:"access_epoch"`
 }
 
 // handleListItemsChanges is the delta-fetch sibling of
@@ -442,10 +453,32 @@ func (s *Server) handleListItemsChanges(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 
+	// THE EPOCH USES THE LIVE GRANT SET, NOT THIS DOOR'S QUERY SET (review
+	// round 2). The query above deliberately resolves grants with deleted items
+	// INCLUDED, so a tombstone on a granted item still flows through
+	// (TASK-1354). The fingerprint must not: /items-index resolves LIVE grants,
+	// and a caller holding a grant on a soft-deleted item would otherwise get
+	// permanently disagreeing epochs from the two doors — the client resyncs,
+	// the snapshot restores the index door's value, the next delta contradicts
+	// it again, and the reconcile loop runs to its 50-page cap on every sync
+	// trigger, forever. Two values on two wires that are compared against each
+	// other have to have ONE definition, and the live set is it: it is what the
+	// SSE revalidation tick already holds, so all three sites agree.
+	//
+	// The cost is one extra grant resolve on this door, and the consequence is
+	// that soft-deleting a granted item does change the epoch once. That is a
+	// single spurious resync which then converges, rather than a storm that
+	// never does.
+	_, liveGrantedItemIDs, liveGrantErr := s.guestResourceFilter(r, workspaceID)
+	if liveGrantErr != nil {
+		writeInternalError(w, liveGrantErr)
+		return
+	}
 	writeJSON(w, http.StatusOK, itemsChangesResponse{
 		Changes:                    changes,
 		Cursor:                     strconv.FormatInt(cursorSeq, 10),
 		IncludesUnparentedMetadata: params.IncludeUnparentedMetadata,
+		AccessEpoch:                computeAccessEpoch(visibleIDs, liveGrantedItemIDs),
 	})
 }
 

--- a/internal/server/handlers_items_access_epoch_test.go
+++ b/internal/server/handlers_items_access_epoch_test.go
@@ -1,0 +1,253 @@
+package server
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// TestAccessEpoch_DoorsAgreeForAGrantOnASoftDeletedItem is the review-round-2
+// regression, and it exists because the fixture that was supposed to prove the
+// doors agree could not have caught this: it had no item grants at all, so both
+// doors hashed the same empty list and agreed for the wrong reason.
+//
+// The two doors resolve grants with DIFFERENT resolvers, deliberately:
+// /items-changes includes soft-deleted granted items so a tombstone still
+// reaches the client (TASK-1354), /items-index does not. Computing the
+// fingerprint from whatever each door happened to resolve made the two
+// permanently disagree for a caller holding a grant on a soft-deleted item —
+// and permanent disagreement between the value the client STORES and the value
+// it COMPARES is not a stale row, it is a resync loop: the snapshot restores
+// the index door's epoch, the next delta contradicts it, and the client runs
+// its reconcile to the 50-page cap on every sync trigger, forever.
+//
+// The fix is that the epoch has ONE definition — the live grant set, which is
+// also what the SSE tick holds. This test's fixture is the discriminating one:
+// a grant on an item that has been soft-deleted, which is exactly the input
+// that made the two resolvers differ.
+func TestAccessEpoch_DoorsAgreeForAGrantOnASoftDeletedItem(t *testing.T) {
+	srv := testServer(t)
+
+	owner, err := srv.store.CreateUser(models.UserCreate{
+		Email: "owner@example.com", Name: "Owner", Password: "correct-horse-battery-staple", Role: "admin",
+	})
+	if err != nil {
+		t.Fatalf("create owner: %v", err)
+	}
+	guest, err := srv.store.CreateUser(models.UserCreate{
+		Email: "guest@example.com", Name: "Guest", Password: "correct-horse-battery-staple", Role: "member",
+	})
+	if err != nil {
+		t.Fatalf("create guest: %v", err)
+	}
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "GrantEpoch", OwnerID: owner.ID})
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, owner.ID, "owner"); err != nil {
+		t.Fatalf("add owner: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, guest.ID, "editor"); err != nil {
+		t.Fatalf("add guest: %v", err)
+	}
+	schema := `{"fields":[{"key":"status","type":"select","options":["open","done"],"default":"open"}]}`
+	kept, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{Name: "Kept", Slug: "kept", Prefix: "KEP", Schema: schema})
+	if err != nil {
+		t.Fatalf("create kept: %v", err)
+	}
+	other, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{Name: "Other", Slug: "other", Prefix: "OTH", Schema: schema})
+	if err != nil {
+		t.Fatalf("create other: %v", err)
+	}
+	// Restricted to `kept`, plus an item-level grant into `other`.
+	if err := srv.store.SetMemberCollectionAccess(ws.ID, guest.ID, "specific", []string{kept.ID}); err != nil {
+		t.Fatalf("set collection access: %v", err)
+	}
+	granted, err := srv.store.CreateItem(ws.ID, other.ID, models.ItemCreate{Title: "Granted", Fields: `{"status":"open"}`})
+	if err != nil {
+		t.Fatalf("create granted item: %v", err)
+	}
+	if _, err := srv.store.CreateItemGrant(ws.ID, granted.ID, guest.ID, "view", owner.ID); err != nil {
+		t.Fatalf("create item grant: %v", err)
+	}
+	token, err := srv.store.CreateSession(guest.ID, "test", "192.0.2.1", testSessionUA, webSessionTTL)
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	epochs := func(when string) (string, string) {
+		t.Helper()
+		rr := getAuthedSession(t, srv, "/api/v1/workspaces/"+ws.Slug+"/items-index", token)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("%s items-index: %d: %s", when, rr.Code, rr.Body.String())
+		}
+		var index itemsIndexResponse
+		parseJSON(t, rr, &index)
+
+		rr = getAuthedSession(t, srv, "/api/v1/workspaces/"+ws.Slug+"/items-changes?since=0", token)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("%s items-changes: %d: %s", when, rr.Code, rr.Body.String())
+		}
+		var delta itemsChangesResponse
+		parseJSON(t, rr, &delta)
+		return index.AccessEpoch, delta.AccessEpoch
+	}
+
+	// Baseline: a LIVE grant. Both resolvers return it, so this leg agrees even
+	// on the unfixed code — it is here as the control that says the fixture
+	// reaches the grant path at all.
+	if idx, chg := epochs("live grant"); idx != chg {
+		t.Fatalf("doors disagree with a live grant: /items-index %q vs /items-changes %q", idx, chg)
+	}
+
+	// The discriminating leg: soft-delete the granted item. /items-changes'
+	// resolver still returns the grant; /items-index's does not.
+	if err := srv.store.DeleteItem(granted.ID); err != nil {
+		t.Fatalf("soft-delete granted item: %v", err)
+	}
+	idx, chg := epochs("soft-deleted grant")
+	if idx != chg {
+		t.Errorf("doors disagree after the granted item was soft-deleted: /items-index %q vs /items-changes %q\n"+
+			"a client storing one and comparing the other resyncs on every poll, forever", idx, chg)
+	}
+}
+
+// TestItemsChanges_AccessEpochChangesOnRevocation is the IDEA-2898 repro.
+//
+// The defect: a member's collection access is narrowed with NO accompanying
+// item write. No row changes, so /items-changes has nothing to say — and the
+// moved-out tombstone path (BUG-1675) only fires when an ITEM moves, not when
+// the CALLER's access set moves. The client's local index therefore keeps
+// serving the revoked collection's rows from its warm cache, which is what
+// ItemPicker lists.
+//
+// The assertion this test exists for is the SECOND half: the response must
+// carry a per-caller access fingerprint that CHANGES when the caller's
+// effective visible set changes, so the client can trigger the authoritative
+// resync it already implements (localIndex.svelte.ts resyncProjectionScope).
+//
+// The first half — that the delta itself carries no eviction signal — is
+// asserted too, and it is TRUE BOTH BEFORE AND AFTER the fix. It is the
+// mechanism, not the fix; it is here so a future reader can see why the
+// fingerprint is the signal rather than a tombstone.
+func TestItemsChanges_AccessEpochChangesOnRevocation(t *testing.T) {
+	srv := testServer(t)
+
+	admin, err := srv.store.CreateUser(models.UserCreate{
+		Email: "admin@example.com", Name: "Admin", Password: "correct-horse-battery-staple", Role: "admin",
+	})
+	if err != nil {
+		t.Fatalf("create admin: %v", err)
+	}
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "AccessEpochWS", OwnerID: admin.ID})
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, admin.ID, "owner"); err != nil {
+		t.Fatalf("add admin member: %v", err)
+	}
+	schema := `{"fields":[{"key":"status","type":"select","options":["open","done"],"default":"open"}]}`
+	kept, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{Name: "Kept", Slug: "kept", Prefix: "KEP", Schema: schema})
+	if err != nil {
+		t.Fatalf("create kept: %v", err)
+	}
+	revoked, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{Name: "Revoked", Slug: "revoked", Prefix: "REV", Schema: schema})
+	if err != nil {
+		t.Fatalf("create revoked: %v", err)
+	}
+
+	member, err := srv.store.CreateUser(models.UserCreate{
+		Email: "member@example.com", Name: "Member", Password: "correct-horse-battery-staple", Role: "member",
+	})
+	if err != nil {
+		t.Fatalf("create member: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, member.ID, "editor"); err != nil {
+		t.Fatalf("add member: %v", err)
+	}
+	// Both collections visible to start.
+	if err := srv.store.SetMemberCollectionAccess(ws.ID, member.ID, "specific", []string{kept.ID, revoked.ID}); err != nil {
+		t.Fatalf("set member collection access: %v", err)
+	}
+	token, err := srv.store.CreateSession(member.ID, "test", "192.0.2.1", testSessionUA, webSessionTTL)
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	item, err := srv.store.CreateItem(ws.ID, revoked.ID, models.ItemCreate{Title: "Secret title", Fields: `{"status":"open"}`})
+	if err != nil {
+		t.Fatalf("create item: %v", err)
+	}
+
+	// Baseline: the member can see the item, and the response carries an
+	// access fingerprint.
+	rr := getAuthedSession(t, srv, "/api/v1/workspaces/"+ws.Slug+"/items-changes?since=0", token)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("baseline items-changes: %d: %s", rr.Code, rr.Body.String())
+	}
+	var baseline itemsChangesResponse
+	parseJSON(t, rr, &baseline)
+	seen := false
+	for _, c := range baseline.Changes {
+		if c.ID == item.ID {
+			seen = true
+		}
+	}
+	if !seen {
+		t.Fatalf("member should see the item at baseline")
+	}
+	if baseline.AccessEpoch == "" {
+		t.Fatalf("baseline response carries no access_epoch")
+	}
+	baseCursor := baseline.Cursor
+	baseEpoch := baseline.AccessEpoch
+
+	// Revoke access to the collection holding the item. NOTHING is written to
+	// any item: this is the ordinary shape of revocation, and it is exactly
+	// the case the delta stream cannot express.
+	if err := srv.store.SetMemberCollectionAccess(ws.ID, member.ID, "specific", []string{kept.ID}); err != nil {
+		t.Fatalf("revoke collection access: %v", err)
+	}
+
+	rr = getAuthedSession(t, srv, "/api/v1/workspaces/"+ws.Slug+"/items-changes?since="+baseCursor, token)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("post-revocation items-changes: %d: %s", rr.Code, rr.Body.String())
+	}
+	var delta itemsChangesResponse
+	parseJSON(t, rr, &delta)
+
+	// The mechanism, true before AND after the fix: no row-level signal exists
+	// for this revocation. Asserting it is what makes the fingerprint's job
+	// legible — there is nothing else in this response that could evict.
+	for _, c := range delta.Changes {
+		if c.ID == item.ID {
+			t.Errorf("unexpected row-level eviction signal for the revoked item: moved_out=%v deleted=%v", c.MovedOut, c.Deleted)
+		}
+	}
+
+	// The fix: the fingerprint must have moved.
+	if delta.AccessEpoch == "" {
+		t.Fatalf("post-revocation response carries no access_epoch")
+	}
+	if delta.AccessEpoch == baseEpoch {
+		t.Errorf("access_epoch unchanged across a revocation (%q) — the client has no signal to resync", delta.AccessEpoch)
+	}
+
+	// Both doors must agree, or a cold bootstrap and a delta poll would
+	// disagree about the caller's scope and flap the resync.
+	rr = getAuthedSession(t, srv, "/api/v1/workspaces/"+ws.Slug+"/items-index", token)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("items-index: %d: %s", rr.Code, rr.Body.String())
+	}
+	var index itemsIndexResponse
+	parseJSON(t, rr, &index)
+	if index.AccessEpoch != delta.AccessEpoch {
+		t.Errorf("access_epoch disagrees across doors: /items-index %q vs /items-changes %q", index.AccessEpoch, delta.AccessEpoch)
+	}
+	for _, it := range index.Items {
+		if it.ID == item.ID {
+			t.Errorf("revoked item still returned by /items-index")
+		}
+	}
+}

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -253,6 +253,13 @@ function planLimitMessage(err: PadApiError): string {
  * see last time you synced" — a 403 mid-session means access was
  * revoked, and the offending entry should drop.
  *
+ * That decision covers a 403 on a READ the user actually made. It never
+ * covered a revocation the user does not click into — one that writes no
+ * row and so reaches no endpoint — which left the cache listing titles
+ * from a collection the caller could no longer open. IDEA-2898 closes
+ * that half elsewhere (an access fingerprint on the item doors, compared
+ * in localIndex); this handler is unchanged and still owns the 403.
+ *
  * The scope is the WHOLE WORKSPACE. Pad's server returns 403 from
  * the workspace-access middleware (see internal/server/middleware_auth.go:
  * `permission_denied`, `not a member of this workspace`), and item-
@@ -1069,6 +1076,7 @@ export const api = {
 				total: number;
 				cursor: string;
 				includes_unparented_metadata: boolean;
+				access_epoch?: string;
 			}>(
 				`/workspaces/${ws}/items-index${qs({
 					collection: opts?.collection,
@@ -1089,6 +1097,12 @@ export const api = {
 				total: raw.total,
 				cursor: raw.cursor,
 				includes_unparented_metadata: raw.includes_unparented_metadata === true,
+				// Passed through UNNORMALIZED, deliberately: the value is
+				// opaque and only ever compared for equality, and coercing an
+				// absent field to a string would turn "this server does not
+				// send it" into a value that can differ from a real one
+				// (IDEA-2898).
+				access_epoch: raw.access_epoch,
 			};
 		},
 
@@ -1122,6 +1136,7 @@ export const api = {
 				changes: (ItemChangeRow & { content?: string })[];
 				cursor: string;
 				includes_unparented_metadata: boolean;
+				access_epoch?: string;
 			}>(
 				`/workspaces/${ws}/items-changes${qs({
 					since: sinceCursor,
@@ -1142,6 +1157,12 @@ export const api = {
 				changes,
 				cursor: raw.cursor,
 				includes_unparented_metadata: raw.includes_unparented_metadata === true,
+				// Passed through UNNORMALIZED, deliberately: the value is
+				// opaque and only ever compared for equality, and coercing an
+				// absent field to a string would turn "this server does not
+				// send it" into a value that can differ from a real one
+				// (IDEA-2898).
+				access_epoch: raw.access_epoch,
 			};
 		},
 

--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -63,6 +63,7 @@ import {
 	persistDelta,
 	persistRemovals,
 	persistReplace,
+	persistAccessEpoch,
 	persistRetag,
 	persistUpserts,
 	wipe as persistWipe,
@@ -117,6 +118,13 @@ class WorkspaceState {
 	// and a revocation that writes no row leaves no other trace. Null only
 	// before the first response of a session lands.
 	accessEpoch = $state<string | null>(null);
+	// Has the DURABLE cache been read yet this session? (IDEA-2898, review of
+	// the reduced tip.) `accessEpoch === null` and `items.size === 0` say what
+	// RAM holds, which is not the same claim: during `bootstrap`'s hydrate
+	// await, RAM is empty and the cache on disk may be full. Adopting an epoch
+	// on that evidence is the silent adopt this change exists to prevent — see
+	// `ensureAccessScope`.
+	cacheRead = $state(false);
 
 	// `scopeEpoch` bumps every time a projection resync installs a new
 	// authoritative snapshot (i.e. the scope changed). Reconcile loops capture
@@ -591,6 +599,10 @@ export const localIndex = {
 						}
 					: await persistHydrate(userId, ws);
 				if (isStale()) return;
+				// The durable cache has now answered, whatever it said. From
+				// here an empty RAM state is evidence about the cache and not
+				// merely about how far bootstrap has got.
+				state.cacheRead = true;
 				// A populated cache is one we've successfully synced
 				// from before — either there are rows, or the cursor
 				// has moved off the "0" floor (empty workspaces /
@@ -1129,9 +1141,24 @@ export const localIndex = {
 				// Same joined-resync case as below.
 				if (state.accessEpoch === null) {
 					state.accessEpoch = accessEpoch;
+					await persistAccessEpoch(state.userId, ws, accessEpoch);
 				}
 				return true;
 			}
+			// AN EMPTY RAM STATE IS NOT AN EMPTY CACHE. This is the silent
+			// adopt, and it is only safe once the durable cache has actually
+			// answered: `bootstrap` awaits `hydrate` before it merges anything,
+			// and an SSE-driven `deltaSync` runs on its own subscription rather
+			// than behind that await, so it can reach this line with RAM empty
+			// and IDB holding rows from a scope nobody has checked. Adopting
+			// there would stamp the new epoch onto the durable cache — via the
+			// delta this caller is about to apply — and the stale row would then
+			// hydrate under an epoch that agrees with the server forever.
+			//
+			// Declining to adopt is the safe direction: the delta persists with
+			// a null epoch, and a null baseline over a populated cache resyncs
+			// on the next reconcile.
+			if (!state.cacheRead) return false;
 			state.accessEpoch = accessEpoch;
 			return false;
 		}
@@ -1156,6 +1183,14 @@ export const localIndex = {
 		// where we can tell the fallback was dropped.
 		if (state.accessEpoch === beforeResync) {
 			state.accessEpoch = accessEpoch;
+			// ...AND DURABLY, not only in RAM. The resync we JOINED ran its own
+			// `persistReplace` with its own baseline, so the meta row still
+			// records `beforeResync`; assigning here would leave RAM and disk
+			// disagreeing, and the next reload would hydrate the old baseline
+			// and resync again — every reload, for a scope that has not changed
+			// since. The started-resync path has no such gap, because its
+			// fallback is applied BEFORE the persist that happens inside it.
+			await persistAccessEpoch(state.userId, ws, accessEpoch);
 		}
 		return true;
 	},

--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -111,6 +111,12 @@ class WorkspaceState {
 	// persisted with the cursor because the same user/workspace cache can
 	// outlive a permission upgrade or downgrade.
 	includesUnparentedMetadata = $state<boolean | null>(null);
+	// The caller's access fingerprint as of the last authoritative snapshot or
+	// delta (IDEA-2898). Persisted with the cursor for the same reason
+	// `includesUnparentedMetadata` is: the cache outlives a permission change,
+	// and a revocation that writes no row leaves no other trace. Null only
+	// before the first response of a session lands.
+	accessEpoch = $state<string | null>(null);
 
 	// `scopeEpoch` bumps every time a projection resync installs a new
 	// authoritative snapshot (i.e. the scope changed). Reconcile loops capture
@@ -297,7 +303,21 @@ function rebuildSearchIndex(ws: string, state: WorkspaceState): void {
 	localSearch.rebuild(ws, state.items.values());
 }
 
-async function resyncProjectionScope(ws: string, state: WorkspaceState): Promise<void> {
+async function resyncProjectionScope(
+	ws: string,
+	state: WorkspaceState,
+	// The epoch the SERVER most recently told this caller, when the caller has
+	// one. Used only if the authoritative snapshot carries none — an older
+	// server answering /items-index during a mixed deployment. Passing it in
+	// rather than patching `state.accessEpoch` after the resync returns is what
+	// keeps RAM and IDB agreeing: `persistReplace` happens inside this
+	// function, so a post-hoc assignment would leave the durable meta row a
+	// version behind the in-memory baseline. The next warm boot hydrates the
+	// DURABLE one, so it would start from a baseline this session had already
+	// superseded and resync on its first delta — a full snapshot per reload,
+	// for a scope that never actually changed (round 2).
+	fallbackEpoch?: string,
+): Promise<void> {
 	const pending = projectionResyncs.get(ws);
 	if (pending) return pending;
 	const generation = state.generation;
@@ -378,6 +398,24 @@ async function resyncProjectionScope(ws: string, state: WorkspaceState): Promise
 		// for them. (The scope epoch was already bumped before the fetch above.)
 		state.fencedIds = new Set(toDrop);
 		state.includesUnparentedMetadata = resp.includes_unparented_metadata;
+		// The snapshot IS the new scope, so its epoch is the new baseline. Set
+		// here rather than at the call sites: every route into a resync ends
+		// here, and a baseline left stale would re-fire the resync on the very
+		// next poll.
+		//
+		// ABSENT means UNKNOWN, and unknown must not erase what we know
+		// (review round 1 F3). `?? null` here read "no epoch on the snapshot"
+		// as "this workspace has no baseline", which during a mixed deployment
+		// — a delta from a new server, a snapshot from an old one — sent the
+		// reconcile loop into the null-baseline branch and resynced again, up
+		// to the 50-page cap, a full snapshot per iteration. Keeping the prior
+		// value leaves the loop's own termination to `ensureAccessScope`,
+		// which records the epoch it was TOLD once a resync has run.
+		if (resp.access_epoch !== undefined) {
+			state.accessEpoch = resp.access_epoch;
+		} else if (fallbackEpoch !== undefined) {
+			state.accessEpoch = fallbackEpoch;
+		}
 		for (const row of resp.items) {
 			const next = toSkinny(row);
 			const existing = state.items.get(next.id);
@@ -430,6 +468,16 @@ async function resyncProjectionScope(ws: string, state: WorkspaceState): Promise
 			snapshot,
 			state.cursor,
 			resp.includes_unparented_metadata,
+			// The state's baseline, NOT `resp.access_epoch ?? null` (round 2).
+			// F3 deliberately keeps a known baseline when the snapshot carries
+			// no epoch; writing null here would contradict it in the durable
+			// copy. A null on disk is not a harmless gap: `ensureAccessScope`
+			// reads a null baseline over a POPULATED cache as "cannot know what
+			// this was authorised for" and resyncs, so the next warm boot would
+			// pay a full snapshot to rediscover the epoch this one already
+			// knew. The fix for an absent epoch on the wire must not become an
+			// absent epoch on disk.
+			state.accessEpoch,
 		);
 	})();
 	projectionResyncs.set(ws, promise);
@@ -538,6 +586,7 @@ export const localIndex = {
 							items: [],
 							cursor: state.cursor,
 							includesUnparentedMetadata: state.includesUnparentedMetadata,
+							accessEpoch: state.accessEpoch,
 							retags: {},
 						}
 					: await persistHydrate(userId, ws);
@@ -554,6 +603,13 @@ export const localIndex = {
 				const hasCache = reentry || cacheIsPopulated;
 				if (!reentry && cacheIsPopulated) {
 					state.includesUnparentedMetadata = cached.includesUnparentedMetadata;
+					// Adopt the PERSISTED epoch, not a fresh one — it is the
+					// baseline the first reconcile compares against, and it is
+					// the only record of what this cache was authorised for
+					// when it was written. Overwriting it with the incoming
+					// response's value is exactly the silent adopt that leaves
+					// an offline revocation undetected.
+					state.accessEpoch = cached.accessEpoch;
 					for (const row of cached.items) {
 						mergeRow(state, row);
 					}
@@ -628,6 +684,26 @@ export const localIndex = {
 								// data (Codex P2 round 8).
 								continue;
 							}
+							// IDEA-2898. The caller's visible set changed with no row
+							// change to carry it — a revocation writes no item, so
+							// nothing else in this response could evict the rows it
+							// hid. Delegated to `ensureAccessScope` rather than
+							// re-implemented here: an inline copy is a second
+							// definition of the same rule, and the first draft of it
+							// already diverged (it skipped the null-baseline case,
+							// which is precisely the offline-revocation cache this
+							// exists for). One tested function, two call sites.
+							//
+							// `continue`, never `break`, for the same reason as the
+							// projection branch below: the resync pins the cursor to
+							// the snapshot's, so post-snapshot mutations are only
+							// replayed if the loop polls again. It cannot re-fire,
+							// because the resync set the epoch to the snapshot's.
+							if (await localIndex.ensureAccessScope(ws, delta.access_epoch)) {
+								if (isStale()) return;
+								continue;
+							}
+							if (isStale()) return;
 							if (
 								state.includesUnparentedMetadata !== null &&
 								state.includesUnparentedMetadata !== delta.includes_unparented_metadata
@@ -714,10 +790,17 @@ export const localIndex = {
 						// state stays 'ready' so the UI keeps working.
 						// `pendingResync` remains true so the next
 						// bootstrap() call retries (Codex P2 round 5).
-						// Permission revocation that doesn't change
-						// row data is NOT covered here — TASK-1360 and
-						// DOC-1342 decision #3 explicitly punt that in
-						// favor of the 403-on-click purge path.
+						// Permission revocation that doesn't change row
+						// data used to be uncovered here — TASK-1360 and
+						// DOC-1342 decision #3 punted it in favour of the
+						// 403-on-click purge. IDEA-2898 covers it now, and
+						// not from this branch: the caller's access
+						// fingerprint rides on the delta response, and a
+						// change routes through `ensureAccessScope` above
+						// into an authoritative resync. What decision #3
+						// still owns is the item READ — a 403 on click. What
+						// it never reached is the LISTING, which is what
+						// ItemPicker does with these rows.
 						//
 						// A `rate_limited` (429) error lands here too and is
 						// intentionally treated as transient: the per-request
@@ -734,6 +817,9 @@ export const localIndex = {
 					});
 					if (isStale()) return;
 					state.includesUnparentedMetadata = resp.includes_unparented_metadata;
+					if (resp.access_epoch !== undefined) {
+						state.accessEpoch = resp.access_epoch;
+					}
 					for (const row of resp.items) {
 						mergeRow(state, row);
 					}
@@ -770,6 +856,10 @@ export const localIndex = {
 						snapshot,
 						state.cursor,
 						resp.includes_unparented_metadata,
+						// The baseline this snapshot established, so the durable
+						// meta row records the scope its rows were fetched under
+						// (IDEA-2898).
+						state.accessEpoch,
 					).catch(
 						() => undefined,
 					);
@@ -1004,10 +1094,75 @@ export const localIndex = {
 			toPersist,
 			newCursor,
 			includesUnparentedMetadata,
+			state.accessEpoch,
 			toRemove,
 		).catch(
 			() => undefined,
 		);
+	},
+
+	/**
+	 * Force a full snapshot when the caller's ACCESS set changes (IDEA-2898).
+	 *
+	 * The sibling of `ensureProjectionScope`, and deliberately the same shape:
+	 * both answer "the server just told me my scope is not what this cache was
+	 * built under". This one exists for the page-driven `/items-changes` poll,
+	 * which is the path a long-lived session uses after bootstrap has settled
+	 * — bootstrap's own reconcile loop carries the same comparison inline.
+	 *
+	 * Returns true when a resync ran, so the caller can skip applying a delta
+	 * that the snapshot has already superseded.
+	 */
+	async ensureAccessScope(ws: string, accessEpoch: string | undefined): Promise<boolean> {
+		// A server that does not send the field (an older build, mid-deploy)
+		// must not be read as "the set changed". Absence is not a value.
+		if (accessEpoch === undefined) return false;
+		const state = ensureState(ws);
+		if (state.accessEpoch === null) {
+			// No baseline. If this cache holds anything, we cannot know what it
+			// was authorised for, so the safe reading is that it may be stale —
+			// resync rather than adopt. Mirrors ensureProjectionScope's null
+			// branch exactly, including the "empty cache adopts silently" case,
+			// which costs nothing because there is nothing to evict.
+			if (state.items.size > 0 || cursorAsNum(state.cursor) > 0) {
+				await resyncProjectionScope(ws, state, accessEpoch);
+				// Same joined-resync case as below.
+				if (state.accessEpoch === null) {
+					state.accessEpoch = accessEpoch;
+				}
+				return true;
+			}
+			state.accessEpoch = accessEpoch;
+			return false;
+		}
+		if (state.accessEpoch === accessEpoch) return false;
+		// TERMINATION (round 1 F3). The resync adopts the snapshot's epoch when
+		// it has one. When it does not — an older server answering the snapshot
+		// while a newer one answers the delta — the baseline would be unchanged,
+		// the very next poll would compare it against the same incoming epoch,
+		// and it would resync again, forever. So the epoch we were TOLD goes in
+		// as the fallback: a true statement about what the server last said,
+		// which is all the baseline has ever claimed to be, and it lands in RAM
+		// and IDB together.
+		const beforeResync = state.accessEpoch;
+		await resyncProjectionScope(ws, state, accessEpoch);
+		// ...UNLESS THE RESYNC WAS JOINED, not started (round 3). Resyncs are
+		// deduplicated per workspace, so a resync already in flight — started
+		// by a projection mismatch, which passes no fallback — returns its
+		// promise and this caller's fallback is never seen. The baseline is then
+		// unchanged and the next poll asks again. Applying it here after the
+		// await covers the joined case without a second resync; it is the same
+		// statement ("the server last told us this"), made at the only point
+		// where we can tell the fallback was dropped.
+		if (state.accessEpoch === beforeResync) {
+			state.accessEpoch = accessEpoch;
+		}
+		return true;
+	},
+
+	/** The access fingerprint this workspace's cache was last built under. */
+	accessEpochFor(ws: string): string | null {
+		return workspaces.get(ws)?.accessEpoch ?? null;
 	},
 
 	/** Force a full snapshot when the server's projection capability changes. */

--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -115,8 +115,13 @@ class WorkspaceState {
 	// The caller's access fingerprint as of the last authoritative snapshot or
 	// delta (IDEA-2898). Persisted with the cursor for the same reason
 	// `includesUnparentedMetadata` is: the cache outlives a permission change,
-	// and a revocation that writes no row leaves no other trace. Null only
-	// before the first response of a session lands.
+	// and a revocation that writes no row leaves no other trace.
+	//
+	// Null means NO BASELINE, and that outlives the first response: a server
+	// that sends no epoch never supplies one, and the guard below declines to
+	// adopt until the durable cache has been read. A null baseline over a
+	// populated cache resyncs, which is the safe reading of "we cannot know
+	// what this was authorised for".
 	accessEpoch = $state<string | null>(null);
 	// Has the DURABLE cache been read yet this session? (IDEA-2898, review of
 	// the reduced tip.) `accessEpoch === null` and `items.size === 0` say what
@@ -595,6 +600,9 @@ export const localIndex = {
 							cursor: state.cursor,
 							includesUnparentedMetadata: state.includesUnparentedMetadata,
 							accessEpoch: state.accessEpoch,
+							// A reentry is not a read; the durable cache was
+							// read on the bootstrap that set this state up.
+							durableRead: state.cacheRead,
 							retags: {},
 						}
 					: await persistHydrate(userId, ws);
@@ -602,7 +610,13 @@ export const localIndex = {
 				// The durable cache has now answered, whatever it said. From
 				// here an empty RAM state is evidence about the cache and not
 				// merely about how far bootstrap has got.
-				state.cacheRead = true;
+				// `durableRead`, NOT an unconditional true: every failure inside
+				// `hydrate` returns the same empty payload a genuinely empty
+				// cache does, and treating a failed read as an empty cache is
+				// how a silent adopt gets back in through the front door
+				// (review round 2). A transient IDB failure now leaves the
+				// baseline unacquired, which costs a resync and hides nothing.
+				state.cacheRead = cached.durableRead;
 				// A populated cache is one we've successfully synced
 				// from before — either there are rows, or the cursor
 				// has moved off the "0" floor (empty workspaces /
@@ -1141,7 +1155,7 @@ export const localIndex = {
 				// Same joined-resync case as below.
 				if (state.accessEpoch === null) {
 					state.accessEpoch = accessEpoch;
-					await persistAccessEpoch(state.userId, ws, accessEpoch);
+					await persistAccessEpoch(state.userId, ws, accessEpoch, null);
 				}
 				return true;
 			}
@@ -1190,7 +1204,7 @@ export const localIndex = {
 			// and resync again — every reload, for a scope that has not changed
 			// since. The started-resync path has no such gap, because its
 			// fallback is applied BEFORE the persist that happens inside it.
-			await persistAccessEpoch(state.userId, ws, accessEpoch);
+			await persistAccessEpoch(state.userId, ws, accessEpoch, beforeResync);
 		}
 		return true;
 	},

--- a/web/src/lib/stores/localIndexAccessEpoch.svelte.test.ts
+++ b/web/src/lib/stores/localIndexAccessEpoch.svelte.test.ts
@@ -1,0 +1,264 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { api } from '$lib/api/client';
+import type { ItemIndexRow } from '$lib/types';
+import { localIndex } from './localIndex.svelte';
+import { localSearch } from './localSearch.svelte';
+
+/**
+ * IDEA-2898 — a revocation that writes no item.
+ *
+ * The whole class turns on a case the delta stream cannot express: the
+ * caller's visible set narrows, no row changes, and the warm local index goes
+ * on serving the revoked collection. `ItemPicker` reads that index through
+ * exactly two functions — `getByCollection` for its empty-query listing and
+ * `localSearch.search` (+ `findByIdOrSlug`) for its warm query — so every
+ * eviction assertion here is made against BOTH. Asserting only the store map
+ * would leave the MiniSearch index free to keep answering with a title the
+ * caller may no longer see, which is the disclosure this closes.
+ */
+
+const ws = 'access-epoch-test';
+
+function row(id: string, seq: number, collection = 'kept'): ItemIndexRow {
+	return {
+		id,
+		seq,
+		title: `Title ${id}`,
+		collection_slug: collection,
+		created_at: '2026-01-01T00:00:00Z',
+		updated_at: '2026-01-01T00:00:00Z',
+	} as ItemIndexRow;
+}
+
+/** Both of ItemPicker's read paths, asked about one id. */
+function pickerCanSee(id: string, collection: string): boolean {
+	const listed = localIndex
+		.getByCollection(ws, collection)
+		.some((r) => r.id === id);
+	const searched = localSearch
+		.search(ws, `Title ${id}`, { limit: 20 })
+		.some((hit) => hit.id === id);
+	return listed || searched;
+}
+
+/**
+ * Establish a baseline epoch on an EMPTY cache, then populate — the order a
+ * real session takes (a cold snapshot carries the epoch that describes it).
+ * Adopting a baseline onto an already-populated cache is not a no-op: it is
+ * the unknown-provenance case, and it resyncs by design (see "resyncs a
+ * populated cache that carries no baseline epoch").
+ */
+async function seedUnder(epoch: string, rows: ItemIndexRow[]): Promise<void> {
+	await localIndex.ensureAccessScope(ws, epoch);
+	for (const r of rows) localIndex.upsert(ws, r);
+	localIndex.applyDelta(ws, [], String(rows.length), false);
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	localIndex.reset(ws);
+});
+
+describe('localIndex access-epoch scope', () => {
+	it('evicts a revoked collection from both ItemPicker read paths when the epoch changes', async () => {
+		await seedUnder('epoch-before', [row('keeper', 1, 'kept'), row('secret', 2, 'revoked')]);
+		expect(pickerCanSee('secret', 'revoked')).toBe(true);
+
+		// The authoritative snapshot under the narrowed scope omits the revoked
+		// collection entirely — which is what makes the eviction exact rather
+		// than a client-side guess about what the server would allow.
+		vi.spyOn(api.items, 'listIndex').mockResolvedValueOnce({
+			items: [row('keeper', 1, 'kept')],
+			total: 1,
+			cursor: '2',
+			includes_unparented_metadata: false,
+			access_epoch: 'epoch-after',
+		});
+
+		expect(await localIndex.ensureAccessScope(ws, 'epoch-after')).toBe(true);
+		expect(pickerCanSee('secret', 'revoked')).toBe(false);
+		// The control leg: eviction is scoped to what the snapshot dropped, not
+		// a blanket wipe that would look identical on the assertion above.
+		expect(pickerCanSee('keeper', 'kept')).toBe(true);
+		expect(localIndex.accessEpochFor(ws)).toBe('epoch-after');
+	});
+
+	it('does not resync when the epoch is unchanged', async () => {
+		await seedUnder('steady', [row('keeper', 1, 'kept')]);
+
+		const listIndex = vi.spyOn(api.items, 'listIndex');
+		expect(await localIndex.ensureAccessScope(ws, 'steady')).toBe(false);
+		// A resync on every poll would be strictly worse than the defect: it
+		// re-fetches the whole index each time. Asserting the REQUEST was never
+		// issued is the only thing that can tell "no resync" apart from "a
+		// resync that happened to change nothing".
+		expect(listIndex).not.toHaveBeenCalled();
+	});
+
+	it('does not resync when the server sends no epoch at all', async () => {
+		await seedUnder('known', [row('keeper', 1, 'kept')]);
+
+		const listIndex = vi.spyOn(api.items, 'listIndex');
+		// An older server mid-deploy. Absence is not a value: reading it as a
+		// changed set would make every poll against such a server a full
+		// resync, and reading it as an unchanged set is what we do instead.
+		expect(await localIndex.ensureAccessScope(ws, undefined)).toBe(false);
+		expect(listIndex).not.toHaveBeenCalled();
+		expect(localIndex.accessEpochFor(ws)).toBe('known');
+	});
+
+	it('resyncs a populated cache that carries no baseline epoch', async () => {
+		// The offline-revocation case, and the reason the epoch is persisted at
+		// all: this cache was written under some scope nobody recorded, so it
+		// cannot be shown to be current. Adopting the incoming epoch here would
+		// mark stale rows as authorised without ever checking them.
+		localIndex.upsert(ws, row('unknown-provenance', 1, 'kept'));
+		localIndex.applyDelta(ws, [], '1', false);
+		expect(localIndex.accessEpochFor(ws)).toBeNull();
+
+		const listIndex = vi.spyOn(api.items, 'listIndex').mockResolvedValueOnce({
+			items: [],
+			total: 0,
+			cursor: '1',
+			includes_unparented_metadata: false,
+			access_epoch: 'fresh',
+		});
+		expect(await localIndex.ensureAccessScope(ws, 'fresh')).toBe(true);
+		expect(listIndex).toHaveBeenCalled();
+		expect(pickerCanSee('unknown-provenance', 'kept')).toBe(false);
+	});
+
+	it("reaches the comparison from bootstrap's own reconcile loop, not just the page's poll", async () => {
+		// CONVE-19: the comparison being CORRECT is proved by the tests above;
+		// this proves it is REACHED from the path every route shares. It matters
+		// because the page-driven poll lives in the collection route component,
+		// so item detail and the copy dialog — the picker's actual home — only
+		// ever reconcile through here. A version of this change that wired only
+		// the page would pass every other test in this file.
+		const listIndex = vi.spyOn(api.items, 'listIndex');
+
+		// Cold boot: one authoritative snapshot, two collections visible.
+		listIndex.mockResolvedValueOnce({
+			items: [row('keeper', 1, 'kept'), row('secret', 2, 'revoked')],
+			total: 2,
+			cursor: '2',
+			includes_unparented_metadata: false,
+			access_epoch: 'e1',
+		});
+		await localIndex.bootstrap(ws, { userId: null });
+		expect(pickerCanSee('secret', 'revoked')).toBe(true);
+
+		// Put the workspace into the reentry state the reconcile loop runs in
+		// (ready + pendingResync), the way a real resync does.
+		listIndex.mockResolvedValueOnce({
+			items: [row('keeper', 1, 'kept'), row('secret', 2, 'revoked')],
+			total: 2,
+			cursor: '2',
+			includes_unparented_metadata: false,
+			access_epoch: 'e2',
+		});
+		expect(await localIndex.ensureAccessScope(ws, 'e2')).toBe(true);
+		expect(pickerCanSee('secret', 'revoked')).toBe(true);
+
+		// Now the revocation, visible ONLY as a changed epoch on the delta.
+		vi.spyOn(api.items, 'changes').mockResolvedValue({
+			changes: [],
+			cursor: '5',
+			includes_unparented_metadata: false,
+			access_epoch: 'e3',
+		});
+		listIndex.mockResolvedValueOnce({
+			items: [row('keeper', 1, 'kept')],
+			total: 1,
+			cursor: '5',
+			includes_unparented_metadata: false,
+			access_epoch: 'e3',
+		});
+
+		await localIndex.bootstrap(ws, { userId: null });
+
+		expect(pickerCanSee('secret', 'revoked')).toBe(false);
+		expect(pickerCanSee('keeper', 'kept')).toBe(true);
+		expect(localIndex.accessEpochFor(ws)).toBe('e3');
+	});
+
+	it('keeps a known baseline when a snapshot carries no epoch, and stops asking', async () => {
+		// Review round 1, F3. Mixed deployment: the delta comes from a server
+		// that sends the field, the resync's snapshot from one that does not.
+		// `?? null` read absent as "no baseline", so the null-baseline branch
+		// resynced again on the next poll — a full snapshot per iteration up to
+		// the 50-page cap.
+		//
+		// The counterfactual is the whole test: ONE resync, not two. Asserting
+		// only that the first resync happened would pass on the unfixed code.
+		await seedUnder('old', [row('keeper', 1, 'kept')]);
+
+		const listIndex = vi.spyOn(api.items, 'listIndex').mockResolvedValue({
+			items: [row('keeper', 1, 'kept')],
+			total: 1,
+			cursor: '1',
+			includes_unparented_metadata: false,
+			// No access_epoch: an older server answering the snapshot.
+		});
+
+		expect(await localIndex.ensureAccessScope(ws, 'new')).toBe(true);
+		// The baseline is what the server TOLD us, not null — a true statement
+		// about what we were last told, which is all the baseline ever claims.
+		expect(localIndex.accessEpochFor(ws)).toBe('new');
+
+		expect(await localIndex.ensureAccessScope(ws, 'new')).toBe(false);
+		expect(listIndex).toHaveBeenCalledTimes(1);
+	});
+
+	it('records the told-epoch even when it JOINS a resync that was already running', async () => {
+		// Round 3, P2. Resyncs are deduplicated per workspace, so a resync
+		// already in flight — started by a PROJECTION mismatch, which passes no
+		// fallback — returns its promise and the access caller's fallback is
+		// never seen. The baseline then stays unchanged and the next poll asks
+		// for the same resync again.
+		//
+		// The instrument has to hold the first resync OPEN across the second
+		// call, or the two never overlap and the test passes against code that
+		// has the bug. That timing is the test.
+		await seedUnder('old', [row('keeper', 1, 'kept')]);
+
+		let release: (() => void) | null = null;
+		let inFlight: () => void = () => {};
+		const started = new Promise<void>((res) => {
+			inFlight = res;
+		});
+		const snapshot = {
+			items: [row('keeper', 1, 'kept')],
+			total: 1,
+			cursor: '1',
+			includes_unparented_metadata: true,
+			// No access_epoch — the mixed-deployment case, so only a fallback
+			// can move the baseline.
+		};
+		vi.spyOn(api.items, 'listIndex').mockImplementationOnce(() => {
+			inFlight();
+			return new Promise((res) => {
+				release = () => res(snapshot as never);
+			}) as never;
+		});
+
+		// Projection mismatch starts the resync; it passes no fallback.
+		const projection = localIndex.ensureProjectionScope(ws, true);
+		await started;
+		// The access caller joins the SAME promise.
+		const access = localIndex.ensureAccessScope(ws, 'told');
+		release!();
+		await Promise.all([projection, access]);
+
+		expect(localIndex.accessEpochFor(ws)).toBe('told');
+	});
+
+	it('adopts silently when there is no baseline and nothing cached', async () => {
+		// Nothing to evict, so a resync would buy nothing and cost a full
+		// index fetch on every cold start.
+		const listIndex = vi.spyOn(api.items, 'listIndex');
+		expect(await localIndex.ensureAccessScope(ws, 'first')).toBe(false);
+		expect(listIndex).not.toHaveBeenCalled();
+		expect(localIndex.accessEpochFor(ws)).toBe('first');
+	});
+});

--- a/web/src/lib/stores/localIndexAccessEpoch.svelte.test.ts
+++ b/web/src/lib/stores/localIndexAccessEpoch.svelte.test.ts
@@ -182,6 +182,30 @@ describe('localIndex access-epoch scope', () => {
 		expect(localIndex.accessEpochFor(ws)).toBe('e3');
 	});
 
+	it('adopts the COLD snapshot\'s epoch, so the next quiet poll does not resync', async () => {
+		// The cold bootstrap path is the only place a first-ever session gets a
+		// baseline. Dropping it there is invisible to every eviction test in
+		// this file — the cache would simply have no baseline, and a
+		// null baseline over a populated cache resyncs, which LOOKS like the
+		// change working. The discriminating case is the QUIET one: an
+		// unchanged scope must cost nothing.
+		const listIndex = vi.spyOn(api.items, 'listIndex');
+		listIndex.mockResolvedValueOnce({
+			items: [row('keeper', 1, 'kept')],
+			total: 1,
+			cursor: '1',
+			includes_unparented_metadata: false,
+			access_epoch: 'cold-e1',
+		});
+		await localIndex.bootstrap(ws, { userId: null });
+		expect(localIndex.accessEpochFor(ws)).toBe('cold-e1');
+
+		listIndex.mockClear();
+		// Same scope as the snapshot just installed. Nothing to do.
+		expect(await localIndex.ensureAccessScope(ws, 'cold-e1')).toBe(false);
+		expect(listIndex).not.toHaveBeenCalled();
+	});
+
 	it('keeps a known baseline when a snapshot carries no epoch, and stops asking', async () => {
 		// Review round 1, F3. Mixed deployment: the delta comes from a server
 		// that sends the field, the resync's snapshot from one that does not.

--- a/web/src/lib/stores/localIndexAccessEpoch.svelte.test.ts
+++ b/web/src/lib/stores/localIndexAccessEpoch.svelte.test.ts
@@ -42,16 +42,28 @@ function pickerCanSee(id: string, collection: string): boolean {
 }
 
 /**
- * Establish a baseline epoch on an EMPTY cache, then populate — the order a
- * real session takes (a cold snapshot carries the epoch that describes it).
- * Adopting a baseline onto an already-populated cache is not a no-op: it is
- * the unknown-provenance case, and it resyncs by design (see "resyncs a
- * populated cache that carries no baseline epoch").
+ * Establish a baseline epoch and populate the index, the order a real session
+ * takes: a cold snapshot carries the epoch that describes it. Adopting a
+ * baseline onto an already-populated cache is not a no-op — it is the
+ * unknown-provenance case, and it resyncs by design (see "resyncs a populated
+ * cache that carries no baseline epoch").
  */
 async function seedUnder(epoch: string, rows: ItemIndexRow[]): Promise<void> {
-	await localIndex.ensureAccessScope(ws, epoch);
-	for (const r of rows) localIndex.upsert(ws, r);
-	localIndex.applyDelta(ws, [], String(rows.length), false);
+	// Through a COLD BOOTSTRAP, which is how a real session acquires its first
+	// baseline: the snapshot carries the epoch that describes it. The earlier
+	// shortcut — calling `ensureAccessScope` on a never-bootstrapped workspace —
+	// stopped working when the silent adopt was gated on the durable cache
+	// having answered, and it was the less faithful of the two anyway.
+	const listIndex = vi.spyOn(api.items, 'listIndex');
+	listIndex.mockResolvedValueOnce({
+		items: rows,
+		total: rows.length,
+		cursor: String(rows.length),
+		includes_unparented_metadata: false,
+		access_epoch: epoch,
+	});
+	await localIndex.bootstrap(ws, { userId: null });
+	listIndex.mockClear();
 }
 
 afterEach(() => {
@@ -277,12 +289,48 @@ describe('localIndex access-epoch scope', () => {
 		expect(localIndex.accessEpochFor(ws)).toBe('told');
 	});
 
-	it('adopts silently when there is no baseline and nothing cached', async () => {
+	it('adopts silently when there is no baseline and the cache is known empty', async () => {
 		// Nothing to evict, so a resync would buy nothing and cost a full
 		// index fetch on every cold start.
+		//
+		// PROPERTY CHANGED in review of the reduced tip, and said out loud
+		// rather than quietly rewritten: this used to hold for a workspace that
+		// had never been bootstrapped at all. It no longer does, because RAM
+		// being empty was standing in for "the cache is empty" and those are
+		// different claims while a hydrate is still in flight. The cold
+		// bootstrap below is what makes the cache's emptiness KNOWN; the
+		// unbootstrapped case is the next test.
 		const listIndex = vi.spyOn(api.items, 'listIndex');
+		listIndex.mockResolvedValueOnce({
+			items: [],
+			total: 0,
+			cursor: '0',
+			includes_unparented_metadata: false,
+		});
+		await localIndex.bootstrap(ws, { userId: null });
+		listIndex.mockClear();
+
 		expect(await localIndex.ensureAccessScope(ws, 'first')).toBe(false);
 		expect(listIndex).not.toHaveBeenCalled();
 		expect(localIndex.accessEpochFor(ws)).toBe('first');
+	});
+
+	it('does NOT adopt before the durable cache has answered', async () => {
+		// The race this closes: `bootstrap` awaits `hydrate` before it merges
+		// anything, but an SSE-driven `deltaSync` runs on its own subscription
+		// rather than behind that await — so it can reach the comparison with
+		// RAM empty and IDB holding rows from a scope nobody has checked.
+		// Adopting there stamps the new epoch onto the durable cache through
+		// the delta that follows, and the stale row then hydrates under an
+		// epoch that agrees with the server forever: the signal is not merely
+		// wrong once, it is permanently inert.
+		//
+		// Declining costs nothing. The delta persists with a null epoch, and a
+		// null baseline over a populated cache resyncs on the next reconcile.
+		const listIndex = vi.spyOn(api.items, 'listIndex');
+
+		expect(await localIndex.ensureAccessScope(ws, 'e2')).toBe(false);
+		expect(listIndex).not.toHaveBeenCalled();
+		expect(localIndex.accessEpochFor(ws)).toBeNull();
 	});
 });

--- a/web/src/lib/stores/localIndexAccessEpochPageWiring.test.ts
+++ b/web/src/lib/stores/localIndexAccessEpochPageWiring.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * IDEA-2898 — a SOURCE PIN for the page-level call site, and an honest
+ * statement of what it is worth.
+ *
+ * The collection route's `deltaSync` is the second driver of the access-epoch
+ * comparison (the first, bootstrap's reconcile loop, is pinned BEHAVIOURALLY in
+ * localIndexAccessEpoch.svelte.test.ts). It lives inside a ~3700-line page
+ * component with no component-level harness, and a mutation run confirmed the
+ * gap rather than assuming it: disabling the call left every other test in this
+ * unit green.
+ *
+ * NARROWED from the version on the full branch, which pinned TWO call sites.
+ * The second — `applyDelta` declaring the epoch its batch was built under — was
+ * part of the cross-tab pairing guard, which moved to PLAN-2903 along with the
+ * code it guarded. This pin covers only what this branch ships.
+ *
+ * WHAT THIS PROVES: that the comparison is still invoked at that call site, so
+ * its silent removal fails a test instead of nothing.
+ *
+ * WHAT IT DOES NOT PROVE: that the surrounding logic is correct, that the call
+ * is reached, or that the value is the right one. It is a tripwire, not a test
+ * of behaviour, and it should be DELETED the day the page's deltaSync grows a
+ * real harness or moves into the store (IDEA-2901 would move it).
+ *
+ * AND ITS MEASURED LIMIT, because a pin that is trusted further than it reaches
+ * is worse than none. Two mutants were run against it. Deleting the call KILLS
+ * it, which is the silent-removal shape it exists for. Short-circuiting the
+ * call — `if (false && await localIndex.ensureAccessScope(...))` — SURVIVES,
+ * because the text this pin matches is still on the line. A source pin cannot
+ * see reachability; only a harness on that component could, and that is the
+ * same missing harness that makes this file necessary.
+ *
+ * The anchor is deliberately the enclosing call rather than a bare identifier —
+ * `access_epoch` appears in that file for several unrelated reasons and a
+ * substring match would pass while the call was gone.
+ */
+const pageSource = readFileSync(
+	fileURLToPath(
+		new URL('../../routes/[username]/[workspace]/[collection]/+page.svelte', import.meta.url),
+	),
+	'utf8',
+);
+
+describe('IDEA-2898 — the collection route still drives the access-epoch comparison', () => {
+	it('compares the delta epoch before applying, via ensureAccessScope', () => {
+		expect(pageSource).toContain('localIndex.ensureAccessScope(ws, delta.access_epoch)');
+	});
+});

--- a/web/src/lib/stores/localIndexAccessEpochWiring.svelte.test.ts
+++ b/web/src/lib/stores/localIndexAccessEpochWiring.svelte.test.ts
@@ -57,6 +57,54 @@ afterEach(() => {
 });
 
 describe('IDEA-2898 — what the resync hands on', () => {
+	it('adopts the PERSISTED epoch on a warm hydrate, so an unchanged scope costs nothing', async () => {
+		// The offline-revocation case turns on this line, and its absence is
+		// almost invisible: with no baseline adopted, a populated cache resyncs
+		// on the first delta, which looks like detection working. The
+		// discriminating case is the QUIET one — a cache whose scope has NOT
+		// changed must not pay a full snapshot on every reload.
+		//
+		// Needs the mocked persistence module: jsdom has no IndexedDB, so the
+		// real `hydrate` always returns an empty cache and the warm branch is
+		// unreachable in the behavioural file.
+		persistence.hydrate.mockResolvedValueOnce({
+			items: [row('cached', 1, 'kept')],
+			cursor: '1',
+			includesUnparentedMetadata: false,
+			accessEpoch: 'persisted-e1',
+			retags: {},
+		} as unknown as Awaited<ReturnType<typeof persistence.hydrate>>);
+		const listIndex = vi.spyOn(api.items, 'listIndex');
+		vi.spyOn(api.items, 'changes').mockResolvedValue({
+			changes: [],
+			cursor: '1',
+			includes_unparented_metadata: false,
+			access_epoch: 'persisted-e1',
+		});
+
+		await localIndex.bootstrap(ws, { userId: null });
+
+		expect(localIndex.accessEpochFor(ws)).toBe('persisted-e1');
+		// The scope the cache was written under is the scope the server still
+		// reports, so no authoritative snapshot was needed.
+		expect(listIndex).not.toHaveBeenCalled();
+	});
+
+	it('hands persistDelta the baseline the rows were applied under', async () => {
+		// `applyDelta` writes through to IDB, and the meta row it stamps is the
+		// ONLY record of the scope for the next session. Passing null there
+		// leaves every reload with no baseline over a populated cache, which
+		// resyncs on the first delta — a full snapshot per reload, forever, for
+		// a scope that never changed. Invisible in jsdom, where persistence is
+		// a no-op, so it is asserted as an ARGUMENT.
+		await localIndex.ensureAccessScope(ws, 'e1');
+		localIndex.applyDelta(ws, [], '7', false);
+
+		expect(persistence.persistDelta).toHaveBeenCalled();
+		const args = persistence.persistDelta.mock.calls.at(-1) as unknown[];
+		expect(args[5]).toBe('e1');
+	});
+
 	it('writes the PRESERVED baseline to IDB when a resync snapshot carries no epoch', async () => {
 		// F3 keeps a known baseline in RAM when the snapshot has none. Writing
 		// `null` to the durable copy would contradict it, and the contradiction

--- a/web/src/lib/stores/localIndexAccessEpochWiring.svelte.test.ts
+++ b/web/src/lib/stores/localIndexAccessEpochWiring.svelte.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { api } from '$lib/api/client';
+import type { ItemIndexRow } from '$lib/types';
+
+/**
+ * IDEA-2898 — the WIRING assertion (CONVE-19).
+ *
+ * One of this change's properties is not about what a function decides but
+ * about what it HANDS ON: a resync writing `null` to the durable epoch while
+ * deliberately keeping a known one in RAM. It is invisible to a behavioural
+ * test in jsdom, because IDB is unsupported there and the persistence calls are
+ * no-ops — the store's own tests would pass with the argument dropped.
+ *
+ * So this file mocks the persistence module and asserts the ARGUMENT. That is a
+ * weaker kind of test and it is the right one here: the question is whether the
+ * caller passes the value, not whether the callee honours it (the callee is
+ * pinned by localIndexPersistenceAccessEpoch.idb.test.ts against a real
+ * database).
+ */
+
+const persistence = vi.hoisted(() => ({
+	hydrate: vi.fn(async () => ({
+		items: [],
+		cursor: '0',
+		includesUnparentedMetadata: null,
+		accessEpoch: null,
+		retags: {},
+	})),
+	persistDelta: vi.fn(async () => undefined),
+	persistRemovals: vi.fn(async () => undefined),
+	persistReplace: vi.fn(async () => undefined),
+	persistRetag: vi.fn(async () => undefined),
+	persistUpserts: vi.fn(async () => undefined),
+	wipe: vi.fn(async () => undefined),
+}));
+vi.mock('./localIndexPersistence', () => persistence);
+
+const { localIndex } = await import('./localIndex.svelte');
+
+const ws = 'access-epoch-wiring';
+
+function row(id: string, seq: number, collection = 'kept'): ItemIndexRow {
+	return {
+		id,
+		seq,
+		title: `Title ${id}`,
+		collection_slug: collection,
+		created_at: '2026-01-01T00:00:00Z',
+		updated_at: '2026-01-01T00:00:00Z',
+	} as ItemIndexRow;
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	for (const fn of Object.values(persistence)) fn.mockClear();
+	localIndex.reset(ws);
+});
+
+describe('IDEA-2898 — what the resync hands on', () => {
+	it('writes the PRESERVED baseline to IDB when a resync snapshot carries no epoch', async () => {
+		// F3 keeps a known baseline in RAM when the snapshot has none. Writing
+		// `null` to the durable copy would contradict it, and the contradiction
+		// outlives the session: the next warm boot hydrates the durable value,
+		// reads a null baseline over a populated cache as "cannot know what
+		// this was authorised for", and pays a full snapshot to rediscover the
+		// epoch this session already knew.
+		await localIndex.ensureAccessScope(ws, 'e1');
+		localIndex.upsert(ws, row('keeper', 1, 'kept'));
+		localIndex.applyDelta(ws, [], '1', false);
+
+		vi.spyOn(api.items, 'listIndex').mockResolvedValueOnce({
+			items: [row('keeper', 1, 'kept')],
+			total: 1,
+			cursor: '1',
+			includes_unparented_metadata: false,
+			// No access_epoch — an older server answering the snapshot.
+		});
+		await localIndex.ensureAccessScope(ws, 'e2');
+
+		expect(persistence.persistReplace).toHaveBeenCalled();
+		const args = persistence.persistReplace.mock.calls.at(-1) as unknown[];
+		expect(args[5]).not.toBeNull();
+		expect(args[5]).toBe(localIndex.accessEpochFor(ws));
+	});
+});

--- a/web/src/lib/stores/localIndexAccessEpochWiring.svelte.test.ts
+++ b/web/src/lib/stores/localIndexAccessEpochWiring.svelte.test.ts
@@ -29,6 +29,7 @@ const persistence = vi.hoisted(() => ({
 	persistDelta: vi.fn(async () => undefined),
 	persistRemovals: vi.fn(async () => undefined),
 	persistReplace: vi.fn(async () => undefined),
+	persistAccessEpoch: vi.fn(async () => undefined),
 	persistRetag: vi.fn(async () => undefined),
 	persistUpserts: vi.fn(async () => undefined),
 	wipe: vi.fn(async () => undefined),
@@ -90,6 +91,104 @@ describe('IDEA-2898 — what the resync hands on', () => {
 		expect(listIndex).not.toHaveBeenCalled();
 	});
 
+	it('persists the told epoch after a JOINED resync, not only in RAM', async () => {
+		// Resyncs are deduplicated per workspace. When `ensureAccessScope`
+		// joins one that is already running, that resync did its own
+		// `persistReplace` under its OWN baseline — so assigning the told epoch
+		// afterwards updates RAM and leaves the meta row behind. The session
+		// converges and every reload then hydrates the stale baseline and pays
+		// a full resync for a scope that has not changed since. Invisible to a
+		// single-session behavioural test, which is why it is asserted here.
+		persistence.hydrate.mockResolvedValueOnce({
+			items: [row('cached', 1, 'kept')],
+			cursor: '1',
+			includesUnparentedMetadata: false,
+			accessEpoch: 'e1',
+			retags: {},
+		} as unknown as Awaited<ReturnType<typeof persistence.hydrate>>);
+		vi.spyOn(api.items, 'changes').mockResolvedValue({
+			changes: [],
+			cursor: '1',
+			includes_unparented_metadata: false,
+			access_epoch: 'e1',
+		});
+		await localIndex.bootstrap(ws, { userId: null });
+		expect(localIndex.accessEpochFor(ws)).toBe('e1');
+
+		// A resync that carries NO epoch on its snapshot, started first and
+		// still in flight, so the next caller joins it rather than starting one.
+		let releaseSnapshot: (() => void) | undefined;
+		vi.spyOn(api.items, 'listIndex').mockReturnValue(
+			new Promise((resolve) => {
+				releaseSnapshot = () =>
+					resolve({
+						items: [row('cached', 1, 'kept')],
+						total: 1,
+						cursor: '1',
+						includes_unparented_metadata: false,
+						// No access_epoch: an older server answering the snapshot.
+					});
+			}) as unknown as ReturnType<typeof api.items.listIndex>,
+		);
+		const first = localIndex.ensureProjectionScope(ws, true);
+		const joined = localIndex.ensureAccessScope(ws, 'e2');
+		releaseSnapshot?.();
+		await Promise.all([first, joined]);
+
+		expect(localIndex.accessEpochFor(ws)).toBe('e2');
+		expect(persistence.persistAccessEpoch).toHaveBeenCalled();
+		const args = persistence.persistAccessEpoch.mock.calls.at(-1) as unknown[];
+		expect(args[2]).toBe('e2');
+	});
+
+	it('persists the told epoch after a joined resync on a NULL baseline too', async () => {
+		// The same durable-repair as above, on the other branch. A populated
+		// cache with no recorded baseline resyncs by design; if that resync is
+		// one it JOINED, the meta row is left with no epoch and the very next
+		// reload repeats the whole thing. Two branches, one property — and the
+		// first version of this fix had it on only one of them, which no test
+		// in this file could tell apart.
+		persistence.hydrate.mockResolvedValueOnce({
+			items: [row('cached', 1, 'kept')],
+			cursor: '1',
+			includesUnparentedMetadata: false,
+			accessEpoch: null,
+			retags: {},
+		} as unknown as Awaited<ReturnType<typeof persistence.hydrate>>);
+		vi.spyOn(api.items, 'changes').mockResolvedValue({
+			changes: [],
+			cursor: '1',
+			includes_unparented_metadata: false,
+		});
+		let releaseSnapshot: (() => void) | undefined;
+		vi.spyOn(api.items, 'listIndex').mockReturnValue(
+			new Promise((resolve) => {
+				releaseSnapshot = () =>
+					resolve({
+						items: [row('cached', 1, 'kept')],
+						total: 1,
+						cursor: '1',
+						includes_unparented_metadata: false,
+						// No access_epoch on the snapshot.
+					});
+			}) as unknown as ReturnType<typeof api.items.listIndex>,
+		);
+		await localIndex.bootstrap(ws, { userId: null });
+		expect(localIndex.accessEpochFor(ws)).toBeNull();
+
+		persistence.persistAccessEpoch.mockClear();
+		const first = localIndex.ensureProjectionScope(ws, true);
+		const joined = localIndex.ensureAccessScope(ws, 'told');
+		releaseSnapshot?.();
+		await Promise.all([first, joined]);
+
+		expect(localIndex.accessEpochFor(ws)).toBe('told');
+		expect(persistence.persistAccessEpoch).toHaveBeenCalled();
+		expect(
+			(persistence.persistAccessEpoch.mock.calls.at(-1) as unknown[])[2],
+		).toBe('told');
+	});
+
 	it('hands persistDelta the baseline the rows were applied under', async () => {
 		// `applyDelta` writes through to IDB, and the meta row it stamps is the
 		// ONLY record of the scope for the next session. Passing null there
@@ -97,7 +196,18 @@ describe('IDEA-2898 — what the resync hands on', () => {
 		// resyncs on the first delta — a full snapshot per reload, forever, for
 		// a scope that never changed. Invisible in jsdom, where persistence is
 		// a no-op, so it is asserted as an ARGUMENT.
-		await localIndex.ensureAccessScope(ws, 'e1');
+		// Through a cold bootstrap, because the silent adopt now requires the
+		// durable cache to have answered first.
+		vi.spyOn(api.items, 'listIndex').mockResolvedValueOnce({
+			items: [],
+			total: 0,
+			cursor: '0',
+			includes_unparented_metadata: false,
+			access_epoch: 'e1',
+		});
+		await localIndex.bootstrap(ws, { userId: null });
+		persistence.persistDelta.mockClear();
+
 		localIndex.applyDelta(ws, [], '7', false);
 
 		expect(persistence.persistDelta).toHaveBeenCalled();

--- a/web/src/lib/stores/localIndexAccessEpochWiring.svelte.test.ts
+++ b/web/src/lib/stores/localIndexAccessEpochWiring.svelte.test.ts
@@ -24,6 +24,7 @@ const persistence = vi.hoisted(() => ({
 		cursor: '0',
 		includesUnparentedMetadata: null,
 		accessEpoch: null,
+		durableRead: true,
 		retags: {},
 	})),
 	persistDelta: vi.fn(async () => undefined),
@@ -73,6 +74,7 @@ describe('IDEA-2898 — what the resync hands on', () => {
 			cursor: '1',
 			includesUnparentedMetadata: false,
 			accessEpoch: 'persisted-e1',
+			durableRead: true,
 			retags: {},
 		} as unknown as Awaited<ReturnType<typeof persistence.hydrate>>);
 		const listIndex = vi.spyOn(api.items, 'listIndex');
@@ -104,6 +106,7 @@ describe('IDEA-2898 — what the resync hands on', () => {
 			cursor: '1',
 			includesUnparentedMetadata: false,
 			accessEpoch: 'e1',
+			durableRead: true,
 			retags: {},
 		} as unknown as Awaited<ReturnType<typeof persistence.hydrate>>);
 		vi.spyOn(api.items, 'changes').mockResolvedValue({
@@ -153,6 +156,7 @@ describe('IDEA-2898 — what the resync hands on', () => {
 			cursor: '1',
 			includesUnparentedMetadata: false,
 			accessEpoch: null,
+			durableRead: true,
 			retags: {},
 		} as unknown as Awaited<ReturnType<typeof persistence.hydrate>>);
 		vi.spyOn(api.items, 'changes').mockResolvedValue({
@@ -187,6 +191,55 @@ describe('IDEA-2898 — what the resync hands on', () => {
 		expect(
 			(persistence.persistAccessEpoch.mock.calls.at(-1) as unknown[])[2],
 		).toBe('told');
+	});
+
+	it('does NOT adopt when the durable read FAILED, only when it answered', async () => {
+		// `hydrate` returns the same empty payload for a real IDB failure as for
+		// a genuinely empty cache — deliberately, since a best-effort cache
+		// should not take the app down. But those are opposite facts here, and
+		// reading a failure as "nothing stored" puts the silent adopt straight
+		// back: the durable cache may hold rows from a scope nobody checked,
+		// and adopting stamps the new epoch onto them through the next delta.
+		persistence.hydrate.mockResolvedValueOnce({
+			items: [],
+			cursor: '0',
+			includesUnparentedMetadata: null,
+			accessEpoch: null,
+			durableRead: false,
+			retags: {},
+		} as unknown as Awaited<ReturnType<typeof persistence.hydrate>>);
+		vi.spyOn(api.items, 'listIndex').mockResolvedValueOnce({
+			items: [],
+			total: 0,
+			cursor: '0',
+			includes_unparented_metadata: false,
+		});
+		await localIndex.bootstrap(ws, { userId: null });
+
+		expect(await localIndex.ensureAccessScope(ws, 'e2')).toBe(false);
+		expect(localIndex.accessEpochFor(ws)).toBeNull();
+
+		// CONTROL LEG. The same shape with a SUCCESSFUL read adopts, so this is
+		// a test of the read's outcome and not of the bootstrap generally.
+		localIndex.reset(ws);
+		persistence.hydrate.mockResolvedValueOnce({
+			items: [],
+			cursor: '0',
+			includesUnparentedMetadata: null,
+			accessEpoch: null,
+			durableRead: true,
+			retags: {},
+		} as unknown as Awaited<ReturnType<typeof persistence.hydrate>>);
+		vi.spyOn(api.items, 'listIndex').mockResolvedValueOnce({
+			items: [],
+			total: 0,
+			cursor: '0',
+			includes_unparented_metadata: false,
+		});
+		await localIndex.bootstrap(ws, { userId: null });
+
+		expect(await localIndex.ensureAccessScope(ws, 'e2')).toBe(false);
+		expect(localIndex.accessEpochFor(ws)).toBe('e2');
 	});
 
 	it('hands persistDelta the baseline the rows were applied under', async () => {

--- a/web/src/lib/stores/localIndexAccessEpochWiring.svelte.test.ts
+++ b/web/src/lib/stores/localIndexAccessEpochWiring.svelte.test.ts
@@ -142,6 +142,11 @@ describe('IDEA-2898 — what the resync hands on', () => {
 		expect(persistence.persistAccessEpoch).toHaveBeenCalled();
 		const args = persistence.persistAccessEpoch.mock.calls.at(-1) as unknown[];
 		expect(args[2]).toBe('e2');
+		// AND the value it expects to be replacing. The patch is a
+		// compare-and-set; a wrong `expectedPrevious` makes it a no-op that
+		// still looks right in RAM, and the disagreement only shows up as a
+		// resync on the next reload.
+		expect(args[3]).toBe('e1');
 	});
 
 	it('persists the told epoch after a joined resync on a NULL baseline too', async () => {
@@ -188,9 +193,10 @@ describe('IDEA-2898 — what the resync hands on', () => {
 
 		expect(localIndex.accessEpochFor(ws)).toBe('told');
 		expect(persistence.persistAccessEpoch).toHaveBeenCalled();
-		expect(
-			(persistence.persistAccessEpoch.mock.calls.at(-1) as unknown[])[2],
-		).toBe('told');
+		const nullBranchArgs = persistence.persistAccessEpoch.mock.calls.at(-1) as unknown[];
+		expect(nullBranchArgs[2]).toBe('told');
+		// The baseline being repaired on this branch is the ABSENT one.
+		expect(nullBranchArgs[3]).toBeNull();
 	});
 
 	it('does NOT adopt when the durable read FAILED, only when it answered', async () => {

--- a/web/src/lib/stores/localIndexPersistence.idb.test.ts
+++ b/web/src/lib/stores/localIndexPersistence.idb.test.ts
@@ -31,7 +31,7 @@ describe('BUG-2609 end-to-end: stale snapshot does not clobber a newer persisted
 		const WS = 'ws-2609';
 
 		// 1) The SSE delta lands first — newer-seq row + cursor advance, atomic.
-		await persistDelta(U, WS, [row('x', 7)], 'cursor-7', false);
+		await persistDelta(U, WS, [row('x', 7)], 'cursor-7', false, null);
 		// 2) The stale RAM snapshot (older seq) lands LAST — the fire-and-forget
 		//    upsert that BUG-2609's evidence run captured mid-flight.
 		await persistUpserts(U, WS, [row('x', 5)]);
@@ -52,7 +52,7 @@ describe('BUG-2609 end-to-end: stale snapshot does not clobber a newer persisted
 		const U = null;
 		const WS = 'ws-2609-asym';
 
-		await persistDelta(U, WS, [row('x', 7)], 'cursor-7', false);
+		await persistDelta(U, WS, [row('x', 7)], 'cursor-7', false, null);
 		await persistUpserts(U, WS, [row('x', undefined)]); // seq-less snapshot lands last
 
 		expect((await rawItem(U, WS, 'x'))?.seq).toBe(7);

--- a/web/src/lib/stores/localIndexPersistence.ts
+++ b/web/src/lib/stores/localIndexPersistence.ts
@@ -42,7 +42,9 @@ import { resolveRowWrite, type Tombstone } from './itemRowMerge';
  * store-creation migrations. Bumped 1 → 2 in PLAN-2636 unit 2 to add the
  * `tombstones` object store (BUG-2633). Distinct from
  * `LOCAL_INDEX_SCHEMA_VERSION`, which versions the ROW SHAPE: the row shape did
- * not change, so that constant stays 3. A v1 DB reopening under v2 gets the
+ * not change in that unit, so the constant stayed 3 there. (It is 4 now — the
+ * meta row gained `accessEpoch` in IDEA-2898. Two independent counters, and
+ * neither implies the other.) A v1 DB reopening under v2 gets the
  * upgrade callback with `oldVersion === 1`; `items`/`meta` data is RETAINED and
  * only the new store is created (empty — old exposure until first resync, not
  * corruption). An OLD build reopening a v2 DB at version 1 gets a VersionError,
@@ -63,13 +65,23 @@ export const IDB_FORMAT_VERSION = 2;
  * `/items-index`. Server truth (items.content) is never persisted
  * here, so a cache wipe loses nothing.
  */
-export const LOCAL_INDEX_SCHEMA_VERSION = 3;
+export const LOCAL_INDEX_SCHEMA_VERSION = 4;
 
 /** Result of a `hydrate()` call. Empty payload when there's no cache yet. */
 export interface HydrateResult {
 	items: ItemIndexRow[];
 	cursor: string;
 	includesUnparentedMetadata: boolean | null;
+	/**
+	 * The caller's access fingerprint at the time this cache was written
+	 * (IDEA-2898). Persisted for one reason: a revocation that lands while the
+	 * tab is CLOSED writes no row, so the cached rows are stale and nothing in
+	 * the delta stream says so. Comparing the persisted epoch against the next
+	 * response's is what turns that into a resync instead of a silent adopt.
+	 * Null only for a cache with no epoch yet — which the version bump to 4
+	 * makes unreachable for caches written by this build or later.
+	 */
+	accessEpoch: string | null;
 	/**
 	 * The durable retag overlay applied to `items` before return (BUG-2634):
 	 * `collection_id → newSlug`. Returned for inspection; `items` already
@@ -85,6 +97,8 @@ interface MetaRow {
 	cursor: string;
 	schemaVersion: number;
 	includesUnparentedMetadata: boolean;
+	/** See HydrateResult.accessEpoch (IDEA-2898). */
+	accessEpoch: string | null;
 }
 
 /**
@@ -228,6 +242,7 @@ export async function hydrate(
 		items: [],
 		cursor: '0',
 		includesUnparentedMetadata: null,
+		accessEpoch: null,
 		retags: {},
 	};
 	if (!isSupported()) return empty;
@@ -292,6 +307,7 @@ export async function hydrate(
 			items,
 			cursor: meta?.cursor ?? '0',
 			includesUnparentedMetadata: meta?.includesUnparentedMetadata ?? null,
+			accessEpoch: meta?.accessEpoch ?? null,
 			retags,
 		};
 	} catch {
@@ -466,6 +482,7 @@ export async function persistDelta(
 	rows: ItemIndexRow[],
 	cursor: string,
 	includesUnparentedMetadata: boolean,
+	accessEpoch: string | null,
 	removeIds: string[] = [],
 ): Promise<void> {
 	if (!isSupported()) return;
@@ -505,6 +522,7 @@ export async function persistDelta(
 				cursor,
 				schemaVersion: LOCAL_INDEX_SCHEMA_VERSION,
 				includesUnparentedMetadata,
+				accessEpoch,
 			} satisfies MetaRow)
 			.catch(() => undefined);
 		await tx.done;
@@ -543,6 +561,7 @@ export async function persistReplace(
 	rows: ItemIndexRow[],
 	cursor: string,
 	includesUnparentedMetadata: boolean,
+	accessEpoch: string | null,
 ): Promise<void> {
 	if (!isSupported()) return;
 	const db = await open(userId, ws);
@@ -570,6 +589,7 @@ export async function persistReplace(
 				cursor,
 				schemaVersion: LOCAL_INDEX_SCHEMA_VERSION,
 				includesUnparentedMetadata,
+				accessEpoch,
 			} satisfies MetaRow)
 			.catch(() => undefined);
 		await tx.done;

--- a/web/src/lib/stores/localIndexPersistence.ts
+++ b/web/src/lib/stores/localIndexPersistence.ts
@@ -599,6 +599,43 @@ export async function persistReplace(
 }
 
 /**
+ * Record a new access epoch on an EXISTING cache, touching nothing else
+ * (IDEA-2898, review of the reduced tip).
+ *
+ * There is one caller and one reason for it. `ensureAccessScope` may JOIN a
+ * resync that is already in flight rather than start one; the resync it joined
+ * ran its own `persistReplace` under its own baseline, so the meta row records
+ * the OLD epoch while RAM has adopted the told one. Without this the two
+ * disagree durably: the session converges, and every reload hydrates the stale
+ * baseline and pays a full resync for a scope that has not changed since.
+ *
+ * Deliberately a no-op when there is no meta row. A cache that has never synced
+ * has nothing to describe, and minting a meta row here would invent a cursor.
+ */
+export async function persistAccessEpoch(
+	userId: string | null,
+	ws: string,
+	accessEpoch: string | null,
+): Promise<void> {
+	if (!isSupported()) return;
+	const db = await open(userId, ws);
+	if (!db) return;
+	try {
+		const tx = db.transaction('meta', 'readwrite');
+		const store = tx.objectStore('meta');
+		const cached = (await store.get('sync')) as MetaRow | undefined;
+		if (!cached) {
+			await tx.done.catch(() => undefined);
+			return;
+		}
+		store.put({ ...cached, accessEpoch } satisfies MetaRow).catch(() => undefined);
+		await tx.done;
+	} catch {
+		/* swallow — best-effort cache */
+	}
+}
+
+/**
  * Delete rows by id (hard remove). Used by `localIndex.remove` for
  * 403 purge (TASK-1360) and any other hard-delete path. Soft deletes
  * stay in the cache as upserts with `deleted_at` populated — they

--- a/web/src/lib/stores/localIndexPersistence.ts
+++ b/web/src/lib/stores/localIndexPersistence.ts
@@ -78,8 +78,13 @@ export interface HydrateResult {
 	 * tab is CLOSED writes no row, so the cached rows are stale and nothing in
 	 * the delta stream says so. Comparing the persisted epoch against the next
 	 * response's is what turns that into a resync instead of a silent adopt.
-	 * Null only for a cache with no epoch yet — which the version bump to 4
-	 * makes unreachable for caches written by this build or later.
+	 *
+	 * Null means NO BASELINE, and this build can still WRITE one: a server that
+	 * predates `access_epoch` omits it, and `persistDelta`/`persistReplace`
+	 * record that absence honestly rather than inventing a value. What the
+	 * version bump to 4 rules out is a PRE-IDEA-2898 cache being read as though
+	 * it had a baseline — those are wiped, not adopted. Both cases are covered
+	 * in localIndexPersistenceAccessEpoch.idb.test.ts.
 	 */
 	accessEpoch: string | null;
 	/**

--- a/web/src/lib/stores/localIndexPersistence.ts
+++ b/web/src/lib/stores/localIndexPersistence.ts
@@ -83,6 +83,22 @@ export interface HydrateResult {
 	 */
 	accessEpoch: string | null;
 	/**
+	 * Did this call actually READ the durable cache? (IDEA-2898, review round 2
+	 * of the reduced tip.)
+	 *
+	 * Every failure here returns the same empty payload as a genuinely empty
+	 * cache — deliberately, because a best-effort cache that throws should not
+	 * take the app down with it. But "there is nothing stored" and "I could not
+	 * find out" are opposite facts for a caller deciding whether it is safe to
+	 * adopt a new access epoch, and the empty payload cannot tell them apart.
+	 *
+	 * TRUE when the read succeeded, AND when IndexedDB is unsupported — with no
+	 * durable cache in the picture there is nothing that could later contradict
+	 * an adopted epoch. FALSE only when a database that might hold rows could
+	 * not be opened or read.
+	 */
+	durableRead: boolean;
+	/**
 	 * The durable retag overlay applied to `items` before return (BUG-2634):
 	 * `collection_id → newSlug`. Returned for inspection; `items` already
 	 * reflect it, so the warm-boot caller needs no further action. Empty when
@@ -243,9 +259,12 @@ export async function hydrate(
 		cursor: '0',
 		includesUnparentedMetadata: null,
 		accessEpoch: null,
+		durableRead: false,
 		retags: {},
 	};
-	if (!isSupported()) return empty;
+	// Unsupported is not a failed read: there is no durable cache to be wrong
+	// about, now or later.
+	if (!isSupported()) return { ...empty, durableRead: true };
 
 	const db = await open(userId, ws);
 	if (!db) return empty;
@@ -261,7 +280,9 @@ export async function hydrate(
 		if (meta && meta.schemaVersion !== LOCAL_INDEX_SCHEMA_VERSION) {
 			await tx.done.catch(() => undefined);
 			await wipe(userId, ws);
-			return empty;
+			// A successful read that found an incompatible cache and destroyed
+			// it. There is now genuinely nothing stored, so this is `true`.
+			return { ...empty, durableRead: true };
 		}
 
 		const retagsRow = (await metaStore.get('retags')) as RetagsRow | undefined;
@@ -308,6 +329,7 @@ export async function hydrate(
 			cursor: meta?.cursor ?? '0',
 			includesUnparentedMetadata: meta?.includesUnparentedMetadata ?? null,
 			accessEpoch: meta?.accessEpoch ?? null,
+			durableRead: true,
 			retags,
 		};
 	} catch {
@@ -610,12 +632,18 @@ export async function persistReplace(
  * baseline and pays a full resync for a scope that has not changed since.
  *
  * Deliberately a no-op when there is no meta row. A cache that has never synced
- * has nothing to describe, and minting a meta row here would invent a cursor.
+ * has nothing to describe, and minting a meta row here would invent a cursor —
+ * and a cursor is the claim that everything up to it has been seen, which is
+ * precisely the claim such a cache cannot make.
+ *
+ * `expectedPrevious` makes the patch a COMPARE-AND-SET rather than a blind
+ * overwrite; see the comment at the check.
  */
 export async function persistAccessEpoch(
 	userId: string | null,
 	ws: string,
 	accessEpoch: string | null,
+	expectedPrevious: string | null,
 ): Promise<void> {
 	if (!isSupported()) return;
 	const db = await open(userId, ws);
@@ -625,6 +653,17 @@ export async function persistAccessEpoch(
 		const store = tx.objectStore('meta');
 		const cached = (await store.get('sync')) as MetaRow | undefined;
 		if (!cached) {
+			await tx.done.catch(() => undefined);
+			return;
+		}
+		// COMPARE-AND-SET, because this is a read-modify-write on a row other
+		// writers own. IDB serializes the transactions, but a `persistDelta` or
+		// `persistReplace` carrying a NEWER epoch can commit between the resync
+		// this caller joined and this patch — and a blind overwrite would then
+		// stamp the older epoch onto rows fetched under the newer one, so the
+		// next comparison reports a change that never happened and pays a full
+		// resync for it. Patch only the row this caller is actually repairing.
+		if ((cached.accessEpoch ?? null) !== expectedPrevious) {
 			await tx.done.catch(() => undefined);
 			return;
 		}

--- a/web/src/lib/stores/localIndexPersistence.unit2.idb.test.ts
+++ b/web/src/lib/stores/localIndexPersistence.unit2.idb.test.ts
@@ -9,6 +9,7 @@ import {
 	rawRetags,
 	seedV1Database,
 } from '../../test/idbHarness';
+import { LOCAL_INDEX_SCHEMA_VERSION } from './localIndexPersistence';
 
 /**
  * PLAN-2636 unit 2 — the cache's order-and-merge contract, end-to-end through a
@@ -44,7 +45,7 @@ describe('BUG-2633 — tombstones stop a stale snapshot resurrecting an evicted 
 
 		await persistUpserts(U, WS, [row('x', 5)]);
 		// A delta evicts x (moved-out) and advances the cursor to 10 — atomic.
-		await persistDelta(U, WS, [], '10', false, ['x']);
+		await persistDelta(U, WS, [], '10', false, null, ['x']);
 		// The stale RAM snapshot for x (seq 5, behind the cursor) lands last.
 		await persistUpserts(U, WS, [row('x', 5)]);
 
@@ -60,7 +61,7 @@ describe('BUG-2633 — tombstones stop a stale snapshot resurrecting an evicted 
 		const WS = 'ws-2633-seqless';
 
 		await persistUpserts(U, WS, [row('x', 5)]);
-		await persistDelta(U, WS, [], '10', false, ['x']);
+		await persistDelta(U, WS, [], '10', false, null, ['x']);
 		await persistUpserts(U, WS, [row('x', undefined)]); // optimistic seq-less snapshot
 
 		expect(await rawItem(U, WS, 'x')).toBeUndefined();
@@ -72,7 +73,7 @@ describe('BUG-2633 — tombstones stop a stale snapshot resurrecting an evicted 
 		const WS = 'ws-2633-supersede';
 
 		await persistUpserts(U, WS, [row('x', 5)]);
-		await persistDelta(U, WS, [], '10', false, ['x']); // tombstone x @ 10
+		await persistDelta(U, WS, [], '10', false, null, ['x']); // tombstone x @ 10
 		await persistUpserts(U, WS, [row('x', 11)]); // newer than the tombstone
 
 		expect((await rawItem(U, WS, 'x'))?.seq).toBe(11);
@@ -85,7 +86,7 @@ describe('BUG-2633 — tombstones stop a stale snapshot resurrecting an evicted 
 		const WS = 'ws-2633-purge';
 
 		// A prior sync established rows + a persisted cursor of 20.
-		await persistDelta(U, WS, [row('y', 15)], '20', false);
+		await persistDelta(U, WS, [row('y', 15)], '20', false, null);
 		await persistRemovals(U, WS, ['y']); // no cursor in hand → reads meta.sync (20)
 
 		expect((await rawTombstone(U, WS, 'y'))?.deletedAtSeq).toBe(20);
@@ -121,9 +122,9 @@ describe('BUG-2633 — tombstones stop a stale snapshot resurrecting an evicted 
 		const WS = 'ws-2633-f4';
 
 		await persistUpserts(U, WS, [row('x', 5)]);
-		await persistDelta(U, WS, [], '20', false, ['x']); // tombstone x @ 20
+		await persistDelta(U, WS, [], '20', false, null, ['x']); // tombstone x @ 20
 		// An out-of-order lower-cursor eviction for the same id must not lower it.
-		await persistDelta(U, WS, [], '10', false, ['x']);
+		await persistDelta(U, WS, [], '10', false, null, ['x']);
 		expect((await rawTombstone(U, WS, 'x'))?.deletedAtSeq).toBe(20);
 
 		// A snapshot at a seq between the two stamps is still refused.
@@ -150,7 +151,7 @@ describe('BUG-2634 — durable retag overlay survives a racing delta and a reloa
 
 		// A delta captured BEFORE the rename commits AFTER it, at a newer seq,
 		// carrying the dead slug — no seq compare can arbitrate an out-of-band field.
-		await persistDelta(U, WS, [collRow('a1', 2, 'coll-a', 'old-a')], '2', false);
+		await persistDelta(U, WS, [collRow('a1', 2, 'coll-a', 'old-a')], '2', false, null);
 		expect((await rawItem(U, WS, 'a1'))?.collection_slug).toBe('old-a'); // stored row regressed...
 
 		// ...but hydrate reapplies the overlay, so the reader sees the rename.
@@ -168,7 +169,7 @@ describe('BUG-2634 — durable retag overlay survives a racing delta and a reloa
 		// Rename coll-a → new-a: a1 rewritten in place + overlay persisted.
 		await persistRetag(U, WS, 'coll-a', ['a1'], 'new-a');
 		// a1 then genuinely MOVES to coll-b via an authoritative delta at a newer seq.
-		await persistDelta(U, WS, [collRow('a1', 2, 'coll-b', 'b-slug')], '2', false);
+		await persistDelta(U, WS, [collRow('a1', 2, 'coll-b', 'b-slug')], '2', false, null);
 		expect((await rawItem(U, WS, 'a1'))?.collection_id).toBe('coll-b');
 
 		// Membership is by collection_id: the coll-a overlay must NOT rewrite a1's
@@ -201,7 +202,7 @@ describe('BUG-2634 — durable retag overlay survives a racing delta and a reloa
 		expect(await rawRetags(U, WS)).toEqual({ 'coll-a': 'new-a' });
 
 		// A projection resync installs an authoritative snapshot (live slugs).
-		await persistReplace(U, WS, [collRow('a1', 3, 'coll-a', 'authoritative')], '3', true);
+		await persistReplace(U, WS, [collRow('a1', 3, 'coll-a', 'authoritative')], '3', true, null);
 		expect(await rawRetags(U, WS)).toBeUndefined();
 		// Hydrate no longer rewrites the slug — the overlay is gone.
 		expect((await hydrate(U, WS)).items.find((i) => i.id === 'a1')?.collection_slug).toBe(
@@ -247,10 +248,10 @@ describe('persistReplace clears the tombstone store too', () => {
 		const WS = 'ws-replace-tombstones';
 
 		await persistUpserts(U, WS, [row('x', 5)]);
-		await persistDelta(U, WS, [], '10', false, ['x']); // tombstone x
+		await persistDelta(U, WS, [], '10', false, null, ['x']); // tombstone x
 		expect(await rawTombstones(U, WS)).toHaveLength(1);
 
-		await persistReplace(U, WS, [row('y', 1)], '10', false);
+		await persistReplace(U, WS, [row('y', 1)], '10', false, null);
 		expect(await rawTombstones(U, WS)).toHaveLength(0);
 	});
 });
@@ -262,7 +263,12 @@ describe('v1 → v2 migration through the real module', () => {
 		// Seed a pre-unit-2 (format v1) database with an item + meta.
 		await seedV1Database(U, WS, [row('keep', 3)], {
 			cursor: '3',
-			schemaVersion: 3,
+			// The CURRENT cache-shape version, not a literal: these fixtures
+			// exercise the IDB FORMAT migration (v1 → v2), and a hard-coded
+			// version silently becomes a STALE-cache fixture the next time
+			// LOCAL_INDEX_SCHEMA_VERSION moves — which is how IDEA-2898's bump
+			// to 4 turned this into a wipe and failed the hydrate assertion.
+			schemaVersion: LOCAL_INDEX_SCHEMA_VERSION,
 			includesUnparentedMetadata: true,
 		});
 
@@ -291,7 +297,7 @@ describe('raw readers address the module database', () => {
 			{ id: 'r', seq: 1, collection_id: 'c', collection_slug: 's' } as unknown as ItemIndexRow,
 		]);
 		await persistRetag(U, WS, 'c', ['r'], 's2');
-		await persistDelta(U, WS, [], '9', false, ['r']);
+		await persistDelta(U, WS, [], '9', false, null, ['r']);
 
 		expect(await rawRetags(U, WS)).toEqual({ c: 's2' });
 		expect((await rawTombstone(U, WS, 'r'))?.deletedAtSeq).toBe(9);

--- a/web/src/lib/stores/localIndexPersistenceAccessEpoch.idb.test.ts
+++ b/web/src/lib/stores/localIndexPersistenceAccessEpoch.idb.test.ts
@@ -70,6 +70,39 @@ describe('IDEA-2898 — the access epoch survives a reload', () => {
 		expect((await hydrate(U, WS)).accessEpoch).toBeNull();
 	});
 
+	it('persistAccessEpoch rewrites ONLY the epoch on an existing cache', async () => {
+		const U = null;
+		const WS = 'ws-epoch-patch';
+		const { persistReplace, persistAccessEpoch, hydrate } = await loadPersistence();
+
+		await persistReplace(U, WS, [row('a', 1)], '5', false, 'e1');
+		await persistAccessEpoch(U, WS, 'e2');
+
+		const after = await hydrate(U, WS);
+		expect(after.accessEpoch).toBe('e2');
+		// Everything else the meta row carries is untouched — this exists to
+		// repair a baseline after a JOINED resync, not to make a claim about
+		// how far the cache has synced.
+		expect(after.cursor).toBe('5');
+		expect(after.includesUnparentedMetadata).toBe(false);
+		expect(after.items.map((r) => r.id)).toEqual(['a']);
+	});
+
+	it('persistAccessEpoch does NOT mint a meta row for a cache that never synced', async () => {
+		const U = null;
+		const WS = 'ws-epoch-patch-empty';
+		const { persistAccessEpoch, hydrate } = await loadPersistence();
+
+		await persistAccessEpoch(U, WS, 'e1');
+
+		// A cache with no meta row has nothing to describe. Writing one here
+		// would invent a cursor — and a cursor is a claim that everything up to
+		// it has been seen, which is exactly the claim this cache cannot make.
+		const after = await hydrate(U, WS);
+		expect(after.accessEpoch).toBeNull();
+		expect(after.cursor).toBe('0');
+	});
+
 	it('reads a meta row with no epoch key as null, not undefined', async () => {
 		const U = null;
 		const WS = 'ws-epoch-legacy-key';

--- a/web/src/lib/stores/localIndexPersistenceAccessEpoch.idb.test.ts
+++ b/web/src/lib/stores/localIndexPersistenceAccessEpoch.idb.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import type { ItemIndexRow } from '$lib/types';
+import { loadPersistence, openSecondConnection } from '../../test/idbHarness';
+
+/**
+ * IDEA-2898 — the durable half of the access baseline.
+ *
+ * The comparison in `localIndex` can only detect an OFFLINE revocation if the
+ * epoch the cache was written under survives the tab being closed. That is this
+ * module's whole job here: `persistDelta` and `persistReplace` stamp the meta
+ * row, and `hydrate` hands the stamp back so the first delta of the next
+ * session has something to disagree with.
+ *
+ * These are sequential calls through the real module, which is how the
+ * PLAN-2636 races are pinned: IDB serializes the transactions, so ordering the
+ * calls IS the interleaving.
+ *
+ * SCOPE. This file covers only what the minimal shape ships. The cross-tab
+ * hazard — a write from a tab that has not yet learned the new scope
+ * reinserting a row while the cache still advertises the current epoch — is
+ * NOT closed here and is not meant to be; it is F2, and PLAN-2903 owns it.
+ */
+
+function row(id: string, seq: number): ItemIndexRow {
+	return { id, seq, collection_slug: 'c' } as unknown as ItemIndexRow;
+}
+
+describe('IDEA-2898 — the access epoch survives a reload', () => {
+	it('round-trips the epoch a replace was written under', async () => {
+		const U = null;
+		const WS = 'ws-epoch-replace';
+		const { persistReplace, hydrate } = await loadPersistence();
+
+		await persistReplace(U, WS, [row('a', 1)], '5', false, 'e1');
+
+		const after = await hydrate(U, WS);
+		expect(after.accessEpoch).toBe('e1');
+		expect(after.cursor).toBe('5');
+		expect(after.items.map((r) => r.id)).toEqual(['a']);
+	});
+
+	it('moves the stored epoch forward when a delta carries a new one', async () => {
+		const U = null;
+		const WS = 'ws-epoch-delta';
+		const { persistReplace, persistDelta, hydrate } = await loadPersistence();
+
+		await persistReplace(U, WS, [row('a', 1)], '5', false, 'e1');
+		await persistDelta(U, WS, [row('b', 6)], '6', false, 'e2');
+
+		// The stamp tracks the LAST authoritative statement, not the first —
+		// otherwise a session that resynced would keep re-detecting the same
+		// change on every reload.
+		const after = await hydrate(U, WS);
+		expect(after.accessEpoch).toBe('e2');
+		expect(after.cursor).toBe('6');
+	});
+
+	it('hydrates a null epoch rather than inventing one when the server sent none', async () => {
+		const U = null;
+		const WS = 'ws-epoch-absent';
+		const { persistDelta, hydrate } = await loadPersistence();
+
+		// A server that predates the field: the caller has no epoch to stamp.
+		await persistDelta(U, WS, [row('a', 1)], '5', false, null);
+
+		// Null must stay null. `ensureAccessScope` reads a null baseline over a
+		// populated cache as "cannot know what this was authorised for" and
+		// resyncs; substituting any value here would turn that into a silent
+		// adopt, which is the exact defect this change exists to close.
+		expect((await hydrate(U, WS)).accessEpoch).toBeNull();
+	});
+
+	it('reads a meta row with no epoch key as null, not undefined', async () => {
+		const U = null;
+		const WS = 'ws-epoch-legacy-key';
+		const { hydrate, LOCAL_INDEX_SCHEMA_VERSION } = await loadPersistence();
+
+		// A meta row at the CURRENT cache version whose `accessEpoch` key is
+		// simply absent. Written raw, at the module's own format version, so
+		// the ONLY thing this fixture can exercise is the missing key — a
+		// stale `schemaVersion` would wipe the cache for an unrelated reason
+		// and the assertion would no longer discriminate.
+		const db = await openSecondConnection(U, WS);
+		try {
+			await db.put('meta', {
+				key: 'sync',
+				cursor: '5',
+				schemaVersion: LOCAL_INDEX_SCHEMA_VERSION,
+				includesUnparentedMetadata: true,
+			});
+			await db.put('items', row('a', 1));
+		} finally {
+			db.close();
+		}
+
+		// NULL, not undefined. `ensureAccessScope` branches on `=== null` to
+		// find the no-baseline case; an `undefined` would miss that branch,
+		// compare unequal to every incoming epoch, and resync on every poll
+		// forever.
+		const after = await hydrate(U, WS);
+		expect(after.accessEpoch).toBeNull();
+		expect(after.items.map((r) => r.id)).toEqual(['a']);
+	});
+});

--- a/web/src/lib/stores/localIndexPersistenceAccessEpoch.idb.test.ts
+++ b/web/src/lib/stores/localIndexPersistenceAccessEpoch.idb.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import type { ItemIndexRow } from '$lib/types';
-import { loadPersistence, openSecondConnection } from '../../test/idbHarness';
+import { openDB } from 'idb';
+import { loadPersistence, openSecondConnection, harnessDbName } from '../../test/idbHarness';
 
 /**
  * IDEA-2898 — the durable half of the access baseline.
@@ -76,7 +77,7 @@ describe('IDEA-2898 — the access epoch survives a reload', () => {
 		const { persistReplace, persistAccessEpoch, hydrate } = await loadPersistence();
 
 		await persistReplace(U, WS, [row('a', 1)], '5', false, 'e1');
-		await persistAccessEpoch(U, WS, 'e2');
+		await persistAccessEpoch(U, WS, 'e2', 'e1');
 
 		const after = await hydrate(U, WS);
 		expect(after.accessEpoch).toBe('e2');
@@ -93,7 +94,7 @@ describe('IDEA-2898 — the access epoch survives a reload', () => {
 		const WS = 'ws-epoch-patch-empty';
 		const { persistAccessEpoch, hydrate } = await loadPersistence();
 
-		await persistAccessEpoch(U, WS, 'e1');
+		await persistAccessEpoch(U, WS, 'e1', null);
 
 		// A cache with no meta row has nothing to describe. Writing one here
 		// would invent a cursor — and a cursor is a claim that everything up to
@@ -101,6 +102,91 @@ describe('IDEA-2898 — the access epoch survives a reload', () => {
 		const after = await hydrate(U, WS);
 		expect(after.accessEpoch).toBeNull();
 		expect(after.cursor).toBe('0');
+	});
+
+	it('refuses to patch a meta row another writer has already moved on', async () => {
+		const U = null;
+		const WS = 'ws-epoch-cas';
+		const { persistReplace, persistAccessEpoch, hydrate } = await loadPersistence();
+
+		await persistReplace(U, WS, [row('a', 1)], '5', false, 'e1');
+		// A newer authoritative write lands first — rows fetched under e3.
+		await persistReplace(U, WS, [row('b', 9)], '9', false, 'e3');
+
+		// The late joined-resync patch still believes it is repairing e1.
+		await persistAccessEpoch(U, WS, 'e2', 'e1');
+
+		// Blind overwrite would stamp e2 onto rows fetched under e3, so the
+		// next comparison would report a change that never happened and pay a
+		// full resync for it.
+		const after = await hydrate(U, WS);
+		expect(after.accessEpoch).toBe('e3');
+		expect(after.cursor).toBe('9');
+	});
+
+	it('reports whether the durable cache was actually READ', async () => {
+		const U = null;
+		const WS = 'ws-epoch-durable-read';
+		const { persistReplace, hydrate } = await loadPersistence();
+
+		// A cache that has never been written still counts as READ: the answer
+		// "there is nothing stored" is a real answer.
+		expect((await hydrate(U, WS)).durableRead).toBe(true);
+
+		await persistReplace(U, WS, [row('a', 1)], '5', false, 'e1');
+		expect((await hydrate(U, WS)).durableRead).toBe(true);
+	});
+
+	it('reports a FAILED read as not-read, with the same empty payload', async () => {
+		const U = null;
+		const WS = 'ws-epoch-unreadable';
+		const { hydrate } = await loadPersistence();
+
+		// A database at a HIGHER format version than this build knows: the
+		// module's own open() gets a VersionError and gives up. This is the
+		// real shape of the failure — a newer tab upgraded the store — and it
+		// is deterministic, unlike simulating a transaction abort.
+		const ahead = await openDB(harnessDbName(U, WS), 99, {
+			upgrade(db) {
+				if (!db.objectStoreNames.contains('items')) {
+					db.createObjectStore('items', { keyPath: 'id' });
+				}
+				if (!db.objectStoreNames.contains('meta')) {
+					db.createObjectStore('meta', { keyPath: 'key' });
+				}
+			},
+		});
+		ahead.close();
+
+		const after = await hydrate(U, WS);
+		// The payload is INDISTINGUISHABLE from an empty cache — that is the
+		// whole point, and why the flag has to carry the difference.
+		expect(after.items).toEqual([]);
+		expect(after.cursor).toBe('0');
+		expect(after.accessEpoch).toBeNull();
+		expect(after.durableRead).toBe(false);
+	});
+
+	it('reports a read that THREW as not-read, on the other failure path', async () => {
+		const U = null;
+		const WS = 'ws-epoch-throwing-read';
+		const { hydrate } = await loadPersistence();
+
+		// The sibling of the test above, and a different code path: here the
+		// database OPENS (same format version, so no upgrade runs) and the read
+		// itself throws, because the store the transaction names is not there.
+		// Both paths must report not-read; they are one statement written
+		// twice, and a mutation on either is invisible to a test of the other.
+		const crippled = await openDB(harnessDbName(U, WS), 2, {
+			upgrade(db) {
+				db.createObjectStore('meta', { keyPath: 'key' });
+			},
+		});
+		crippled.close();
+
+		const after = await hydrate(U, WS);
+		expect(after.items).toEqual([]);
+		expect(after.durableRead).toBe(false);
 	});
 
 	it('reads a meta row with no epoch key as null, not undefined', async () => {

--- a/web/src/lib/stores/localIndexUnparented.svelte.test.ts
+++ b/web/src/lib/stores/localIndexUnparented.svelte.test.ts
@@ -55,8 +55,14 @@ describe('localIndex unparented projection compatibility', () => {
 		expect(localIndex.findByIdOrSlug(ws, 'created')?.is_unparented).toBe(true);
 	});
 
-	it('bumps the persistent cache contract so version-1 rows are fully resynced', () => {
-		expect(LOCAL_INDEX_SCHEMA_VERSION).toBe(3);
+	it('bumps the persistent cache contract so older caches are fully resynced', () => {
+		// 4 since IDEA-2898: the meta row gained `accessEpoch`, and a cache
+		// written without one has no baseline to compare a revocation against.
+		// Adopting the incoming epoch for such a cache would be the silent
+		// adopt the whole change exists to prevent, so the bump makes those
+		// caches unreachable — they wipe and re-bootstrap from an
+		// authoritative snapshot instead.
+		expect(LOCAL_INDEX_SCHEMA_VERSION).toBe(4);
 	});
 
 	it('fully resyncs when projection permission is downgraded or upgraded', async () => {

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -1052,6 +1052,18 @@ export interface ItemIndexResponse {
 	items: ItemIndexRow[];
 	total: number;
 	includes_unparented_metadata: boolean;
+	/**
+	 * Opaque fingerprint of the CALLER's effective visible set (IDEA-2898).
+	 * It does not describe the data in this response; it describes what the
+	 * caller was allowed to see when the server built it. A changed value
+	 * means the local cache was built under a scope that no longer holds —
+	 * which is the only signal a revocation that wrote no row produces.
+	 *
+	 * Optional on the TYPE, not on the wire: a client can meet a server that
+	 * predates this field during a deploy, and `undefined` must read as "no
+	 * information", never as "the set changed".
+	 */
+	access_epoch?: string;
 	// `cursor` is the workspace-scoped monotonic `seq` cursor (TASK-1353).
 	// Holds MAX(seq) across the requested scope as a decimal-encoded
 	// string. When the result set is empty but the workspace has items,
@@ -1095,6 +1107,8 @@ export interface ItemChangesResponse {
 	changes: ItemChangeRow[];
 	cursor: string;
 	includes_unparented_metadata: boolean;
+	/** See `ItemIndexResponse.access_epoch` (IDEA-2898). */
+	access_epoch?: string;
 }
 
 export interface ItemCreate {

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -1100,6 +1100,14 @@
 					// reporting catch-up on stale data (Codex P2 round 8).
 					continue;
 				}
+				if (await localIndex.ensureAccessScope(ws, delta.access_epoch)) {
+					// IDEA-2898: the caller's visible set changed with no row
+					// change to carry it. Same `continue` discipline as the
+					// projection branch below and for the same reason — the
+					// resync pinned the cursor, so post-snapshot mutations are
+					// only replayed if we keep looping.
+					continue;
+				}
 				if (await localIndex.ensureProjectionScope(ws, delta.includes_unparented_metadata)) {
 					// A resync just pinned the cursor to the snapshot cursor to
 					// replay post-snapshot mutations under the new scope. Keep

--- a/web/src/test/idbHarness.idb.test.ts
+++ b/web/src/test/idbHarness.idb.test.ts
@@ -7,6 +7,7 @@ import {
 	versionErrorOnDowngradeOpen,
 	rawItem,
 } from './idbHarness';
+import { LOCAL_INDEX_SCHEMA_VERSION } from '$lib/stores/localIndexPersistence';
 
 /**
  * PLAN-2636 unit 1 — capability pins for the two things the lead named as
@@ -47,7 +48,12 @@ describe('format-version migration (unit-2 v1→v2 prerequisite)', () => {
 		const WS = 'ws-migrate';
 		await seedV1Database(U, WS, [row('keep', 3)], {
 			cursor: 'c1',
-			schemaVersion: 3,
+			// The CURRENT cache-shape version, not a literal: these fixtures
+			// exercise the IDB FORMAT migration (v1 → v2), and a hard-coded
+			// version silently becomes a STALE-cache fixture the next time
+			// LOCAL_INDEX_SCHEMA_VERSION moves — which is how IDEA-2898's bump
+			// to 4 turned this into a wipe and failed the hydrate assertion.
+			schemaVersion: LOCAL_INDEX_SCHEMA_VERSION,
 			includesUnparentedMetadata: true,
 		});
 


### PR DESCRIPTION
Closes IDEA-2898 in its minimal shape. The cross-tab durable-cache half is **PLAN-2903** and is deliberately not here.

## The defect

A revocation that writes no item is invisible to the delta stream. `/items-changes` can only express changes to ROWS, and the moved-out tombstone path (BUG-1675) fires when an ITEM moves, not when the CALLER's access set moves. So the web client's warm local index goes on serving rows for a collection the caller can no longer see — and `ItemPicker` lists those rows as titles, in the copy dialog and in item detail.

Revocation without an accompanying write is the ordinary shape of revocation, not an edge case.

## Why it had been left

Not an oversight. DOC-1342 decision #3 punted it deliberately, in favour of the 403-on-click purge, on the grounds that the alternatives — *"revocation events on SSE, periodic re-auth sweeps"* — added real complexity for a rare condition.

Two things have changed since:

1. **Both alternatives now exist**, built later for the leak side rather than the cache side. The SSE connection re-verifies access and rebuilds its filter set every 60s (`sseMembershipRevalInterval`), and the client already had an authoritative resync that drops rows absent from a fresh snapshot, fences them, and replaces IDB in one transaction (`resyncProjectionScope`). The complexity that decision priced was already paid on both sides of the wire; what was missing between them was a comparison and a flag.
2. **The mitigation defends the wrong verb.** "Click a stale item, get a 403" protects the item READ. The picker's exposure is the LISTING: you learn a title exists in a collection you can no longer open without ever clicking.

DOC-1342 decision #3 is amended in this workspace to record both.

## The change

**Server — a per-caller access fingerprint on the two doors that already compute it.** `access_epoch` on `/items-index` and `/items-changes`: a canonical hash of the caller's effective visible set (`"all"` when unrestricted, else sorted collection ids plus sorted granted item ids). Both handlers already resolve those lists before writing their response, so this costs **no additional query on either door**. The value is opaque, derived only from the caller's own access, and discloses nothing about anyone else's.

**ONE definition, across three sites.** `/items-changes` resolves item grants with soft-deleted items included — deliberately, since TASK-1354, so a tombstone on a granted item still reaches the client — while `/items-index` resolves them live. Fingerprinting whatever each door had already resolved would make the two **permanently disagree** for a caller holding a grant on a soft-deleted item: the client stores one door's value, compares the other's, resyncs, and runs the reconcile to its 50-page cap on every sync trigger, forever. All three sites now hash the LIVE grant set, which is what the SSE tick already holds.

**Client — compare, then reuse the eviction that already exists.** `localIndex` stores the epoch beside the cursor and compares it the way it already compares `includes_unparented_metadata`. A change routes into `resyncProjectionScope`, whose snapshot is server-filtered — so the eviction is exact rather than a client-side guess about what the server would allow. `ItemPicker` needs no change at all: it cannot serve a row the index no longer holds.

**Promptness — the existing event, from the existing tick.** The 60s revalidation tick already recomputes the caller's visible set; it now compares the new epoch against the old and emits the EXISTING `sync_required` when they differ. No new event type, no new client handler, no extra query.

## What this does NOT close, stated plainly

A revocation is detected and the index evicted within one reconcile. **A cross-tab race remains open:** a write from a tab that has not yet learned the new scope can reinsert a row into the durable cache while the cache still advertises the current epoch, in which case nothing re-fires until the next access change. Tracked as **PLAN-2903**.

That is a strict improvement on the pre-change state, where a revocation carrying no row change was not detected at all — but it is a real limitation and it is the reason this PR is a reduction rather than the whole branch.

## Why this is a reduction, and where the rest went

The original branch (`origin/idea/2898-access-epoch`, still pushed at `84cd8f64`) carried six adversarial review rounds. Laying the rounds side by side rather than reading them as a queue was the actual finding: **the server half was clean for four consecutive rounds while every finding from round 3 onward was in the client cache layer.** Two changes were wearing one ref. The lead ruled the split.

What lands here: the server fingerprint, the client comparison (`ensureAccessScope`), the resync's baseline handling, and the epoch persisted beside the cursor. No round found a defect in the comparison itself.

What moves to PLAN-2903: every cross-tab fence (`metaAgrees` and its use in the three persistence writers), `scopeUnconfirmed` and its bootstrap handling, the cold-path supersession/omission/cursor decision, and the `applyDelta` pairing guard. All of it stays reachable on the pushed branch — PLAN-2903 starts from that history rather than from a blank file, and the six review outputs are the argument for every piece.

The page source pin, which on the full branch covered TWO call sites, was split rather than moved: the `applyDelta` half went with the pairing guard it pinned, and the pin was **narrowed to the `ensureAccessScope` call this branch ships**. That half was kept because a mutation run measured it uncovered rather than assumed it covered — deleting the call left every other test green.

**This branch is not a subset of that one's commits.** The keep/move line runs inside two of its seven commits, so the reduced tree is rebuilt from the branch's FINAL state minus the move-set. The code kept is the version that survived six rounds, not its first draft.

## Decisions a reviewer would otherwise have to re-derive

- **Placement is inside `localIndex`'s own delta/bootstrap path, not the collection route page.** The route-only placement would leave item detail and the copy dialog — the picker's actual home — reconciling never.
- **The bootstrap loop DELEGATES to `ensureAccessScope` rather than inlining the comparison.** The first draft inlined it and the copy had already diverged, skipping the null-baseline case that is precisely the offline-revocation cache the persistence exists for.
- **The epoch is persisted, and the cache-shape version bumps 3 → 4.** A revocation that lands while the tab is closed writes no row, so a cache with no recorded epoch cannot be shown to be current; adopting the incoming one would mark stale rows authorised without checking them.
- **Absent is not a value.** `access_epoch` is optional on the wire so a client can meet an older server mid-deploy. `undefined` means "no information" and never "the set changed" — and never "no baseline" either.
- **The resync's baseline is set BEFORE `persistReplace`, not patched after it returns.** `persistReplace` runs inside the resync, so a post-hoc assignment leaves the durable meta row a version behind RAM and the next warm boot resyncs for a scope that never changed. Same reason the resync writes the STATE's baseline rather than `resp.access_epoch ?? null`: a null on disk is read by `ensureAccessScope` as "no baseline" over a populated cache, and costs a full snapshot to rediscover what this session already knew.
- **The told-epoch fallback is applied again AFTER the await**, for the case where the resync was JOINED rather than started — resyncs are deduplicated per workspace, so one started by a projection mismatch passes no fallback and swallows this caller's.
- **`writeSSEEvent`, not `writeSSEResetCursorEvent`.** The latter blanks `Last-Event-ID` because the STREAM has a hole. This stream has none.

## The bar

**Evicted within one reconcile on every consumer path; within ~60s only while a route holding the delta subscription is open.**

Stated this way deliberately. A warm IDB hydrate paints before the first delta answers, so a revoked row can be on screen for one round-trip — the same window `resyncProjectionScope` already accepts by design, and closing it would mean blocking the warm paint on an authz round-trip. And the `sync_required` → `deltaSync` subscription lives in the collection route component, so off-route the tick's signal arrives and nothing acts on it. That second half is filed as **IDEA-2901** (it is not specific to access changes — every `sync_required` has that reach) and ruled out of this unit's scope.

## The test that agreed for the wrong reason

Worth one paragraph because it is the reason the one-definition fix is trustworthy. The door-agreement test written to catch exactly that divergence **passed against genuinely broken code**, because its fixture had no item grants at all: both doors hashed the same empty list and agreed for the wrong reason. The replacement fixture is a grant on a soft-deleted item — the one input that discriminates.

## Prose sweep (CONVE-23)

Statements this change falsified, each true when written: the `localIndex` comment recording the decision-#3 punt, the `AccessRevokedScope` doc citing decision #3 as the whole answer, and decision #3 itself.

Reducing falsified two more that I had written myself on the full branch — the `fallbackEpoch` doc and the `persistReplace` argument comment both explained themselves in terms of a cross-tab fence this shape no longer has. Both rewritten to the reason that survives, along with the wiring test's header.

## Three review rounds on the reduced tip, and what they found

The full branch's six rounds describe a different tree, so this one was reviewed from scratch. Rounds went **4 → 3 → 2**, and every finding in rounds 1 and 2 was the same class: **a silent adopt**, arriving in the machinery this change itself introduced.

**Round 1 (2 × P1, 1 × P2 accepted).**
- *An empty RAM state is not an empty cache.* `bootstrap` awaits `hydrate` before merging anything, but the SSE-driven `deltaSync` runs on its own subscription rather than behind that await — so it can reach the comparison with RAM empty and IDB holding rows from a scope nobody checked. The "nothing to evict, adopt silently" branch then stamps the new epoch onto the durable cache through the delta that follows, and the stale row hydrates under an epoch that agrees with the server **forever**. Not wrong once — permanently inert, which is worse than the defect being closed. Fixed with `cacheRead`; declining to adopt fails toward a resync and hides nothing.
- *A joined resync updates RAM and leaves the disk behind.* Resyncs are deduplicated per workspace; the one this caller JOINED already ran its `persistReplace` under its own baseline. The code's own comment claimed the epoch "lands in RAM and IDB together" — true of the started path, false of the joined one three lines below it. Fixed with `persistAccessEpoch`, on both branches.
- The fourth finding (a total revocation reaching the `unauthorized` SSE path, which evicts nothing until the tab's next request) was checked, confirmed to be already covered on the next request by the TASK-1360 403 purge, and filed as **IDEA-2904** rather than absorbed here — it is a different case with a different mechanism.

**Round 2 (1 × P1, 1 × P2, 1 × P3 accepted)** — round 1's fixes, not quite finished.
- *A failed cache read is not an empty cache.* `hydrate` returns the same empty payload for a real IDB failure as for an empty cache, so `cacheRead` re-opened the exact hole round 1 closed. `HydrateResult.durableRead` carries the difference the payload cannot.
- *`persistAccessEpoch` was a blind read-modify-write* on a row other writers own. Now a compare-and-set against the epoch the caller believes it is repairing.

**Round 3 (2 × P3, no behavioural findings).** A comment claiming the schema bump made a null epoch unreachable (it does not — an older server omits the field), and two tests that asserted the epoch handed to the compare-and-set but not the value it expects to be REPLACING, which a wrong expectation would have passed.

## Mutation ledger — 38 real mutants on this tip, 37 killed

Plus 4 controls, all behaving. Every mutant build-checked; each is the defect itself rather than a crash that resembles one.

**Fingerprint (9):** constant epoch · no sort · sort-in-place · nil-equals-empty · no list separator · grants ignored · **delta door computes from its own include-deleted query set** · tick-never-emits · **tick-always-emits** · tick hashes slugs not ids.

**Comparison (11):** never-resync-on-change · undefined-is-a-value · null-baseline-adopts · absent-erases-baseline · fallback-ignored · joined-resync-check-gone · resync-persists-wire-value · bootstrap-loop-not-wired · warm-hydrate-drops-epoch · cold-path-drops-epoch · applyDelta-omits-epoch.

**Persistence (5):** persistDelta-drops-meta-epoch · hydrate-returns-undefined · schema-version-not-bumped · persistAccessEpoch-mints-meta · persistAccessEpoch-clobbers-cursor.

**Round-1 and round-2 fixes (11):** adopt-before-cache-read · cacheRead-set-true-always · joined-not-persisted · null-branch-not-persisted · failed-read-counts-as-read · hydrate-catch-reports-read · hydrate-open-failure-reports-read · cas-removed · cas-inverted · cas-expected-wrong (× 2 call sites).

**Page wiring (2):** call-deleted (killed) · call-short-circuited (**survives**, see below).

**The survivor, stated rather than hidden.** `if (false && await localIndex.ensureAccessScope(...))` survives the page source pin, because the text the pin matches is still on the line; deleting the call kills it. A source pin cannot see reachability — only a harness on that 3700-line component could, and that is the same missing harness that makes the pin necessary. Both mutants and this conclusion are in the pin's own docblock.

**Two mutants that survived for the WRONG reason**, and are worth more than the ones that died on time. The naive removal of `persistAccessEpoch`'s "no meta row" guard cannot be detected at all: without it the code dereferences `undefined`, the catch swallows the throw, and the outcome is identical — the crash compensated for the defect. Replaced with a faithful version that mints a valid row, which dies. And `hydrate`'s two failure exits are one statement written twice: a mutant on the `catch` survived a test written for the `open` failure, which is how the second fixture (a database whose `items` store is missing, so the open succeeds and the read throws) came to exist.

**Two instrument corrections, both caught by the runner's own controls rather than by inspection.** `go vet` was in the Go build gate — it flags unreachable code, so the positive control (an early `return`) scored BUILD-FAIL while compiling perfectly. And the web runs passed `--reporter=basic`, which this vitest does not have: every web mutant failed to START and the classifier read that as a verdict. The classifier now requires the full baseline population to have RUN before it will call anything killed, because a mutant that stops a file loading also prints a failing summary.

## Gates — on this tip, `6e6e9718`, rebased on `6f8b6eb9`

| Gate | Result |
|---|---|
| `go build ./...` · `go vet ./...` | exit 0 |
| `gofmt -l internal/ cmd/` | no output |
| Go suite, SQLite | exit 0 · 29 packages ok · zero FAIL |
| Go suite, **Postgres** | **exit 0** · 29 packages ok · **zero FAIL lines, no NO-TESTS banner** · server 158.8s, store 230.6s, mcp 14.5s · wall 239.9s |
| `npm run check` | exit 0 · 1099 files · **0 errors** · 6 warnings, all pre-existing |
| web vitest | exit 0 · **131 files, 2150 tests, all passing** |

Postgres ran on a private container on its own port (`padtest-docapp-2898-min-…`), which tore itself down. Exit codes are read from unpiped runs written to files — an earlier run of this suite was piped to `tail`, which hands the exit status to `tail`, so it was re-run rather than reported from a number that could not be cited.

Every figure above, and the mutation matrix, was re-run **after** the rebase onto `6f8b6eb9`. A rebase makes a different tree, and the same rule that says the full branch's gates do not carry to this one says the pre-rebase gates do not carry either. (The store leg's drop from 497s to 231s is `6f8b6eb9` itself — TASK-2900's Postgres template — not anything in this change.)

https://claude.ai/code/session_01Xk9M5UVPdc84xL5E1mZkm8
