### PR TITLE
feat(server,web,cli): say when a relation's copy target is unusable, instead of offering a picker that cannot answer (IDEA-2899)

### DIFF
--- a/cmd/pad/cmd_item.go
+++ b/cmd/pad/cmd_item.go
@@ -2197,7 +2197,18 @@ func renderItemCopyNeedsValue(out io.Writer, p *cli.ItemCopyPreflight, overrides
 		// makes `--field owner_ref=<ref>` answerable. Same reason the dialog
 		// needs it, on the surface that has no picker at all.
 		if f.Collection != "" {
-			fmt.Fprintf(w, "  %-20s   target collection: %s\n", "", itemCopyLine(f.Collection))
+			// IDEA-2899. Naming the target is only useful if the target is
+			// there: it can have been deleted, or be one this caller cannot
+			// read. Saying "target collection: people" and then refusing every
+			// ref the user finds is the CLI version of the dialog's empty
+			// picker — it sends someone looking for a value that does not
+			// exist for them.
+			if f.CollectionUnavailable {
+				fmt.Fprintf(w, "  %-20s   target collection: %s — NOT AVAILABLE to you (deleted, or you cannot access it)\n",
+					"", itemCopyLine(f.Collection))
+			} else {
+				fmt.Fprintf(w, "  %-20s   target collection: %s\n", "", itemCopyLine(f.Collection))
+			}
 		}
 		if f.Message != "" {
 			fmt.Fprintf(w, "  %-20s   %s\n", "", itemCopyLine(f.Message))
@@ -2210,10 +2221,22 @@ func renderItemCopyNeedsValue(out io.Writer, p *cli.ItemCopyPreflight, overrides
 	// instead (Codex round 6). Empty keys are not currently rejected by
 	// collection-schema validation, so this is reachable.
 	unnamed := 0
+	unfillable := 0
 	var toAdd, toFix []string
 	for _, f := range p.Fields.NeedsValue {
 		if strings.TrimSpace(f.Key) == "" {
 			unnamed++
+			continue
+		}
+		// A relation whose TARGET is unavailable cannot be supplied either
+		// (IDEA-2899), and for the same reason the empty-key case above is
+		// excluded: `--field owner_ref=<value>` is a command with no value that
+		// can satisfy it, since the referent validation this command runs
+		// against would refuse anything the user could name. Printing it is
+		// handing someone a command that cannot work — the exact failure the
+		// empty-key branch was written to avoid.
+		if f.CollectionUnavailable {
+			unfillable++
 			continue
 		}
 		if _, ok := supplied(f.Key); ok {
@@ -2238,6 +2261,13 @@ func renderItemCopyNeedsValue(out io.Writer, p *cli.ItemCopyPreflight, overrides
 			fmt.Fprintf(w, " --field %s=<a valid value>", k)
 		}
 		fmt.Fprintln(w)
+	}
+	if unfillable > 0 {
+		fmt.Fprintf(w, "\n%s a relation whose target collection is not available to you, so no --field value can satisfy %s.\n",
+			map[bool]string{true: "One field is", false: pluralize(unfillable, "field is", "fields are")}[unfillable == 1],
+			map[bool]string{true: "it", false: "them"}[unfillable == 1])
+		fmt.Fprintf(w, "That is a permissions or schema problem in %s/%s, not something\nthis command can resolve.\n",
+			p.Destination.WorkspaceSlug, p.Destination.CollectionSlug)
 	}
 	if unnamed > 0 {
 		fmt.Fprintf(w, "\n%s came back with an empty key and cannot be supplied with --field.\n",

--- a/cmd/pad/cmd_item.go
+++ b/cmd/pad/cmd_item.go
@@ -1840,10 +1840,10 @@ func runItemCopy(opts itemCopyOptions, deps itemCopyDeps, stdout, stderr io.Writ
 		// telling someone to use `--field` is advice that cannot be followed,
 		// and the error is the one line a script or a hurried reader sees.
 		hint := " (use --field key=value)"
-		if itemCopyUnfillable(pre.Fields.NeedsValue) == len(pre.Fields.NeedsValue) {
+		if tally := itemCopyTally(pre.Fields.NeedsValue); tally.AllUnfillable() {
 			hint = fmt.Sprintf(" (no --field can supply %s: %s)",
-				map[bool]string{true: "it", false: "them"}[len(pre.Fields.NeedsValue) == 1],
-				itemCopyUnfillableWhy(pre.Fields.NeedsValue))
+				map[bool]string{true: "it", false: "them"}[tally.Total == 1],
+				tally.Why())
 		}
 		return fmt.Errorf("copy refused: %s in %s/%s %s a value%s",
 			pluralize(len(pre.Fields.NeedsValue), "field", "fields"),
@@ -2128,24 +2128,21 @@ func renderItemCopyPreflight(out io.Writer, p *cli.ItemCopyPreflight) error {
 		// a relation whose target collection is unavailable, and one whose key
 		// is empty. Both send someone to run a command that is refused for
 		// exactly the reason they are already stuck.
-		unfillable := itemCopyUnfillable(p.Fields.NeedsValue)
+		tally := itemCopyTally(p.Fields.NeedsValue)
+		fields := pluralize(tally.Total, "field", "fields")
+		needs := map[bool]string{true: "needs", false: "need"}[tally.Total == 1]
 		switch {
-		case unfillable == len(p.Fields.NeedsValue):
+		case tally.AllUnfillable():
 			fmt.Fprintf(w, "%s still %s a value, and no --field can supply %s: %s.\n",
-				pluralize(len(p.Fields.NeedsValue), "field", "fields"),
-				map[bool]string{true: "needs", false: "need"}[len(p.Fields.NeedsValue) == 1],
-				map[bool]string{true: "it", false: "them"}[len(p.Fields.NeedsValue) == 1],
-				itemCopyUnfillableWhy(p.Fields.NeedsValue))
-		case unfillable > 0:
+				fields, needs,
+				map[bool]string{true: "it", false: "them"}[tally.Total == 1],
+				tally.Why())
+		case tally.Unfillable > 0:
 			fmt.Fprintf(w, "%s still %s a value. Supply the rest with --field key=value, then re-run without --dry-run — but %d of them cannot be supplied at all (%s).\n",
-				pluralize(len(p.Fields.NeedsValue), "field", "fields"),
-				map[bool]string{true: "needs", false: "need"}[len(p.Fields.NeedsValue) == 1],
-				unfillable,
-				itemCopyUnfillableWhy(p.Fields.NeedsValue))
+				fields, needs, tally.Unfillable, tally.Why())
 		default:
 			fmt.Fprintf(w, "%s still %s a value. Supply with --field key=value, then re-run without --dry-run.\n",
-				pluralize(len(p.Fields.NeedsValue), "field", "fields"),
-				map[bool]string{true: "needs", false: "need"}[len(p.Fields.NeedsValue) == 1])
+				fields, needs)
 		}
 		return w.err
 	}
@@ -2261,7 +2258,7 @@ func renderItemCopyNeedsValue(out io.Writer, p *cli.ItemCopyPreflight, overrides
 	// instead (Codex round 6). Empty keys are not currently rejected by
 	// collection-schema validation, so this is reachable.
 	unnamed := 0
-	unfillable := itemCopyUnavailableTarget(p.Fields.NeedsValue)
+	unfillable := itemCopyTally(p.Fields.NeedsValue).UnavailableTarget
 	var toAdd, toFix []string
 	for _, f := range p.Fields.NeedsValue {
 		if strings.TrimSpace(f.Key) == "" {
@@ -2317,94 +2314,77 @@ func renderItemCopyNeedsValue(out io.Writer, p *cli.ItemCopyPreflight, overrides
 	return w.err
 }
 
-// itemCopyUnfillable counts needs_value rows NO `--field` can satisfy, for
-// EITHER reason (IDEA-2899).
+// itemCopyFieldTally is what every "how do I supply this" sentence in the copy
+// path is computed from (IDEA-2899).
 //
-// Consulted by the two sites that state the advice in ONE sentence — the
-// --dry-run summary and the returned error. (The detailed render has its own
-// per-row handling and uses `itemCopyUnavailableTarget` plus its separate
-// empty-key branch, because it explains each reason where the row is printed.)
-// The first version of this fix touched only that render, and a review found
-// the other two still printing `--field key=value` at someone for whom no value
-// exists. Sites independently answering "how do I supply this" is exactly how
-// they diverge, so they ask one function instead.
+// ONE pass, ONE shape, because the alternative was measured. This started as a
+// single count, grew a second for the other reason a row cannot be supplied,
+// then a phrase function, and each addition falsified the previous round's
+// wording somewhere else: four review rounds, and every finding but the first
+// lived in this layer while the server half stayed clean. That distribution is
+// the finding — not the individual bugs, which were each small and each real.
 //
-// TWO reasons, not one, and the second was already here: an EMPTY KEY cannot be
-// supplied because `--field =value` is rejected by this command's own parser,
-// which the detailed render has explained since Codex round 6. That render is
-// the only site that knew; the summary and the error went on advising `--field`
-// for those rows too. A predicate named "unfillable" that answered for one of
-// the two reasons would have been a worse trap than no predicate — right at the
-// site that defined it, wrong everywhere it was reused.
-func itemCopyUnfillable(rows []cli.ItemCopyPreflightNeedsValue) int {
-	n := 0
-	for _, f := range rows {
-		if f.CollectionUnavailable || strings.TrimSpace(f.Key) == "" {
-			n++
-		}
-	}
-	return n
+// So the branching is gone. Callers ask for the tally and read the fields they
+// need; there is no second definition of "unfillable" to drift from the first,
+// and no sentence describing a subset of what a predicate counts.
+type itemCopyFieldTally struct {
+	// Total is every needs_value row.
+	Total int
+	// UnavailableTarget is rows naming a relation target this caller cannot
+	// use — deleted, or unreadable (IDEA-2899).
+	UnavailableTarget int
+	// EmptyKey is rows the destination reported with no key. `--field =value`
+	// is rejected by this command's own parser, so these have been unfillable
+	// since Codex round 6; only the detailed render knew it.
+	EmptyKey int
+	// Unfillable is rows carrying EITHER fault. NOT the sum: one row can carry
+	// BOTH — a relation with an empty key whose target is also unavailable —
+	// and counting it twice would make `Unfillable == Total` false for a set
+	// that is entirely unfillable, which is the comparison every caller makes.
+	Unfillable int
 }
 
-// itemCopyUnfillableWhy names WHY no `--field` can supply the given rows, for
-// the two sites that state it in one sentence (IDEA-2899, review round 3).
-//
-// Broadening `itemCopyUnfillable` to cover empty keys without broadening the
-// SENTENCE was the defect: a set of empty-key rows selected the all-unfillable
-// branch and was then explained as "the relation target is not available to
-// you", which is a false statement about rows that have no relation in them.
-// Widening what a rule ACTS on silently widens what it SAYS, and the tell is a
-// sentence that was true while the predicate was narrower.
-//
-// Counts the two faults INDEPENDENTLY — no `continue` between them — because
-// ONE row can carry both: a relation with an empty key whose target is also
-// unavailable. Skipping the second count made such a row report only the
-// relation reason, and a mixed-case test built from TWO rows could not see it
-// (review round 4). One row with both faults and two rows with one each are
-// different fixtures, and only the first exercises this.
-//
-// Returns "" when nothing is unfillable.
-func itemCopyUnfillableWhy(rows []cli.ItemCopyPreflightNeedsValue) string {
-	targets, keys := 0, 0
+func itemCopyTally(rows []cli.ItemCopyPreflightNeedsValue) itemCopyFieldTally {
+	t := itemCopyFieldTally{Total: len(rows)}
 	for _, f := range rows {
+		bad := false
 		if f.CollectionUnavailable {
-			targets++
+			t.UnavailableTarget++
+			bad = true
 		}
 		if strings.TrimSpace(f.Key) == "" {
-			keys++
+			t.EmptyKey++
+			bad = true
+		}
+		if bad {
+			t.Unfillable++
 		}
 	}
+	return t
+}
+
+// AllUnfillable is the condition the error and the summary both test: no
+// `--field` resolves ANY of them, so advising one is advice that cannot be
+// followed. False for an empty set, which has nothing to advise about.
+func (t itemCopyFieldTally) AllUnfillable() bool {
+	return t.Total > 0 && t.Unfillable == t.Total
+}
+
+// Why names the reasons actually present, for the two sites that state it in
+// one sentence. Neutral on number: one caller says "it" and the other may be
+// plural, so the phrase has to read correctly after either.
+//
+// Empty when nothing is unfillable.
+func (t itemCopyFieldTally) Why() string {
 	switch {
-	case targets > 0 && keys > 0:
+	case t.UnavailableTarget > 0 && t.EmptyKey > 0:
 		return "some name a relation target that is not available to you, and some came back with an empty key"
-	case targets > 0:
+	case t.UnavailableTarget > 0:
 		return "the relation target is not available to you"
-	case keys > 0:
-		// Neutral on number, since one call site says "it" and the other can be
-		// plural (review round 4): "an empty key" reads correctly after either.
+	case t.EmptyKey > 0:
 		return "an empty key came back from the destination, which --field cannot address"
 	}
 	return ""
-}
-
-// itemCopyUnavailableTarget counts only the relation half, for the detailed
-// render's own sentence about it — that render explains the empty-key case
-// separately, and the two sentences say different things.
-//
-// DELIBERATELY NOT also excluding empty keys, though the first version did. A
-// row can carry BOTH faults, and a mutant removing that exclusion survived
-// every test — correctly, because the behaviour it changes is printing two
-// sentences that are both TRUE about such a row instead of one. The guard was
-// tidiness dressed as a rule, and a condition nothing can distinguish is a
-// condition the next reader has to re-derive.
-func itemCopyUnavailableTarget(rows []cli.ItemCopyPreflightNeedsValue) int {
-	n := 0
-	for _, f := range rows {
-		if f.CollectionUnavailable {
-			n++
-		}
-	}
-	return n
 }
 
 // renderItemCopyResult writes the outcome of a completed copy.

--- a/cmd/pad/cmd_item.go
+++ b/cmd/pad/cmd_item.go
@@ -1834,10 +1834,19 @@ func runItemCopy(opts itemCopyOptions, deps itemCopyDeps, stdout, stderr io.Writ
 			// that cannot be written to has nowhere to report that.
 			_ = renderItemCopyNeedsValue(stderr, pre, req.FieldOverrides)
 		}
-		return fmt.Errorf("copy refused: %s in %s/%s %s a value (use --field key=value)",
+		// The hint is CONDITIONAL for the same reason the render's Add: line
+		// is (IDEA-2899): when every unresolved field is a relation whose
+		// target is unavailable, `--field` cannot resolve any of them, and the
+		// error is the one line a script or a hurried reader actually sees.
+		hint := " (use --field key=value)"
+		if itemCopyUnfillable(pre.Fields.NeedsValue) == len(pre.Fields.NeedsValue) {
+			hint = " (no --field can supply it: the relation target is not available to you)"
+		}
+		return fmt.Errorf("copy refused: %s in %s/%s %s a value%s",
 			pluralize(len(pre.Fields.NeedsValue), "field", "fields"),
 			targetWorkspace, targetCollection,
-			map[bool]string{true: "needs", false: "need"}[len(pre.Fields.NeedsValue) == 1])
+			map[bool]string{true: "needs", false: "need"}[len(pre.Fields.NeedsValue) == 1],
+			hint)
 	}
 	if !pre.Valid {
 		// needs_value is empty but the server still says the mapping is
@@ -2111,9 +2120,28 @@ func renderItemCopyPreflight(out io.Writer, p *cli.ItemCopyPreflight) error {
 
 	fmt.Fprintln(w)
 	if len(p.Fields.NeedsValue) > 0 {
-		fmt.Fprintf(w, "%s still %s a value. Supply with --field key=value, then re-run without --dry-run.\n",
-			pluralize(len(p.Fields.NeedsValue), "field", "fields"),
-			map[bool]string{true: "needs", false: "need"}[len(p.Fields.NeedsValue) == 1])
+		// IDEA-2899. "Supply with --field key=value" is advice, and advice that
+		// cannot be followed is worse than none: a relation whose target
+		// collection is unavailable has no value that satisfies it, so telling
+		// someone to supply one sends them to run a command that is refused for
+		// exactly the reason they are stuck.
+		unfillable := itemCopyUnfillable(p.Fields.NeedsValue)
+		switch {
+		case unfillable == len(p.Fields.NeedsValue):
+			fmt.Fprintf(w, "%s still %s a value, and no --field can supply %s: the relation target is not available to you.\n",
+				pluralize(len(p.Fields.NeedsValue), "field", "fields"),
+				map[bool]string{true: "needs", false: "need"}[len(p.Fields.NeedsValue) == 1],
+				map[bool]string{true: "it", false: "them"}[len(p.Fields.NeedsValue) == 1])
+		case unfillable > 0:
+			fmt.Fprintf(w, "%s still %s a value. Supply the rest with --field key=value, then re-run without --dry-run — but %d of them cannot be supplied at all (the relation target is not available to you).\n",
+				pluralize(len(p.Fields.NeedsValue), "field", "fields"),
+				map[bool]string{true: "needs", false: "need"}[len(p.Fields.NeedsValue) == 1],
+				unfillable)
+		default:
+			fmt.Fprintf(w, "%s still %s a value. Supply with --field key=value, then re-run without --dry-run.\n",
+				pluralize(len(p.Fields.NeedsValue), "field", "fields"),
+				map[bool]string{true: "needs", false: "need"}[len(p.Fields.NeedsValue) == 1])
+		}
 		return w.err
 	}
 	// `valid` is the server's own gate, and it means only that
@@ -2221,7 +2249,7 @@ func renderItemCopyNeedsValue(out io.Writer, p *cli.ItemCopyPreflight, overrides
 	// instead (Codex round 6). Empty keys are not currently rejected by
 	// collection-schema validation, so this is reachable.
 	unnamed := 0
-	unfillable := 0
+	unfillable := itemCopyUnfillable(p.Fields.NeedsValue)
 	var toAdd, toFix []string
 	for _, f := range p.Fields.NeedsValue {
 		if strings.TrimSpace(f.Key) == "" {
@@ -2236,7 +2264,6 @@ func renderItemCopyNeedsValue(out io.Writer, p *cli.ItemCopyPreflight, overrides
 		// handing someone a command that cannot work — the exact failure the
 		// empty-key branch was written to avoid.
 		if f.CollectionUnavailable {
-			unfillable++
 			continue
 		}
 		if _, ok := supplied(f.Key); ok {
@@ -2276,6 +2303,25 @@ func renderItemCopyNeedsValue(out io.Writer, p *cli.ItemCopyPreflight, overrides
 			p.Destination.WorkspaceSlug, p.Destination.CollectionSlug)
 	}
 	return w.err
+}
+
+// itemCopyUnfillable counts needs_value rows no `--field` can satisfy — a
+// relation whose target collection is not available to this caller (IDEA-2899).
+//
+// ONE definition, consulted by all three places that tell a user to supply a
+// value: the detailed render, the --dry-run summary, and the returned error.
+// The first version of this fix touched only the render, and a review found the
+// other two still printing `--field key=value` at someone for whom no value
+// exists. Three sites independently answering "how do I supply this" is exactly
+// how they diverge, so they now ask one function instead.
+func itemCopyUnfillable(rows []cli.ItemCopyPreflightNeedsValue) int {
+	n := 0
+	for _, f := range rows {
+		if f.CollectionUnavailable {
+			n++
+		}
+	}
+	return n
 }
 
 // renderItemCopyResult writes the outcome of a completed copy.

--- a/cmd/pad/cmd_item.go
+++ b/cmd/pad/cmd_item.go
@@ -1841,7 +1841,8 @@ func runItemCopy(opts itemCopyOptions, deps itemCopyDeps, stdout, stderr io.Writ
 		// and the error is the one line a script or a hurried reader sees.
 		hint := " (use --field key=value)"
 		if itemCopyUnfillable(pre.Fields.NeedsValue) == len(pre.Fields.NeedsValue) {
-			hint = fmt.Sprintf(" (no --field can supply it: %s)",
+			hint = fmt.Sprintf(" (no --field can supply %s: %s)",
+				map[bool]string{true: "it", false: "them"}[len(pre.Fields.NeedsValue) == 1],
 				itemCopyUnfillableWhy(pre.Fields.NeedsValue))
 		}
 		return fmt.Errorf("copy refused: %s in %s/%s %s a value%s",
@@ -2155,8 +2156,15 @@ func renderItemCopyPreflight(out io.Writer, p *cli.ItemCopyPreflight) error {
 	return w.err
 }
 
-// renderItemCopyNeedsValue is the refusal. It names every unresolved field
-// and shows the exact flags to add.
+// renderItemCopyNeedsValue is the refusal. It names every unresolved field and
+// shows the flags to add FOR THE ONES A FLAG CAN ADDRESS.
+//
+// Not every one can (IDEA-2899). A field the destination reported with an empty
+// key cannot be named by `--field` at all, and a relation whose target
+// collection is unavailable to this caller has no value that would resolve it.
+// Those rows are named and explained, and deliberately left out of the `Add:`
+// line — printing a command that is refused for exactly the reason someone is
+// already stuck is worse than printing nothing.
 //
 // No MUTATING request was sent. The read-only preflight has of course
 // already run — that is where this information came from — so do not read
@@ -2348,13 +2356,19 @@ func itemCopyUnfillable(rows []cli.ItemCopyPreflightNeedsValue) int {
 // Widening what a rule ACTS on silently widens what it SAYS, and the tell is a
 // sentence that was true while the predicate was narrower.
 //
+// Counts the two faults INDEPENDENTLY — no `continue` between them — because
+// ONE row can carry both: a relation with an empty key whose target is also
+// unavailable. Skipping the second count made such a row report only the
+// relation reason, and a mixed-case test built from TWO rows could not see it
+// (review round 4). One row with both faults and two rows with one each are
+// different fixtures, and only the first exercises this.
+//
 // Returns "" when nothing is unfillable.
 func itemCopyUnfillableWhy(rows []cli.ItemCopyPreflightNeedsValue) string {
 	targets, keys := 0, 0
 	for _, f := range rows {
 		if f.CollectionUnavailable {
 			targets++
-			continue
 		}
 		if strings.TrimSpace(f.Key) == "" {
 			keys++
@@ -2362,11 +2376,13 @@ func itemCopyUnfillableWhy(rows []cli.ItemCopyPreflightNeedsValue) string {
 	}
 	switch {
 	case targets > 0 && keys > 0:
-		return "the relation target is not available to you, and the rest came back with an empty key"
+		return "some name a relation target that is not available to you, and some came back with an empty key"
 	case targets > 0:
 		return "the relation target is not available to you"
 	case keys > 0:
-		return "the destination reported them with an empty key, which --field cannot address"
+		// Neutral on number, since one call site says "it" and the other can be
+		// plural (review round 4): "an empty key" reads correctly after either.
+		return "an empty key came back from the destination, which --field cannot address"
 	}
 	return ""
 }

--- a/cmd/pad/cmd_item.go
+++ b/cmd/pad/cmd_item.go
@@ -1835,12 +1835,14 @@ func runItemCopy(opts itemCopyOptions, deps itemCopyDeps, stdout, stderr io.Writ
 			_ = renderItemCopyNeedsValue(stderr, pre, req.FieldOverrides)
 		}
 		// The hint is CONDITIONAL for the same reason the render's Add: line
-		// is (IDEA-2899): when every unresolved field is a relation whose
-		// target is unavailable, `--field` cannot resolve any of them, and the
-		// error is the one line a script or a hurried reader actually sees.
+		// is (IDEA-2899): when NO unresolved field can be supplied — an
+		// unavailable relation target, or a key `--field` cannot address —
+		// telling someone to use `--field` is advice that cannot be followed,
+		// and the error is the one line a script or a hurried reader sees.
 		hint := " (use --field key=value)"
 		if itemCopyUnfillable(pre.Fields.NeedsValue) == len(pre.Fields.NeedsValue) {
-			hint = " (no --field can supply it: the relation target is not available to you)"
+			hint = fmt.Sprintf(" (no --field can supply it: %s)",
+				itemCopyUnfillableWhy(pre.Fields.NeedsValue))
 		}
 		return fmt.Errorf("copy refused: %s in %s/%s %s a value%s",
 			pluralize(len(pre.Fields.NeedsValue), "field", "fields"),
@@ -2121,22 +2123,24 @@ func renderItemCopyPreflight(out io.Writer, p *cli.ItemCopyPreflight) error {
 	fmt.Fprintln(w)
 	if len(p.Fields.NeedsValue) > 0 {
 		// IDEA-2899. "Supply with --field key=value" is advice, and advice that
-		// cannot be followed is worse than none: a relation whose target
-		// collection is unavailable has no value that satisfies it, so telling
-		// someone to supply one sends them to run a command that is refused for
-		// exactly the reason they are stuck.
+		// cannot be followed is worse than none. Two rows cannot be supplied:
+		// a relation whose target collection is unavailable, and one whose key
+		// is empty. Both send someone to run a command that is refused for
+		// exactly the reason they are already stuck.
 		unfillable := itemCopyUnfillable(p.Fields.NeedsValue)
 		switch {
 		case unfillable == len(p.Fields.NeedsValue):
-			fmt.Fprintf(w, "%s still %s a value, and no --field can supply %s: the relation target is not available to you.\n",
+			fmt.Fprintf(w, "%s still %s a value, and no --field can supply %s: %s.\n",
 				pluralize(len(p.Fields.NeedsValue), "field", "fields"),
 				map[bool]string{true: "needs", false: "need"}[len(p.Fields.NeedsValue) == 1],
-				map[bool]string{true: "it", false: "them"}[len(p.Fields.NeedsValue) == 1])
+				map[bool]string{true: "it", false: "them"}[len(p.Fields.NeedsValue) == 1],
+				itemCopyUnfillableWhy(p.Fields.NeedsValue))
 		case unfillable > 0:
-			fmt.Fprintf(w, "%s still %s a value. Supply the rest with --field key=value, then re-run without --dry-run — but %d of them cannot be supplied at all (the relation target is not available to you).\n",
+			fmt.Fprintf(w, "%s still %s a value. Supply the rest with --field key=value, then re-run without --dry-run — but %d of them cannot be supplied at all (%s).\n",
 				pluralize(len(p.Fields.NeedsValue), "field", "fields"),
 				map[bool]string{true: "needs", false: "need"}[len(p.Fields.NeedsValue) == 1],
-				unfillable)
+				unfillable,
+				itemCopyUnfillableWhy(p.Fields.NeedsValue))
 		default:
 			fmt.Fprintf(w, "%s still %s a value. Supply with --field key=value, then re-run without --dry-run.\n",
 				pluralize(len(p.Fields.NeedsValue), "field", "fields"),
@@ -2308,12 +2312,14 @@ func renderItemCopyNeedsValue(out io.Writer, p *cli.ItemCopyPreflight, overrides
 // itemCopyUnfillable counts needs_value rows NO `--field` can satisfy, for
 // EITHER reason (IDEA-2899).
 //
-// ONE definition, consulted by all three places that tell a user to supply a
-// value: the detailed render, the --dry-run summary, and the returned error.
-// The first version of this fix touched only the render, and a review found the
-// other two still printing `--field key=value` at someone for whom no value
-// exists. Three sites independently answering "how do I supply this" is exactly
-// how they diverge, so they ask one function instead.
+// Consulted by the two sites that state the advice in ONE sentence — the
+// --dry-run summary and the returned error. (The detailed render has its own
+// per-row handling and uses `itemCopyUnavailableTarget` plus its separate
+// empty-key branch, because it explains each reason where the row is printed.)
+// The first version of this fix touched only that render, and a review found
+// the other two still printing `--field key=value` at someone for whom no value
+// exists. Sites independently answering "how do I supply this" is exactly how
+// they diverge, so they ask one function instead.
 //
 // TWO reasons, not one, and the second was already here: an EMPTY KEY cannot be
 // supplied because `--field =value` is rejected by this command's own parser,
@@ -2330,6 +2336,39 @@ func itemCopyUnfillable(rows []cli.ItemCopyPreflightNeedsValue) int {
 		}
 	}
 	return n
+}
+
+// itemCopyUnfillableWhy names WHY no `--field` can supply the given rows, for
+// the two sites that state it in one sentence (IDEA-2899, review round 3).
+//
+// Broadening `itemCopyUnfillable` to cover empty keys without broadening the
+// SENTENCE was the defect: a set of empty-key rows selected the all-unfillable
+// branch and was then explained as "the relation target is not available to
+// you", which is a false statement about rows that have no relation in them.
+// Widening what a rule ACTS on silently widens what it SAYS, and the tell is a
+// sentence that was true while the predicate was narrower.
+//
+// Returns "" when nothing is unfillable.
+func itemCopyUnfillableWhy(rows []cli.ItemCopyPreflightNeedsValue) string {
+	targets, keys := 0, 0
+	for _, f := range rows {
+		if f.CollectionUnavailable {
+			targets++
+			continue
+		}
+		if strings.TrimSpace(f.Key) == "" {
+			keys++
+		}
+	}
+	switch {
+	case targets > 0 && keys > 0:
+		return "the relation target is not available to you, and the rest came back with an empty key"
+	case targets > 0:
+		return "the relation target is not available to you"
+	case keys > 0:
+		return "the destination reported them with an empty key, which --field cannot address"
+	}
+	return ""
 }
 
 // itemCopyUnavailableTarget counts only the relation half, for the detailed

--- a/cmd/pad/cmd_item.go
+++ b/cmd/pad/cmd_item.go
@@ -2249,7 +2249,7 @@ func renderItemCopyNeedsValue(out io.Writer, p *cli.ItemCopyPreflight, overrides
 	// instead (Codex round 6). Empty keys are not currently rejected by
 	// collection-schema validation, so this is reachable.
 	unnamed := 0
-	unfillable := itemCopyUnfillable(p.Fields.NeedsValue)
+	unfillable := itemCopyUnavailableTarget(p.Fields.NeedsValue)
 	var toAdd, toFix []string
 	for _, f := range p.Fields.NeedsValue {
 		if strings.TrimSpace(f.Key) == "" {
@@ -2305,16 +2305,44 @@ func renderItemCopyNeedsValue(out io.Writer, p *cli.ItemCopyPreflight, overrides
 	return w.err
 }
 
-// itemCopyUnfillable counts needs_value rows no `--field` can satisfy — a
-// relation whose target collection is not available to this caller (IDEA-2899).
+// itemCopyUnfillable counts needs_value rows NO `--field` can satisfy, for
+// EITHER reason (IDEA-2899).
 //
 // ONE definition, consulted by all three places that tell a user to supply a
 // value: the detailed render, the --dry-run summary, and the returned error.
 // The first version of this fix touched only the render, and a review found the
 // other two still printing `--field key=value` at someone for whom no value
 // exists. Three sites independently answering "how do I supply this" is exactly
-// how they diverge, so they now ask one function instead.
+// how they diverge, so they ask one function instead.
+//
+// TWO reasons, not one, and the second was already here: an EMPTY KEY cannot be
+// supplied because `--field =value` is rejected by this command's own parser,
+// which the detailed render has explained since Codex round 6. That render is
+// the only site that knew; the summary and the error went on advising `--field`
+// for those rows too. A predicate named "unfillable" that answered for one of
+// the two reasons would have been a worse trap than no predicate — right at the
+// site that defined it, wrong everywhere it was reused.
 func itemCopyUnfillable(rows []cli.ItemCopyPreflightNeedsValue) int {
+	n := 0
+	for _, f := range rows {
+		if f.CollectionUnavailable || strings.TrimSpace(f.Key) == "" {
+			n++
+		}
+	}
+	return n
+}
+
+// itemCopyUnavailableTarget counts only the relation half, for the detailed
+// render's own sentence about it — that render explains the empty-key case
+// separately, and the two sentences say different things.
+//
+// DELIBERATELY NOT also excluding empty keys, though the first version did. A
+// row can carry BOTH faults, and a mutant removing that exclusion survived
+// every test — correctly, because the behaviour it changes is printing two
+// sentences that are both TRUE about such a row instead of one. The guard was
+// tidiness dressed as a rule, and a condition nothing can distinguish is a
+// condition the next reader has to re-derive.
+func itemCopyUnavailableTarget(rows []cli.ItemCopyPreflightNeedsValue) int {
 	n := 0
 	for _, f := range rows {
 		if f.CollectionUnavailable {

--- a/cmd/pad/item_copy_test.go
+++ b/cmd/pad/item_copy_test.go
@@ -1795,3 +1795,95 @@ func TestRenderItemCopyNeedsValue_AvailableRelationTargetIsUnchanged(t *testing.
 		t.Fatalf("a fillable relation lost its suggestion:\n%s", got)
 	}
 }
+
+// unfillableOnlyPreflight is a refusal whose ONLY unresolved field is a
+// relation nobody can supply (IDEA-2899).
+func unfillableOnlyPreflight() *cli.ItemCopyPreflight {
+	p := fullPreflight()
+	p.Fields.NeedsValue = []cli.ItemCopyPreflightNeedsValue{{
+		Key: "owner_ref", Label: "Owner", Type: "relation",
+		Collection: "people", CollectionUnavailable: true,
+		Required: true, Reason: "missing_required",
+	}}
+	return p
+}
+
+// IDEA-2899, found by review AFTER the render was fixed and the reason the
+// advice now goes through ONE predicate. Three places tell a user how to supply
+// a value — the detailed render, the --dry-run summary, and the returned error
+// — and fixing only the first left the other two printing `--field key=value`
+// at someone for whom no value exists. The error is the line a script or a
+// hurried reader actually sees.
+func TestRunItemCopy_ErrorDoesNotSuggestFieldWhenNothingCanSupplyIt(t *testing.T) {
+	d := &recordingDeps{t: t, preflight: unfillableOnlyPreflight(), forbidCopy: true}
+
+	var out, errOut bytes.Buffer
+	err := runItemCopy(baseOpts(), d.deps(), &out, &errOut)
+	if err == nil {
+		t.Fatal("expected a non-nil error so the command exits non-zero")
+	}
+	if strings.Contains(err.Error(), "use --field key=value") {
+		t.Fatalf("the error tells the user to supply a value for a field no value can satisfy: %v", err)
+	}
+	if !strings.Contains(err.Error(), "not available to you") {
+		t.Fatalf("the error does not say WHY the field cannot be supplied: %v", err)
+	}
+	if len(d.copyCalls) != 0 {
+		t.Fatalf("no mutating request may be sent; got %d", len(d.copyCalls))
+	}
+}
+
+// The CONTROL for the above, on the same command path: an ordinary refusal
+// still carries the hint, so the change did not simply delete it.
+func TestRunItemCopy_ErrorKeepsTheFieldHintWhenAFieldCanBeSupplied(t *testing.T) {
+	d := &recordingDeps{t: t, preflight: fullPreflight(), forbidCopy: true}
+
+	var out, errOut bytes.Buffer
+	err := runItemCopy(baseOpts(), d.deps(), &out, &errOut)
+	if err == nil {
+		t.Fatal("expected a non-nil error")
+	}
+	if !strings.Contains(err.Error(), "use --field key=value") {
+		t.Fatalf("an ordinary refusal lost its hint: %v", err)
+	}
+}
+
+// The third site: the --dry-run summary, which is a different function again.
+func TestRunItemCopy_DryRunSummaryDoesNotSuggestAnImpossibleField(t *testing.T) {
+	d := &recordingDeps{t: t, preflight: unfillableOnlyPreflight(), forbidCopy: true}
+	opts := baseOpts()
+	opts.DryRun = true
+
+	var out, errOut bytes.Buffer
+	if err := runItemCopy(opts, d.deps(), &out, &errOut); err != nil {
+		t.Fatalf("dry run should not error: %v", err)
+	}
+	got := out.String()
+	if strings.Contains(got, "Supply with --field key=value") {
+		t.Fatalf("the dry-run summary still tells the user to supply a value nothing can satisfy:\n%s", got)
+	}
+	if !strings.Contains(got, "not available to you") {
+		t.Fatalf("the dry-run summary does not say why the field cannot be supplied:\n%s", got)
+	}
+
+	// MIXED CASE, which is the one a switch gets wrong: one fillable field and
+	// one that is not. The advice must survive for the fillable one and the
+	// caveat must appear for the other.
+	mixed := unfillableOnlyPreflight()
+	mixed.Fields.NeedsValue = append(mixed.Fields.NeedsValue, cli.ItemCopyPreflightNeedsValue{
+		Key: "priority", Label: "Priority", Type: "select",
+		Options: []string{"low", "high"}, Required: true, Reason: "missing_required",
+	})
+	d2 := &recordingDeps{t: t, preflight: mixed, forbidCopy: true}
+	var out2, errOut2 bytes.Buffer
+	if err := runItemCopy(opts, d2.deps(), &out2, &errOut2); err != nil {
+		t.Fatalf("dry run should not error: %v", err)
+	}
+	got2 := out2.String()
+	if !strings.Contains(got2, "--field key=value") {
+		t.Fatalf("the mixed case lost the advice for the field that CAN be supplied:\n%s", got2)
+	}
+	if !strings.Contains(got2, "cannot be supplied at all") {
+		t.Fatalf("the mixed case does not flag the field that cannot be supplied:\n%s", got2)
+	}
+}

--- a/cmd/pad/item_copy_test.go
+++ b/cmd/pad/item_copy_test.go
@@ -1887,3 +1887,56 @@ func TestRunItemCopy_DryRunSummaryDoesNotSuggestAnImpossibleField(t *testing.T) 
 		t.Fatalf("the mixed case does not flag the field that cannot be supplied:\n%s", got2)
 	}
 }
+
+// The OTHER reason a row cannot be supplied, and the one that was already here:
+// an empty key. `--field =value` is rejected by this command's own parser, and
+// the detailed render has explained that since Codex round 6 — but the summary
+// and the error went on advising `--field` for those rows, because the first
+// version of `itemCopyUnfillable` answered for the relation reason only.
+//
+// Review round 2. A predicate named "unfillable" that covered one of two
+// reasons is a worse trap than no predicate: correct at the site that defined
+// it, wrong everywhere it was reused.
+func TestRunItemCopy_EmptyKeyRowsAreUnfillableToo(t *testing.T) {
+	p := fullPreflight()
+	p.Fields.NeedsValue = []cli.ItemCopyPreflightNeedsValue{{
+		Key: "", Label: "", Type: "text", Required: true, Reason: "missing_required",
+	}}
+	d := &recordingDeps{t: t, preflight: p, forbidCopy: true}
+
+	var out, errOut bytes.Buffer
+	err := runItemCopy(baseOpts(), d.deps(), &out, &errOut)
+	if err == nil {
+		t.Fatal("expected a non-nil error")
+	}
+	if strings.Contains(err.Error(), "use --field key=value") {
+		t.Fatalf("the error advises --field for a row whose key is empty; `--field =value` is "+
+			"rejected by this command's own parser: %v", err)
+	}
+
+	// The --dry-run summary is the third site and a different function.
+	opts := baseOpts()
+	opts.DryRun = true
+	d2 := &recordingDeps{t: t, preflight: p, forbidCopy: true}
+	var out2, errOut2 bytes.Buffer
+	if err := runItemCopy(opts, d2.deps(), &out2, &errOut2); err != nil {
+		t.Fatalf("dry run should not error: %v", err)
+	}
+	if strings.Contains(out2.String(), "Supply with --field key=value") {
+		t.Fatalf("the dry-run summary advises --field for an empty-key row:\n%s", out2.String())
+	}
+
+	// AND the detailed render still describes it as an empty key rather than as
+	// an unavailable relation target — one predicate for the advice, two
+	// explanations, because the two reasons are not interchangeable to a reader.
+	var out3, errOut3 bytes.Buffer
+	d3 := &recordingDeps{t: t, preflight: p, forbidCopy: true}
+	_ = runItemCopy(baseOpts(), d3.deps(), &out3, &errOut3)
+	stderr := errOut3.String()
+	if !strings.Contains(stderr, "empty key") {
+		t.Fatalf("the detailed render stopped explaining the empty-key case:\n%s", stderr)
+	}
+	if strings.Contains(stderr, "not available to you") {
+		t.Fatalf("an empty-key row is described as an unavailable relation target:\n%s", stderr)
+	}
+}

--- a/cmd/pad/item_copy_test.go
+++ b/cmd/pad/item_copy_test.go
@@ -1940,3 +1940,73 @@ func TestRunItemCopy_EmptyKeyRowsAreUnfillableToo(t *testing.T) {
 		t.Fatalf("an empty-key row is described as an unavailable relation target:\n%s", stderr)
 	}
 }
+
+// Review round 3, and the sharpest miss of this unit: broadening what a
+// predicate ACTS on silently broadened what the sentence SAYS. Once
+// `itemCopyUnfillable` counted empty keys too, a set of empty-key rows selected
+// the all-unfillable branch and was explained as "the relation target is not
+// available to you" — a false statement about rows containing no relation.
+//
+// The tell was available: a sentence that was true while the predicate was
+// narrower is a sentence to re-read when it widens.
+func TestRunItemCopy_UnfillableExplanationMatchesTheActualReason(t *testing.T) {
+	emptyKeyOnly := fullPreflight()
+	emptyKeyOnly.Fields.NeedsValue = []cli.ItemCopyPreflightNeedsValue{{
+		Key: "", Type: "text", Required: true, Reason: "missing_required",
+	}}
+
+	d := &recordingDeps{t: t, preflight: emptyKeyOnly, forbidCopy: true}
+	var out, errOut bytes.Buffer
+	err := runItemCopy(baseOpts(), d.deps(), &out, &errOut)
+	if err == nil {
+		t.Fatal("expected a non-nil error")
+	}
+	if strings.Contains(err.Error(), "relation target") {
+		t.Fatalf("an empty-key-only refusal is explained as a relation problem: %v", err)
+	}
+	if !strings.Contains(err.Error(), "empty key") {
+		t.Fatalf("the error does not name the actual reason: %v", err)
+	}
+
+	// The --dry-run summary states it in one sentence too.
+	opts := baseOpts()
+	opts.DryRun = true
+	d2 := &recordingDeps{t: t, preflight: emptyKeyOnly, forbidCopy: true}
+	var out2, errOut2 bytes.Buffer
+	if err := runItemCopy(opts, d2.deps(), &out2, &errOut2); err != nil {
+		t.Fatalf("dry run should not error: %v", err)
+	}
+	if strings.Contains(out2.String(), "relation target") {
+		t.Fatalf("the dry-run summary explains an empty-key row as a relation problem:\n%s", out2.String())
+	}
+
+	// CONTROL: a relation-only refusal still says relation. Without this leg the
+	// fix could have been "never mention relations", which is the same defect
+	// pointing the other way.
+	d3 := &recordingDeps{t: t, preflight: unfillableOnlyPreflight(), forbidCopy: true}
+	var out3, errOut3 bytes.Buffer
+	err3 := runItemCopy(baseOpts(), d3.deps(), &out3, &errOut3)
+	if err3 == nil || !strings.Contains(err3.Error(), "relation target") {
+		t.Fatalf("a relation-only refusal lost its explanation: %v", err3)
+	}
+
+	// MIXED: both reasons present, and the sentence must not pick one.
+	mixed := fullPreflight()
+	mixed.Fields.NeedsValue = []cli.ItemCopyPreflightNeedsValue{
+		{Key: "owner_ref", Type: "relation", Collection: "people",
+			CollectionUnavailable: true, Required: true, Reason: "missing_required"},
+		{Key: "", Type: "text", Required: true, Reason: "missing_required"},
+	}
+	d4 := &recordingDeps{t: t, preflight: mixed, forbidCopy: true}
+	var out4, errOut4 bytes.Buffer
+	err4 := runItemCopy(baseOpts(), d4.deps(), &out4, &errOut4)
+	if err4 == nil {
+		t.Fatal("expected a non-nil error")
+	}
+	for _, want := range []string{"relation target", "empty key"} {
+		if !strings.Contains(err4.Error(), want) {
+			t.Fatalf("the mixed refusal omits %q, so one of the two reasons goes unexplained: %v",
+				want, err4)
+		}
+	}
+}

--- a/cmd/pad/item_copy_test.go
+++ b/cmd/pad/item_copy_test.go
@@ -1709,3 +1709,89 @@ func TestRenderItemCopyNeedsValue_RelationNamesItsTargetCollection(t *testing.T)
 		t.Fatalf("the select row lost its options line:\n%s", got)
 	}
 }
+
+// IDEA-2899. Naming the target is only useful if the target is THERE. When it
+// is not — deleted, or unreadable by this caller — the CLI must say so and must
+// NOT print `--field owner_ref=<value>`: the referent validation this command
+// runs against would refuse anything the user could name, so the suggestion is
+// a command that cannot work. Same disposition as the empty-key branch, which
+// exists for exactly that reason.
+func TestRenderItemCopyNeedsValue_UnavailableRelationTargetIsNotSuggested(t *testing.T) {
+	pre := &cli.ItemCopyPreflight{
+		Destination: cli.ItemCopyPreflightDestination{
+			WorkspaceSlug: "dest-ws", CollectionSlug: "tasks",
+		},
+		Fields: cli.ItemCopyPreflightFields{
+			NeedsValue: []cli.ItemCopyPreflightNeedsValue{
+				{
+					Key: "owner_ref", Label: "Owner", Type: "relation",
+					Collection: "people", CollectionUnavailable: true,
+					Required: true, Reason: "missing_required",
+				},
+				// A row the CLI CAN fill, in the same render. Without it the
+				// test could pass by suppressing the Add: line entirely, which
+				// would be a different and worse bug.
+				{
+					Key: "priority", Label: "Priority", Type: "select",
+					Options: []string{"low", "high"}, Required: true,
+					Reason: "missing_required",
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := renderItemCopyNeedsValue(&buf, pre, nil); err != nil {
+		t.Fatalf("renderItemCopyNeedsValue: %v", err)
+	}
+	got := buf.String()
+
+	if !strings.Contains(got, "NOT AVAILABLE to you") {
+		t.Fatalf("the unavailable target is rendered as though it were usable:\n%s", got)
+	}
+	if strings.Contains(got, "--field owner_ref=") {
+		t.Fatalf("the CLI suggests supplying a relation whose target is unavailable; no value "+
+			"can satisfy it and the command would be refused:\n%s", got)
+	}
+	// THE OTHER DIRECTION, which is what makes the assertion above mean
+	// something: the fillable row is still suggested.
+	if !strings.Contains(got, "--field priority=<value>") {
+		t.Fatalf("the fillable row lost its suggestion, so the fix suppressed more than the one "+
+			"row it should have:\n%s", got)
+	}
+	if !strings.Contains(got, "no --field value can satisfy") {
+		t.Fatalf("nothing explains WHY the relation is missing from the Add: line; a suggestion "+
+			"that silently omits a required field reads as a bug in the CLI:\n%s", got)
+	}
+}
+
+// The control for the line above: an AVAILABLE target renders exactly as it did
+// before this change, so `omitempty`'s absent-means-available contract is
+// exercised on the CLI surface and not only on the web one.
+func TestRenderItemCopyNeedsValue_AvailableRelationTargetIsUnchanged(t *testing.T) {
+	pre := &cli.ItemCopyPreflight{
+		Destination: cli.ItemCopyPreflightDestination{
+			WorkspaceSlug: "dest-ws", CollectionSlug: "tasks",
+		},
+		Fields: cli.ItemCopyPreflightFields{
+			NeedsValue: []cli.ItemCopyPreflightNeedsValue{{
+				Key: "owner_ref", Label: "Owner", Type: "relation",
+				Collection: "people", Required: true, Reason: "missing_required",
+			}},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := renderItemCopyNeedsValue(&buf, pre, nil); err != nil {
+		t.Fatalf("renderItemCopyNeedsValue: %v", err)
+	}
+	got := buf.String()
+
+	if strings.Contains(got, "NOT AVAILABLE") {
+		t.Fatalf("a row with no flag was rendered as unavailable; absence must mean available, "+
+			"or a server that does not report:\n%s", got)
+	}
+	if !strings.Contains(got, "--field owner_ref=<value>") {
+		t.Fatalf("a fillable relation lost its suggestion:\n%s", got)
+	}
+}

--- a/cmd/pad/item_copy_test.go
+++ b/cmd/pad/item_copy_test.go
@@ -2037,3 +2037,41 @@ func TestRunItemCopy_ARowWithBothFaultsReportsBoth(t *testing.T) {
 		}
 	}
 }
+
+// The tally as a unit, including the case its callers cannot currently reach.
+//
+// Both call sites sit inside `if len(NeedsValue) > 0`, so `Total == 0` never
+// arrives today and a mutant removing the guard SURVIVES every command-level
+// test. Keeping an unreachable guard and calling it defence is how a promise
+// becomes a lie, so it is tested where it IS reachable: an empty set is not
+// "entirely unfillable", and a future caller outside that gate would otherwise
+// be told, silently, that nothing can be supplied.
+func TestItemCopyTally(t *testing.T) {
+	if got := itemCopyTally(nil); got.AllUnfillable() {
+		t.Fatalf("an empty set reports AllUnfillable: %+v", got)
+	}
+
+	// ONE row, BOTH faults. Unfillable must be 1, not 2 — otherwise
+	// `Unfillable == Total` is false for a set that is entirely unfillable,
+	// which is the comparison both callers make.
+	both := itemCopyTally([]cli.ItemCopyPreflightNeedsValue{{
+		Key: "", Type: "relation", CollectionUnavailable: true,
+	}})
+	if both.Unfillable != 1 || both.Total != 1 || !both.AllUnfillable() {
+		t.Fatalf("a single row with both faults tallied wrong: %+v", both)
+	}
+	if both.UnavailableTarget != 1 || both.EmptyKey != 1 {
+		t.Fatalf("both reasons should be counted for the same row: %+v", both)
+	}
+
+	// A whitespace-only key is an empty key: `--field " "=value` names nothing
+	// either, and the render has trimmed since Codex round 6.
+	if got := itemCopyTally([]cli.ItemCopyPreflightNeedsValue{{Key: "   "}}); got.EmptyKey != 1 {
+		t.Fatalf("a whitespace-only key is not counted as empty: %+v", got)
+	}
+
+	// A perfectly ordinary row is unfillable in neither sense.
+	if got := itemCopyTally([]cli.ItemCopyPreflightNeedsValue{{Key: "size", Type: "select"}}); got.Unfillable != 0 || got.Why() != "" {
+		t.Fatalf("an ordinary row was tallied as unfillable: %+v (why=%q)", got, got.Why())
+	}
+}

--- a/cmd/pad/item_copy_test.go
+++ b/cmd/pad/item_copy_test.go
@@ -2010,3 +2010,30 @@ func TestRunItemCopy_UnfillableExplanationMatchesTheActualReason(t *testing.T) {
 		}
 	}
 }
+
+// ONE row carrying BOTH faults — an empty key AND an unavailable relation
+// target. Review round 4, and the fixture that matters: the mixed-case test
+// above uses TWO rows with one fault each, and a `continue` between the two
+// counts made a single dual-fault row report only the relation reason. Two
+// rows with one fault each and one row with two are different inputs, and only
+// the second exercises the counting.
+func TestRunItemCopy_ARowWithBothFaultsReportsBoth(t *testing.T) {
+	p := fullPreflight()
+	p.Fields.NeedsValue = []cli.ItemCopyPreflightNeedsValue{{
+		Key: "", Type: "relation", Collection: "people",
+		CollectionUnavailable: true, Required: true, Reason: "missing_required",
+	}}
+
+	d := &recordingDeps{t: t, preflight: p, forbidCopy: true}
+	var out, errOut bytes.Buffer
+	err := runItemCopy(baseOpts(), d.deps(), &out, &errOut)
+	if err == nil {
+		t.Fatal("expected a non-nil error")
+	}
+	for _, want := range []string{"relation target", "empty key"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("a row with BOTH faults omits %q, so one reason goes unexplained: %v",
+				want, err)
+		}
+	}
+}

--- a/internal/cli/client_items_copy.go
+++ b/internal/cli/client_items_copy.go
@@ -154,7 +154,16 @@ type ItemCopyPreflightNeedsValue struct {
 	// server's field for field — a mirror that silently lags is a mirror that
 	// lies, and the CLI renders these rows.
 	Collection string `json:"collection,omitempty"`
-	Required   bool   `json:"required"`
+	// CollectionUnavailable is true when Collection names a target this caller
+	// cannot use — deleted, or not readable by them (IDEA-2899). Mirrored for
+	// the same reason Collection is, and the CLI uses it for the same decision
+	// the dialog does: a row whose target is unavailable must not appear in the
+	// `--field key=<value>` suggestion, because there is no value to supply.
+	//
+	// ABSENT means available OR a server that does not report; only an explicit
+	// true says the target is unusable.
+	CollectionUnavailable bool `json:"collection_unavailable,omitempty"`
+	Required              bool `json:"required"`
 	// Reason is "missing_required" or "invalid_value".
 	Reason  string `json:"reason"`
 	Message string `json:"message,omitempty"`

--- a/internal/cli/client_items_copy.go
+++ b/internal/cli/client_items_copy.go
@@ -141,8 +141,14 @@ type ItemCopyPreflightDropped struct {
 	Reason string `json:"reason"`
 }
 
-// ItemCopyPreflightNeedsValue is one destination field the caller must
-// resolve with an override before the copy can proceed.
+// ItemCopyPreflightNeedsValue is one destination field the copy cannot satisfy
+// on its own.
+//
+// Usually the caller resolves it with an override. Not always: a row carrying
+// `CollectionUnavailable` names a relation target that is deleted or unreadable
+// by this caller, and a row with an EMPTY key cannot be named by `--field` — so
+// the copy cannot proceed at all, and the CLI says so instead of advising a
+// flag (IDEA-2899).
 type ItemCopyPreflightNeedsValue struct {
 	Key     string   `json:"key"`
 	Label   string   `json:"label,omitempty"`

--- a/internal/server/handlers_items_copy_preflight.go
+++ b/internal/server/handlers_items_copy_preflight.go
@@ -992,14 +992,21 @@ func (s *Server) handleCopyItemPreflight(w http.ResponseWriter, r *http.Request)
 				reason = "missing_required"
 			}
 			resp.Fields.NeedsValue = append(resp.Fields.NeedsValue, ItemCopyPreflightNeedsValue{
-				Key:        def.Key,
-				Label:      def.Label,
-				Type:       def.Type,
-				Options:    def.Options,
-				Collection: def.Collection,
-				// Gated on the TYPE as well as the map, so a non-relation field
-				// that happens to carry a `collection` in its schema can never
-				// pick up a flag whose meaning is defined only for relations.
+				Key:     def.Key,
+				Label:   def.Label,
+				Type:    def.Type,
+				Options: def.Options,
+				// GATED ON THE TYPE, both of them. The doc on this field says
+				// `collection` is empty for every non-relation type, and until
+				// now that was a claim about schemas rather than about this
+				// code: nothing stops a schema declaring `collection` on a
+				// `select` — the validator does not police keys it has no use
+				// for — and the value was copied straight through. The CLI then
+				// printed "target collection: people" under a select, which is
+				// a relation fact asserted about a field that has none (review
+				// round 2). Gating here makes the documented contract true at
+				// the only place that can make it true.
+				Collection:            relationTargetSlug(def),
 				CollectionUnavailable: def.Type == "relation" && unavailableTargets[def.Collection],
 				Required:              def.Required,
 				Reason:                reason,

--- a/internal/server/handlers_items_copy_preflight.go
+++ b/internal/server/handlers_items_copy_preflight.go
@@ -354,7 +354,30 @@ type ItemCopyPreflightNeedsValue struct {
 	// before. Not a wire-version question for the same reason
 	// `models.ItemWriteWarnings` was not.
 	Collection string `json:"collection,omitempty"`
-	Required   bool   `json:"required"`
+	// CollectionUnavailable is true when `Collection` names a target this
+	// caller cannot actually use in the destination — the slug names no live
+	// collection, or names one they cannot read (IDEA-2899).
+	//
+	// Naming a target is not the same as having one. Without this the dialog
+	// offers the row a picker that can return nothing, and since the row is not
+	// blocked, Confirm stays disabled with only the generic required-field
+	// message: the user is told a value is missing and never told that no value
+	// is reachable.
+	//
+	// DELETED and UNREADABLE are deliberately NOT distinguished. They are
+	// different facts with the same consequence — no picker can be built — and
+	// the client has no branch that would differ between them. Distinguishing
+	// them would also disclose to a caller who cannot read a collection that it
+	// nonetheless exists, which is a fact this endpoint has no reason to leak.
+	//
+	// `omitempty` on a BOOL drops `false`, which is why the field is phrased
+	// negatively. Present-and-true means the server checked and the target is
+	// unusable; ABSENT means available, or a server that does not report. The
+	// client must block only on an explicit true, so absence stays "no
+	// information" rather than becoming a value — the same rule
+	// `access_epoch` follows on the item doors.
+	CollectionUnavailable bool `json:"collection_unavailable,omitempty"`
+	Required              bool `json:"required"`
 	// Reason is "missing_required" (no value and no default) or
 	// "invalid_value" (a value carried across that the destination schema
 	// rejects — only reachable for non-override values; an INVALID
@@ -942,6 +965,17 @@ func (s *Server) handleCopyItemPreflight(w http.ResponseWriter, r *http.Request)
 		},
 	}
 
+	// Which relation targets the destination schema names that this caller
+	// cannot use (IDEA-2899). Computed once for the whole response rather than
+	// per row: a schema can declare several relations onto one collection, and
+	// the answer does not vary between them. Runs no query at all when the
+	// destination declares no relation field.
+	unavailableTargets, err := s.relationTargetsUnavailable(r, dst.Workspace.ID, targetSchema)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+
 	// carried / needs_value, walked in destination-schema order so the
 	// response is stable across identical calls.
 	//
@@ -963,9 +997,13 @@ func (s *Server) handleCopyItemPreflight(w http.ResponseWriter, r *http.Request)
 				Type:       def.Type,
 				Options:    def.Options,
 				Collection: def.Collection,
-				Required:   def.Required,
-				Reason:     reason,
-				Message:    iss.Message,
+				// Gated on the TYPE as well as the map, so a non-relation field
+				// that happens to carry a `collection` in its schema can never
+				// pick up a flag whose meaning is defined only for relations.
+				CollectionUnavailable: def.Type == "relation" && unavailableTargets[def.Collection],
+				Required:              def.Required,
+				Reason:                reason,
+				Message:               iss.Message,
 			})
 			continue
 		}

--- a/internal/server/handlers_items_copy_preflight.go
+++ b/internal/server/handlers_items_copy_preflight.go
@@ -225,7 +225,15 @@ type ItemCopyPreflightFields struct {
 
 	// NeedsValue are destination fields the copy cannot satisfy on its
 	// own: required-and-empty, or carrying a value the destination schema
-	// rejects. Supply an override for each and the entry clears.
+	// rejects. Supplying an override clears the entry — for the ones an
+	// override CAN clear.
+	//
+	// Some cannot be (IDEA-2899). A row whose `collection_unavailable` is set
+	// names a relation target that has been deleted or that this caller cannot
+	// read, so no value would resolve it; and a row the destination schema
+	// reported with an EMPTY key cannot be addressed by an override at all.
+	// Both are reported rather than hidden, because a caller that is told only
+	// "supply a value" will go looking for one that does not exist.
 	NeedsValue []ItemCopyPreflightNeedsValue `json:"needs_value"`
 }
 

--- a/internal/server/handlers_items_copy_relation_test.go
+++ b/internal/server/handlers_items_copy_relation_test.go
@@ -1183,3 +1183,119 @@ func TestCopyPreflight_RequiredRelationNeedsValueCarriesItsCollection(t *testing
 		}
 	}
 }
+
+// needsValueRow returns the needs_value row for key, or nil.
+func needsValueRow(pre ItemCopyPreflight, key string) *ItemCopyPreflightNeedsValue {
+	for i := range pre.Fields.NeedsValue {
+		if pre.Fields.NeedsValue[i].Key == key {
+			return &pre.Fields.NeedsValue[i]
+		}
+	}
+	return nil
+}
+
+// IDEA-2899. TASK-2869 made a needs_value relation row COLLECTABLE as soon as
+// it names a target collection. Naming one is not having one: the slug can name
+// a collection that has been deleted, or one this caller cannot read. The
+// dialog then mounts a picker that can return nothing and, because the row is
+// not blocked, Confirm stays disabled with only the generic required-field
+// message — a value is missing and nothing says no value is reachable.
+//
+// The client cannot answer this itself: its destination collection list is
+// filtered by `canEditCollection` (it drives the copy-INTO picker), while a
+// relation TARGET needs only READ access. Testing against the editable list
+// would refuse rows the user could have filled in, which is a worse failure and
+// invisible to whoever hits it.
+func TestCopyPreflight_RelationNeedsValueReportsADeletedTarget(t *testing.T) {
+	f := newCopyRelationFixtureWith(t, noDestDefault, nil, true)
+
+	// CONTROL LEG FIRST, on the same fixture, so the two legs differ in exactly
+	// one fact: whether the target collection is still there. A test that only
+	// ever sees the broken state cannot show the flag tracks anything.
+	live := needsValueRow(f.ok(f.baseBody()), "owner_ref")
+	if live == nil {
+		t.Fatalf("a REQUIRED relation with no value produced no needs_value row")
+	}
+	if live.CollectionUnavailable {
+		t.Fatalf("target %q is live and readable, yet the row reports it unavailable: %+v",
+			f.targetsB.Slug, live)
+	}
+
+	// "" opts out of the optimistic-concurrency check, as every other test
+	// that deletes a collection does; nothing here races the delete.
+	if err := f.srv.store.DeleteCollection(f.targetsB.ID, ""); err != nil {
+		t.Fatalf("DeleteCollection(targetsB): %v", err)
+	}
+
+	gone := needsValueRow(f.ok(f.baseBody()), "owner_ref")
+	if gone == nil {
+		t.Fatalf("the needs_value row disappeared when its target was deleted; "+
+			"the field is still required and still unsatisfiable: %+v", f.ok(f.baseBody()).Fields)
+	}
+	if !gone.CollectionUnavailable {
+		t.Fatalf("target %q is DELETED and the row does not say so: %+v",
+			f.targetsB.Slug, gone)
+	}
+	// The slug is still reported. The client needs it to say WHICH target is
+	// gone; suppressing it would trade one silent failure for another.
+	if gone.Collection != f.targetsB.Slug {
+		t.Fatalf("row stopped naming its target once it became unavailable: %+v", gone)
+	}
+}
+
+// The other half of the same defect, and the half the client provably cannot
+// compute: the collection EXISTS and this caller cannot read it.
+func TestCopyPreflight_RelationNeedsValueReportsAnUnreadableTarget(t *testing.T) {
+	f := newCopyRelationFixtureWith(t, noDestDefault, nil, true)
+
+	// An editor who may copy INTO the destination collection but may NOT read
+	// the relation's target. That combination is the whole point: every
+	// permission the dialog can see is satisfied, so nothing on the client side
+	// could distinguish this from a usable target.
+	u := f.restrictedEditor("rel-target-hidden@example.com", "reltargethidden",
+		[]string{f.collA.ID, f.targetsA.ID}, []string{f.collB.ID})
+
+	rr := f.call(u, reqOpts{}, f.baseBody())
+	if rr.Code != http.StatusOK {
+		t.Fatalf("preflight as restricted editor: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var pre ItemCopyPreflight
+	if err := json.Unmarshal(rr.Body.Bytes(), &pre); err != nil {
+		t.Fatalf("parse preflight: %v", err)
+	}
+
+	row := needsValueRow(pre, "owner_ref")
+	if row == nil {
+		t.Fatalf("a REQUIRED relation with no value produced no needs_value row: %+v", pre.Fields)
+	}
+	if !row.CollectionUnavailable {
+		t.Fatalf("target %q is unreadable by this caller and the row does not say so: %+v",
+			f.targetsB.Slug, row)
+	}
+
+	// CONTROL LEG: the OWNER, who can read it, gets no flag on the same field
+	// of the same fixture. Without this the test would pass against a server
+	// that flagged every relation row unconditionally.
+	if owner := needsValueRow(f.ok(f.baseBody()), "owner_ref"); owner == nil || owner.CollectionUnavailable {
+		t.Fatalf("the owner can read %q, yet their row reports it unavailable: %+v",
+			f.targetsB.Slug, owner)
+	}
+}
+
+// `omitempty` on a bool drops FALSE, which is what makes the field's negative
+// phrasing load-bearing: absent must read as "available, or a server that does
+// not report", never as "unavailable". A client that blocked on absence would
+// refuse every row against a server predating this change.
+func TestCopyPreflight_AvailableRelationTargetOmitsTheFlagEntirely(t *testing.T) {
+	f := newCopyRelationFixtureWith(t, noDestDefault, nil, true)
+
+	rr := f.call(f.owner, reqOpts{}, f.baseBody())
+	if rr.Code != http.StatusOK {
+		t.Fatalf("preflight: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if strings.Contains(rr.Body.String(), "collection_unavailable") {
+		t.Fatalf("a response whose relation targets are all usable still mentions "+
+			"collection_unavailable; it must be omitted so the wire is byte-identical "+
+			"to before this change:\n%s", rr.Body.String())
+	}
+}

--- a/internal/server/handlers_items_copy_relation_test.go
+++ b/internal/server/handlers_items_copy_relation_test.go
@@ -1343,3 +1343,40 @@ func TestCopyPreflight_OnlyRelationRowsCarryTheUnavailableFlag(t *testing.T) {
 			"can perfectly well collect: %+v", bucket.Type, bucket)
 	}
 }
+
+// THE BOUNDARY, pinned deliberately rather than left to be rediscovered.
+//
+// A review asked whether a target collection that is live and readable but
+// holds NO items the caller can pick should be flagged too: the picker is empty
+// either way, so the symptom looks identical. It must NOT be, and the reason is
+// the one that shaped this whole change — over-blocking is the worse failure.
+//
+// An unavailable target is unfixable from inside the dialog: nothing the user
+// does makes a deleted or unreadable collection pickable, so refusing the copy
+// costs them nothing they had. An EMPTY collection is a "nothing to pick YET"
+// state that the user can resolve by creating the item and retrying, and
+// blocking would refuse a copy they were about to be able to complete. Testing
+// for it would also cost a live-visible-item COUNT per relation target on a
+// dry-run the UI calls on every keystroke.
+//
+// The weaker case — an empty picker that says nothing about why it is empty —
+// is IDEA-2905, and it belongs to the picker rather than to this flag.
+func TestCopyPreflight_AnEmptyButReadableTargetIsNotReportedUnavailable(t *testing.T) {
+	f := newCopyRelationFixtureWith(t, noDestDefault, nil, true)
+
+	// targetsB is live and readable; remove its only item so the picker there
+	// would come back empty.
+	if err := f.srv.store.DeleteItem(f.targetB.ID); err != nil {
+		t.Fatalf("DeleteItem(targetB): %v", err)
+	}
+
+	row := needsValueRow(f.ok(f.baseBody()), "owner_ref")
+	if row == nil {
+		t.Fatalf("a REQUIRED relation with no value produced no needs_value row")
+	}
+	if row.CollectionUnavailable {
+		t.Fatalf("an EMPTY but readable target was reported unavailable: %+v\n"+
+			"blocking here refuses a copy the user could complete by creating the target item",
+			row)
+	}
+}

--- a/internal/server/handlers_items_copy_relation_test.go
+++ b/internal/server/handlers_items_copy_relation_test.go
@@ -1299,3 +1299,47 @@ func TestCopyPreflight_AvailableRelationTargetOmitsTheFlagEntirely(t *testing.T)
 			"to before this change:\n%s", rr.Body.String())
 	}
 }
+
+// The flag's meaning is defined for RELATION rows only, so the builder gates
+// on the field TYPE as well as on the unavailable-target set. Nothing stops a
+// schema declaring `collection` on a field of another type — the validator does
+// not police keys it has no use for — and such a field would otherwise pick up
+// a flag that says nothing true about it: the dialog would block a perfectly
+// collectable `select` because some relation elsewhere in the schema points at
+// a collection that happens to be gone.
+//
+// Found by a surviving mutant, not by inspection: dropping the type gate left
+// every other test in this file green.
+func TestCopyPreflight_OnlyRelationRowsCarryTheUnavailableFlag(t *testing.T) {
+	f := newCopyRelationFixtureWith(t, noDestDefault, nil, true)
+
+	// A destination schema where a NON-relation required field names the same
+	// target slug as the relation does. One deleted collection, two rows that
+	// mention it, and only one of them means anything by it.
+	schema := fmt.Sprintf(`{"fields":[
+		{"key":"status","label":"Status","type":"select","options":["open","done"],"required":true},
+		{"key":"owner_ref","label":"Owner","type":"relation","collection":%q,"required":true},
+		{"key":"bucket","label":"Bucket","type":"select","options":["a","b"],"collection":%q,"required":true}
+	]}`, f.targetsB.Slug, f.targetsB.Slug)
+	if _, err := f.srv.store.UpdateCollection(f.collB.ID, models.CollectionUpdate{Schema: &schema}); err != nil {
+		t.Fatalf("UpdateCollection(collB): %v", err)
+	}
+	if err := f.srv.store.DeleteCollection(f.targetsB.ID, ""); err != nil {
+		t.Fatalf("DeleteCollection(targetsB): %v", err)
+	}
+
+	pre := f.ok(f.baseBody())
+	rel := needsValueRow(pre, "owner_ref")
+	if rel == nil || !rel.CollectionUnavailable {
+		t.Fatalf("the RELATION row should report its deleted target: %+v", pre.Fields.NeedsValue)
+	}
+	bucket := needsValueRow(pre, "bucket")
+	if bucket == nil {
+		t.Fatalf("the required select produced no needs_value row: %+v", pre.Fields.NeedsValue)
+	}
+	if bucket.CollectionUnavailable {
+		t.Fatalf("a %s row carries collection_unavailable; the flag is defined for "+
+			"relations only, and blocking this row would refuse a value the dialog "+
+			"can perfectly well collect: %+v", bucket.Type, bucket)
+	}
+}

--- a/internal/server/handlers_items_copy_relation_test.go
+++ b/internal/server/handlers_items_copy_relation_test.go
@@ -1342,6 +1342,15 @@ func TestCopyPreflight_OnlyRelationRowsCarryTheUnavailableFlag(t *testing.T) {
 			"relations only, and blocking this row would refuse a value the dialog "+
 			"can perfectly well collect: %+v", bucket.Type, bucket)
 	}
+	// AND IT CARRIES NO TARGET AT ALL (review round 2). The field's doc says
+	// `collection` is empty for every non-relation type; until this unit that
+	// was a claim about the schemas people write rather than a property of the
+	// response, and the CLI rendered "target collection: people" beneath a
+	// select because it checks only for a non-empty slug.
+	if bucket.Collection != "" {
+		t.Fatalf("a %s row carries collection %q; only a relation names a target, and the "+
+			"CLI prints this as one: %+v", bucket.Type, bucket.Collection, bucket)
+	}
 }
 
 // THE BOUNDARY, pinned deliberately rather than left to be rediscovered.

--- a/internal/server/relation_target_availability.go
+++ b/internal/server/relation_target_availability.go
@@ -1,0 +1,85 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// relationTargetsUnavailable reports which relation TARGET collections declared
+// by a destination schema this caller cannot actually use (IDEA-2899).
+//
+// The copy dialog offers a picker for a `needs_value` relation row as soon as
+// the row names a target collection (TASK-2869). Naming one is not the same as
+// having one: the slug can name a collection that has been deleted, or one this
+// caller cannot read. In both cases the dialog mounts a picker that can return
+// nothing, and because the row is not blocked, Confirm stays disabled with only
+// the generic required-field message — the user is told a value is missing and
+// never told that no value is reachable.
+//
+// THE CLIENT CANNOT ANSWER THIS ITSELF, which is why it is here. The dialog's
+// destination collection list is filtered through `canEditCollection`, because
+// it drives the copy-INTO picker. A relation TARGET needs only READ access, so
+// a perfectly usable target routinely does not appear in that list; testing
+// against it would refuse rows the user could have filled in. Over-blocking is
+// the worse failure — it is invisible to the person hitting it — so the
+// decision belongs where the read-scoped view exists.
+//
+// `visibleCollectionIDs` is that view, and its NAV-LENIENT shape is right here
+// rather than merely tolerable: it includes a collection reachable only through
+// an item-level grant, and the question this answers is "could a picker here
+// return anything at all". One granted item is a picker with one row, which is
+// usable. The stricter full-access set would reject it and be wrong.
+//
+// Costs nothing for the overwhelming majority of calls: a schema declaring no
+// relation field runs no query at all.
+func (s *Server) relationTargetsUnavailable(
+	r *http.Request,
+	workspaceID string,
+	schema models.CollectionSchema,
+) (map[string]bool, error) {
+	targets := make(map[string]bool)
+	for _, def := range schema.Fields {
+		if def.Type == "relation" && def.Collection != "" {
+			targets[def.Collection] = true
+		}
+	}
+	if len(targets) == 0 {
+		return nil, nil
+	}
+
+	// nil means no filtering — an admin on a cookie session, or an
+	// unauthenticated caller. Everything live is then readable.
+	visible, err := s.visibleCollectionIDs(r, workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	var visibleSet map[string]bool
+	if visible != nil {
+		visibleSet = make(map[string]bool, len(visible))
+		for _, id := range visible {
+			visibleSet[id] = true
+		}
+	}
+
+	unavailable := make(map[string]bool)
+	for slug := range targets {
+		coll, err := s.store.GetCollectionBySlug(workspaceID, slug)
+		if err != nil {
+			return nil, err
+		}
+		// GetCollectionBySlug already excludes soft-deleted rows, so a nil
+		// result covers BOTH "never existed" and "was deleted". They are
+		// different facts with the same consequence — no picker can be built —
+		// and the wire deliberately does not distinguish them; see the
+		// `CollectionUnavailable` doc comment.
+		if coll == nil {
+			unavailable[slug] = true
+			continue
+		}
+		if visibleSet != nil && !visibleSet[coll.ID] {
+			unavailable[slug] = true
+		}
+	}
+	return unavailable, nil
+}

--- a/internal/server/relation_target_availability.go
+++ b/internal/server/relation_target_availability.go
@@ -83,3 +83,20 @@ func (s *Server) relationTargetsUnavailable(
 	}
 	return unavailable, nil
 }
+
+// relationTargetSlug is the target collection slug a field def declares, and
+// the empty string for any field that is not a relation.
+//
+// `ItemCopyPreflightNeedsValue.Collection` documents itself as empty for every
+// non-relation type. That was a claim about the schemas anyone would write, not
+// a property this code enforced: a `select` carrying `"collection": "people"`
+// is storable — field validation has no use for the key and does not police it
+// — and the value was copied into the response unchanged, so the CLI rendered
+// "target collection: people" beneath a select. One line, at the only place
+// that can make the documented contract true.
+func relationTargetSlug(def models.FieldDef) string {
+	if def.Type != "relation" {
+		return ""
+	}
+	return def.Collection
+}

--- a/web/src/lib/components/items/CopyItemDialog.svelte
+++ b/web/src/lib/components/items/CopyItemDialog.svelte
@@ -48,7 +48,7 @@ user hunting for an item that provably does not exist.
 	import FieldEditor from '$lib/components/fields/FieldEditor.svelte';
 	import { api, PadApiError } from '$lib/api/client';
 	import { copyDropReasonMessage } from '$lib/items/copyDropReasons';
-	import { isCollectable } from '$lib/items/copyNeedsValue';
+	import { isCollectable, uncollectableReason } from '$lib/items/copyNeedsValue';
 	import { canEditCollection } from '$lib/utils/permissions';
 	import { parseSchema } from '$lib/types';
 	import type {
@@ -251,6 +251,17 @@ user hunting for an item that provably does not exist.
 	/** Required destination fields the dialog cannot safely collect a value for. */
 	let blockedFields = $derived(
 		(preflight?.fields.needs_value ?? []).filter((f) => !isCollectable(f))
+	);
+
+	/**
+	 * The first blocked field the CLI could actually fill, or null (IDEA-2899).
+	 *
+	 * `blockedFields[0]` was fine while every blocked row was type-shaped. It
+	 * is not now: with a relation whose target is unavailable sorted first, the
+	 * printed command would name the ONE field the CLI cannot set either.
+	 */
+	let cliFillableField = $derived(
+		blockedFields.find((f) => uncollectableReason(f) === 'type') ?? null
 	);
 
 	let warnings = $derived(preflight?.warnings ?? null);
@@ -1149,16 +1160,34 @@ user hunting for an item that provably does not exist.
 									<p class="notice notice-error" role="alert">
 										{#each blockedFields as f (f.key)}
 											<span class="blocked-line">
-												<strong>{f.label || f.key}</strong> is a required
-												<code>{f.type ?? 'unknown'}</code> field. This dialog can’t collect a value
-												for that type safely.
+												{#if uncollectableReason(f) === 'unavailable_target'}
+													<strong>{f.label || f.key}</strong> points at
+													<code>{f.collection}</code> in {destWorkspaceName}, which isn’t
+													available to you — it may have been deleted, or you may not have
+													access to it. There’s no value this field can be given here.
+												{:else}
+													<strong>{f.label || f.key}</strong> is a required
+													<code>{f.type ?? 'unknown'}</code> field. This dialog can’t collect a
+													value for that type safely.
+												{/if}
 											</span>
 										{/each}
-										Use the CLI instead:
-										<code
-											>pad item copy {sourceRef} --to-workspace {destWs} --collection {destColl}
-											--field {blockedFields[0].key}=value</code
-										>
+										<!--
+											The CLI is offered ONLY for the type-shaped failures (IDEA-2899).
+											It genuinely helps there: `json` and `multi_select` cannot be typed
+											into this dialog safely and `--field` can set them. It is worse than
+											useless for an unavailable relation target — the CLI runs as the
+											same user against the same referent validation, so the command
+											would be refused for the same reason, and printing it sends someone
+											to do work that cannot succeed.
+										-->
+										{#if cliFillableField}
+											Use the CLI instead:
+											<code
+												>pad item copy {sourceRef} --to-workspace {destWs} --collection {destColl}
+												--field {cliFillableField.key}=value</code
+											>
+										{/if}
 									</p>
 								{/if}
 								<div class="needs-list">

--- a/web/src/lib/components/items/CopyItemDialog.svelte
+++ b/web/src/lib/components/items/CopyItemDialog.svelte
@@ -133,6 +133,15 @@ user hunting for an item that provably does not exist.
 	 * the dangerous case: enterable and silently invalid. So a required field of
 	 * any uncollectable type renders an explicit blocked state naming the field
 	 * and its type, rather than a dead Confirm or a lying input.
+	 *
+	 * TYPE IS NO LONGER THE ONLY REASON A ROW IS BLOCKED (IDEA-2899). A
+	 * `relation` whose target collection is deleted or unreadable is blocked
+	 * too, and its message says which collection rather than blaming the type —
+	 * the type is fine, the target is gone. `uncollectableReason` is what tells
+	 * the two apart, and it also decides whether the CLI is worth suggesting:
+	 * it is for a type this dialog cannot collect, and it is NOT for an
+	 * unavailable target or an empty key, both of which the CLI refuses for the
+	 * same reason the dialog does.
 	 */
 	// COLLECTABLE_TYPES and isCollectable now live in `$lib/items/copyNeedsValue`
 	// so they can be tested (TASK-2869, following IDEA-2894): the mutant that
@@ -259,9 +268,15 @@ user hunting for an item that provably does not exist.
 	 * `blockedFields[0]` was fine while every blocked row was type-shaped. It
 	 * is not now: with a relation whose target is unavailable sorted first, the
 	 * printed command would name the ONE field the CLI cannot set either.
+	 *
+	 * An EMPTY KEY is excluded for the same reason and was the round-4 miss:
+	 * `--field =value` is rejected by the CLI's own parser, so a required
+	 * `json` field the destination reported with no key is type-shaped, blocked,
+	 * and still unfillable. The CLI has refused these since Codex round 6; the
+	 * dialog was printing the command anyway.
 	 */
 	let cliFillableField = $derived(
-		blockedFields.find((f) => uncollectableReason(f) === 'type') ?? null
+		blockedFields.find((f) => uncollectableReason(f) === 'type' && f.key.trim() !== '') ?? null
 	);
 
 	let warnings = $derived(preflight?.warnings ?? null);

--- a/web/src/lib/components/items/copyDialogBlockedAdvice.test.ts
+++ b/web/src/lib/components/items/copyDialogBlockedAdvice.test.ts
@@ -35,6 +35,14 @@ describe('IDEA-2899 — the blocked-field notice advises only where advice works
 		expect(source).not.toMatch(/--field \{blockedFields\[0\]\.key\}=value/);
 	});
 
+	it('excludes a row whose KEY is empty, which --field cannot address either', () => {
+		// A required `json` field the destination reported with no key is
+		// type-shaped, blocked, and unfillable: `--field =value` is rejected by
+		// the CLI's own parser, which has refused these since Codex round 6.
+		// The dialog was printing the command anyway (review round 4).
+		expect(source).toMatch(/f\.key\.trim\(\) !== ''/);
+	});
+
 	it('branches the message on why the row is uncollectable', () => {
 		expect(source).toMatch(/uncollectableReason\(f\) === 'unavailable_target'/);
 	});

--- a/web/src/lib/components/items/copyDialogBlockedAdvice.test.ts
+++ b/web/src/lib/components/items/copyDialogBlockedAdvice.test.ts
@@ -1,0 +1,48 @@
+// Node-project test (no DOM): a SOURCE-level guard on the blocked-field notice
+// in `CopyItemDialog.svelte` (IDEA-2899), the same shape as
+// `fieldEditorRelationCallers.test.ts` and for the same reason — the dialog is
+// a large component with no harness, and these are facts about what it RENDERS
+// that no unit test of `copyNeedsValue` can see.
+//
+// WHAT THIS PROVES: that the CLI command is gated on a field the CLI can
+// actually fill, and that the unavailable-target branch exists.
+//
+// WHAT IT DOES NOT PROVE: that either branch is reached, or that the rendered
+// text is right. It is a tripwire, not a test of behaviour. Its measured limit
+// is the same one every source pin has: a mutation that leaves the matched TEXT
+// in place while making it unreachable — wrapping the block in `{#if false}`,
+// say — survives it. Deleting the gate does not. Delete this file the day the
+// dialog grows a component harness.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const source = readFileSync(
+	fileURLToPath(new URL('./CopyItemDialog.svelte', import.meta.url)),
+	'utf8'
+	// Comments stripped, so prose about the rule can never satisfy a pin ON the
+	// rule — the mistake that would make this file self-congratulatory.
+).replace(/<!--[\s\S]*?-->/g, '');
+
+describe('IDEA-2899 — the blocked-field notice advises only where advice works', () => {
+	it('offers the CLI only for a field the CLI can fill', () => {
+		// `blockedFields[0]` was correct while every blocked row was
+		// type-shaped. With an unavailable relation target sorted first it names
+		// the ONE field `--field` cannot set either, sending the user to run a
+		// command that is refused for exactly the reason they are stuck.
+		expect(source).toMatch(/\{#if cliFillableField\}/);
+		expect(source).toMatch(/--field \{cliFillableField\.key\}=value/);
+		expect(source).not.toMatch(/--field \{blockedFields\[0\]\.key\}=value/);
+	});
+
+	it('branches the message on why the row is uncollectable', () => {
+		expect(source).toMatch(/uncollectableReason\(f\) === 'unavailable_target'/);
+	});
+
+	it('names the target collection in the unavailable branch', () => {
+		// Without the slug the message says a field is unusable and not which
+		// collection is missing — which is the same "told there is a problem,
+		// not told what" failure this change exists to fix, one level up.
+		expect(source).toMatch(/<code>\{f\.collection\}<\/code>/);
+	});
+});

--- a/web/src/lib/items/copyNeedsValue.test.ts
+++ b/web/src/lib/items/copyNeedsValue.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isCollectable, COLLECTABLE_TYPES } from './copyNeedsValue';
+import { isCollectable, uncollectableReason, COLLECTABLE_TYPES } from './copyNeedsValue';
 import type { ItemCopyPreflightNeedsValue } from '$lib/types';
 
 const row = (over: Partial<ItemCopyPreflightNeedsValue>): ItemCopyPreflightNeedsValue => ({
@@ -37,5 +37,75 @@ describe('isCollectable', () => {
 
 	it('treats a missing type as text, which is collectable', () => {
 		expect(isCollectable(row({}))).toBe(true);
+	});
+});
+
+describe('IDEA-2899 — a relation whose target is not usable', () => {
+	it('refuses a relation whose target the server reports unavailable', () => {
+		expect(
+			isCollectable(row({ type: 'relation', collection: 'people-b', collection_unavailable: true }))
+		).toBe(false);
+	});
+
+	// THE CONTRACT, and the reason the flag is phrased negatively. `omitempty`
+	// on a Go bool drops FALSE, so the server omits the field when the target is
+	// fine — and a server predating this change omits it always. Absence is "no
+	// information" and must never block; a client that read it as a value would
+	// refuse every relation row against an older server.
+	it('treats an ABSENT flag as no information, not as unavailable', () => {
+		expect(isCollectable(row({ type: 'relation', collection: 'people-b' }))).toBe(true);
+		expect(
+			isCollectable(row({ type: 'relation', collection: 'people-b', collection_unavailable: false }))
+		).toBe(true);
+	});
+
+	// `undefined` stated explicitly, since it is the shape an older server
+	// produces and the one the whole contract turns on.
+	//
+	// NOT a test of the strict `=== true` spelling: over the domain this
+	// field's type admits (`boolean | undefined`) the truthiness form is
+	// equivalent, a mutant swapping it in survives, and manufacturing an
+	// off-contract value to kill that mutant would be testing a rule nobody
+	// holds. The reason for the strict form is recorded in the source.
+	it('treats an explicitly undefined flag as no information', () => {
+		const odd = { type: 'relation', collection: 'people-b', collection_unavailable: undefined };
+		expect(isCollectable(row(odd as Partial<ItemCopyPreflightNeedsValue>))).toBe(true);
+	});
+
+	it('does not touch non-relation rows carrying the flag', () => {
+		// The server gates the flag on the field TYPE, so this shape should not
+		// arrive. Asserted anyway: the client must not grow a second, laxer
+		// definition of what the flag means, because two definitions of one rule
+		// is how the pair drifts.
+		expect(isCollectable(row({ type: 'text', collection_unavailable: true }))).toBe(true);
+		expect(isCollectable(row({ type: 'select', collection_unavailable: true }))).toBe(true);
+	});
+});
+
+describe('uncollectableReason', () => {
+	it('is null for anything collectable', () => {
+		expect(uncollectableReason(row({ type: 'text' }))).toBeNull();
+		expect(uncollectableReason(row({ type: 'relation', collection: 'people-b' }))).toBeNull();
+	});
+
+	// The distinction that earns this function: the dialog offers a CLI command
+	// for type-shaped failures and must NOT offer one here. The CLI runs as the
+	// same user against the same referent validation, so the printed command
+	// would be refused for the same reason.
+	it('separates an unavailable target from a type it cannot collect', () => {
+		expect(
+			uncollectableReason(
+				row({ type: 'relation', collection: 'people-b', collection_unavailable: true })
+			)
+		).toBe('unavailable_target');
+		expect(uncollectableReason(row({ type: 'json' }))).toBe('type');
+		expect(uncollectableReason(row({ type: 'multi_select' }))).toBe('type');
+	});
+
+	// A relation naming NO target is TASK-2869's case and stays type-shaped:
+	// there is no collection to name in the message, so the copy that names one
+	// would render an empty code span.
+	it('calls a relation with no target a type failure, not an unavailable one', () => {
+		expect(uncollectableReason(row({ type: 'relation' }))).toBe('type');
 	});
 });

--- a/web/src/lib/items/copyNeedsValue.ts
+++ b/web/src/lib/items/copyNeedsValue.ts
@@ -40,6 +40,55 @@ export const COLLECTABLE_TYPES = new Set([
  */
 export function isCollectable(row: ItemCopyPreflightNeedsValue): boolean {
 	const type = row.type ?? 'text';
-	if (type === 'relation') return Boolean(row.collection);
+	if (type === 'relation') {
+		if (!row.collection) return false;
+		// IDEA-2899. Naming a target is not having one: the slug can name a
+		// collection that has been deleted, or one this caller cannot read.
+		// Either way the picker mounts and returns nothing, and the row stays
+		// out of `blockedFields`, so Confirm is disabled with only the generic
+		// required-field message — a value is missing and nothing says no value
+		// is reachable.
+		//
+		// STRICT `=== true`, not truthiness. The field is ABSENT when the target
+		// is fine AND absent from a server that predates it, so absence must
+		// read as "no information" rather than as a value.
+		//
+		// SAID PLAINLY BECAUSE A MUTANT PROVED IT: over the domain this field's
+		// TYPE admits — `boolean | undefined` — `!row.collection_unavailable`
+		// is EQUIVALENT, and swapping it in kills no test and breaks nothing.
+		// It is not a defect and no test is owed for it. The strict form is
+		// kept for a reason about the next edit rather than this one: it states
+		// the contract in the code, so the inverse spelling
+		// (`collection_available`, which WOULD block every row against a server
+		// that omits it) reads as the mistake it is.
+		return row.collection_unavailable !== true;
+	}
 	return COLLECTABLE_TYPES.has(type);
+}
+
+/**
+ * Why a row cannot be collected, for the message the dialog shows.
+ *
+ * The two reasons need DIFFERENT copy and, more importantly, different advice.
+ * A `json` or `multi_select` field genuinely cannot be typed into this dialog
+ * safely, and the CLI can set it — so pointing at `pad item copy --field` is
+ * real help. An unavailable relation TARGET is not like that: the CLI runs as
+ * the same user against the same referent validation, so the command the dialog
+ * would print gets refused for the same reason. Offering it sends the user to
+ * do work that cannot succeed.
+ */
+export type UncollectableReason = 'type' | 'unavailable_target';
+
+export function uncollectableReason(
+	row: ItemCopyPreflightNeedsValue
+): UncollectableReason | null {
+	if (isCollectable(row)) return null;
+	const type = row.type ?? 'text';
+	// A relation naming a target the caller cannot use — as opposed to one
+	// naming no target at all, which is the TASK-2869 case and stays a
+	// type-shaped failure: there is nothing to point the user at.
+	if (type === 'relation' && row.collection && row.collection_unavailable === true) {
+		return 'unavailable_target';
+	}
+	return 'type';
 }

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -854,6 +854,25 @@ export interface ItemCopyPreflightNeedsValue {
 	 * workspace items the copy cannot use.
 	 */
 	collection?: string;
+	/**
+	 * True when `collection` names a target this caller cannot USE in the
+	 * destination — the slug names no live collection, or names one they cannot
+	 * read (IDEA-2899).
+	 *
+	 * The client cannot work this out for itself. `destCollections` is filtered
+	 * through `canEditCollection` because it drives the copy-INTO picker, while
+	 * a relation TARGET needs only READ access, so a perfectly usable target
+	 * routinely does not appear there. Testing against that list would refuse
+	 * rows the user could have filled in.
+	 *
+	 * ABSENT IS NOT FALSE-ish BY ACCIDENT — it is the contract. The server omits
+	 * the field when the target is fine, and a server predating this change
+	 * omits it always. So absence means "no information" and must never block;
+	 * only an explicit `true` does. Deleted and unreadable are deliberately
+	 * indistinguishable here: same consequence, and separating them would tell a
+	 * caller who cannot read a collection that it nonetheless exists.
+	 */
+	collection_unavailable?: boolean;
 	required: boolean;
 	reason: 'missing_required' | 'invalid_value';
 	message?: string;


### PR DESCRIPTION
Closes IDEA-2899.

## The defect

TASK-2869 made a `needs_value` **relation** row collectable in the cross-workspace copy dialog as soon as the row names a target collection. Naming one is not having one: the slug can name a collection that has been **deleted** in the destination, or one this caller **cannot read**.

The dialog then mounts a picker that can return nothing. And because the row is not in `blockedFields`, Confirm stays disabled carrying only the generic required-field message — the user is told a value is missing and never told that **no value is reachable**.

## Why the server answers it

The client provably cannot. `destCollections` is filtered through `canEditCollection`, because it drives the copy-**INTO** picker. A relation **TARGET** needs only READ access, so a perfectly usable target routinely does not appear in that list, and testing against it would refuse rows the user could have filled in. Over-blocking is the worse failure — it is invisible to whoever hits it.

`visibleCollectionIDs` is the read-scoped view, and its **nav-lenient** shape is right here rather than merely tolerable: it includes a collection reachable only through an item-level grant, and the question is "could a picker here return anything at all". One granted item is a picker with one row, which is usable.

Costs nothing on the common path: a destination schema declaring no relation field runs **no query at all**; otherwise one `visibleCollectionIDs` plus one lookup per DISTINCT target.

## The wire shape, and the trap it avoids

`collection_unavailable` is phrased **negatively on purpose**. `omitempty` on a Go bool drops `false`, so a positively-phrased `collection_available` would make "unavailable" indistinguishable from "field absent", and a client would have to read absence as a value. Present-and-true means the server checked and the target is unusable; **absent means available, or a server that does not report**. Every consumer blocks only on an explicit true.

Deleted and unreadable are deliberately **not** distinguished: same consequence, no client branch would differ, and separating them would tell a caller who cannot read a collection that it nonetheless exists.

## Three surfaces, because two of them were giving advice that cannot be followed

The flag itself is small. The larger half of this PR is what the surfaces DO with it.

**Web.** `isCollectable` refuses a flagged row, so it lands in `blockedFields` and Confirm is disabled with a reason. The existing blocked message said *"is a required `<type>` field. This dialog can't collect a value for that type safely"* and printed `pad item copy … --field key=value`. Both halves are false here — the type is fine, the TARGET is gone, and the CLI runs as the same user against the same referent validation, so the command it prints is refused for exactly the reason the user is stuck. The message now branches, names the collection and the destination workspace, and the CLI line is gated on a field the CLI can **actually** fill.

**CLI.** Same problem, three sites: the detailed refusal, the `--dry-run` summary, and the returned error — the last being the line a script sees. All three now read one tally. A row is unfillable for **either** of two reasons: an unavailable relation target, or an **empty key**, which `--field =value` cannot address and which has been refused since Codex round 6 — a case only the detailed render knew about.

## What this deliberately does NOT do

A target collection that is live and readable but **empty** is not flagged, and a test pins that boundary. The symptom looks identical (an empty picker) but the cases differ where it matters: an unavailable target is unfixable from inside the dialog, so blocking costs the user nothing they had; an empty collection is resolved by creating the item and retrying, and blocking would refuse a copy they were about to complete. It would also cost a live-visible-item count per relation target on a dry run the UI calls on every keystroke. The weaker case — an empty picker that says nothing about **why** — is **IDEA-2905**.

## Five review rounds, and the distribution was the finding

Rounds returned **2 → 2 → 2 → 4 → 0**. The counts looked like slow convergence. Read as a set, they said something else: **every defect after round 1 lived in the advice layer**, while the server half that computes availability stayed clean throughout. Round 4 fixed something round 3 introduced to fix something round 2 introduced.

That is the accretion shape, so round 5's change removes branches instead of adding a seventh guard: three helpers collapse into one `itemCopyTally` computed in a single walk, so there is no second definition of "unfillable" to drift from the first and no sentence describing a subset of what a predicate counts. Round 5 came back clean.

The four rounds of findings, each accepted and fixed:

- **The advice was fixed at one door and not its siblings** — twice. First the CLI's detailed render while the summary and the error still said `--field key=value`; then the CLI's empty-key exclusion while the dialog still printed `--field =value` for a required `json` field the destination reported with no key.
- **Broadening what a predicate ACTS on silently broadened what a sentence SAYS.** Once "unfillable" covered empty keys, a set of empty-key rows was explained as *"the relation target is not available to you"* — false about rows containing no relation. The tell was there: a sentence true while the predicate was narrower is one to re-read when it widens.
- **One row can carry BOTH faults.** A `continue` between the two counters made a dual-fault row report half of itself, and the mixed-case test used TWO rows with one fault each — a different input, and the only one it exercised.
- **`Collection` was emitted for non-relation fields** while its own doc said otherwise. A `select` carrying `"collection": "people"` is storable — validation has no use for the key — so the CLI printed "target collection: people" beneath a select. `relationTargetSlug` makes the documented contract true at the only place that can.
- **Four documents** claimed every `needs_value` row is resolvable with an override. True when written; falsified by this change.

## Mutation ledger — 34 real mutants, 33 killed, 1 recorded equivalent

Plus 4 controls, all behaving. Every mutant build-checked; each is the defect itself rather than a crash that resembles one. Counted from the run specs rather than from memory.

**Server, 5:** flag never set · flag always set · deleted target not flagged · unreadable target not flagged · type gate dropped · nil-visible-set read as "nothing visible" (which would flag every target for the callers who can see everything).

**Web, 6:** flag ignored · absent blocks · reason collapses to type · reason ignores a missing target · dialog's CLI gate removed · message branch removed · dialog allows an empty-key row into the suggestion.

**CLI, 23 across four rounds:** suppression removed · suppression applied to everything · label not marked · explanation dropped · predicate counts nothing · empty keys not unfillable · render conflates the two reasons · error hint unconditional · error hint always suppressed · dry-run unbranched · dry-run mixed case collapsed · `Collection` not type-gated · `Why()` always says relation · `Why()` never names keys · `Why()` counts keys as targets · `Why()` loses the mixed case · the `continue` restored · `Unfillable` double-counts · `AllUnfillable` true on an empty set · empty-key rows counted as targets · render uses either reason.

**The one recorded EQUIVALENT rather than killed.** In `isCollectable`, `collection_unavailable !== true` and `!collection_unavailable` behave identically over the domain the type admits (`boolean | undefined`), and a mutant swapping them survives. Manufacturing an off-contract value to kill it would be testing a rule nobody holds, so the source records why the strict form is kept: it states the contract where the next edit will read it, and the inverse spelling would block every row against an older server.

**One guard needed a new test rather than a new fixture.** `AllUnfillable`'s `Total > 0` is unreachable from both current callers, so a mutant removing it survived every command-level test. Keeping an unreachable guard and calling it defence is how a promise becomes a lie, so the tally is unit-tested directly.

**Two mutants had to be rewritten because they survived for the WRONG reason** — a `go vet` unreachable-code failure scored as BUILD-FAIL rather than as a verdict, and an anchor that matched text the mutant left in place. Both are the instrument failing, not the tests.

## Gates — on this tip, `626bc763`, on `00d650a8`

| Gate | Result |
|---|---|
| `go build ./...` · `go vet ./...` | exit 0 |
| `gofmt -l internal/ cmd/` | no output |
| Go suite, SQLite | exit 0 · 29 packages ok · zero FAIL |
| Go suite, **Postgres** | **exit 0** · 29 packages ok · **zero FAIL lines, no NO-TESTS banner** · wall 235.6s |
| `npm run check` | exit 0 · 1100 files · **0 errors** · 6 warnings, all pre-existing |
| web vitest | exit 0 · **132 files, 2161 tests** |

Postgres ran on a private container on its own port, which tore itself down. Exit codes read from unpiped runs written to files.

https://claude.ai/code/session_01Xk9M5UVPdc84xL5E1mZkm8
