### PR TITLE
perf(store): run the store suite in parallel (TASK-2900 deliverable 3)

### DIFF
--- a/internal/store/account_deletion_comments_test.go
+++ b/internal/store/account_deletion_comments_test.go
@@ -14,6 +14,7 @@ import (
 // admin-only to edit. testStore enables PRAGMA foreign_keys, so without the
 // detach step this fails with a FK violation.
 func TestDeleteAccountAtomic_DetachesAuthoredComments(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	user, err := s.CreateUser(models.UserCreate{

--- a/internal/store/account_deletion_test.go
+++ b/internal/store/account_deletion_test.go
@@ -23,6 +23,7 @@ import (
 //   - the workspace is soft-deleted (recoverable), the second user and
 //     their data are untouched.
 func TestDeleteAccountAtomic_FullyPopulatedUser(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	// The account under deletion, plus a bystander whose data must survive.

--- a/internal/store/activities_debounce_race_test.go
+++ b/internal/store/activities_debounce_race_test.go
@@ -93,6 +93,7 @@ func changesOf(t *testing.T, a models.Activity) string {
 // re-read is pinned instead by the mutation matrix (M5) and by
 // TestMergeIntoUnlinkedActivity_RefusesMovedRow at the statement level.
 func TestCreateActivityDebounced_ConcurrentMergeKeepsBothChanges(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Race")
 	doc := createTestDoc(t, s, ws.ID, "Doc", "content")
@@ -149,6 +150,7 @@ func TestCreateActivityDebounced_ConcurrentMergeKeepsBothChanges(t *testing.T) {
 // loop forever or drop the change text. Presentation degrades (an extra
 // timeline entry), content does not.
 func TestCreateActivityDebounced_ContentionPastTheBoundKeepsTheChange(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Race")
 	doc := createTestDoc(t, s, ws.ID, "Doc", "content")
@@ -206,6 +208,7 @@ func TestCreateActivityDebounced_ContentionPastTheBoundKeepsTheChange(t *testing
 // expectation, same row, same call) is what makes the refusal evidence of a
 // predicate rather than of a merge that no longer works at all.
 func TestMergeIntoUnlinkedActivity_RefusesMovedRow(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "CAS")
 	doc := createTestDoc(t, s, ws.ID, "Doc", "content")
@@ -255,6 +258,7 @@ func TestMergeIntoUnlinkedActivity_RefusesMovedRow(t *testing.T) {
 // dispositions — retry, or start a fresh row — so each of its three inputs
 // gets a leg.
 func TestDebounceRowUnchanged(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Classify")
 	doc := createTestDoc(t, s, ws.ID, "Doc", "content")
@@ -329,6 +333,7 @@ func TestDebounceRowUnchanged(t *testing.T) {
 // (matrix M3) — and it is listed here so nobody reads it as evidence for
 // the CAS.
 func TestCreateActivityDebounced_FrozenRowIsNotRetried(t *testing.T) {
+	t.Parallel()
 	s, item := agentNameFixture(t)
 
 	writer := models.Activity{
@@ -378,6 +383,7 @@ func TestCreateActivityDebounced_FrozenRowIsNotRetried(t *testing.T) {
 // assigned into. A test that only passed `null` as the incoming side would
 // go green against the unguarded code and say nothing.
 func TestMergeActivityMeta_NullBlobDoesNotPanic(t *testing.T) {
+	t.Parallel()
 	got := mergeActivityMeta("null", `{"agent":"rook","changes":"status: open → done"}`)
 	var m map[string]any
 	if err := json.Unmarshal([]byte(got), &m); err != nil {
@@ -415,6 +421,7 @@ func TestMergeActivityMeta_NullBlobDoesNotPanic(t *testing.T) {
 // or hand-written caller can leave behind: CreateActivity only substitutes
 // "{}" for the EMPTY string.
 func TestCreateActivityDebounced_NullMetadataRowSurvives(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Null")
 	doc := createTestDoc(t, s, ws.ID, "Doc", "content")

--- a/internal/store/activities_test.go
+++ b/internal/store/activities_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestCreateActivityDebounced_NonUpdateActions(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	doc := createTestDoc(t, s, ws.ID, "Doc", "content")
@@ -45,6 +46,7 @@ func TestCreateActivityDebounced_NonUpdateActions(t *testing.T) {
 }
 
 func TestCreateActivityDebounced_CoalescesUpdates(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	doc := createTestDoc(t, s, ws.ID, "Doc", "content")
@@ -96,6 +98,7 @@ func TestCreateActivityDebounced_CoalescesUpdates(t *testing.T) {
 // future cutoff excludes everything. Timestamp-agnostic (uses past/future
 // relative to now) so it doesn't flake on clock skew.
 func TestListWorkspaceActivity_SinceFilter(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	doc := createTestDoc(t, s, ws.ID, "Doc", "content")
@@ -145,6 +148,7 @@ func TestListWorkspaceActivity_SinceFilter(t *testing.T) {
 }
 
 func TestCreateActivityDebounced_DifferentUsersDontCoalesce(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	doc := createTestDoc(t, s, ws.ID, "Doc", "content")
@@ -192,6 +196,7 @@ func TestCreateActivityDebounced_DifferentUsersDontCoalesce(t *testing.T) {
 }
 
 func TestCreateActivityDebounced_DifferentDocsDontCoalesce(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	doc1 := createTestDoc(t, s, ws.ID, "Doc 1", "content 1")
@@ -274,6 +279,7 @@ func TestCreateActivityDebounced_TimestampBumped(t *testing.T) {
 }
 
 func TestCreateActivityDebounced_MetadataMerge(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	doc := createTestDoc(t, s, ws.ID, "Doc", "content")
@@ -318,6 +324,7 @@ func TestCreateActivityDebounced_MetadataMerge(t *testing.T) {
 }
 
 func TestCreateActivityDebounced_AgentMetaPreserved(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	doc := createTestDoc(t, s, ws.ID, "Doc", "content")
@@ -365,6 +372,7 @@ func TestCreateActivityDebounced_AgentMetaPreserved(t *testing.T) {
 }
 
 func TestCreateActivityDebounced_MultipleRapidSaves(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	doc := createTestDoc(t, s, ws.ID, "Doc", "content")
@@ -390,6 +398,7 @@ func TestCreateActivityDebounced_MultipleRapidSaves(t *testing.T) {
 }
 
 func TestCreateActivityDebounced_NoUserID(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	doc := createTestDoc(t, s, ws.ID, "Doc", "content")
@@ -426,6 +435,7 @@ func TestCreateActivityDebounced_NoUserID(t *testing.T) {
 }
 
 func TestCollapseChanges(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		in   string
@@ -574,6 +584,7 @@ func TestCollapseChanges(t *testing.T) {
 // instead of a 30-step keystroke chain (as seen on BUG-1419's timeline
 // pre-fix).
 func TestMergeActivityMeta_CollapsesSameFieldRun(t *testing.T) {
+	t.Parallel()
 	existing := `{"changes":"component: → e; component: e → ed; component: ed → edi"}`
 	incoming := `{"changes":"component: edi → editor"}`
 	got := mergeActivityMeta(existing, incoming)
@@ -589,6 +600,7 @@ func TestMergeActivityMeta_CollapsesSameFieldRun(t *testing.T) {
 }
 
 func TestMergeActivityMeta(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		existing string
@@ -653,6 +665,7 @@ func TestMergeActivityMeta(t *testing.T) {
 // row COUNT: splitting into two rows that both name the same writer would be a
 // different bug wearing this fix's passing test (CONVE-12).
 func TestCreateActivityDebounced_WriterIdentitySplitsRuns(t *testing.T) {
+	t.Parallel()
 	oneAccount := func(t *testing.T) (st *Store, wsID, docID, userID string) {
 		t.Helper()
 		st = testStore(t)

--- a/internal/store/activities_user_feed_test.go
+++ b/internal/store/activities_user_feed_test.go
@@ -10,6 +10,7 @@ import (
 // verifies the per-user filter + ordering + pagination behavior backing
 // the /admin/users/{id}/activity endpoint. PLAN-1542 / TASK-1546.
 func TestListUserActivity(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	alice := createTestUser(t, s, "alice@example.com", "Alice", "password123")
 	bob := createTestUser(t, s, "bob@example.com", "Bob", "password123")

--- a/internal/store/activity_id_with_error_test.go
+++ b/internal/store/activity_id_with_error_test.go
@@ -21,6 +21,7 @@ import (
 // cheapest way to make every write fail deterministically, and what is under
 // test is the pairing of the two return values, not which error occurs.
 func TestActivityWriters_ErrorNeverCarriesAnID(t *testing.T) {
+	t.Parallel()
 	base := testStore(t)
 	ws := createTestWorkspace(t, base, "IDContract")
 	doc := createTestDoc(t, base, ws.ID, "Doc", "content")
@@ -70,6 +71,7 @@ func TestActivityWriters_ErrorNeverCarriesAnID(t *testing.T) {
 // change that returned "" unconditionally would satisfy every assertion
 // above, and break every caller.
 func TestActivityWriters_SuccessStillReturnsTheID(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "IDContractOK")
 	doc := createTestDoc(t, s, ws.ID, "Doc", "content")
@@ -123,6 +125,7 @@ func TestActivityWriters_SuccessStillReturnsTheID(t *testing.T) {
 // and finds the row, then the write fails. That is the state in which the old
 // code handed back a real id for a PREVIOUS activity.
 func TestActivityDebounce_MergeFailureCarriesNoID(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "MergeFailure")
 	doc := createTestDoc(t, s, ws.ID, "Doc", "content")
@@ -182,6 +185,7 @@ func TestActivityDebounce_MergeFailureCarriesNoID(t *testing.T) {
 // it in production: a comment linked to the candidate row freezes it
 // (TASK-2760), so the merge's NOT EXISTS arm declines the write.
 func TestActivityDebounce_ClassifierFailureCarriesNoID(t *testing.T) {
+	t.Parallel()
 	s, item := agentNameFixture(t)
 
 	writer := models.Activity{

--- a/internal/store/agent_roles_test.go
+++ b/internal/store/agent_roles_test.go
@@ -14,6 +14,7 @@ import (
 // / "unassigned" while still keeping role_id null (the marker that
 // distinguishes an unassigned bucket from a real role with that slug).
 func TestGetRoleBreakdown_UnassignedRowHasExplicitLabels(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := newTestWorkspace(t, s, "rb-bug987")
 

--- a/internal/store/api_tokens_test.go
+++ b/internal/store/api_tokens_test.go
@@ -13,6 +13,7 @@ import (
 // constraint on api_tokens.workspace_id fixed in migration
 // 068_api_tokens_workspace_nullable.sql (Postgres already allowed NULL).
 func TestCreateAPITokenUserScoped(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u := createTestUser(t, s, "test@test.com", "Test", "password123")
 
@@ -42,6 +43,7 @@ func TestCreateAPITokenUserScoped(t *testing.T) {
 }
 
 func TestCreateAPITokenWithExpiry(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u := createTestUser(t, s, "test@test.com", "Test", "password123")
 	ws := createTestWorkspace(t, s, "TokenTest")
@@ -69,6 +71,7 @@ func TestCreateAPITokenWithExpiry(t *testing.T) {
 }
 
 func TestCreateAPITokenExpiryOverride(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u := createTestUser(t, s, "test@test.com", "Test", "password123")
 	ws := createTestWorkspace(t, s, "TokenTest")
@@ -88,6 +91,7 @@ func TestCreateAPITokenExpiryOverride(t *testing.T) {
 }
 
 func TestCreateAPITokenMaxLifetimeEnforced(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u := createTestUser(t, s, "test@test.com", "Test", "password123")
 	ws := createTestWorkspace(t, s, "TokenTest")
@@ -107,6 +111,7 @@ func TestCreateAPITokenMaxLifetimeEnforced(t *testing.T) {
 }
 
 func TestCreateAPITokenNoExpiry(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u := createTestUser(t, s, "test@test.com", "Test", "password123")
 	ws := createTestWorkspace(t, s, "TokenTest")
@@ -125,6 +130,7 @@ func TestCreateAPITokenNoExpiry(t *testing.T) {
 }
 
 func TestValidateTokenExpired(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u := createTestUser(t, s, "test@test.com", "Test", "password123")
 	ws := createTestWorkspace(t, s, "TokenTest")
@@ -164,6 +170,7 @@ func TestValidateTokenExpired(t *testing.T) {
 }
 
 func TestRotateAPIToken(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u := createTestUser(t, s, "test@test.com", "Test", "password123")
 	ws := createTestWorkspace(t, s, "TokenTest")
@@ -217,6 +224,7 @@ func TestRotateAPIToken(t *testing.T) {
 }
 
 func TestRotateAPITokenWrongUser(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u1 := createTestUser(t, s, "user1@test.com", "User 1", "password123")
 	u2 := createTestUser(t, s, "user2@test.com", "User 2", "password123")
@@ -239,6 +247,7 @@ func TestRotateAPITokenWrongUser(t *testing.T) {
 }
 
 func TestRotateAPITokenWithNewExpiry(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u := createTestUser(t, s, "test@test.com", "Test", "password123")
 	ws := createTestWorkspace(t, s, "TokenTest")
@@ -268,6 +277,7 @@ func TestRotateAPITokenWithNewExpiry(t *testing.T) {
 }
 
 func TestListAndDeleteAPITokens(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u := createTestUser(t, s, "test@test.com", "Test", "password123")
 	ws := createTestWorkspace(t, s, "TokenTest")
@@ -299,6 +309,7 @@ func TestListAndDeleteAPITokens(t *testing.T) {
 }
 
 func TestValidateTokenUpdatesLastUsed(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u := createTestUser(t, s, "test@test.com", "Test", "password123")
 	ws := createTestWorkspace(t, s, "TokenTest")

--- a/internal/store/attachments_copy_plan_test.go
+++ b/internal/store/attachments_copy_plan_test.go
@@ -129,6 +129,7 @@ func assertSourceSet(t *testing.T, p *AttachmentCopyPlan, want ...string) {
 // TestPlanAttachmentCopy_RefsInContentOnly is the base case: one image
 // reference in the body, one row, one map entry, the bytes counted.
 func TestPlanAttachmentCopy_RefsInContentOnly(t *testing.T) {
+	t.Parallel()
 	f := newPlanFixture(t)
 	a := f.attach(t, f.wsA, "shot.png", 1234)
 
@@ -153,6 +154,7 @@ func TestPlanAttachmentCopy_RefsInContentOnly(t *testing.T) {
 // a reference living only in a field value (no markdown around it, nested
 // inside an array) must still be cloned.
 func TestPlanAttachmentCopy_RefsInFieldsOnly(t *testing.T) {
+	t.Parallel()
 	f := newPlanFixture(t)
 	bare := f.attach(t, f.wsA, "bare.png", 10)
 	nested := f.attach(t, f.wsA, "nested.pdf", 20)
@@ -171,6 +173,7 @@ func TestPlanAttachmentCopy_RefsInFieldsOnly(t *testing.T) {
 // TestPlanAttachmentCopy_RefsInBoth covers the union, and pins that the
 // two sources are merged rather than one shadowing the other.
 func TestPlanAttachmentCopy_RefsInBoth(t *testing.T) {
+	t.Parallel()
 	f := newPlanFixture(t)
 	inBody := f.attach(t, f.wsA, "body.png", 5)
 	inField := f.attach(t, f.wsA, "field.png", 7)
@@ -188,6 +191,7 @@ func TestPlanAttachmentCopy_RefsInBoth(t *testing.T) {
 // Two rows would mean the rewrite maps the old id to whichever new id won,
 // and the dry-run would double the bytes.
 func TestPlanAttachmentCopy_SameRefTwice(t *testing.T) {
+	t.Parallel()
 	f := newPlanFixture(t)
 	a := f.attach(t, f.wsA, "shot.png", 900)
 
@@ -209,6 +213,7 @@ func TestPlanAttachmentCopy_SameRefTwice(t *testing.T) {
 // resolves to nothing to clone and nothing to count — it is not a
 // reference, so it is not an unresolvable reference either.
 func TestPlanAttachmentCopy_EmptyRefsIgnored(t *testing.T) {
+	t.Parallel()
 	f := newPlanFixture(t)
 
 	plan := f.plan(t, f.req("see pad-attachment: and pad-attachment:)", map[string]any{
@@ -230,6 +235,7 @@ func TestPlanAttachmentCopy_EmptyRefsIgnored(t *testing.T) {
 // a cosmetic one: this body was already broken in workspace A (nothing
 // resolves `<uuid>x` there either), and it stays exactly as broken in B.
 func TestPlanAttachmentCopy_JunkSuffixIsUnresolvable(t *testing.T) {
+	t.Parallel()
 	f := newPlanFixture(t)
 	a := f.attach(t, f.wsA, "shot.png", 77)
 
@@ -247,6 +253,7 @@ func TestPlanAttachmentCopy_JunkSuffixIsUnresolvable(t *testing.T) {
 // choice: an attachment whose id is not RFC4122-shaped is still
 // enumerated and still cloned. A canonical-UUID-only regex would drop it.
 func TestPlanAttachmentCopy_NonUUIDIdResolves(t *testing.T) {
+	t.Parallel()
 	f := newPlanFixture(t)
 	a := &models.Attachment{
 		ID:          "legacy_img-42",
@@ -273,6 +280,7 @@ func TestPlanAttachmentCopy_NonUUIDIdResolves(t *testing.T) {
 // planner skipped fenced references the rewrite would leave workspace A's
 // UUID in the copied body, and that UUID 403s on download from B.
 func TestPlanAttachmentCopy_RefsInCodeFencesAreCloned(t *testing.T) {
+	t.Parallel()
 	f := newPlanFixture(t)
 	a := f.attach(t, f.wsA, "shot.png", 42)
 
@@ -293,6 +301,7 @@ func TestPlanAttachmentCopy_RefsInCodeFencesAreCloned(t *testing.T) {
 // referencing it — invisible, and un-GC-able because item_id is set — and
 // would overstate the dry-run's byte total.
 func TestPlanAttachmentCopy_DroppedFieldNotCloned(t *testing.T) {
+	t.Parallel()
 	f := newPlanFixture(t)
 	kept := f.attach(t, f.wsA, "kept.png", 100)
 	dropped := f.attach(t, f.wsA, "dropped.png", 999999)
@@ -345,6 +354,7 @@ func TestPlanAttachmentCopy_DroppedFieldNotCloned(t *testing.T) {
 // controls, bypassing the download handler's workspace check
 // (handleGetAttachment, handlers_attachments.go) entirely.
 func TestPlanAttachmentCopy_ForeignRefNotCloned(t *testing.T) {
+	t.Parallel()
 	f := newPlanFixture(t)
 	mine := f.attach(t, f.wsA, "mine.png", 11)
 	theirs := f.attach(t, f.wsC, "theirs.png", 5_000_000)
@@ -367,6 +377,7 @@ func TestPlanAttachmentCopy_ForeignRefNotCloned(t *testing.T) {
 // is out of scope exactly like a foreign one. Cloning it would resurrect
 // bytes the workspace already deleted.
 func TestPlanAttachmentCopy_SoftDeletedRefNotCloned(t *testing.T) {
+	t.Parallel()
 	f := newPlanFixture(t)
 	gone := f.attach(t, f.wsA, "gone.png", 64)
 	if err := f.s.SoftDeleteAttachment(gone.ID); err != nil {
@@ -391,6 +402,7 @@ func TestPlanAttachmentCopy_SoftDeletedRefNotCloned(t *testing.T) {
 // reference is a pre-existing condition. The resolvable siblings still
 // plan normally.
 func TestPlanAttachmentCopy_DanglingRefNotFatal(t *testing.T) {
+	t.Parallel()
 	f := newPlanFixture(t)
 	real := f.attach(t, f.wsA, "real.png", 8)
 	ghost := newID()
@@ -410,6 +422,7 @@ func TestPlanAttachmentCopy_DanglingRefNotFatal(t *testing.T) {
 // remapped to the NEW original's id, and the original emitted first so a
 // caller inserting in order never writes a parent_id ahead of its parent.
 func TestPlanAttachmentCopy_VariantsFollowParent(t *testing.T) {
+	t.Parallel()
 	f := newPlanFixture(t)
 	orig := f.attach(t, f.wsA, "shot.png", 1000)
 	sm := f.variant(t, f.wsA, orig, models.AttachmentVariantThumbSm, 10)
@@ -446,6 +459,7 @@ func TestPlanAttachmentCopy_VariantsFollowParent(t *testing.T) {
 // workspace A's original must not be dragged in by the variant traversal.
 // An unscoped `WHERE parent_id IN (...)` would clone it.
 func TestPlanAttachmentCopy_ForeignVariantNotFollowed(t *testing.T) {
+	t.Parallel()
 	f := newPlanFixture(t)
 	orig := f.attach(t, f.wsA, "shot.png", 100)
 	ours := f.variant(t, f.wsA, orig, models.AttachmentVariantThumbSm, 5)
@@ -467,6 +481,7 @@ func TestPlanAttachmentCopy_ForeignVariantNotFollowed(t *testing.T) {
 // TestPlanAttachmentCopy_SoftDeletedVariantNotFollowed: the variant
 // traversal carries the deleted_at half of the scope too.
 func TestPlanAttachmentCopy_SoftDeletedVariantNotFollowed(t *testing.T) {
+	t.Parallel()
 	f := newPlanFixture(t)
 	orig := f.attach(t, f.wsA, "shot.png", 100)
 	dead := f.variant(t, f.wsA, orig, models.AttachmentVariantThumbSm, 7)
@@ -488,6 +503,7 @@ func TestPlanAttachmentCopy_SoftDeletedVariantNotFollowed(t *testing.T) {
 // so the in-scope parent is pulled in as the clone root and the whole
 // variant set comes with it.
 func TestPlanAttachmentCopy_RefToVariantPullsInParent(t *testing.T) {
+	t.Parallel()
 	f := newPlanFixture(t)
 	orig := f.attach(t, f.wsA, "shot.png", 100)
 	sm := f.variant(t, f.wsA, orig, models.AttachmentVariantThumbSm, 5)
@@ -511,6 +527,7 @@ func TestPlanAttachmentCopy_RefToVariantPullsInParent(t *testing.T) {
 // workspace A but its parent lives elsewhere, so following the parent
 // would clone a foreign original. The reference is unresolvable instead.
 func TestPlanAttachmentCopy_RefToVariantWithForeignParent(t *testing.T) {
+	t.Parallel()
 	f := newPlanFixture(t)
 	foreignOrig := f.attach(t, f.wsC, "theirs.png", 4_000)
 	localThumb := f.variant(t, f.wsA, foreignOrig, models.AttachmentVariantThumbSm, 6)
@@ -540,6 +557,7 @@ func TestPlanAttachmentCopy_RefToVariantWithForeignParent(t *testing.T) {
 // content-addressed columns carried over verbatim so a same-instance copy
 // is a row copy rather than a byte copy.
 func TestPlanAttachmentCopy_RowShape(t *testing.T) {
+	t.Parallel()
 	f := newPlanFixture(t)
 	src := f.attach(t, f.wsA, "shot.png", 4096)
 
@@ -587,6 +605,7 @@ func TestPlanAttachmentCopy_RowShape(t *testing.T) {
 // destination item yet and writes nothing, so an empty TargetItemID is
 // legal there and simply leaves item_id nil.
 func TestPlanAttachmentCopy_DryRunAllowsEmptyTargetItem(t *testing.T) {
+	t.Parallel()
 	f := newPlanFixture(t)
 	src := f.attach(t, f.wsA, "shot.png", 3)
 
@@ -609,6 +628,7 @@ func TestPlanAttachmentCopy_DryRunAllowsEmptyTargetItem(t *testing.T) {
 // blobs — referenced by the copied body, so never GC'd, and invisible
 // through every item-scoped surface.
 func TestPlanAttachmentCopy_InsertablePlanRequiresTargetItem(t *testing.T) {
+	t.Parallel()
 	f := newPlanFixture(t)
 	src := f.attach(t, f.wsA, "shot.png", 3)
 
@@ -627,6 +647,7 @@ func TestPlanAttachmentCopy_InsertablePlanRequiresTargetItem(t *testing.T) {
 // The plan must say so per row rather than emit a key the target backend
 // cannot resolve.
 func TestPlanAttachmentCopy_CrossBackendDetected(t *testing.T) {
+	t.Parallel()
 	f := newPlanFixture(t)
 	src := f.attachWith(t, f.wsA, "shot.png", 12, "fs:deadbeef", "deadbeef")
 
@@ -655,6 +676,7 @@ func TestPlanAttachmentCopy_CrossBackendDetected(t *testing.T) {
 // orchestration that forgets the Get/Put step fails loudly at insert
 // rather than quietly creating an attachment that 404s on download.
 func TestPlanAttachmentCopy_CrossBackendRowUninsertable(t *testing.T) {
+	t.Parallel()
 	f := newPlanFixture(t)
 	src := f.attachWith(t, f.wsA, "shot.png", 12, "fs:deadbeef", "deadbeef")
 
@@ -680,6 +702,7 @@ func TestPlanAttachmentCopy_CrossBackendRowUninsertable(t *testing.T) {
 // TestPlanAttachmentCopy_SameBackendNoTransfer: naming the backend
 // explicitly, when it matches, must NOT trigger a pointless byte copy.
 func TestPlanAttachmentCopy_SameBackendNoTransfer(t *testing.T) {
+	t.Parallel()
 	f := newPlanFixture(t)
 	src := f.attachWith(t, f.wsA, "shot.png", 12, "fs:deadbeef", "deadbeef")
 
@@ -703,6 +726,7 @@ func TestPlanAttachmentCopy_SameBackendNoTransfer(t *testing.T) {
 // backend prefix cannot be routed by the registry, so it is treated as
 // needing a real transfer rather than assumed resolvable.
 func TestPlanAttachmentCopy_PrefixlessKeyNeedsTransfer(t *testing.T) {
+	t.Parallel()
 	f := newPlanFixture(t)
 	src := f.attachWith(t, f.wsA, "shot.png", 12, "legacy-key-no-prefix", "hash1")
 
@@ -724,6 +748,7 @@ func TestPlanAttachmentCopy_PrefixlessKeyNeedsTransfer(t *testing.T) {
 // Per DR-16 storage is reported, not enforced — the dry-run's number must
 // agree with the storage page, not with a hash-deduped fiction.
 func TestPlanAttachmentCopy_DedupedBlobsCountedPerRow(t *testing.T) {
+	t.Parallel()
 	f := newPlanFixture(t)
 	a := f.attachWith(t, f.wsA, "one.png", 500, "fs:samehash", "samehash")
 	b := f.attachWith(t, f.wsA, "two.png", 500, "fs:samehash", "samehash")
@@ -744,6 +769,7 @@ func TestPlanAttachmentCopy_DedupedBlobsCountedPerRow(t *testing.T) {
 // same inputs, so the guarantee is structural — this pins it against a
 // future change that special-cases DryRun and lets the two drift.
 func TestPlanAttachmentCopy_DryRunTotalsMatchTheRealCopy(t *testing.T) {
+	t.Parallel()
 	f := newPlanFixture(t)
 	orig := f.attach(t, f.wsA, "shot.png", 1000)
 	f.variant(t, f.wsA, orig, models.AttachmentVariantThumbSm, 10)
@@ -791,6 +817,7 @@ func TestPlanAttachmentCopy_DryRunTotalsMatchTheRealCopy(t *testing.T) {
 // first-appearance order (content before fields), so a dry-run and the
 // subsequent copy list the same rows in the same order.
 func TestPlanAttachmentCopy_DeterministicOrder(t *testing.T) {
+	t.Parallel()
 	f := newPlanFixture(t)
 	first := f.attach(t, f.wsA, "first.png", 1)
 	second := f.attach(t, f.wsA, "second.png", 2)
@@ -812,6 +839,7 @@ func TestPlanAttachmentCopy_DeterministicOrder(t *testing.T) {
 // that same map to the destination item after planning, so a mutation
 // here would corrupt the copy.
 func TestPlanAttachmentCopy_DoesNotMutateCallerFields(t *testing.T) {
+	t.Parallel()
 	f := newPlanFixture(t)
 	a := f.attach(t, f.wsA, "shot.png", 5)
 
@@ -839,6 +867,7 @@ func TestPlanAttachmentCopy_DoesNotMutateCallerFields(t *testing.T) {
 // TestPlanAttachmentCopy_NoRefs: nothing referenced, nothing planned, and
 // a non-nil map so callers can index it unconditionally.
 func TestPlanAttachmentCopy_NoRefs(t *testing.T) {
+	t.Parallel()
 	f := newPlanFixture(t)
 
 	plan := f.plan(t, f.req("just prose", map[string]any{"status": "open"}))
@@ -855,6 +884,7 @@ func TestPlanAttachmentCopy_NoRefs(t *testing.T) {
 // the plan safe are mandatory. An empty SourceWorkspaceID in particular
 // would turn the DR-11a scope into "any workspace".
 func TestPlanAttachmentCopy_RequiredInputs(t *testing.T) {
+	t.Parallel()
 	f := newPlanFixture(t)
 
 	for _, tc := range []struct {
@@ -883,6 +913,7 @@ func TestPlanAttachmentCopy_RequiredInputs(t *testing.T) {
 // — which the planner would report as "not referenced" rather than as an
 // error.
 func TestChunkStrings(t *testing.T) {
+	t.Parallel()
 	ids := func(n int) []string {
 		out := make([]string, n)
 		for i := range out {
@@ -935,6 +966,7 @@ func TestChunkStrings(t *testing.T) {
 // — that one pins the split arithmetic, this one pins that a plan built
 // from more than one query is complete.
 func TestPlanAttachmentCopy_ManyRefsChunked(t *testing.T) {
+	t.Parallel()
 	if testing.Short() {
 		t.Skip("creates attachmentPlanChunk+1 rows")
 	}
@@ -969,6 +1001,7 @@ func TestPlanAttachmentCopy_ManyRefsChunked(t *testing.T) {
 // reference equals, field for field, the plan produced for a UUID that
 // names nothing at all.
 func TestPlanAttachmentCopy_DeniedRefIsExactlyDangling(t *testing.T) {
+	t.Parallel()
 	f := newPlanFixture(t)
 	secret := f.attach(t, f.wsA, "secret.png", 4096)
 	f.variant(t, f.wsA, secret, models.AttachmentVariantThumbMd, 20)
@@ -1001,6 +1034,7 @@ func TestPlanAttachmentCopy_DeniedRefIsExactlyDangling(t *testing.T) {
 // reference naming a VARIANT whose original the caller may not see cannot
 // smuggle that original in as its clone root.
 func TestPlanAttachmentCopy_DeniedParentSinksTheVariantRef(t *testing.T) {
+	t.Parallel()
 	f := newPlanFixture(t)
 	orig := f.attach(t, f.wsA, "shot.png", 1000)
 	thumb := f.variant(t, f.wsA, orig, models.AttachmentVariantThumbSm, 10)
@@ -1026,6 +1060,7 @@ func TestPlanAttachmentCopy_DeniedParentSinksTheVariantRef(t *testing.T) {
 // cannot see drops out on its own, without taking the legitimate original
 // with it.
 func TestPlanAttachmentCopy_DeniedVariantDropsOnlyItself(t *testing.T) {
+	t.Parallel()
 	f := newPlanFixture(t)
 	orig := f.attach(t, f.wsA, "shot.png", 1000)
 	sm := f.variant(t, f.wsA, orig, models.AttachmentVariantThumbSm, 10)
@@ -1050,6 +1085,7 @@ func TestPlanAttachmentCopy_DeniedVariantDropsOnlyItself(t *testing.T) {
 // transient database error into a copy that quietly drops the user's
 // images.
 func TestPlanAttachmentCopy_AuthorizerErrorIsFatal(t *testing.T) {
+	t.Parallel()
 	f := newPlanFixture(t)
 	a := f.attach(t, f.wsA, "shot.png", 10)
 
@@ -1065,6 +1101,7 @@ func TestPlanAttachmentCopy_AuthorizerErrorIsFatal(t *testing.T) {
 // claim itself: every row the plan emits was offered to the authorizer.
 // The gate is only worth what it is asked about.
 func TestPlanAttachmentCopy_AuthorizerSeesEveryClonedRow(t *testing.T) {
+	t.Parallel()
 	f := newPlanFixture(t)
 	orig := f.attach(t, f.wsA, "shot.png", 1000)
 	sm := f.variant(t, f.wsA, orig, models.AttachmentVariantThumbSm, 10)

--- a/internal/store/attachments_document_refs_test.go
+++ b/internal/store/attachments_document_refs_test.go
@@ -36,6 +36,7 @@ func (f *gcClaimFixture) createDocument(t *testing.T, content string) *models.Do
 // as referenced. Before the fix the scan covered items and comments only, so
 // this returned false and the GC was free to reclaim a live reference.
 func TestAttachmentReferenced_SeesDocumentContent(t *testing.T) {
+	t.Parallel()
 	f := newGCClaimFixture(t)
 	a := f.seedNeverAttached(t)
 
@@ -64,6 +65,7 @@ func TestAttachmentReferenced_SeesDocumentContent(t *testing.T) {
 // A soft-deleted document must NOT hold a reference, mirroring items. Without
 // this the scan would pin blobs behind deleted content forever.
 func TestAttachmentReferenced_IgnoresDeletedDocument(t *testing.T) {
+	t.Parallel()
 	f := newGCClaimFixture(t)
 	a := f.seedNeverAttached(t)
 	doc := f.createDocument(t, "![img](pad-attachment:"+a.ID+")")
@@ -95,6 +97,7 @@ func TestAttachmentReferenced_IgnoresDeletedDocument(t *testing.T) {
 // A document in ANOTHER workspace must not hold the reference — the scan is
 // workspace-scoped, and a pasted foreign id must not pin someone else's rows.
 func TestAttachmentReferenced_DocumentScanIsWorkspaceScoped(t *testing.T) {
+	t.Parallel()
 	f := newGCClaimFixture(t)
 	a := f.seedNeverAttached(t)
 
@@ -125,6 +128,7 @@ func TestAttachmentReferenced_DocumentScanIsWorkspaceScoped(t *testing.T) {
 // they were differently shaped: UpdateDocument already had a transaction,
 // CreateDocument had none and needed one.
 func TestDocumentWrites_StampAttachmentRefs(t *testing.T) {
+	t.Parallel()
 	t.Run("create stamps", func(t *testing.T) {
 		f := newGCClaimFixture(t)
 		a := f.seedNeverAttached(t)
@@ -191,6 +195,7 @@ func TestDocumentWrites_StampAttachmentRefs(t *testing.T) {
 // destination, and the clone it should have pointed at ends up referenced by
 // nothing.
 func TestRemapAttachmentReferences_RewritesCommentBodies(t *testing.T) {
+	t.Parallel()
 	f := newGCClaimFixture(t)
 	oldID, newID := "11111111-1111-4111-8111-111111111111", "22222222-2222-4222-8222-222222222222"
 
@@ -229,6 +234,7 @@ func TestRemapAttachmentReferences_RewritesCommentBodies(t *testing.T) {
 // unless the remap adds one, which is exactly the never-attached shape the GC
 // claims.
 func TestRemapAttachmentReferences_StampsTheRewrittenTarget(t *testing.T) {
+	t.Parallel()
 	f := newGCClaimFixture(t)
 	target := f.seedNeverAttached(t)
 	oldID := "33333333-3333-4333-8333-333333333333"
@@ -262,6 +268,7 @@ func TestRemapAttachmentReferences_StampsTheRewrittenTarget(t *testing.T) {
 // whole id map would vouch for rows no text points at, keeping genuinely
 // unreferenced clones alive for an extra GC window.
 func TestRemapAttachmentReferences_DoesNotStampUnreferencedClones(t *testing.T) {
+	t.Parallel()
 	f := newGCClaimFixture(t)
 	unreferenced := f.seedNeverAttached(t)
 

--- a/internal/store/attachments_dr15_test.go
+++ b/internal/store/attachments_dr15_test.go
@@ -64,6 +64,7 @@ func dr15CopyOneAttachment(t *testing.T) (copyFixture, *models.Attachment, *mode
 // otherwise a delete in workspace B would silently remove the file from
 // workspace A, which content-addressed sharing makes plausible-looking.
 func TestDR15_DeletingCloneLeavesSourceLive(t *testing.T) {
+	t.Parallel()
 	f, orig, clone := dr15CopyOneAttachment(t)
 
 	if err := f.s.SoftDeleteAttachment(clone.ID); err != nil {
@@ -92,6 +93,7 @@ func TestDR15_DeletingCloneLeavesSourceLive(t *testing.T) {
 // independence is pinned via delete in both directions; restore would ride the
 // same row separation.)
 func TestDR15_DeletingSourceLeavesCloneLive(t *testing.T) {
+	t.Parallel()
 	f, orig, clone := dr15CopyOneAttachment(t)
 
 	if err := f.s.SoftDeleteAttachment(orig.ID); err != nil {
@@ -121,6 +123,7 @@ func TestDR15_DeletingSourceLeavesCloneLive(t *testing.T) {
 // isn't a surprise, and so a change that started charging only one side fails
 // here.
 func TestDR15_MoveLeavesSourceAttachmentsLiveAndChargesBoth(t *testing.T) {
+	t.Parallel()
 	f := newCopyFixture(t)
 	// The source item comes first so the original can be ATTACHED to it
 	// (item_id = src.ID) — which is what makes the "move leaves source
@@ -258,6 +261,7 @@ func TestDR15_MoveLeavesSourceAttachmentsLiveAndChargesBoth(t *testing.T) {
 // This pins the store-level divergence that is the root of that orphan; it is
 // known behavior, not fixed here.
 func TestDR15_BundleExportOrphansAttachmentOfSoftDeletedParent(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Bundle Orphan")
 	col := createTestCollection(t, s, ws.ID, "Tasks")

--- a/internal/store/attachments_gc_claim_test.go
+++ b/internal/store/attachments_gc_claim_test.go
@@ -82,6 +82,7 @@ func (f *gcClaimFixture) rowExists(t *testing.T, id string) bool {
 }
 
 func TestStampAttachmentRefs_ItemContentAndFields(t *testing.T) {
+	t.Parallel()
 	f := newGCClaimFixture(t)
 	inContent := f.seedNeverAttached(t)
 	inFields := f.seedNeverAttached(t)
@@ -117,6 +118,7 @@ func TestStampAttachmentRefs_ItemContentAndFields(t *testing.T) {
 }
 
 func TestStampAttachmentRefs_Comments(t *testing.T) {
+	t.Parallel()
 	f := newGCClaimFixture(t)
 	inCreate := f.seedNeverAttached(t)
 	inEdit := f.seedNeverAttached(t)
@@ -143,6 +145,7 @@ func TestStampAttachmentRefs_Comments(t *testing.T) {
 }
 
 func TestStampAttachmentRefs_WorkspaceScoped(t *testing.T) {
+	t.Parallel()
 	f := newGCClaimFixture(t)
 	foreign := f.seedNeverAttached(t)
 
@@ -171,6 +174,7 @@ func TestStampAttachmentRefs_WorkspaceScoped(t *testing.T) {
 }
 
 func TestClaimNeverAttached_PredicateLegs(t *testing.T) {
+	t.Parallel()
 	f := newGCClaimFixture(t)
 	cutoff := time.Now().Add(-15 * time.Minute)
 
@@ -232,6 +236,7 @@ func TestClaimNeverAttached_PredicateLegs(t *testing.T) {
 }
 
 func TestClaimSoftDeleted_RefusesRestoredRow(t *testing.T) {
+	t.Parallel()
 	f := newGCClaimFixture(t)
 	a := f.seedNeverAttached(t)
 	oldTS := time.Now().Add(-40 * 24 * time.Hour).UTC().Format(time.RFC3339)
@@ -269,6 +274,7 @@ func TestClaimSoftDeleted_RefusesRestoredRow(t *testing.T) {
 // blob is only reclaimed after a successful claim (row-before-bytes in
 // the sweep), the bytes survive by construction.
 func TestClaimProtocol_FiledRaceSequence(t *testing.T) {
+	t.Parallel()
 	f := newGCClaimFixture(t)
 	a := f.seedNeverAttached(t)
 
@@ -311,6 +317,7 @@ func TestClaimProtocol_FiledRaceSequence(t *testing.T) {
 // (and, on Postgres, its own row lock) — not just the claim's parent
 // NOT EXISTS belt.
 func TestStampAttachmentRefs_StampsVariantsOfReferencedOriginal(t *testing.T) {
+	t.Parallel()
 	f := newGCClaimFixture(t)
 	orig := f.seedNeverAttached(t)
 
@@ -351,6 +358,7 @@ func TestStampAttachmentRefs_StampsVariantsOfReferencedOriginal(t *testing.T) {
 // selection, must refuse — the parent-liveness re-read happens inside
 // the claim's own transaction, under a Postgres row lock.
 func TestClaimOrphanedVariant_RestoreRefusesAtClaimTime(t *testing.T) {
+	t.Parallel()
 	f := newGCClaimFixture(t)
 	parent := f.seedNeverAttached(t)
 
@@ -423,6 +431,7 @@ func TestClaimOrphanedVariant_RestoreRefusesAtClaimTime(t *testing.T) {
 // the claim, so the fix cannot have widened into reclaiming healthy
 // thumbnails.
 func TestOrphanedVariant_ForeignParentDoesNotShield(t *testing.T) {
+	t.Parallel()
 	f := newGCClaimFixture(t)
 
 	// A LIVE parent in a different workspace.

--- a/internal/store/attachments_live_item_test.go
+++ b/internal/store/attachments_live_item_test.go
@@ -44,6 +44,7 @@ func countLiveAttachments(t *testing.T, s *Store, wsID string) int {
 }
 
 func TestCreateAttachmentForLiveItem_LiveParentInserts(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	wsID, _, row := liveItemAttachmentFixture(t, s)
 
@@ -59,6 +60,7 @@ func TestCreateAttachmentForLiveItem_LiveParentInserts(t *testing.T) {
 }
 
 func TestCreateAttachmentForLiveItem_ArchivedParentRefuses(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	wsID, itemID, row := liveItemAttachmentFixture(t, s)
 
@@ -77,6 +79,7 @@ func TestCreateAttachmentForLiveItem_ArchivedParentRefuses(t *testing.T) {
 // A non-null item_id that names nothing at all is refused, not silently
 // written as if it were an orphan.
 func TestCreateAttachmentForLiveItem_MalformedParentRefuses(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	wsID, _, row := liveItemAttachmentFixture(t, s)
 
@@ -93,6 +96,7 @@ func TestCreateAttachmentForLiveItem_MalformedParentRefuses(t *testing.T) {
 // item_id carries no FK or same-workspace constraint, so a live item in
 // ANOTHER workspace would pass a liveness-only re-check.
 func TestCreateAttachmentForLiveItem_ForeignWorkspaceParentRefuses(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	wsID, _, row := liveItemAttachmentFixture(t, s)
 
@@ -198,6 +202,7 @@ func waitForLockWait(t *testing.T, s *Store, needle string, done <-chan error) {
 // while the first is live — the interleaving this test constructs is
 // unrepresentable there, which is why the locking clause is dialect-gated.
 func TestCreateAttachmentForLiveItem_BlocksOnArchivingWriter(t *testing.T) {
+	t.Parallel()
 	pgURL := os.Getenv("PAD_TEST_POSTGRES_URL")
 	if pgURL == "" {
 		t.Skip("PAD_TEST_POSTGRES_URL not set — the lock only exists on Postgres")

--- a/internal/store/attachments_restore_stamp_test.go
+++ b/internal/store/attachments_restore_stamp_test.go
@@ -37,6 +37,7 @@ func stampAged(t *testing.T, f *gcClaimFixture, id string, when time.Time) {
 const restoreStaleWindow = 15 * time.Minute
 
 func TestRestoreDocument_ReStampsAttachmentRefs(t *testing.T) {
+	t.Parallel()
 	f := newGCClaimFixture(t)
 	att := f.seedNeverAttached(t)
 
@@ -78,6 +79,7 @@ func TestRestoreDocument_ReStampsAttachmentRefs(t *testing.T) {
 }
 
 func TestRestoreItem_ReStampsAttachmentRefs(t *testing.T) {
+	t.Parallel()
 	f := newGCClaimFixture(t)
 	// Unattached upload (item_id NULL) referenced only from an item's content
 	// — the reachable item-leg case (an item-attached row carries item_id and
@@ -122,6 +124,7 @@ func TestRestoreItem_ReStampsAttachmentRefs(t *testing.T) {
 // attachment referenced only from a field value (e.g. a cover image) must be
 // re-stamped on restore too, since RestoreItem stamps content AND fields.
 func TestRestoreItem_ReStampsFieldsRefs(t *testing.T) {
+	t.Parallel()
 	f := newGCClaimFixture(t)
 	att := f.seedNeverAttached(t)
 

--- a/internal/store/attachments_test.go
+++ b/internal/store/attachments_test.go
@@ -14,6 +14,7 @@ import (
 // upload-time behavior in WorkspaceStorageLimit, which returns -1
 // rather than rejecting the upload outright).
 func TestWorkspaceStorageInfo_NoOwner(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	wsID := newID()
@@ -51,6 +52,7 @@ func TestWorkspaceStorageInfo_NoOwner(t *testing.T) {
 //     pro/self-hosted bypass override resolution; the flag still
 //     surfaces the configured override for admin visibility)
 func TestWorkspaceStorageInfo_FreePlanResolution(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	owner, err := s.CreateUser(models.UserCreate{
@@ -128,6 +130,7 @@ func TestWorkspaceStorageInfo_FreePlanResolution(t *testing.T) {
 // in collections they can't access, and orphans (item_id IS NULL)
 // must be hidden as well so filenames don't leak.
 func TestWorkspaceAttachments_VisibilityFilter(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	wsID := newID()
@@ -248,6 +251,7 @@ func TestWorkspaceAttachments_VisibilityFilter(t *testing.T) {
 //   - The row carries item_deleted=true so the UI can render the
 //     "(deleted)" badge.
 func TestWorkspaceAttachments_SurfacesSoftDeletedParents(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	wsID := newID()
@@ -341,6 +345,7 @@ func TestWorkspaceAttachments_SurfacesSoftDeletedParents(t *testing.T) {
 // Count and result queries must agree — a restricted caller's total
 // must match the rows they actually get back.
 func TestWorkspaceAttachments_ForeignParentYieldsNullMetadata(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	wsA, wsB := newID(), newID()
@@ -528,6 +533,7 @@ func TestWorkspaceAttachments_ForeignParentYieldsNullMetadata(t *testing.T) {
 // Again the predicate belongs in ON: the row must still list, with
 // only the collection columns nulled.
 func TestWorkspaceAttachments_ForeignCollectionYieldsNullCollectionMetadata(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	wsA, wsB := newID(), newID()
@@ -593,6 +599,7 @@ func TestWorkspaceAttachments_ForeignCollectionYieldsNullCollectionMetadata(t *t
 // the earlier prefix-only mapping silently passed those filters
 // through with no MIME predicate, returning the full list.
 func TestWorkspaceAttachments_CategoryFilters(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	wsID := newID()
@@ -669,6 +676,7 @@ func TestWorkspaceAttachments_CategoryFilters(t *testing.T) {
 // used_bytes — and that soft-deleted rows are excluded so the user
 // sees the post-delete value (Settings → Storage UX expectation).
 func TestWorkspaceStorageInfo_TracksLiveAttachments(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	wsID := newID()
@@ -721,6 +729,7 @@ func TestWorkspaceStorageInfo_TracksLiveAttachments(t *testing.T) {
 // the batched form at its own layer so the two cannot drift apart
 // silently.
 func TestAttachmentHashesWithRows(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Hash Rows")
 

--- a/internal/store/bug1791_archived_marker_test.go
+++ b/internal/store/bug1791_archived_marker_test.go
@@ -14,6 +14,7 @@ import (
 // surfaced by `all=true` looked identical to a live row, which read as
 // corruption when it then 404'd on get/update.
 func TestListItems_IncludeArchived_PopulatesDeletedAt(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")

--- a/internal/store/cascade_serial_guard_test.go
+++ b/internal/store/cascade_serial_guard_test.go
@@ -1,0 +1,122 @@
+package store
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TASK-2900. TestUpdateDocument_CascadeExhaustionRollsBackTheWholeRename
+// assigns the package-level cascadeRewriteAttempts and restores it in a defer.
+// That is safe only while the test runs in the SEQUENTIAL phase, where no
+// t.Parallel() test is in flight; adding t.Parallel() to it would make the
+// mutation visible to every other cascade test, and the symptom would appear
+// in THOSE tests rather than in this one.
+//
+// A comment saying "must not call t.Parallel()" protects nobody against the
+// next sweep — this repository just ran one that touched 844 test functions.
+// So the invariant is enforced rather than asserted.
+//
+// This guard reads SOURCE, which makes it an instrument with an adversary, so
+// its own failure modes are worth stating:
+//
+//   - It anchors the identifier END (`\b`) so a future
+//     `...RollsBackTheWholeRenameV2` is not silently matched by a prefix.
+//   - It strips line comments before scanning, so the words "t.Parallel()"
+//     inside the explanatory comment above the mutation cannot satisfy or
+//     trip it. Verified by the fact that the comment above that line contains
+//     the string and this test passes.
+//   - It FAILS CLOSED: if the function or the file cannot be found, that is a
+//     failure, not a pass. A guard that silently finds nothing to check is the
+//     failure mode this whole class has.
+func TestCascadeExhaustionStaysSerial(t *testing.T) {
+	const file = "documents_cascade_lost_update_test.go"
+	const fn = "TestUpdateDocument_CascadeExhaustionRollsBackTheWholeRename"
+
+	src, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("guard cannot read %s: %v — failing closed rather than passing vacuously", file, err)
+	}
+
+	// Anchor the identifier's END so a renamed-with-suffix function does not
+	// match this guard while escaping what it guards.
+	start := regexp.MustCompile(`func ` + regexp.QuoteMeta(fn) + `\b`).FindIndex(src)
+	if start == nil {
+		t.Fatalf("guard cannot find %s in %s — the function was renamed or moved, so this guard is "+
+			"no longer guarding anything. Re-point it or delete it deliberately; do not leave it green.", fn, file)
+	}
+
+	rest := string(src[start[1]:])
+	// Bound the scan at the next top-level func so a later test's
+	// t.Parallel() is not attributed to this one.
+	if end := strings.Index(rest, "\nfunc "); end >= 0 {
+		rest = rest[:end]
+	}
+
+	// Strip line comments: the mutation site carries an explanatory comment
+	// that mentions t.Parallel() by name, and a guard that a comment can trip
+	// is the comment-blindness failure inverted.
+	var body strings.Builder
+	for _, line := range strings.Split(rest, "\n") {
+		if idx := strings.Index(line, "//"); idx >= 0 {
+			line = line[:idx]
+		}
+		body.WriteString(line)
+		body.WriteString("\n")
+	}
+
+	if strings.Contains(body.String(), "t.Parallel()") {
+		t.Fatalf("%s calls t.Parallel(), but it assigns the package-level cascadeRewriteAttempts. "+
+			"That mutation would become visible to every concurrently-running test, and the flakes "+
+			"would appear in the OTHER cascade tests rather than in this one. Either drop the "+
+			"t.Parallel() or stop mutating the global.", fn)
+	}
+
+	// Positive control on the instrument itself: the same scan must FIND
+	// t.Parallel() in a function that has it, or this guard proves nothing.
+	ctl, err := os.ReadFile("collections_test.go")
+	if err == nil && !strings.Contains(string(ctl), "t.Parallel()") {
+		t.Fatal("control failed: the sweep should have added t.Parallel() to collections_test.go, " +
+			"so a scan that cannot see it there cannot be trusted to see it above")
+	}
+}
+
+// TestMigrationGuardTestsStaySerial is the same guard for the other file whose
+// tests mutate package globals — store.AllowSchemaAhead and store.BinaryVersion,
+// both EXPORTED, which is why my `^var [a-z]` sweep missed them and codex did
+// not. It guards the whole FILE rather than named functions, because every test
+// in it touches one of those two globals and a new one added there would too.
+func TestMigrationGuardTestsStaySerial(t *testing.T) {
+	const file = "migration_guard_test.go"
+
+	src, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("guard cannot read %s: %v — failing closed rather than passing vacuously", file, err)
+	}
+
+	var body strings.Builder
+	for _, line := range strings.Split(string(src), "\n") {
+		if idx := strings.Index(line, "//"); idx >= 0 {
+			line = line[:idx]
+		}
+		body.WriteString(line)
+		body.WriteString("\n")
+	}
+
+	if strings.Contains(body.String(), "t.Parallel()") {
+		t.Fatalf("a test in %s calls t.Parallel(), but every test in that file mutates a package-level "+
+			"global (AllowSchemaAhead / BinaryVersion) and restores it in a t.Cleanup. Under parallelism "+
+			"that window is open across every concurrently-running test — AllowSchemaAhead=true would "+
+			"disarm the schema-ahead guard for whoever else is running, which is the property two of "+
+			"those tests exist to assert.", file)
+	}
+
+	// Same positive control as the guard above: the scan must be able to SEE a
+	// real t.Parallel() somewhere, or its silence here means nothing.
+	ctl, err := os.ReadFile("collections_test.go")
+	if err == nil && !strings.Contains(string(ctl), "t.Parallel()") {
+		t.Fatal("control failed: the sweep should have added t.Parallel() to collections_test.go, " +
+			"so a scan that cannot see it there cannot be trusted to see it in migration_guard_test.go")
+	}
+}

--- a/internal/store/collection_traits_backfill_test.go
+++ b/internal/store/collection_traits_backfill_test.go
@@ -21,6 +21,7 @@ import (
 // Runs against whichever dialect testStore provides, so `make test-pg` covers
 // the Postgres statements and the default suite covers SQLite.
 func TestCollectionTraitsBackfill(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Backfill Test")
 	if err := s.SeedCollectionsFromTemplate(ws.ID, "startup"); err != nil {
@@ -209,6 +210,7 @@ func mustTraits(t *testing.T, s *Store, collID string) models.CollectionTraits {
 // have its filter silently discarded, shipping an unfiltered payload. This
 // test fails the moment the two rules disagree.
 func TestFilterKeyRuleMatchesStoreSanitizer(t *testing.T) {
+	t.Parallel()
 	keys := []string{
 		"status", "trigger", "invocation_slug", "agent-role", "a1", "_leading",
 		"", " ", "stat us", "status;drop", "sta.tus", "status'", "état", "a\tb",
@@ -237,6 +239,7 @@ func TestFilterKeyRuleMatchesStoreSanitizer(t *testing.T) {
 // artifact export. The archive looks fine and the workspace is quietly inert:
 // exactly the BUG-2702 failure mode, reintroduced through a different door.
 func TestImportLegacyArchiveInfersTraits(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	owner := createTestUser(t, s, "legacy-archive-owner@test.com", "Legacy Owner", "password123")
 	src := createTestWorkspace(t, s, "Legacy Archive Source")
@@ -319,6 +322,7 @@ func TestImportLegacyArchiveInfersTraits(t *testing.T) {
 // The custom declarations below differ from the canonical set on purpose; a
 // test using the canonical values would pass whether or not the guard exists.
 func TestImportDoesNotOverrideSurvivingTraits(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	owner := createTestUser(t, s, "custom-traits-owner@test.com", "Custom Owner", "password123")
 	src := createTestWorkspace(t, s, "Custom Traits Source")
@@ -383,6 +387,7 @@ func TestImportDoesNotOverrideSurvivingTraits(t *testing.T) {
 // Go constant, so this is the only thing stopping the two from drifting — and
 // a drift would be silent, since both sides independently produce valid traits.
 func TestBackfillSQLMatchesCanonicalTraits(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Backfill Parity")
 	if err := s.SeedCollectionsFromTemplate(ws.ID, "startup"); err != nil {

--- a/internal/store/collections_relation_rename_test.go
+++ b/internal/store/collections_relation_rename_test.go
@@ -61,6 +61,7 @@ func relationTargetOf(t *testing.T, s *Store, collID, key string) string {
 }
 
 func TestRenameMigratesRelationTargetsInSiblingCollections(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "RelRenameSibling")
 
@@ -90,6 +91,7 @@ func TestRenameMigratesRelationTargetsInSiblingCollections(t *testing.T) {
 }
 
 func TestRenameMigratesASelfReferencingRelation(t *testing.T) {
+	t.Parallel()
 	// The renamed collection is also the row being UPDATEd, so its own schema
 	// rewrite has to compose with the update rather than be clobbered by it.
 	s := testStore(t)
@@ -117,6 +119,7 @@ func TestRenameMigratesASelfReferencingRelation(t *testing.T) {
 }
 
 func TestRenameWithASimultaneousSchemaWriteMigratesTheSuppliedSchema(t *testing.T) {
+	t.Parallel()
 	// A caller that renames AND supplies a new schema in one call: the
 	// migration must apply to what the caller sent, not to what was stored,
 	// or the rewrite silently reverts their edit.
@@ -161,6 +164,7 @@ func TestRenameWithASimultaneousSchemaWriteMigratesTheSuppliedSchema(t *testing.
 }
 
 func TestRenameLeavesUnrelatedFieldsAndCollectionsAlone(t *testing.T) {
+	t.Parallel()
 	// CONTROL. Without this the propagation tests are satisfied by a change
 	// that rewrites the string everywhere it appears.
 	s := testStore(t)
@@ -277,6 +281,7 @@ func TestConcurrentRenamesOfMutuallyReferencingCollectionsDoNotDeadlock(t *testi
 }
 
 func TestRenameAdvancesTheMigratedSiblingsConcurrencyToken(t *testing.T) {
+	t.Parallel()
 	// codex round 1 P1. `collections.updated_at` doubles as the OCC token
 	// (BUG-2265). Rewriting a sibling's schema without advancing it lets a
 	// client still holding the PRE-rename schema — and a token that still
@@ -325,6 +330,7 @@ func TestRenameAdvancesTheMigratedSiblingsConcurrencyToken(t *testing.T) {
 }
 
 func TestRenamePreservesSchemaPropertiesItDoesNotUnderstand(t *testing.T) {
+	t.Parallel()
 	// codex round 1 P2. Round-tripping through `models.CollectionSchema` drops
 	// every property that struct does not declare, so a rename would silently
 	// erase forward-compatible metadata from any relation-bearing schema.
@@ -374,6 +380,7 @@ func TestRenamePreservesSchemaPropertiesItDoesNotUnderstand(t *testing.T) {
 }
 
 func TestConcurrentRenamesOfTheSameCollectionLeaveRelationsPointingAtIt(t *testing.T) {
+	t.Parallel()
 	// codex round 1 P1 (the third one). Both racers read the collection's slug
 	// via the pre-transaction GetCollection. If the retarget uses THAT value
 	// rather than the one re-read under the row lock, the loser migrates
@@ -425,6 +432,7 @@ func TestConcurrentRenamesOfTheSameCollectionLeaveRelationsPointingAtIt(t *testi
 }
 
 func TestRenameNeverRegressesAMigratedSiblingsToken(t *testing.T) {
+	t.Parallel()
 	// codex round 2 P1. A sibling updated between the rename's timestamp and
 	// the scan already holds a NEWER token; stamping the rename's value on it
 	// moves the OCC token BACKWARDS, breaking the strictly-increasing invariant
@@ -473,6 +481,7 @@ func TestRenameNeverRegressesAMigratedSiblingsToken(t *testing.T) {
 }
 
 func TestRenamePreservesLargeIntegersInUnknownSchemaProperties(t *testing.T) {
+	t.Parallel()
 	// codex round 2 P2. Decoding into `interface{}` turns every JSON number
 	// into float64, so an integer past 2^53 comes back CHANGED and the rename
 	// silently corrupts a property it was only meant to carry through.
@@ -507,6 +516,7 @@ func TestRenamePreservesLargeIntegersInUnknownSchemaProperties(t *testing.T) {
 }
 
 func TestRenameLeavesASchemaWithTrailingJunkUntouched(t *testing.T) {
+	t.Parallel()
 	// codex round 3 P2. `json.Decoder.Decode` stops at the end of the first
 	// value and ignores the rest, where `json.Unmarshal` refuses it — so
 	// re-marshaling such a document would silently discard the trailing bytes.

--- a/internal/store/collections_settings_shape_repair_test.go
+++ b/internal/store/collections_settings_shape_repair_test.go
@@ -33,6 +33,7 @@ import (
 // SQLite rebuild's INSERT…SELECT preserves the literal bytes). Finally
 // 058 runs and is the migration under test.
 func TestCollectionsSettingsShapeRepair_SQLite(t *testing.T) {
+	t.Parallel()
 	if os.Getenv("PAD_TEST_POSTGRES_URL") != "" {
 		t.Skip("SQLite-specific (json_valid / json_type)")
 	}
@@ -163,6 +164,7 @@ func TestCollectionsSettingsShapeRepair_SQLite(t *testing.T) {
 // helpers' normalizers) then re-run pgmigrations/037's UPDATE clause and
 // assert every malformed row is repaired to '{}'::jsonb.
 func TestCollectionsSettingsShapeRepair_Postgres(t *testing.T) {
+	t.Parallel()
 	if os.Getenv("PAD_TEST_POSTGRES_URL") == "" {
 		t.Skip("PAD_TEST_POSTGRES_URL not set")
 	}

--- a/internal/store/collections_slug_race_pg_test.go
+++ b/internal/store/collections_slug_race_pg_test.go
@@ -78,6 +78,7 @@ func holdUncommittedRename(t *testing.T, s *Store, wsID, collID, newSlug string)
 // BUG-2875: a create must queue behind an in-flight rename, not slip between
 // its scan and its commit.
 func TestCreateCollectionWaitsForAnUncommittedRename(t *testing.T) {
+	t.Parallel()
 	s, wsID, alpha := slugRacePGStore(t)
 
 	tx := holdUncommittedRename(t, s, wsID, alpha.ID, "gamma")
@@ -127,6 +128,7 @@ func TestCreateCollectionWaitsForAnUncommittedRename(t *testing.T) {
 // renames deriving the same slug serialize into `gamma` and `gamma-2` rather
 // than one of them failing on the UNIQUE index.
 func TestRenameAllocatesItsSlugUnderTheWorkspaceLock(t *testing.T) {
+	t.Parallel()
 	s, wsID, alpha := slugRacePGStore(t)
 	beta, err := s.CreateCollection(wsID, models.CollectionCreate{Name: "Beta", Slug: "beta"})
 	if err != nil {

--- a/internal/store/collections_test.go
+++ b/internal/store/collections_test.go
@@ -42,6 +42,7 @@ import (
 // not-null constraint", SQLSTATE 23502), so we only assert that an error
 // surfaces — not its content.
 func TestCollectionsSettingsNotNullEnforced(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "NOT NULL Enforcement")
 
@@ -60,6 +61,7 @@ func TestCollectionsSettingsNotNullEnforced(t *testing.T) {
 // TEXT and Postgres stores it as JSONB (which normalizes to `{}` on
 // readback); both surface through GetCollection as the Go string `{}`.
 func TestCollectionsSettingsDefaultsToEmptyObject(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Settings Default")
 
@@ -93,6 +95,7 @@ func TestCollectionsSettingsDefaultsToEmptyObject(t *testing.T) {
 // `collections.settings always holds valid JSON` invariant at the API
 // boundary, where the schema constraint alone is not sufficient.
 func TestUpdateCollectionCoercesEmptyStringSettings(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Update Coerce Empty Settings")
 
@@ -124,6 +127,7 @@ func TestUpdateCollectionCoercesEmptyStringSettings(t *testing.T) {
 // token (BUG-2265) lets the settings write through unchanged. Mirrors the item
 // path's TestUpdateItemExpectedUpdatedAtMatch.
 func TestUpdateCollectionExpectedUpdatedAtMatch(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "OCCCollMatch")
 
@@ -163,6 +167,7 @@ func TestUpdateCollectionExpectedUpdatedAtMatch(t *testing.T) {
 // *CollectionUpdateConflictError and the write does NOT land — the BUG-2265
 // last-write-wins fix. Mirrors TestUpdateItemExpectedUpdatedAtConflict.
 func TestUpdateCollectionExpectedUpdatedAtConflict(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "OCCCollConflict")
 
@@ -217,6 +222,7 @@ func TestUpdateCollectionExpectedUpdatedAtConflict(t *testing.T) {
 // advances once. (Failure-rollback is covered structurally: the migration runs
 // inside the same tx, so an error returns before commit.)
 func TestUpdateCollectionAppliesMigrationsAtomically(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "OCCCollMigrate")
 
@@ -281,6 +287,7 @@ func TestUpdateCollectionAppliesMigrationsAtomically(t *testing.T) {
 // serializes everything. Either way, with the correct order every worker
 // succeeds.
 func TestUpdateCollectionMigrationNoDeadlockWithItemCreate(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "OCCCollDeadlock")
 	coll, err := s.CreateCollection(ws.ID, models.CollectionCreate{
@@ -341,6 +348,7 @@ func TestUpdateCollectionMigrationNoDeadlockWithItemCreate(t *testing.T) {
 // strictly past the token, so replaying the stale token conflicts — DETERMINISTIC
 // regardless of timing.
 func TestUpdateCollectionTokenAdvancesPreventsSameSecondClobber(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "OCCCollSameSecond")
 
@@ -399,6 +407,7 @@ func TestUpdateCollectionTokenAdvancesPreventsSameSecondClobber(t *testing.T) {
 // the row's current value, so it can't regress the concurrency token in the
 // same wall-clock second and let a stale guarded token clobber newer data.
 func TestUpdateCollectionTokenlessWriteStillAdvancesToken(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "OCCCollTokenlessMono")
 
@@ -439,6 +448,7 @@ func TestUpdateCollectionTokenlessWriteStillAdvancesToken(t *testing.T) {
 // the legacy last-write-wins path — an unconditional write that always lands
 // (CLI / MCP / API callers that don't opt in). BUG-2265 is additive.
 func TestUpdateCollectionNoTokenSkipsConcurrencyCheck(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "OCCCollNoToken")
 
@@ -470,6 +480,7 @@ func TestUpdateCollectionNoTokenSkipsConcurrencyCheck(t *testing.T) {
 // a collection with non-NULL JSON settings round-trips through the minimal
 // query intact on both drivers.
 func TestListCollectionsMinimalReturnsSettingsJSON(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "ListCollectionsMinimal JSON Settings")
 
@@ -528,6 +539,7 @@ func TestListCollectionsMinimalReturnsSettingsJSON(t *testing.T) {
 // to inject "" settings, then asserts ImportWorkspace materializes them
 // back to valid JSON on the destination side.
 func TestExportImportRoundTripWithEmptyStringSettings(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	owner := createTestUser(t, s, "round-trip-owner@test.com", "Round Trip Owner", "password123")
 	src := createTestWorkspace(t, s, "Export-Import Round Trip Empty Settings")
@@ -581,6 +593,7 @@ func TestExportImportRoundTripWithEmptyStringSettings(t *testing.T) {
 // (or shrunk) its starter pack and the motivating "agent-self workspace
 // with no ghost collections" use case is no longer protected.
 func TestSeedFromBlankTemplate(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Blank Test")
 
@@ -636,6 +649,7 @@ func TestSeedFromBlankTemplate(t *testing.T) {
 // dashboard / list-items tests in internal/server/ which all rely on
 // "empty Template + zero items" semantics.
 func TestSeedFromTemplateAlwaysIncludesOnboardPlaybook(t *testing.T) {
+	t.Parallel()
 	for _, name := range []string{"blank", "startup", "scrum", "product", "hiring", "interviewing"} {
 		t.Run(name, func(t *testing.T) {
 			s := testStore(t)
@@ -670,6 +684,7 @@ func TestSeedFromTemplateAlwaysIncludesOnboardPlaybook(t *testing.T) {
 // the onboard playbook. This is the path tests and direct API
 // callers use to get a bare workspace.
 func TestSeedWithEmptyTemplateNameSkipsOnboard(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Empty-Template Onboard Skip Test")
 	if err := s.SeedCollectionsFromTemplate(ws.ID, ""); err != nil {
@@ -697,6 +712,7 @@ func TestSeedWithEmptyTemplateNameSkipsOnboard(t *testing.T) {
 // every server restart. The fix gates the rescue on "workspace has zero
 // collections" so blank (which ships 2 system collections) is a no-op.
 func TestBlankWorkspaceSurvivesSeedDefaultCollections(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Blank Survival Test")
 
@@ -740,6 +756,7 @@ func TestBlankWorkspaceSurvivesSeedDefaultCollections(t *testing.T) {
 // collection landed, the auto-upgrade must still materialize the Software
 // defaults.
 func TestEmptyWorkspaceStillGetsDefaults(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Empty Rescue Test")
 
@@ -791,6 +808,7 @@ func collectionSlugs(colls []models.Collection) []string {
 // predicates that differ still differ — soft-delete state and workspace scope
 // are checked below.
 func TestCollectionAccessorsShareOneHydration(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Hydration")
 	other := createTestWorkspace(t, s, "Elsewhere")

--- a/internal/store/comments_agent_name_test.go
+++ b/internal/store/comments_agent_name_test.go
@@ -54,6 +54,7 @@ func agentNamesByID(comments []models.Comment) map[string]string {
 }
 
 func TestListComments_AgentNameFromLinkedActivity(t *testing.T) {
+	t.Parallel()
 	s, item := agentNameFixture(t)
 
 	named := commentWithActivity(t, s, item, `{"agent":"wren"}`, "named", "")
@@ -146,6 +147,7 @@ func TestListComments_AgentNameFromLinkedActivity(t *testing.T) {
 // comment query still carries the name, because it does not depend on that
 // window at all. A handler-side join of the two lists would have lost it here.
 func TestListCommentsBeforeTime_AgentNameSurvivesActivityWindow(t *testing.T) {
+	t.Parallel()
 	s, item := agentNameFixture(t)
 
 	c := commentWithActivity(t, s, item, `{"agent":"wren"}`, "early", "")
@@ -206,6 +208,7 @@ func equalStringMaps(a, b map[string]string) bool {
 // activity query now excludes comment-linked rows itself, so the outcome does
 // not depend on which comments happened to be fetched alongside.
 func TestListDocumentActivityBeforeTime_ExcludesCommentLinkedRows(t *testing.T) {
+	t.Parallel()
 	s, item := agentNameFixture(t)
 
 	linked := commentWithActivity(t, s, item, `{"agent":"wren"}`, "linked", "")
@@ -243,6 +246,7 @@ func TestListDocumentActivityBeforeTime_ExcludesCommentLinkedRows(t *testing.T) 
 // activity id alone, and nothing in the schema says a comment's activity
 // belongs to the comment's item.
 func TestListComments_AgentNameNeverReadAcrossItems(t *testing.T) {
+	t.Parallel()
 	s, item := agentNameFixture(t)
 	other := createTestItem(t, s, item.WorkspaceID, item.CollectionID, "Other", "")
 
@@ -305,6 +309,7 @@ func TestListComments_AgentNameNeverReadAcrossItems(t *testing.T) {
 // shape this test used to carry is now the BUG-2763 identity matrix's, in
 // activities_test.go.
 func TestCreateActivityDebounced_NeverMergesIntoCommentLinkedRow(t *testing.T) {
+	t.Parallel()
 	s, item := agentNameFixture(t)
 	user, err := s.CreateUser(models.UserCreate{Email: "shared@test.com", Name: "Dave", Password: "correct-horse-battery-staple"})
 	if err != nil {
@@ -379,6 +384,7 @@ func TestCreateActivityDebounced_NeverMergesIntoCommentLinkedRow(t *testing.T) {
 // is still the right shape for THIS test: it pins the predicate itself,
 // independently of any caller.)
 func TestMergeIntoUnlinkedActivity_RefusesLinkedRow(t *testing.T) {
+	t.Parallel()
 	s, item := agentNameFixture(t)
 	mk := func(meta string) string {
 		id, err := s.CreateActivity(models.Activity{

--- a/internal/store/connected_apps_test.go
+++ b/internal/store/connected_apps_test.go
@@ -99,6 +99,7 @@ func seedAccess(t *testing.T, s *Store, requestID, clientID, subject string, ts 
 }
 
 func TestListUserOAuthConnections_DeduplicatesChain(t *testing.T) {
+	t.Parallel()
 	s := newConnectedTestStore(t)
 	uid := seedUser(t, s, "list-dedup@example.com")
 	clientID := seedClient(t, s, "Claude Desktop")
@@ -149,6 +150,7 @@ func TestListUserOAuthConnections_DeduplicatesChain(t *testing.T) {
 }
 
 func TestListUserOAuthConnections_FiltersBySubject(t *testing.T) {
+	t.Parallel()
 	s := newConnectedTestStore(t)
 	alice := seedUser(t, s, "alice-conn@example.com")
 	bob := seedUser(t, s, "bob-conn@example.com")
@@ -176,6 +178,7 @@ func TestListUserOAuthConnections_FiltersBySubject(t *testing.T) {
 }
 
 func TestListUserOAuthConnections_ExcludesInactiveChains(t *testing.T) {
+	t.Parallel()
 	s := newConnectedTestStore(t)
 	uid := seedUser(t, s, "inactive@example.com")
 	clientID := seedClient(t, s, "Test Client")
@@ -197,6 +200,7 @@ func TestListUserOAuthConnections_ExcludesInactiveChains(t *testing.T) {
 }
 
 func TestRevokeUserOAuthConnection_OwnershipCheck(t *testing.T) {
+	t.Parallel()
 	s := newConnectedTestStore(t)
 	alice := seedUser(t, s, "revoke-alice@example.com")
 	bob := seedUser(t, s, "revoke-bob@example.com")
@@ -234,6 +238,7 @@ func TestRevokeUserOAuthConnection_OwnershipCheck(t *testing.T) {
 }
 
 func TestRevokeUserOAuthConnection_Idempotent(t *testing.T) {
+	t.Parallel()
 	s := newConnectedTestStore(t)
 	uid := seedUser(t, s, "idem@example.com")
 	clientID := seedClient(t, s, "Idem Tester")
@@ -248,6 +253,7 @@ func TestRevokeUserOAuthConnection_Idempotent(t *testing.T) {
 }
 
 func TestRevokeUserOAuthConnection_UnknownChain(t *testing.T) {
+	t.Parallel()
 	s := newConnectedTestStore(t)
 	uid := seedUser(t, s, "unknown@example.com")
 	if err := s.RevokeUserOAuthConnection(uid, "no-such-chain"); err != ErrConnectionNotFound {
@@ -256,6 +262,7 @@ func TestRevokeUserOAuthConnection_UnknownChain(t *testing.T) {
 }
 
 func TestClassifyCapabilityTier(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		scopes string
 		want   models.CapabilityTier
@@ -291,6 +298,7 @@ func TestClassifyCapabilityTier(t *testing.T) {
 //   - explicit slug list               → (hasKey=true, isStar=false, slugs=<list>)
 //     → seeder writes all_current_workspaces=0, one join row per slug.
 func TestExtractAllowedWorkspacesFromSessionExtra(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name      string
 		in        string

--- a/internal/store/dashboard_batch_test.go
+++ b/internal/store/dashboard_batch_test.go
@@ -30,6 +30,7 @@ func linkBlocks(t *testing.T, s *Store, workspaceID, blockerID, blockedID string
 }
 
 func TestGetChildItemsForParents(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -83,6 +84,7 @@ func TestGetChildItemsForParents(t *testing.T) {
 }
 
 func TestGetChildItemsForParentsExcludesDeleted(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -110,6 +112,7 @@ func TestGetChildItemsForParentsExcludesDeleted(t *testing.T) {
 }
 
 func TestGetChildItemsForParentsEmpty(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	byParent, err := s.GetChildItemsForParents(nil)
 	if err != nil {
@@ -121,6 +124,7 @@ func TestGetChildItemsForParentsEmpty(t *testing.T) {
 }
 
 func TestGetBlocksEdges(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -157,6 +161,7 @@ func TestGetBlocksEdges(t *testing.T) {
 }
 
 func TestGetBlocksEdgesExcludesDeleted(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -179,6 +184,7 @@ func TestGetBlocksEdgesExcludesDeleted(t *testing.T) {
 }
 
 func TestGetItemsByIDsIncludeDeleted(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -217,6 +223,7 @@ func TestGetItemsByIDsIncludeDeleted(t *testing.T) {
 }
 
 func TestGetItemsByIDsIncludeDeletedEmpty(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	got, err := s.GetItemsByIDsIncludeDeleted(nil)
 	if err != nil {
@@ -228,6 +235,7 @@ func TestGetItemsByIDsIncludeDeletedEmpty(t *testing.T) {
 }
 
 func TestListItemsNoContentProjection(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")

--- a/internal/store/dialect_test.go
+++ b/internal/store/dialect_test.go
@@ -3,6 +3,7 @@ package store
 import "testing"
 
 func TestRebindQuery(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name  string
 		input string
@@ -26,6 +27,7 @@ func TestRebindQuery(t *testing.T) {
 }
 
 func TestDateBucket(t *testing.T) {
+	t.Parallel()
 	// Day/hour bucketing is fixed-width substring on the UTC RFC3339 TEXT, so
 	// both dialects emit the same expression. Verify each granularity.
 	for _, d := range []Dialect{&sqliteDialect{}, &postgresDialect{}} {
@@ -43,6 +45,7 @@ func TestDateBucket(t *testing.T) {
 }
 
 func TestSQLiteDialect(t *testing.T) {
+	t.Parallel()
 	d := &sqliteDialect{}
 
 	if d.Driver() != DriverSQLite {
@@ -63,6 +66,7 @@ func TestSQLiteDialect(t *testing.T) {
 }
 
 func TestPostgresDialect(t *testing.T) {
+	t.Parallel()
 	d := &postgresDialect{}
 
 	if d.Driver() != DriverPostgres {

--- a/internal/store/documents_cascade_lost_update_test.go
+++ b/internal/store/documents_cascade_lost_update_test.go
@@ -48,6 +48,7 @@ import (
 //   - the old title is gone. Without it, a rewrite that APPENDED rather than
 //     replaced would pass the second assertion.
 func TestUpdateDocument_CascadeDoesNotOverwriteConcurrentEdit(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	if s.dialect.Driver() != DriverPostgres {
 		t.Skip("asserts a Postgres READ COMMITTED lost-update property; SQLite's BEGIN IMMEDIATE closes the window structurally")
@@ -119,6 +120,7 @@ func TestUpdateDocument_CascadeDoesNotOverwriteConcurrentEdit(t *testing.T) {
 // So the assertion is that the rename SUCCEEDS, and the counterfactual is
 // specific: with the probe removed, this returns the exhaustion error.
 func TestUpdateDocument_CascadeTreatsSoftDeletedLinkerAsDone(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	if s.dialect.Driver() != DriverPostgres {
 		t.Skip("needs a write to commit inside the cascade's window, which SQLite's BEGIN IMMEDIATE prevents")
@@ -180,6 +182,23 @@ func TestUpdateDocument_CascadeExhaustionRollsBackTheWholeRename(t *testing.T) {
 	target := createTestDoc(t, s, ws.ID, originalTitle, "the document being renamed")
 	linker := createTestDoc(t, s, ws.ID, "EpsilonLinker", "before [[Epsilon]] after")
 
+	// THIS TEST MUST NOT CALL t.Parallel() (TASK-2900), and the line below is
+	// why: cascadeRewriteAttempts is a PACKAGE-LEVEL global, so the window
+	// between this assignment and the deferred restore is visible to every
+	// other test running at the same time. This test would not flake; the
+	// other cascade tests would, intermittently.
+	//
+	// It is safe as written because Go holds a test that calls t.Parallel()
+	// and resumes it only after the sequential pass over the package's
+	// top-level tests has finished — so a test that does NOT call it runs with
+	// no parallel test in flight. That is MEASURED, not assumed: a probe with
+	// serial mutators either side of eight parallel observers, including a
+	// serial test declared AFTER them, recorded zero observations of the
+	// mutation across a 300ms window.
+	//
+	// TestCascadeExhaustionStaysSerial enforces the "must not" above, because
+	// a comment protects nobody against the next sweep — and this repository
+	// just ran one that touched 844 test functions.
 	restore := cascadeRewriteAttempts
 	cascadeRewriteAttempts = 1
 	defer func() { cascadeRewriteAttempts = restore }()
@@ -246,6 +265,7 @@ func TestUpdateDocument_CascadeExhaustionRollsBackTheWholeRename(t *testing.T) {
 // Multiple links in one body, and a second linker, so it also covers the loop
 // rather than a single-row happy path.
 func TestUpdateDocument_CascadeRewritesEveryLinkOnBothDialects(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "CascadeBothDialects")
 

--- a/internal/store/documents_rename_deadlock_test.go
+++ b/internal/store/documents_rename_deadlock_test.go
@@ -126,6 +126,7 @@ func TestUpdateDocument_ConcurrentMutualRenamesDoNotDeadlock(t *testing.T) {
 // nothing carries any more, and every backlink is left pointing at a title
 // that no longer resolves.
 func TestUpdateDocument_CascadeUsesTheTitleUnderTheLock(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "CascadeTitle")
 	target := createTestDoc(t, s, ws.ID, "One", "the subject")
@@ -180,6 +181,7 @@ func TestUpdateDocument_CascadeUsesTheTitleUnderTheLock(t *testing.T) {
 // is still written, so the document ends up titled One with every backlink
 // pointing at [[Two]]: a rename that silently breaks its own links.
 func TestUpdateDocument_RenameBackToTheStaleTitleStillCascades(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "RenameBack")
 	target := createTestDoc(t, s, ws.ID, "One", "the subject")
@@ -238,6 +240,7 @@ func TestUpdateDocument_RenameBackToTheStaleTitleStillCascades(t *testing.T) {
 // TestUpdateDocument_DeleteLandingBeforeTheWriteIsNotOverwritten, on a path
 // where it is the only mechanism.
 func TestUpdateDocument_DeletedArchivedBeforeTheLockIsNotRenamed(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "DeleteRace")
 	target := createTestDoc(t, s, ws.ID, "Doomed", "the subject")
@@ -288,6 +291,7 @@ func TestUpdateDocument_DeletedArchivedBeforeTheLockIsNotRenamed(t *testing.T) {
 // (that is the property), and the rename key must be TAKEN (otherwise the
 // first leg passes against an implementation that acquires nothing at all).
 func TestDocumentRenameLock_DoesNotContendWithTheSeqLock(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	if s.dialect.Driver() != DriverPostgres {
 		t.Skip("advisory locks are a Postgres construct; the helper is a no-op elsewhere")
@@ -334,6 +338,7 @@ func TestDocumentRenameLock_DoesNotContendWithTheSeqLock(t *testing.T) {
 // write to an archived row, and it is tested where it is the sole mechanism
 // rather than where another one would mask it.
 func TestUpdateDocument_DeleteLandingBeforeTheWriteIsNotOverwritten(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	if s.dialect.Driver() != DriverPostgres {
 		// SQLite cannot reach this interleaving at all: the open transaction

--- a/internal/store/done_field_test.go
+++ b/internal/store/done_field_test.go
@@ -12,6 +12,7 @@ import (
 // terminal_options declared, child-progress counts reflect THAT field's
 // terminals — not status, and not the global default list.
 func TestGetItemProgress_DoneFieldFollowsBoardGroupBy(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "DoneFieldTest")
 
@@ -109,6 +110,7 @@ func TestGetItemProgress_DoneFieldFollowsBoardGroupBy(t *testing.T) {
 // a collection without board_group_by (i.e. shipped today) should have its
 // `status` field drive done-detection, exactly as before.
 func TestGetItemProgress_DefaultsToStatusWithoutSettings(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "DefaultStatusTest")
 
@@ -164,6 +166,7 @@ func TestGetItemProgress_DefaultsToStatusWithoutSettings(t *testing.T) {
 // per-collection `collection_id = ? AND ...` clause and would always be
 // counted as active.
 func TestGetItemProgress_HonorsSoftDeletedChildCollections(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "SoftDeleteTest")
 
@@ -223,6 +226,7 @@ func TestGetItemProgress_HonorsSoftDeletedChildCollections(t *testing.T) {
 // come from multiple collections with different done-field configurations,
 // each child is evaluated against its own collection's rules.
 func TestGetItemProgress_MixedChildCollections(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "MixedChildTest")
 

--- a/internal/store/email_verification_test.go
+++ b/internal/store/email_verification_test.go
@@ -57,6 +57,7 @@ func countVerificationTokens(t *testing.T, s *Store) int {
 // TestEmailVerification_CreateLookupConsume covers the happy path: mint →
 // non-destructive lookup → consume flips users.email_verified_at → single-use.
 func TestEmailVerification_CreateLookupConsume(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u := createUnverifiedUser(t, s, "verify@example.com")
 
@@ -115,6 +116,7 @@ func TestEmailVerification_CreateLookupConsume(t *testing.T) {
 // TestEmailVerification_ExpiredRejected: an expired token validates as nil and
 // cannot be consumed, and its consume leaves the user unverified.
 func TestEmailVerification_ExpiredRejected(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u := createUnverifiedUser(t, s, "expired@example.com")
 
@@ -135,6 +137,7 @@ func TestEmailVerification_ExpiredRejected(t *testing.T) {
 // TestEmailVerification_ResendInvalidatesPrior: minting a new token invalidates
 // the previous unused one (so resend-verification burns the old link).
 func TestEmailVerification_ResendInvalidatesPrior(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u := createUnverifiedUser(t, s, "resend@example.com")
 
@@ -166,6 +169,7 @@ func TestEmailVerification_ResendInvalidatesPrior(t *testing.T) {
 // TestEmailVerification_HashAtRest: the plaintext is never stored — the column
 // holds the SHA-256 hex of the plaintext.
 func TestEmailVerification_HashAtRest(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u := createUnverifiedUser(t, s, "hash@example.com")
 
@@ -193,6 +197,7 @@ func TestEmailVerification_HashAtRest(t *testing.T) {
 // TestCleanExpiredEmailVerifications: the reaper's store method deletes expired
 // AND used rows but keeps live ones. Exercised on both dialects via test-pg.
 func TestCleanExpiredEmailVerifications(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u := createUnverifiedUser(t, s, "clean@example.com")
 

--- a/internal/store/encryption_test.go
+++ b/internal/store/encryption_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestEncryptDecrypt(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	// Generate a random 32-byte key
@@ -40,6 +41,7 @@ func TestEncryptDecrypt(t *testing.T) {
 }
 
 func TestDecryptPlaintext(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	key := make([]byte, 32)
@@ -58,6 +60,7 @@ func TestDecryptPlaintext(t *testing.T) {
 }
 
 func TestEncryptWithoutKey(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	// No encryption key — encrypt should return plaintext
@@ -72,6 +75,7 @@ func TestEncryptWithoutKey(t *testing.T) {
 }
 
 func TestEncryptDecryptEmpty(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	key := make([]byte, 32)
@@ -97,6 +101,7 @@ func TestEncryptDecryptEmpty(t *testing.T) {
 }
 
 func TestTOTPEncryptionRoundTrip(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	key := make([]byte, 32)

--- a/internal/store/event_outbox_bounds_test.go
+++ b/internal/store/event_outbox_bounds_test.go
@@ -55,6 +55,7 @@ func insertRawOutboxRow(t *testing.T, s *Store, id, workspaceID, occurredAt stri
 }
 
 func TestOutboxLimitSeamsDefaultToTheProductionConstants(t *testing.T) {
+	t.Parallel()
 	// A ZERO-VALUE Store, not just a constructed one. The seams are plain int
 	// fields, so the failure worth excluding is a Store that skipped the
 	// constructor and thereby enforced no bound at all — which is what a
@@ -102,6 +103,7 @@ func TestOutboxLimitSeamsDefaultToTheProductionConstants(t *testing.T) {
 }
 
 func TestOutboxRefusesAPayloadOverTheRowCap(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	s.outboxRowCapOverride = 4096
 	ws := createTestWorkspace(t, s, "OutboxRowCap")
@@ -168,6 +170,7 @@ func TestOutboxRefusesAPayloadOverTheRowCap(t *testing.T) {
 }
 
 func TestOutboxClaimStopsAtTheByteBudget(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	s.outboxRowCapOverride = 8192
 	s.outboxClaimBudgetOverride = 10000
@@ -215,6 +218,7 @@ func TestOutboxClaimStopsAtTheByteBudget(t *testing.T) {
 }
 
 func TestOutboxClaimAlwaysTakesOneRowOverBudget(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	s.outboxRowCapOverride = 65536
 	s.outboxClaimBudgetOverride = 1024
@@ -237,6 +241,7 @@ func TestOutboxClaimAlwaysTakesOneRowOverBudget(t *testing.T) {
 }
 
 func TestOutboxClaimSkipsRowsOverTheRowCapWithoutJamming(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	s.outboxRowCapOverride = 4096 // claimable ceiling is 8192
 	ws := createTestWorkspace(t, s, "OutboxClaimJam")
@@ -287,6 +292,7 @@ func idsOf(events []OutboxEvent) []string {
 }
 
 func TestOutboxClaimSpendsTheBudgetOnBatchSiblingsToo(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	s.outboxRowCapOverride = 8192
 	s.outboxClaimBudgetOverride = 10000
@@ -340,6 +346,7 @@ func TestOutboxClaimSpendsTheBudgetOnBatchSiblingsToo(t *testing.T) {
 }
 
 func TestScrubOutboxUserRefsBatchesWithoutLosingRows(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	// Force many small batches so the cursor, the lock ordering and the
 	// termination condition are all exercised rather than skipped by a single
@@ -442,6 +449,7 @@ func scrubInTxErr(s *Store, userID string) error {
 }
 
 func TestARowWrittenAtTheCapIsStillClaimable(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	s.outboxRowCapOverride = 4096
 	ws := createTestWorkspace(t, s, "OutboxCapRoundTrip")
@@ -485,6 +493,7 @@ func TestARowWrittenAtTheCapIsStillClaimable(t *testing.T) {
 }
 
 func TestOutboxClaimStopsAtTheRowCap(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	s.outboxRowCapOverride = 8192
 	s.outboxClaimRowsOverride = 3
@@ -516,6 +525,7 @@ func TestOutboxClaimStopsAtTheRowCap(t *testing.T) {
 }
 
 func TestBulkEventIsRefusedBeforeItIsMarshalled(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	s.outboxRowCapOverride = 4096
 	ws := createTestWorkspace(t, s, "BulkPreMarshal")
@@ -566,6 +576,7 @@ func TestBulkEventIsRefusedBeforeItIsMarshalled(t *testing.T) {
 }
 
 func TestEverythingWrittenIsClaimable(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	s.outboxRowCapOverride = 4096 // claimable ceiling 8192
 	ws := createTestWorkspace(t, s, "OutboxWriteReadAgreement")
@@ -651,6 +662,7 @@ func TestEverythingWrittenIsClaimable(t *testing.T) {
 }
 
 func TestBatchSiblingQueryIsBoundedInSQL(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	s.outboxRowCapOverride = 8192
 	s.outboxClaimRowsOverride = 3
@@ -680,6 +692,7 @@ func TestBatchSiblingQueryIsBoundedInSQL(t *testing.T) {
 }
 
 func TestScrubSpendsItsByteBudgetNotJustItsRowLimit(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	// Row limit high enough that only the BYTE budget can split the work.
 	s.outboxScrubRowsOverride = 100
@@ -716,6 +729,7 @@ func TestScrubSpendsItsByteBudgetNotJustItsRowLimit(t *testing.T) {
 }
 
 func TestScrubOnlyEverShrinksAPayload(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	deleted, _ := scrubTestUsers(t, s)
 	ws := createTestWorkspace(t, s, "ScrubShrinks")
@@ -769,6 +783,7 @@ func TestScrubOnlyEverShrinksAPayload(t *testing.T) {
 }
 
 func TestAnOversizedEventPastTheHopBoundIsDroppedNotRefused(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	s.outboxRowCapOverride = 4096
 	ws := createTestWorkspace(t, s, "OutboxHopVsSize")

--- a/internal/store/event_outbox_scrub_test.go
+++ b/internal/store/event_outbox_scrub_test.go
@@ -111,6 +111,7 @@ func assignItemSnapshot(t *testing.T, s *Store, itemID, userID string) *models.I
 }
 
 func TestScrubOutboxUserRefs_ItemSnapshot(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	deleted, bystander := scrubTestUsers(t, s)
 	ws := createTestWorkspace(t, s, "Scrub item")
@@ -152,6 +153,7 @@ func TestScrubOutboxUserRefs_ItemSnapshot(t *testing.T) {
 }
 
 func TestScrubOutboxUserRefs_BulkMembers(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	deleted, bystander := scrubTestUsers(t, s)
 	ws := createTestWorkspace(t, s, "Scrub bulk")
@@ -202,6 +204,7 @@ func TestScrubOutboxUserRefs_BulkMembers(t *testing.T) {
 }
 
 func TestScrubOutboxUserRefs_CommentSnapshot(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	deleted, bystander := scrubTestUsers(t, s)
 	ws := createTestWorkspace(t, s, "Scrub comment")
@@ -238,6 +241,7 @@ func TestScrubOutboxUserRefs_CommentSnapshot(t *testing.T) {
 }
 
 func TestScrubOutboxUserRefs_AttachmentSnapshot(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	deleted, bystander := scrubTestUsers(t, s)
 	ws := createTestWorkspace(t, s, "Scrub attachment")
@@ -268,6 +272,7 @@ func TestScrubOutboxUserRefs_AttachmentSnapshot(t *testing.T) {
 }
 
 func TestScrubOutboxUserRefs_MemberRowAndSubjectColumn(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	deleted, bystander := scrubTestUsers(t, s)
 	ws := createTestWorkspace(t, s, "Scrub member")
@@ -339,6 +344,7 @@ func TestScrubOutboxUserRefs_MemberRowAndSubjectColumn(t *testing.T) {
 }
 
 func TestScrubOutboxUserRefs_DispatchedRowsScrubbedNotDeleted(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	deleted, _ := scrubTestUsers(t, s)
 	ws := createTestWorkspace(t, s, "Scrub dispatched")
@@ -379,6 +385,7 @@ func TestScrubOutboxUserRefs_DispatchedRowsScrubbedNotDeleted(t *testing.T) {
 // cross the rewrite verbatim, so an int64 past float64's 2^53 integer range
 // cannot be corrupted by the re-marshal.
 func TestScrubOutboxUserRefs_KeyScopedAndNumberSafe(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	deleted, _ := scrubTestUsers(t, s)
 	ws := createTestWorkspace(t, s, "Scrub scoped")
@@ -427,6 +434,7 @@ func TestScrubOutboxUserRefs_KeyScopedAndNumberSafe(t *testing.T) {
 // re-read must scrub what is actually stored rather than reintroduce the
 // stale bytes.
 func TestScrubOutboxRow_StaleReadRetriesAgainstFreshPayload(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	deleted, bystander := scrubTestUsers(t, s)
 	ws := createTestWorkspace(t, s, "Scrub CAS")
@@ -481,6 +489,7 @@ func TestScrubOutboxRow_StaleReadRetriesAgainstFreshPayload(t *testing.T) {
 }
 
 func TestScrubOutboxUserRefs_RefusesEmptyUserID(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	tx, err := s.db.Begin()
 	if err != nil {
@@ -498,6 +507,7 @@ func TestScrubOutboxUserRefs_RefusesEmptyUserID(t *testing.T) {
 // DeleteAccountAtomic passes every test above and still ships the bug this
 // task is about.
 func TestDeleteAccountAtomic_ScrubsOutbox(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	deleted, bystander := scrubTestUsers(t, s)
 	ws := createTestWorkspace(t, s, "Deletion scrub wiring")

--- a/internal/store/event_outbox_test.go
+++ b/internal/store/event_outbox_test.go
@@ -81,6 +81,7 @@ func clearOutbox(t *testing.T, s *Store) {
 }
 
 func TestOutbox_CreateEmitsItemCreatedWithSnapshot(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Outbox create")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -108,6 +109,7 @@ func TestOutbox_CreateEmitsItemCreatedWithSnapshot(t *testing.T) {
 }
 
 func TestOutbox_BareStatusFlipEmitsStatusChangedOnly(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Outbox status")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -137,6 +139,7 @@ func TestOutbox_BareStatusFlipEmitsStatusChangedOnly(t *testing.T) {
 }
 
 func TestOutbox_MixedUpdateEmitsBothSlices(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Outbox mixed")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -161,6 +164,7 @@ func TestOutbox_MixedUpdateEmitsBothSlices(t *testing.T) {
 }
 
 func TestOutbox_NonStatusUpdateEmitsUpdatedOnly(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Outbox plain")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -179,6 +183,7 @@ func TestOutbox_NonStatusUpdateEmitsUpdatedOnly(t *testing.T) {
 }
 
 func TestOutbox_NoOpUpdateEmitsNothing(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Outbox noop")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -219,6 +224,7 @@ func TestOutbox_NoOpUpdateEmitsNothing(t *testing.T) {
 // two snapshots differing ONLY in the per-mutation bookkeeping columns must
 // compare equal, and one differing in a real field must not.
 func TestItemUpdatedSliceChanged_IgnoresPerMutationBookkeeping(t *testing.T) {
+	t.Parallel()
 	base := &models.Item{
 		ID:          "item-1",
 		WorkspaceID: "ws-1",
@@ -283,6 +289,7 @@ func TestItemUpdatedSliceChanged_IgnoresPerMutationBookkeeping(t *testing.T) {
 }
 
 func TestWriteOutboxTx_RejectsNonCanonicalEvent(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Outbox reject")
 
@@ -306,6 +313,7 @@ func TestWriteOutboxTx_RejectsNonCanonicalEvent(t *testing.T) {
 }
 
 func TestWriteOutboxTx_RejectsEmptyPayload(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Outbox empty")
 
@@ -328,6 +336,7 @@ func TestWriteOutboxTx_RejectsEmptyPayload(t *testing.T) {
 }
 
 func TestWriteOutboxTx_DropsPastCascadeBound(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Outbox hop")
 
@@ -402,6 +411,7 @@ func TestWriteOutboxTx_DropsPastCascadeBound(t *testing.T) {
 }
 
 func TestOutbox_DeleteEmitsPreArchiveSnapshot(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Outbox delete")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -430,6 +440,7 @@ func TestOutbox_DeleteEmitsPreArchiveSnapshot(t *testing.T) {
 }
 
 func TestOutbox_RedeleteEmitsNothing(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Outbox redelete")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -452,6 +463,7 @@ func TestOutbox_RedeleteEmitsNothing(t *testing.T) {
 }
 
 func TestOutbox_RestoreEmitsItemRestored(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Outbox restore")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -472,6 +484,7 @@ func TestOutbox_RestoreEmitsItemRestored(t *testing.T) {
 }
 
 func TestOutbox_MoveEmitsMovedOnlyWhenNothingElseChanged(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Outbox move")
 	from := createTestCollection(t, s, ws.ID, "Tasks")
@@ -490,6 +503,7 @@ func TestOutbox_MoveEmitsMovedOnlyWhenNothingElseChanged(t *testing.T) {
 }
 
 func TestOutbox_CommentCreateAndUpdateEmit(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Outbox comments")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -535,6 +549,7 @@ func TestOutbox_CommentCreateAndUpdateEmit(t *testing.T) {
 }
 
 func TestOutbox_AttachmentAddedSkipsVariants(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Outbox attachments")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -581,6 +596,7 @@ func TestOutbox_AttachmentAddedSkipsVariants(t *testing.T) {
 }
 
 func TestOutbox_MemberJoinedEmits(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Outbox members")
 	user := createTestUser(t, s, "joiner@example.com", "Joiner", "pw-joiner-123")
@@ -613,6 +629,7 @@ func TestOutbox_MemberJoinedEmits(t *testing.T) {
 // ordinary archive of the same item announces itself. Invisible until something
 // consumes the outbox, at which point moves just stop being observable.
 func TestOutbox_CrossWorkspaceMoveEmitsSourceArchive(t *testing.T) {
+	t.Parallel()
 	f := newCopyFixture(t)
 	src := createTestItem(t, f.s, f.wsA.ID, f.colA.ID, "Moving out", "body")
 	clearOutbox(t, f.s)
@@ -670,6 +687,7 @@ func outboxBulkPayload(t *testing.T, s *Store) map[string]any {
 }
 
 func TestOutbox_CollectionOptionRenameEmitsOneBulkEvent(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Outbox option rename")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -745,6 +763,7 @@ func TestOutbox_CollectionOptionRenameEmitsOneBulkEvent(t *testing.T) {
 }
 
 func TestOutbox_WikiTitleCascadeEmitsOneBulkEvent(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Outbox cascade")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -786,6 +805,7 @@ func TestOutbox_WikiTitleCascadeEmitsOneBulkEvent(t *testing.T) {
 // pass them all; and none of them exercise a done-key value the status
 // machinery cannot read.
 func TestItemUpdatedSliceChanged_NonDefaultAndNonStringDoneKey(t *testing.T) {
+	t.Parallel()
 	// A CUSTOM done-field key must behave exactly as "status" does. A
 	// classifier that masks the literal "status" instead of the collection's
 	// declared key fails here and nowhere else.
@@ -838,6 +858,7 @@ func TestItemUpdatedSliceChanged_NonDefaultAndNonStringDoneKey(t *testing.T) {
 }
 
 func TestWriteOutboxTx_RejectsMalformedJSONPayload(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Outbox malformed")
 
@@ -865,6 +886,7 @@ func TestWriteOutboxTx_RejectsMalformedJSONPayload(t *testing.T) {
 }
 
 func TestOutbox_NoOpCommentEditEmitsNothing(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Outbox comment noop")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -907,6 +929,7 @@ func TestOutbox_NoOpCommentEditEmitsNothing(t *testing.T) {
 // workspace's webhook — so the emitter partitions rather than trusting that
 // today's queries happen never to produce one.
 func TestEmitBulkItemEventTx_PartitionsByMemberWorkspace(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	wsA := createTestWorkspace(t, s, "Partition A")
 	wsB := createTestWorkspace(t, s, "Partition B")
@@ -981,6 +1004,7 @@ func TestEmitBulkItemEventTx_PartitionsByMemberWorkspace(t *testing.T) {
 // "this event carries no prior status" — which is exactly the distinction the
 // envelope pseudo-field exists to make.
 func TestOutbox_StatusChangeFromEmptyCarriesEmptyPriorStatus(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Outbox empty prior")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -1033,6 +1057,7 @@ func TestOutbox_StatusChangeFromEmptyCarriesEmptyPriorStatus(t *testing.T) {
 // TASK-2714 bounded that window with the drain and its two prunes; bounded is
 // not zero, so the scrub is still what does the work.
 func TestOutbox_PayloadsOmitAssigneeIdentity(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Outbox PII")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -1072,6 +1097,7 @@ func TestOutbox_PayloadsOmitAssigneeIdentity(t *testing.T) {
 }
 
 func TestOutbox_CommentDeleteEmitsRefOnly(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Outbox comment delete")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -1112,6 +1138,7 @@ func TestOutbox_CommentDeleteEmitsRefOnly(t *testing.T) {
 }
 
 func TestOutbox_SoftDeletedAttachmentClaimEmitsRefOnly(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Outbox attachment removed")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -1162,6 +1189,7 @@ func TestOutbox_SoftDeletedAttachmentClaimEmitsRefOnly(t *testing.T) {
 }
 
 func TestOutbox_NeverAttachedClaimEmitsNothing(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Outbox never attached")
 
@@ -1204,6 +1232,7 @@ func TestOutbox_NeverAttachedClaimEmitsNothing(t *testing.T) {
 // row. Before the gates were made symmetric it announced a removal for a subject
 // no consumer had ever been told about.
 func TestOutbox_VariantClaimEmitsNothing(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Outbox variant removal")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -1268,6 +1297,7 @@ func TestOutbox_VariantClaimEmitsNothing(t *testing.T) {
 // test passed either the correct value or none, which is precisely why this
 // survived eight rounds of review.
 func TestWriteOutboxTx_SubjectKindIsDerivedNotTrusted(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Outbox subject kind")
 
@@ -1314,6 +1344,7 @@ func TestWriteOutboxTx_SubjectKindIsDerivedNotTrusted(t *testing.T) {
 // finding: canonical membership validates the NAME, and said nothing about
 // whether the bytes attached to it were the right shape.
 func TestWriteOutboxTx_RejectsMismatchedPayloadFamily(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Outbox family")
 
@@ -1373,6 +1404,7 @@ func TestWriteOutboxTx_RejectsMismatchedPayloadFamily(t *testing.T) {
 // TASK-2714 edits this table (the handler-path bulk mapping), which is why the
 // independent copy lands as this unit's first commit.
 func TestCanonicalEventsAreFullyDeclared(t *testing.T) {
+	t.Parallel()
 	// The events/1 set at SPEC-3 v1.7. Adding, removing or re-homing an entry
 	// here is a CONTRACT CHANGE: update the spec version and the taxonomy's
 	// doc comment in the same commit.
@@ -1553,6 +1585,7 @@ func outboxRowIDs(t *testing.T, s *Store) []string {
 // and one that ignored the cutoff would take the young pending row that a
 // retry is still owed.
 func TestOutbox_PruneUndispatchedBoundsTheFrozenPayloadWindow(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Outbox retention")
 	clearOutbox(t, s)
@@ -1635,6 +1668,7 @@ func outboxBatchIDsFor(t *testing.T, s *Store, itemID string) []string {
 // Each leg asserts the unstamped control too. Without it the test would pass
 // for an implementation that stamped every event ever written.
 func TestOutbox_WithEventBatchStampsEveryMutationPath(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Outbox batch")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -1736,6 +1770,7 @@ func claimedIDs(evs []OutboxEvent) []string {
 // each pending row is delivered once PER INSTANCE — by construction, not by
 // accident.
 func TestOutbox_ClaimIsExclusiveUntilTheLeaseExpires(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Outbox claim")
 	clearOutbox(t, s)
@@ -1779,6 +1814,7 @@ func TestOutbox_ClaimIsExclusiveUntilTheLeaseExpires(t *testing.T) {
 // a batch would make one bulk operation arrive as two events each reporting a
 // partial member count.
 func TestOutbox_ClaimTakesWholeBatchesPastTheLimit(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Outbox batch claim")
 	clearOutbox(t, s)
@@ -1823,6 +1859,7 @@ func TestOutbox_ClaimTakesWholeBatchesPastTheLimit(t *testing.T) {
 // the whole window — and on a single-instance deployment that is the only
 // reason it would ever wait at all.
 func TestOutbox_FailedAttemptReleasesTheClaim(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Outbox claim release")
 	clearOutbox(t, s)
@@ -1872,6 +1909,7 @@ func TestOutbox_FailedAttemptReleasesTheClaim(t *testing.T) {
 // at the same moment, which is precisely the multi-instance bug the claim
 // exists to prevent.
 func TestOutbox_ClaimArbitratesTheRaceNotJustTheQuery(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Outbox claim race")
 	clearOutbox(t, s)
@@ -1938,6 +1976,7 @@ func sameStrings(got, want []string) bool {
 // Without dedup the members list disagrees with the count in the same
 // payload — the wire event contradicting itself (codex round 1).
 func TestFoldBulkHeader_KeepsOneSnapshotPerItem(t *testing.T) {
+	t.Parallel()
 	header := []byte(`{"batch_id":"b1","op":"move","count":2,"item_ids":["i1","i2"]}`)
 	members := [][]byte{
 		[]byte(`{"id":"i1","status":"open"}`),
@@ -2029,6 +2068,7 @@ func TestFoldBulkHeader_KeepsOneSnapshotPerItem(t *testing.T) {
 // holder is mid-delivery on, and a late release would clear a live claim and
 // hand the event to a third pass.
 func TestOutbox_StaleClaimCannotAckOrReleaseAnotherPass(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Outbox stale claim")
 	clearOutbox(t, s)
@@ -2096,6 +2136,7 @@ func TestOutbox_StaleClaimCannotAckOrReleaseAnotherPass(t *testing.T) {
 // matches zero rows, and a crash in that window loses an event the outbox had
 // already committed (codex round 4).
 func TestOutbox_PruneUndispatchedSparesAClaimedRow(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Outbox prune vs claim")
 	clearOutbox(t, s)
@@ -2145,6 +2186,7 @@ func TestOutbox_PruneUndispatchedSparesAClaimedRow(t *testing.T) {
 // (seq, the unparented bit), so it emits. A relationship-graph link writes only
 // the links table and stays silent.
 func TestOutbox_SetParentLinkEmitsItemUpdated(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Outbox parent link")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -2211,6 +2253,7 @@ func TestOutbox_SetParentLinkEmitsItemUpdated(t *testing.T) {
 // nothing. The same criterion that made SetParentLink emit applies here; the
 // difference is only which transaction does the write.
 func TestOutbox_ParentOnlyUpdateStillEmits(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Outbox parent-only update")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -2267,6 +2310,7 @@ func TestOutbox_ParentOnlyUpdateStillEmits(t *testing.T) {
 // item-update transaction), and DeleteItemLink on the parent link row (the
 // links handler's route).
 func TestOutbox_ParentDetachEmitsOnEveryRoute(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Outbox detach")
 	col := createTestCollection(t, s, ws.ID, "Tasks")

--- a/internal/store/export_soft_deleted_collection_test.go
+++ b/internal/store/export_soft_deleted_collection_test.go
@@ -58,6 +58,7 @@ func archivedCollectionFixture(t *testing.T, s *Store, name string) (*models.Wor
 // section is no longer filtered by a different rule than the collections
 // section.
 func TestExportCarriesSoftDeletedCollections(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws, archived, it := archivedCollectionFixture(t, s, "Export Shape 2884")
 
@@ -113,6 +114,7 @@ func TestExportCarriesSoftDeletedCollections(t *testing.T) {
 // item is live in the source (reachable by ref) and must be live in the
 // target, under a collection that is still archived there.
 func TestRoundTripPreservesItemsUnderSoftDeletedCollection(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	owner := createTestUser(t, s, "roundtrip2884@test.com", "Owner", "password123")
 	ws, _, it := archivedCollectionFixture(t, s, "Round Trip 2884")
@@ -183,6 +185,7 @@ func TestRoundTripPreservesItemsUnderSoftDeletedCollection(t *testing.T) {
 // for a different reason (comments/versions/reminders resolve through the item
 // map), so they are asserted together rather than trusted to follow.
 func TestRoundTripPreservesDependentsUnderSoftDeletedCollection(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	owner := createTestUser(t, s, "deps2884@test.com", "Owner", "password123")
 	ws, _, it := archivedCollectionFixture(t, s, "Dependents 2884")
@@ -255,6 +258,7 @@ func TestRoundTripPreservesDependentsUnderSoftDeletedCollection(t *testing.T) {
 // must not participate in the import's duplicate-declaration scan, and must
 // not be mistaken for the workspace's conventions collection.
 func TestImportRoutingIgnoresSoftDeletedCollections(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	owner := createTestUser(t, s, "routing2884@test.com", "Owner", "password123")
 	ws := createTestWorkspace(t, s, "Routing 2884")
@@ -358,6 +362,7 @@ func TestImportRoutingIgnoresSoftDeletedCollections(t *testing.T) {
 // "" must mean live — the absent→live direction is what keeps every archive
 // ever written importable.
 func TestLegacyBundleWithoutDeletedAtImportsLive(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	owner := createTestUser(t, s, "legacy2884@test.com", "Owner", "password123")
 	ws := createTestWorkspace(t, s, "Legacy 2884")
@@ -426,6 +431,7 @@ func TestLegacyBundleWithoutDeletedAtImportsLive(t *testing.T) {
 // writes has no orphans — but not a hand-edited, foreign, or pre-fix archive,
 // which is exactly the population that needs to import.
 func TestImportSurvivesOrphanedItemDependents(t *testing.T) {
+	t.Parallel()
 	for _, tc := range []struct {
 		name string
 		// seed hangs exactly ONE kind of dependent row off the orphaned item.
@@ -610,6 +616,7 @@ func TestImportSurvivesOrphanedItemDependents(t *testing.T) {
 // is what inference keys on, and slug uniqueness spans deleted rows, so an
 // archived "conventions" and a live one cannot coexist.
 func TestImportDoesNotInferTraitsForArchivedCollections(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	owner := createTestUser(t, s, "inference2884@test.com", "Owner", "password123")
 	ws := createTestWorkspace(t, s, "Inference 2884")
@@ -706,6 +713,7 @@ func keepUnless[T any](in []T, keep bool, drop func(T) bool) []T {
 // and dropping the edge is what item_links already does for a missing
 // endpoint.
 func TestImportSurvivesOrphanedParent(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	owner := createTestUser(t, s, "orphanparent2884@test.com", "Owner", "password123")
 	ws := createTestWorkspace(t, s, "Orphan Parent 2884")
@@ -815,6 +823,7 @@ func TestImportSurvivesOrphanedParent(t *testing.T) {
 // unique violation has already aborted the transaction, so COMMIT fails and
 // the entire restore is lost over a row the loop meant to ignore.
 func TestImportSurvivesDuplicateLinks(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	owner := createTestUser(t, s, "duplinks2884@test.com", "Owner", "password123")
 	ws := createTestWorkspace(t, s, "Duplicate Links 2884")

--- a/internal/store/grants_test.go
+++ b/internal/store/grants_test.go
@@ -18,6 +18,7 @@ import (
 // The positive half of each assertion (same grant, correct workspace) is what
 // keeps the added predicate from being a silent lockout of legitimate guests.
 func TestResolveUserPermission_GrantsDoNotCrossWorkspaces(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	owner := createTestUser(t, s, "owner@example.com", "Owner", "password123")

--- a/internal/store/import_workspace_husk_test.go
+++ b/internal/store/import_workspace_husk_test.go
@@ -78,6 +78,7 @@ func validImportBundle(name, slug string) *models.WorkspaceExport {
 // collection INSERT, not a decode or a version check) and that the import did
 // fail rather than quietly succeeding.
 func TestImportWorkspaceFailureLeavesNoWorkspace(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	ws, err := s.ImportWorkspace(failingImportBundle("Husk Probe", "husk-probe"), "", "")
@@ -106,6 +107,7 @@ func TestImportWorkspaceFailureLeavesNoWorkspace(t *testing.T) {
 // `retry-slug-2` — a degraded slug in every URL, caused by an attempt that
 // stored nothing.
 func TestImportWorkspaceRetryKeepsOriginalSlug(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	if _, err := s.ImportWorkspace(failingImportBundle("Retry Probe", "retry-slug"), "", ""); err == nil {

--- a/internal/store/invitation_test.go
+++ b/internal/store/invitation_test.go
@@ -10,6 +10,7 @@ import (
 // TestCreateInvitation_SetsExpiresAt verifies new invitations get an expires_at
 // ~InvitationTTL in the future, round-tripped through store hydration.
 func TestCreateInvitation_SetsExpiresAt(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	// Minimal workspace + user fixtures
@@ -61,6 +62,7 @@ func TestCreateInvitation_SetsExpiresAt(t *testing.T) {
 // the backfill UPDATE manually (since it only runs during migration time for
 // rows that exist AT migration time), and re-hydrates via the usual store API.
 func TestMigration044_BackfillProducesRFC3339(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	u, err := s.CreateUser(models.UserCreate{

--- a/internal/store/item_links_lineage_test.go
+++ b/internal/store/item_links_lineage_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestCreateItemLinkNormalizesLineageTypes(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -27,6 +28,7 @@ func TestCreateItemLinkNormalizesLineageTypes(t *testing.T) {
 }
 
 func TestCreateItemLinkRejectsInvalidLineageType(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -44,6 +46,7 @@ func TestCreateItemLinkRejectsInvalidLineageType(t *testing.T) {
 }
 
 func TestCreateItemLinkRejectsSelfLinks(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")

--- a/internal/store/item_stars_test.go
+++ b/internal/store/item_stars_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestStarItem(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -35,6 +36,7 @@ func TestStarItem(t *testing.T) {
 }
 
 func TestUnstarItem(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -64,6 +66,7 @@ func TestUnstarItem(t *testing.T) {
 }
 
 func TestIsItemStarred(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -92,6 +95,7 @@ func TestIsItemStarred(t *testing.T) {
 }
 
 func TestAreItemsStarred(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -130,6 +134,7 @@ func TestAreItemsStarred(t *testing.T) {
 }
 
 func TestListStarredItems(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -162,6 +167,7 @@ func TestListStarredItems(t *testing.T) {
 }
 
 func TestListStarredItemsExcludesTerminal(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -200,6 +206,7 @@ func TestListStarredItemsExcludesTerminal(t *testing.T) {
 }
 
 func TestStarsArePerUser(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -234,6 +241,7 @@ func TestStarsArePerUser(t *testing.T) {
 }
 
 func TestCountStarredItems(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -264,6 +272,7 @@ func TestCountStarredItems(t *testing.T) {
 }
 
 func TestDeleteStarsForItem(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")

--- a/internal/store/item_workspace_moves_test.go
+++ b/internal/store/item_workspace_moves_test.go
@@ -106,6 +106,7 @@ func (f moveFixture) bySource(t *testing.T, sourceItemID string) []models.ItemWo
 // every column survives the dialect round-trip — notably archived_source
 // (INTEGER on SQLite, BOOLEAN on Postgres) and the nullable source_seq.
 func TestRecordItemWorkspaceMoveTx_RoundTrip(t *testing.T) {
+	t.Parallel()
 	f := newMoveFixture(t, "RoundTrip")
 	target := f.dest(t, f.dstWS, "Copy")
 
@@ -170,6 +171,7 @@ func TestRecordItemWorkspaceMoveTx_RoundTrip(t *testing.T) {
 // distinction: a plain copy never archives, so it has no source workspace seq
 // and must store NULL.
 func TestRecordItemWorkspaceMoveTx_CopyLeavesSeqNull(t *testing.T) {
+	t.Parallel()
 	f := newMoveFixture(t, "CopySeqNull")
 	target := f.dest(t, f.dstWS, "Copy")
 
@@ -219,6 +221,7 @@ const (
 // the caller's transaction: this is the whole reason the helper is tx-taking
 // rather than self-committing (DR-9).
 func TestRecordItemWorkspaceMoveTx_RollbackLeavesNoRow(t *testing.T) {
+	t.Parallel()
 	f := newMoveFixture(t, "Rollback")
 	target := f.dest(t, f.dstWS, "Copy")
 
@@ -252,6 +255,7 @@ func TestRecordItemWorkspaceMoveTx_RollbackLeavesNoRow(t *testing.T) {
 // catch a blank, and a blank created_by would violate NOT NULL only at the
 // driver layer with a far worse error.
 func TestRecordItemWorkspaceMoveTx_RequiresIdentifiers(t *testing.T) {
+	t.Parallel()
 	f := newMoveFixture(t, "Validation")
 	target := f.dest(t, f.dstWS, "Copy")
 
@@ -292,6 +296,7 @@ func TestRecordItemWorkspaceMoveTx_RequiresIdentifiers(t *testing.T) {
 // through to the ID tiebreak, which is exactly the arbitrary answer source_seq
 // exists to prevent (DR-2a).
 func TestRecordItemWorkspaceMoveTx_SourceSeqMatchesArchivedSource(t *testing.T) {
+	t.Parallel()
 	f := newMoveFixture(t, "SeqInvariant")
 	target := f.dest(t, f.dstWS, "Copy")
 
@@ -332,6 +337,7 @@ func TestRecordItemWorkspaceMoveTx_SourceSeqMatchesArchivedSource(t *testing.T) 
 // row is written in the transaction that creates the target), and left
 // unenforced it would silently change which source the back lookup names.
 func TestItemWorkspaceMoves_TargetIsUnique(t *testing.T) {
+	t.Parallel()
 	f := newMoveFixture(t, "TargetUnique")
 	target := f.dest(t, f.dstWS, "Copy")
 	otherSource := createTestItem(t, f.s, f.srcWS.ID,
@@ -364,6 +370,7 @@ func TestItemWorkspaceMoves_TargetIsUnique(t *testing.T) {
 // direction would fail outright when the purged workspace sits on the other
 // end.
 func TestPurgeWorkspaceData_ClearsItemWorkspaceMovesBothDirections(t *testing.T) {
+	t.Parallel()
 	f := newMoveFixture(t, "Purge")
 	s := f.s
 
@@ -424,6 +431,7 @@ func TestPurgeWorkspaceData_ClearsItemWorkspaceMovesBothDirections(t *testing.T)
 // carries no FK at all — the archived source is precisely the row whose
 // pointer must survive.
 func TestItemWorkspaceMoves_TargetDeleteCascades(t *testing.T) {
+	t.Parallel()
 	f := newMoveFixture(t, "Cascade")
 	target := f.dest(t, f.dstWS, "Copy")
 
@@ -467,6 +475,7 @@ func TestItemWorkspaceMoves_TargetDeleteCascades(t *testing.T) {
 // load, sort, scan and allocate every one of them on every read of the source,
 // and none of them can ever contribute to the result.
 func TestListArchivedItemWorkspaceMovesBySource(t *testing.T) {
+	t.Parallel()
 	f := newMoveFixture(t, "ArchivedOnly")
 
 	// Two plain copies with LATER timestamps than either move, so a query that
@@ -553,6 +562,7 @@ func TestListArchivedItemWorkspaceMovesBySource(t *testing.T) {
 // destination. The ids below are fixed so "arbitrary" is deterministic and the
 // wrong answer is reproducible rather than a coin flip.
 func TestListArchivedItemWorkspaceMovesBySource_SameSecondUsesSourceSeq(t *testing.T) {
+	t.Parallel()
 	f := newMoveFixture(t, "ArchivedOrder")
 	earlier := f.dest(t, f.dstWS, "Earlier Move")
 	later := f.dest(t, f.dst2WS, "Later Move")
@@ -613,6 +623,7 @@ func TestListArchivedItemWorkspaceMovesBySource_SameSecondUsesSourceSeq(t *testi
 // all, because the insert was rejected by the foreign keys long before the
 // constraint under test was reached.
 func TestItemWorkspaceMoves_ArchivedSourceIsConstrainedAtRest(t *testing.T) {
+	t.Parallel()
 	f := newMoveFixture(t, "AtRestCheck")
 	if f.s.dialect.Driver() == DriverPostgres {
 		t.Skip("Postgres enforces this with BOOLEAN; the CHECK exists to match it on SQLite")

--- a/internal/store/items_collab_versions_test.go
+++ b/internal/store/items_collab_versions_test.go
@@ -202,6 +202,7 @@ func TestCollabSnapshotPreservesVersionDiff(t *testing.T) {
 // full op-log state (PruneAndApply) or replace it wholesale (CLI
 // write, version restore).
 func TestCollabSnapshotDoesNotAdvanceOpLogWatermark(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Watermark Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -260,6 +261,7 @@ func TestCollabSnapshotDoesNotAdvanceOpLogWatermark(t *testing.T) {
 // op, so the GC watermark advances. Closes the browser-only-edited-
 // items-never-GC'd hole left by TASK-1309.
 func TestCollabSnapshotCursorMatchesMaxAdvancesWatermark(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Cursor Watermark Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -302,6 +304,7 @@ func TestCollabSnapshotCursorMatchesMaxAdvancesWatermark(t *testing.T) {
 // advance the watermark — the SQL CASE clause's equality check fails
 // and the column keeps its prior value. Per TASK-1319.
 func TestCollabSnapshotCursorBelowMaxLeavesWatermark(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Cursor Below Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -340,6 +343,7 @@ func TestCollabSnapshotCursorBelowMaxLeavesWatermark(t *testing.T) {
 // a collab-snapshot PATCH without OpLogCursor (older client) preserves
 // the conservative TASK-1309 behaviour (watermark unchanged).
 func TestCollabSnapshotNoCursorLeavesWatermark(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "No Cursor Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -366,6 +370,7 @@ func TestCollabSnapshotNoCursorLeavesWatermark(t *testing.T) {
 }
 
 func TestMinAndMaxOpLogIDEmptyAndPopulated(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Min Max Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")

--- a/internal/store/items_create_tx_test.go
+++ b/internal/store/items_create_tx_test.go
@@ -80,6 +80,7 @@ func maxWorkspaceSeq(t *testing.T, s *Store, workspaceID string) int64 {
 // --- Parity: slug allocation, scoped to the destination workspace ---
 
 func TestCreateItemTx_AllocatesWorkspaceScopedSlug(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	wsA := createTestWorkspace(t, s, "Slug Source")
 	wsB := createTestWorkspace(t, s, "Slug Dest")
@@ -96,6 +97,7 @@ func TestCreateItemTx_AllocatesWorkspaceScopedSlug(t *testing.T) {
 }
 
 func TestCreateItemTx_SlugCollisionResolvesToDistinctSlug(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Slug Collision")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -122,6 +124,7 @@ func TestCreateItemTx_SlugCollisionResolvesToDistinctSlug(t *testing.T) {
 }
 
 func TestCreateItemTx_UntitledFallbackSlug(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Untitled Slug")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -136,6 +139,7 @@ func TestCreateItemTx_UntitledFallbackSlug(t *testing.T) {
 // --- Parity: item_number ---
 
 func TestCreateItemTx_AssignsNextItemNumber(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Item Numbers")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -153,6 +157,7 @@ func TestCreateItemTx_AssignsNextItemNumber(t *testing.T) {
 }
 
 func TestCreateItemTx_ItemNumberIsWorkspaceScoped(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	wsA := createTestWorkspace(t, s, "Numbers A")
 	wsB := createTestWorkspace(t, s, "Numbers B")
@@ -171,6 +176,7 @@ func TestCreateItemTx_ItemNumberIsWorkspaceScoped(t *testing.T) {
 // --- Parity: workspace seq (delta sync cursor) ---
 
 func TestCreateItemTx_AdvancesWorkspaceSeq(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Seq")
 	other := createTestWorkspace(t, s, "Seq Other")
@@ -198,6 +204,7 @@ func TestCreateItemTx_AdvancesWorkspaceSeq(t *testing.T) {
 // --- Parity: content flush watermarks ---
 
 func TestCreateItemTx_ContentFlushWatermarks(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Watermarks")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -232,6 +239,7 @@ func TestCreateItemTx_ContentFlushWatermarks(t *testing.T) {
 // --- Parity: initial item_versions row ---
 
 func TestCreateItemTx_WritesInitialVersionForNonEmptyContent(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Versions")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -266,6 +274,7 @@ func TestCreateItemTx_WritesInitialVersionForNonEmptyContent(t *testing.T) {
 }
 
 func TestCreateItemTx_NoVersionForEmptyContent(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Versions Empty")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -279,6 +288,7 @@ func TestCreateItemTx_NoVersionForEmptyContent(t *testing.T) {
 // --- Parity: wiki-link indexing ---
 
 func TestCreateItemTx_IndexesWikiLinksFromContent(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Wiki Index")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -306,6 +316,7 @@ func TestCreateItemTx_IndexesWikiLinksFromContent(t *testing.T) {
 }
 
 func TestCreateItemTx_ResolvesBrokenTitleLinksInDestination(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Broken Titles")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -335,6 +346,7 @@ func TestCreateItemTx_ResolvesBrokenTitleLinksInDestination(t *testing.T) {
 // --- Parity: create-time status_transitions row ---
 
 func TestCreateItemTx_SeedsCreateTimeStatusTransition(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Transitions")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -360,6 +372,7 @@ func TestCreateItemTx_SeedsCreateTimeStatusTransition(t *testing.T) {
 }
 
 func TestCreateItemTx_NoStatusTransitionWhenDoneFieldUnset(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "No Transition")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -373,6 +386,7 @@ func TestCreateItemTx_NoStatusTransitionWhenDoneFieldUnset(t *testing.T) {
 // --- Parity: CreateItem's defaults ---
 
 func TestCreateItemTx_AppliesCreateItemDefaults(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Defaults")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -397,6 +411,7 @@ func TestCreateItemTx_AppliesCreateItemDefaults(t *testing.T) {
 }
 
 func TestCreateItemTx_DefaultsMatchCreateItemExactly(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	wsA := createTestWorkspace(t, s, "Parity A")
 	wsB := createTestWorkspace(t, s, "Parity B")
@@ -447,6 +462,7 @@ func TestCreateItemTx_DefaultsMatchCreateItemExactly(t *testing.T) {
 // --- Parity: assignment-scope validation ---
 
 func TestCreateItemTx_RejectsForeignAssignedUser(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Assign Scope")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -463,6 +479,7 @@ func TestCreateItemTx_RejectsForeignAssignedUser(t *testing.T) {
 }
 
 func TestCreateItemTx_AcceptsMemberAssignedUser(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Assign Member")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -479,6 +496,7 @@ func TestCreateItemTx_AcceptsMemberAssignedUser(t *testing.T) {
 }
 
 func TestCreateItemTx_RejectsForeignAgentRole(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	wsA := createTestWorkspace(t, s, "Role Owner")
 	wsB := createTestWorkspace(t, s, "Role Borrower")
@@ -500,6 +518,7 @@ func TestCreateItemTx_RejectsForeignAgentRole(t *testing.T) {
 }
 
 func TestCreateItemTx_AcceptsLocalAgentRole(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Role Local")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -518,6 +537,7 @@ func TestCreateItemTx_AcceptsLocalAgentRole(t *testing.T) {
 // --- The transaction-participation test ---
 
 func TestCreateItemTx_RollbackPersistsNothing(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Rollback")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -620,6 +640,7 @@ func TestCreateItemTx_RollbackPersistsNothing(t *testing.T) {
 // and duplicate item_numbers or duplicate slugs. Runs on both dialects:
 // Postgres exercises pg_advisory_xact_lock, SQLite exercises BEGIN IMMEDIATE.
 func TestCreateItemTx_ConcurrentCreatesGetDistinctNumbersAndSlugs(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Concurrent Create")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -709,6 +730,7 @@ func TestCreateItemTx_ConcurrentCreatesGetDistinctNumbersAndSlugs(t *testing.T) 
 // stale value on every retry, so a concurrent same-title create made it burn
 // all ten attempts and fail with a unique-constraint error.
 func TestCreateItemTx_MixedWithCreateItemConcurrently(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Mixed Concurrent")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -774,6 +796,7 @@ func TestCreateItemTx_MixedWithCreateItemConcurrently(t *testing.T) {
 // A caller doing more work in the same transaction sees the created item, and
 // its own later failure takes the create down with it.
 func TestCreateItemTx_VisibleToCallerBeforeCommit(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "In-tx Visibility")
 	col := createTestCollection(t, s, ws.ID, "Tasks")

--- a/internal/store/items_cross_workspace_copy_pg_test.go
+++ b/internal/store/items_cross_workspace_copy_pg_test.go
@@ -349,6 +349,7 @@ func deadlocksSettled(t *testing.T, s *Store, before int64) int64 {
 // file header for why the barrier sits BEFORE the first acquisition and for
 // mutation B, which this test is the one to catch.
 func TestCopyItemAcrossWorkspaces_OpposingDirectionsDoNotDeadlock(t *testing.T) {
+	t.Parallel()
 	requirePostgresForConcurrency(t)
 
 	s := testStore(t)
@@ -460,6 +461,7 @@ func TestCopyItemAcrossWorkspaces_OpposingDirectionsDoNotDeadlock(t *testing.T) 
 // ID is a separate requirement, defended by the collision test rather than by
 // either of these — see mutation B in the file header.
 func TestCopyItemAcrossWorkspaces_OpposingMovesDoNotDeadlock(t *testing.T) {
+	t.Parallel()
 	requirePostgresForConcurrency(t)
 
 	s := testStore(t)
@@ -560,6 +562,7 @@ func TestCopyItemAcrossWorkspaces_OpposingMovesDoNotDeadlock(t *testing.T) {
 // transaction, or before the destination lock is acquired — either of which
 // lets both copies read the same pre-copy count and both commit.
 func TestCopyItemAcrossWorkspaces_ConcurrentCopiesCannotJointlyExceedQuota(t *testing.T) {
+	t.Parallel()
 	requirePostgresForConcurrency(t)
 
 	s := testStore(t)
@@ -645,6 +648,7 @@ func TestCopyItemAcrossWorkspaces_ConcurrentCopiesCannotJointlyExceedQuota(t *te
 // the only source of truth for what collides), creates two workspaces with
 // those IDs, and asserts that acquiring both workspaces' locks yields ONE key.
 func TestAcquireWorkspaceLocksOrdered_CollidingKeysTakeOneLock(t *testing.T) {
+	t.Parallel()
 	requirePostgresForConcurrency(t)
 
 	s := testStore(t)

--- a/internal/store/items_cross_workspace_copy_test.go
+++ b/internal/store/items_cross_workspace_copy_test.go
@@ -157,6 +157,7 @@ func maxSeq(t *testing.T, s *Store, workspaceID string) int64 {
 // --- Happy path -------------------------------------------------------------
 
 func TestCopyItemAcrossWorkspaces_PlainCopyLandsInDestination(t *testing.T) {
+	t.Parallel()
 	f := newCopyFixture(t)
 	parent := createTestItem(t, f.s, f.wsA.ID, f.colA.ID, "Parent", "")
 	src, err := f.s.CreateItem(f.wsA.ID, f.colA.ID, models.ItemCreate{
@@ -249,6 +250,7 @@ func TestCopyItemAcrossWorkspaces_PlainCopyLandsInDestination(t *testing.T) {
 // row, wiki-link index, status transition, slug, item_number and seq must all
 // exist in the destination.
 func TestCopyItemAcrossWorkspaces_CreationParity(t *testing.T) {
+	t.Parallel()
 	f := newCopyFixture(t)
 	// A destination item the copied body's [[...]] link resolves to.
 	createTestItem(t, f.s, f.wsB.ID, f.colB.ID, "Target Doc", "")
@@ -292,6 +294,7 @@ func TestCopyItemAcrossWorkspaces_CreationParity(t *testing.T) {
 // have nothing to see, and a spurious bump would make them re-fetch an
 // unchanged item.
 func TestCopyItemAcrossWorkspaces_PlainCopyDoesNotAdvanceSourceSeq(t *testing.T) {
+	t.Parallel()
 	f := newCopyFixture(t)
 	src := createTestItem(t, f.s, f.wsA.ID, f.colA.ID, "Untouched", "body")
 
@@ -331,6 +334,7 @@ func TestCopyItemAcrossWorkspaces_PlainCopyDoesNotAdvanceSourceSeq(t *testing.T)
 // On a MOVE, A must advance so its clients receive the tombstone — otherwise
 // they keep rendering a source item that no longer exists.
 func TestCopyItemAcrossWorkspaces_MoveEmitsTombstoneInSourceWorkspace(t *testing.T) {
+	t.Parallel()
 	f := newCopyFixture(t)
 	src := createTestItem(t, f.s, f.wsA.ID, f.colA.ID, "Moving out", "body")
 
@@ -389,6 +393,7 @@ func TestCopyItemAcrossWorkspaces_MoveEmitsTombstoneInSourceWorkspace(t *testing
 // those stale errors rejects a copy whose override already supplied the
 // missing required field. Overrides must be applied first, then validated.
 func TestCopyItemAcrossWorkspaces_OverrideSatisfiesRequiredField(t *testing.T) {
+	t.Parallel()
 	f := newCopyFixture(t)
 	// A destination collection with a required field the source does not have.
 	dest, err := f.s.CreateCollection(f.wsB.ID, models.CollectionCreate{
@@ -430,6 +435,7 @@ func TestCopyItemAcrossWorkspaces_OverrideSatisfiesRequiredField(t *testing.T) {
 // The mirror image: an override with a value the destination schema rejects
 // must be type-checked. Pre-DR-12 the override was never validated at all.
 func TestCopyItemAcrossWorkspaces_InvalidOverrideRejected(t *testing.T) {
+	t.Parallel()
 	f := newCopyFixture(t)
 	src := createTestItem(t, f.s, f.wsA.ID, f.colA.ID, "Bad override", "")
 
@@ -451,6 +457,7 @@ func TestCopyItemAcrossWorkspaces_InvalidOverrideRejected(t *testing.T) {
 }
 
 func TestCopyItemAcrossWorkspaces_DroppedFieldsReported(t *testing.T) {
+	t.Parallel()
 	f := newCopyFixture(t)
 	dest, err := f.s.CreateCollection(f.wsB.ID, models.CollectionCreate{
 		Name:   "Narrow",
@@ -480,6 +487,7 @@ func TestCopyItemAcrossWorkspaces_DroppedFieldsReported(t *testing.T) {
 // --- Assignment scrubs (DR-8) -----------------------------------------------
 
 func TestCopyItemAcrossWorkspaces_AssigneeCarriesOnlyForDestinationMembers(t *testing.T) {
+	t.Parallel()
 	f := newCopyFixture(t)
 	member := createTestUser(t, f.s, "member@example.com", "Member", "s3cret")
 	stranger := createTestUser(t, f.s, "stranger@example.com", "Stranger", "s3cret")
@@ -543,6 +551,7 @@ func TestCopyItemAcrossWorkspaces_AssigneeCarriesOnlyForDestinationMembers(t *te
 // --- Attachments (DR-11 / DR-11a) -------------------------------------------
 
 func TestCopyItemAcrossWorkspaces_AttachmentsClonedAndRefsRewritten(t *testing.T) {
+	t.Parallel()
 	f := newCopyFixture(t)
 	orig := f.attachIn(t, f.wsA.ID, "diagram.png", 4096)
 	thumb := f.variantOf(t, f.wsA.ID, orig, "thumb-md", 512)
@@ -706,6 +715,7 @@ func TestCopyItemAcrossWorkspaces_AttachmentsClonedAndRefsRewritten(t *testing.T
 // IS NULL` are never cloned, the literal text survives, and the copy is not
 // blocked. The foreign-workspace case is the confused-deputy hole.
 func TestCopyItemAcrossWorkspaces_UnresolvableRefsAreNeverCloned(t *testing.T) {
+	t.Parallel()
 	f := newCopyFixture(t)
 	foreign := f.attachIn(t, f.wsC.ID, "someone-elses.png", 9999)
 	dangling := newID()
@@ -742,6 +752,7 @@ func TestCopyItemAcrossWorkspaces_UnresolvableRefsAreNeverCloned(t *testing.T) {
 // v1 refuses a copy whose bytes live in a backend the destination does not
 // write to, rather than silently inserting a row that 404s on download.
 func TestCopyItemAcrossWorkspaces_CrossBackendRefused(t *testing.T) {
+	t.Parallel()
 	f := newCopyFixture(t)
 	orig := f.attachIn(t, f.wsA.ID, "on-disk.png", 100) // storage_key is "fs:…"
 	src, err := f.s.CreateItem(f.wsA.ID, f.colA.ID, models.ItemCreate{
@@ -771,6 +782,7 @@ func TestCopyItemAcrossWorkspaces_CrossBackendRefused(t *testing.T) {
 // A failure at ANY stage must leave nothing behind in either workspace: no
 // item, no attachment rows, no provenance row, and neither seq advanced.
 func TestCopyItemAcrossWorkspaces_RollbackIsCompleteAtEveryStage(t *testing.T) {
+	t.Parallel()
 	stages := []string{copyStageCreateItem, copyStageAttachments, copyStageArchive, copyStageProvenance}
 	for _, stage := range stages {
 		t.Run(stage, func(t *testing.T) {
@@ -828,6 +840,7 @@ func TestCopyItemAcrossWorkspaces_RollbackIsCompleteAtEveryStage(t *testing.T) {
 // was already inserted. (A row with no key is a live attachment the registry
 // cannot resolve; it fails at download time with nothing to point at.)
 func TestCopyItemAcrossWorkspaces_AttachmentInsertFailureRollsBackTheItem(t *testing.T) {
+	t.Parallel()
 	f := newCopyFixture(t)
 	// Insert an attachment with an empty storage_key directly — CreateAttachment
 	// refuses it, which is precisely the guard being exercised downstream.
@@ -868,6 +881,7 @@ func TestCopyItemAcrossWorkspaces_AttachmentInsertFailureRollsBackTheItem(t *tes
 // --- Scope refusals ---------------------------------------------------------
 
 func TestCopyItemAcrossWorkspaces_TargetCollectionMustBelongToTargetWorkspace(t *testing.T) {
+	t.Parallel()
 	f := newCopyFixture(t)
 	src := createTestItem(t, f.s, f.wsA.ID, f.colA.ID, "Scoped", "")
 
@@ -884,6 +898,7 @@ func TestCopyItemAcrossWorkspaces_TargetCollectionMustBelongToTargetWorkspace(t 
 }
 
 func TestCopyItemAcrossWorkspaces_ArchivedSourceIsNotCopyable(t *testing.T) {
+	t.Parallel()
 	f := newCopyFixture(t)
 	src := createTestItem(t, f.s, f.wsA.ID, f.colA.ID, "Already gone", "")
 	if err := f.s.DeleteItem(src.ID); err != nil {
@@ -930,6 +945,7 @@ func newQuotaFixture(t *testing.T, limit int) copyFixture {
 }
 
 func TestCopyItemAcrossWorkspaces_ItemQuota(t *testing.T) {
+	t.Parallel()
 	// The destination starts empty and the cap is 2: the first copy is
 	// "exactly at limit minus one" and lands; the second fills the cap and
 	// lands; the third is one-over and is refused.
@@ -980,6 +996,7 @@ func TestCopyItemAcrossWorkspaces_ItemQuota(t *testing.T) {
 // CheckLimitTx and invisible to CheckLimit, so swapping the call in the copy
 // path back to the pool form makes this test fail.
 func TestCheckLimitTx_SeesUncommittedRowsInTheTransaction(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	owner := createTestUser(t, s, "tx-count@example.com", "Owner", "s3cret")
 	if err := s.SetUserPlan(owner.ID, "free", ""); err != nil {
@@ -1025,6 +1042,7 @@ func TestCheckLimitTx_SeesUncommittedRowsInTheTransaction(t *testing.T) {
 // collapsed. Colliding keys (two workspaces hashing to one value) are ONE lock,
 // not two.
 func TestSortedDedupedLockKeys(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name string
 		in   []int64
@@ -1072,6 +1090,7 @@ func TestSortedDedupedLockKeys(t *testing.T) {
 // security boundary which makes "a collection in someone else's workspace" a
 // not-found rather than a cross-workspace write.
 func TestCopyAcrossWorkspaces_CollectionMissingSentinels(t *testing.T) {
+	t.Parallel()
 	t.Run("source collection soft-deleted under the lock", func(t *testing.T) {
 		f := newCopyFixture(t)
 		src := createTestItem(t, f.s, f.wsA.ID, f.colA.ID, "Orphaned", "body")
@@ -1137,6 +1156,7 @@ func TestCopyAcrossWorkspaces_CollectionMissingSentinels(t *testing.T) {
 // nothing: it is pure computation over rows already read, and the quota still
 // runs inside the transaction before any insert, which is all DR-16 asks.
 func TestCopyAcrossWorkspaces_BadRequestBeatsQuota(t *testing.T) {
+	t.Parallel()
 	// A cap of 1, already consumed, so the destination is genuinely full.
 	f := newQuotaFixture(t, 1)
 	if _, err := f.s.CreateItem(f.wsB.ID, f.colB.ID, models.ItemCreate{Title: "Occupant"}); err != nil {
@@ -1190,6 +1210,7 @@ func TestCopyAcrossWorkspaces_BadRequestBeatsQuota(t *testing.T) {
 // "pad-attachment:"+old rewrote the `<uuid>` prefix inside it anyway (Codex
 // round 26), producing text matching neither the plan nor the user's input.
 func TestRemapAttachmentRefsTokenizesLikeThePlanner(t *testing.T) {
+	t.Parallel()
 	const (
 		oldID = "11111111-2222-4333-8444-555555555555"
 		newID = "99999999-8888-4777-8666-555555555555"
@@ -1262,6 +1283,7 @@ func TestRemapAttachmentRefsTokenizesLikeThePlanner(t *testing.T) {
 // over a routine permission denial (Codex round 10). The caller's own error
 // type still comes back out through errors.As.
 func TestCopyAcrossWorkspaces_PreCheckRefusalIsWrapped(t *testing.T) {
+	t.Parallel()
 	f := newCopyFixture(t)
 	src := createTestItem(t, f.s, f.wsA.ID, f.colA.ID, "Refused", "body")
 
@@ -1306,6 +1328,7 @@ func TestCopyAcrossWorkspaces_PreCheckRefusalIsWrapped(t *testing.T) {
 // The last two are the ones that make this test worth having; assert on all
 // three so a regression in any implementation strategy is caught.
 func TestCopyAcrossWorkspaces_PreCheckGetsCopies(t *testing.T) {
+	t.Parallel()
 	f := newCopyFixture(t)
 
 	// The assignee must be a member of BOTH workspaces, or DR-8 drops it and
@@ -1400,6 +1423,7 @@ func TestCopyAcrossWorkspaces_PreCheckGetsCopies(t *testing.T) {
 // deadlock=true at ERROR — which this code did until PLAN-2357's final review —
 // leaves an operator unable to tell a lock-ordering bug from ordinary load.
 func TestCopyRollbackErrorClassification(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name        string
 		err         error

--- a/internal/store/items_fieldpatch_test.go
+++ b/internal/store/items_fieldpatch_test.go
@@ -24,6 +24,7 @@ func decodeFields(t *testing.T, fieldsJSON string) map[string]any {
 // TestMergeFieldsPatch exercises the pure shallow-merge helper directly:
 // set, delete-on-null, orphan-key preservation, and empty-base handling.
 func TestMergeFieldsPatch(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name    string
 		current string
@@ -94,6 +95,7 @@ func TestMergeFieldsPatch(t *testing.T) {
 // rest of the fields blob intact, unlike a full `fields` write which replaces
 // everything.
 func TestUpdateItemFieldsPatchMergesNotReplaces(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "FieldPatch")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -125,6 +127,7 @@ func TestUpdateItemFieldsPatchMergesNotReplaces(t *testing.T) {
 // TestUpdateItemFieldsPatchNullDeletes verifies the JSON-null delete sentinel
 // removes a single key while preserving the others.
 func TestUpdateItemFieldsPatchNullDeletes(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "FieldPatchDelete")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -158,6 +161,7 @@ func TestUpdateItemFieldsPatchNullDeletes(t *testing.T) {
 // Before field-level merge, the second full-blob write would have overwritten
 // the first if it had been built from a stale read.
 func TestUpdateItemFieldsPatchSequentialNoClobber(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "FieldPatchSeq")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -193,6 +197,7 @@ func TestUpdateItemFieldsPatchSequentialNoClobber(t *testing.T) {
 // TestUpdateItemExpectedUpdatedAtMatch: a matching optimistic-concurrency
 // token lets the update through.
 func TestUpdateItemExpectedUpdatedAtMatch(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "OCCMatch")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -215,6 +220,7 @@ func TestUpdateItemExpectedUpdatedAtMatch(t *testing.T) {
 // TestUpdateItemExpectedUpdatedAtConflict: a stale token is rejected with
 // *UpdateConflictError, and the item is left unchanged.
 func TestUpdateItemExpectedUpdatedAtConflict(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "OCCConflict")
 	col := createTestCollection(t, s, ws.ID, "Tasks")

--- a/internal/store/items_preimage_test.go
+++ b/internal/store/items_preimage_test.go
@@ -43,6 +43,7 @@ func assertSameFields(t *testing.T, label, got, want, why string) {
 // that is correct but never consumed fixes nothing (CONVE-19).
 
 func TestUpdateItem_PreUpdateIsTheLockedPreWriteView(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "PreImage")
 	coll := createTestCollection(t, s, ws.ID, "Tasks")
@@ -81,6 +82,7 @@ func TestUpdateItem_PreUpdateIsTheLockedPreWriteView(t *testing.T) {
 // "assigned:  → Someone" on every update — a louder version of the bug this
 // field exists to fix.
 func TestUpdateItem_PreUpdateCarriesJoinedDisplayNames(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "PreImageJoins")
 	coll := createTestCollection(t, s, ws.ID, "Tasks")
@@ -122,6 +124,7 @@ func TestUpdateItem_PreUpdateCarriesJoinedDisplayNames(t *testing.T) {
 // lands before the store call begins, so both reads see the same thing and
 // the two implementations are indistinguishable. That is why the seam exists.
 func TestUpdateItem_PreUpdateComesFromTheLockedReRead(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "PreImageLock")
 	coll := createTestCollection(t, s, ws.ID, "Tasks")
@@ -171,6 +174,7 @@ func TestUpdateItem_PreUpdateComesFromTheLockedReRead(t *testing.T) {
 // round 3) — and would make the handler report "assigned:  → Dave" on any
 // update to an already-assigned item.
 func TestUpdateItem_PreUpdateCarriesTheAssignedUser(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "PreImageAssignee")
 	coll := createTestCollection(t, s, ws.ID, "Tasks")

--- a/internal/store/items_rename_bounds_test.go
+++ b/internal/store/items_rename_bounds_test.go
@@ -29,6 +29,7 @@ func bigLinker(t *testing.T, title string, bodyBytes int) string {
 // cross it. Sizes are derived from MaxItemRenameCascadeBytes rather than
 // hardcoded, so the test follows the constant if it is ever retuned.
 func TestItemRenameCascade_RefusesWhenTheCascadeExceedsTheBound(t *testing.T) {
+	t.Parallel()
 	const body = 2 << 20 // the largest body one JSON request can carry
 	perLinker := int64(body) * 2
 	linkers := int(MaxItemRenameCascadeBytes/perLinker) + 2
@@ -91,6 +92,7 @@ func TestItemRenameCascade_RefusesWhenTheCascadeExceedsTheBound(t *testing.T) {
 // across 23 sources. This uses 30 sources at the measured p99.9 body size
 // (51,000 bytes), which is ~9x that worst case and still ~21x under the cap.
 func TestItemRenameCascade_AllowsARealisticCascade(t *testing.T) {
+	t.Parallel()
 	const p999Body = 51000
 	const sources = 30
 
@@ -141,6 +143,7 @@ func TestItemRenameCascade_AllowsARealisticCascade(t *testing.T) {
 // by one whole unit: refusing before the build yields N, refusing after yields
 // N+1. Found by make test-pg, which is the whole reason that gate exists.
 func TestItemRenameCascade_RefusesBeforeBuildingTheRewrittenBody(t *testing.T) {
+	t.Parallel()
 	// Body size chosen so perLinker does NOT divide the cap evenly. With an
 	// exact division the assertion below cannot discriminate: refusing after
 	// the build would total exactly the cap rather than exceeding it. It also
@@ -203,6 +206,7 @@ func TestItemRenameCascade_RefusesBeforeBuildingTheRewrittenBody(t *testing.T) {
 // without the index being re-parsed. The test writes items.content directly so
 // replaceWikiLinks does not run.
 func TestItemRenameCascade_DoesNotChargeForRewritesItWillNotPerform(t *testing.T) {
+	t.Parallel()
 	const body = 2 << 20
 	live := 12
 	drifted := 6
@@ -271,6 +275,7 @@ func TestItemRenameCascade_DoesNotChargeForRewritesItWillNotPerform(t *testing.T
 // linker count and attributed the remaining k-linear growth to the outbox
 // (BUG-2827), which is a different vector entirely.
 func TestItemRenameCascade_BoundsTheScanNotJustTheRewrite(t *testing.T) {
+	t.Parallel()
 	// The largest title one JSON request can deliver (server.defaultJSONBodyLimit
 	// is 2 MiB). This is no longer reachable through the ordinary create path —
 	// models.MaxItemTitleRunes refuses it — so the fixture is seeded as legacy
@@ -427,6 +432,7 @@ func TestItemRenameCascade_BoundsTheScanNotJustTheRewrite(t *testing.T) {
 // worst real cascade was 23 sources, and item titles there are ordinary
 // sentence-length strings.
 func TestItemRenameCascade_ScanBoundAllowsRealisticTitles(t *testing.T) {
+	t.Parallel()
 	const sources = 50
 	title := "A Perfectly Ordinary Item Title Of The Kind Real Workspaces Contain"
 

--- a/internal/store/items_rename_escape_test.go
+++ b/internal/store/items_rename_escape_test.go
@@ -23,6 +23,7 @@ import (
 // the `!applied` arm re-parsed and flipped the index row to broken. Content and
 // index disagreed, and the user saw a stale link.
 func TestCascade_RewritesLinksStoredInEscapedForm(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "EscapeRoundTrip")
 	col := createTestCollection(t, s, ws.ID, "Notes")
@@ -83,6 +84,7 @@ func TestCascade_RewritesLinksStoredInEscapedForm(t *testing.T) {
 // so the source content stayed wrong forever. This test pins the emission AND
 // the recovery, because the permanence is the part that made it medium severity.
 func TestCascade_EmitsEscapedTitlesAndDoesNotDestroyTheIndex(t *testing.T) {
+	t.Parallel()
 	for _, tc := range []struct{ name, newTitle, wantContent string }{
 		{"closing bracket", "New ] Name", `Ref [[New \] Name]] here.`},
 		{"pipe", "New | Name", `Ref [[New \| Name]] here.`},
@@ -169,6 +171,7 @@ func TestCascade_EmitsEscapedTitlesAndDoesNotDestroyTheIndex(t *testing.T) {
 // pins that the rewriter will not be the instrument of destruction even if that
 // gap is never closed.
 func TestCascade_RenameToEmptyTitleDoesNotDestroyLinks(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "EmptyRenameGuard")
 	col := createTestCollection(t, s, ws.ID, "Notes")

--- a/internal/store/items_rename_slug_prefix_test.go
+++ b/internal/store/items_rename_slug_prefix_test.go
@@ -34,6 +34,7 @@ import (
 // costs in practice is recorded in the boundary note at the bottom of this
 // test, which is narrower than the filing predicted.
 func TestItemRename_LiteralSlashTitleIsNotRewrittenAsQualified(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -124,6 +125,7 @@ func TestItemRename_LiteralSlashTitleIsNotRewrittenAsQualified(t *testing.T) {
 // earlier fixture did not have: the decoy's title must contain the slash. The
 // link moves off the renamed item entirely, and nothing in the UI says so.
 func TestItemRename_LiteralSlashTitleRetargetsOntoALiteralSlashSibling(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -179,6 +181,7 @@ func TestItemRename_LiteralSlashTitleRetargetsOntoALiteralSlashSibling(t *testin
 // identical to the case above — "tasks/Setup" — so only the old title tells
 // them apart, and this one must KEEP its prefix across the rename.
 func TestItemRename_GenuinelyQualifiedBracketKeepsItsPrefix(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")

--- a/internal/store/items_test.go
+++ b/internal/store/items_test.go
@@ -77,6 +77,7 @@ func createLegacyTitledItem(t *testing.T, s *Store, workspaceID, collectionID, t
 }
 
 func TestListItems_UnparentedStructuralParity(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Unparented")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -138,6 +139,7 @@ func TestListItems_UnparentedStructuralParity(t *testing.T) {
 }
 
 func TestStructuralItemLinksAdvanceSourceSeqAndMetadata(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Unparented metadata")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -213,6 +215,7 @@ func TestStructuralItemLinksAdvanceSourceSeqAndMetadata(t *testing.T) {
 // --- Collection Tests ---
 
 func TestCollectionCRUD(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 
@@ -303,6 +306,7 @@ func TestCollectionCRUD(t *testing.T) {
 }
 
 func TestCollectionDeleteDefaultRefused(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 
@@ -326,6 +330,7 @@ func TestCollectionDeleteDefaultRefused(t *testing.T) {
 }
 
 func TestCollectionListWithItemCounts(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 
@@ -346,6 +351,7 @@ func TestCollectionListWithItemCounts(t *testing.T) {
 }
 
 func TestSeedDefaultCollections(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 
@@ -388,6 +394,7 @@ func TestSeedDefaultCollections(t *testing.T) {
 }
 
 func TestSeedCollectionsFromTemplateAddsConventionsRoleField(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Template Test")
 
@@ -421,6 +428,7 @@ func TestSeedCollectionsFromTemplateAddsConventionsRoleField(t *testing.T) {
 // the newly-created conventions/playbooks collections. This is what makes
 // templates "batteries included" rather than empty shells.
 func TestSeedCollectionsFromTemplateSeedsStarterPack(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Starter Pack")
 
@@ -456,6 +464,7 @@ func TestSeedCollectionsFromTemplateSeedsStarterPack(t *testing.T) {
 // TestSeedCollectionsFromTemplateHiring verifies end-to-end that the hiring
 // template creates the right collections and seeds its starter pack.
 func TestSeedCollectionsFromTemplateHiring(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Hiring")
 
@@ -521,6 +530,7 @@ func TestSeedCollectionsFromTemplateHiring(t *testing.T) {
 // TestSeedCollectionsFromTemplateInterviewing verifies end-to-end that the
 // interviewing template creates its collections and seeds the starter pack.
 func TestSeedCollectionsFromTemplateInterviewing(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Interviewing")
 
@@ -577,6 +587,7 @@ func TestSeedCollectionsFromTemplateInterviewing(t *testing.T) {
 // partially-initialized workspaces because the second pass saw existing
 // collections and skipped all items.
 func TestSeedCollectionsFromTemplateRecoversPartialInit(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Recover")
 
@@ -608,6 +619,7 @@ func TestSeedCollectionsFromTemplateRecoversPartialInit(t *testing.T) {
 // This invariant is what lets the server's startup auto-upgrade safely iterate
 // every workspace without creating duplicate convention/playbook items each boot.
 func TestSeedCollectionsFromTemplateIdempotentWithSeedItems(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Idempotent")
 
@@ -641,6 +653,7 @@ func TestSeedCollectionsFromTemplateIdempotentWithSeedItems(t *testing.T) {
 // --- Item Tests ---
 
 func TestItemCRUD(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -740,6 +753,7 @@ func TestItemCRUD(t *testing.T) {
 }
 
 func TestItemCodeContextIsHydratedOnRead(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -768,6 +782,7 @@ func TestItemCodeContextIsHydratedOnRead(t *testing.T) {
 }
 
 func TestListItemsIncludesCodeContext(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -796,6 +811,7 @@ func TestListItemsIncludesCodeContext(t *testing.T) {
 }
 
 func TestItemStructuredMetadataIsHydratedOnRead(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -827,6 +843,7 @@ func TestItemStructuredMetadataIsHydratedOnRead(t *testing.T) {
 }
 
 func TestConventionMetadataIsHydratedOnRead(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Conventions")
@@ -855,6 +872,7 @@ func TestConventionMetadataIsHydratedOnRead(t *testing.T) {
 }
 
 func TestItemListByCollection(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	tasks := createTestCollection(t, s, ws.ID, "Tasks")
@@ -883,6 +901,7 @@ func TestItemListByCollection(t *testing.T) {
 }
 
 func TestItemListByFieldFilter(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -924,6 +943,7 @@ func TestItemListByFieldFilter(t *testing.T) {
 }
 
 func TestItemListByTag(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -947,6 +967,7 @@ func TestItemListByTag(t *testing.T) {
 }
 
 func TestItemListPagination(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -977,6 +998,7 @@ func TestItemListPagination(t *testing.T) {
 }
 
 func TestItemFTSSearch(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -1007,6 +1029,7 @@ func TestItemFTSSearch(t *testing.T) {
 }
 
 func TestItemFTSSearchViaListItems(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -1024,6 +1047,7 @@ func TestItemFTSSearchViaListItems(t *testing.T) {
 }
 
 func TestItemSlugUniqueness(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -1046,6 +1070,7 @@ func TestItemSlugUniqueness(t *testing.T) {
 }
 
 func TestCollectionSlugUniqueness(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 
@@ -1069,6 +1094,7 @@ func TestCollectionSlugUniqueness(t *testing.T) {
 // --- Item Link Tests ---
 
 func TestItemLinks(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -1136,6 +1162,7 @@ func TestItemLinks(t *testing.T) {
 // deleted item should resurrect the link automatically — the row is preserved
 // on disk; only the query layer filters it.
 func TestItemLinks_HidesSoftDeletedEndpoints(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -1203,6 +1230,7 @@ func TestItemLinks_HidesSoftDeletedEndpoints(t *testing.T) {
 // TestGetParentForItem_HidesSoftDeletedParent ensures lineage / breadcrumb
 // queries don't surface a soft-deleted ancestor. See BUG-734.
 func TestGetParentForItem_HidesSoftDeletedParent(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -1251,6 +1279,7 @@ func TestGetParentForItem_HidesSoftDeletedParent(t *testing.T) {
 // write fails (here, because it would create a cycle), the field update must
 // roll back too — no partial commit, no half-applied patch.
 func TestUpdateItemWithParentLink_AtomicRollback(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -1298,6 +1327,7 @@ func TestUpdateItemWithParentLink_AtomicRollback(t *testing.T) {
 // when the parent-link write succeeds, BOTH the field change and the link
 // change commit together.
 func TestUpdateItemWithParentLink_AtomicCommit(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -1351,6 +1381,7 @@ func TestUpdateItemWithParentLink_AtomicCommit(t *testing.T) {
 // NOT appear in GetParentMap, so handlers_dashboard.go correctly flags the
 // task as orphaned. See BUG-734 / Codex review on PR #259.
 func TestGetParentMap_ExcludesSoftDeletedEndpoints(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -1413,6 +1444,7 @@ func TestGetParentMap_ExcludesSoftDeletedEndpoints(t *testing.T) {
 // a single WHERE id IN (...) query hydrates many parents at once, scopes to
 // only the requested IDs, computes refs, and drops soft-deleted parents.
 func TestGetItemLineageByIDs(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -1471,6 +1503,7 @@ func TestGetItemLineageByIDs(t *testing.T) {
 // path needs to enforce the same deleted-parent rejection. See BUG-734 /
 // Codex review on PR #259 (3rd pass).
 func TestListItems_ParentFilter_FTS_RespectsSoftDeletedParent(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -1533,6 +1566,7 @@ func TestListItems_ParentFilter_FTS_RespectsSoftDeletedParent(t *testing.T) {
 // GetItem/GetItemBySlug, but raw-UUID input bypasses that path. See
 // BUG-734 / Codex review on PR #259.
 func TestListItems_ParentFilter_RespectsSoftDeletedParent(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -1594,6 +1628,7 @@ func TestListItems_ParentFilter_RespectsSoftDeletedParent(t *testing.T) {
 //     would search for `842` and miss. The OR-combined query keeps the
 //     raw form alive too, so `-842` matches.
 func TestListItems_FTS_HyphenatedSearchTerm(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -1639,6 +1674,7 @@ func TestListItems_FTS_HyphenatedSearchTerm(t *testing.T) {
 // /api/v1/search code path, which routes through Store.SearchItems instead
 // of Store.listItemsFTS.
 func TestSearchItems_HyphenatedQuery(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -1667,6 +1703,7 @@ func TestSearchItems_HyphenatedQuery(t *testing.T) {
 // Same root cause as items: hyphenated queries hit FTS5's boolean parser and
 // 500 unless sanitized. Surfaces /documents?q=task-5 and the web UI doc list.
 func TestListDocuments_HyphenatedQuery(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 
@@ -1709,6 +1746,7 @@ func TestListDocuments_HyphenatedQuery(t *testing.T) {
 // inadvertently breaks one of these will fail this test, before it can
 // silently drift on production DBs the way BUG-822 did.
 func TestStartupInvariants_AllFTSTriggersExist(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	if s.dialect.Driver() != DriverSQLite {
@@ -1740,6 +1778,7 @@ func TestStartupInvariants_AllFTSTriggersExist(t *testing.T) {
 // either add it to expectedFTSTriggers (if it serves an FTS-like role) or
 // extend the exclusion below.
 func TestExpectedFTSTriggers_MatchesActual(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	if s.dialect.Driver() != DriverSQLite {
@@ -1791,6 +1830,7 @@ func TestExpectedFTSTriggers_MatchesActual(t *testing.T) {
 // SELECT, a dialect check that always returns early) and the BUG-822
 // class of drift would go undetected again.
 func TestStartupInvariants_LogsOnMissingTrigger(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	if s.dialect.Driver() != DriverSQLite {
@@ -1876,6 +1916,7 @@ func (h *recordCapturingHandler) WithGroup(_ string) slog.Handler {
 // triggers (likely from a transient quirk during migration 025), and
 // migration 046 restores them.
 func TestMigration046_DocumentsFTSTriggersExist(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	// SQLite-only — Postgres uses a different tsvector trigger setup and
@@ -1905,6 +1946,7 @@ func TestMigration046_DocumentsFTSTriggersExist(t *testing.T) {
 // removing the rebuild step would not break either of the other two BUG-822
 // tests — flagged in Codex review.
 func TestMigration046_RebuildRecoversUnindexedDocs(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	if s.dialect.Driver() != DriverSQLite {
@@ -1961,6 +2003,7 @@ func TestMigration046_RebuildRecoversUnindexedDocs(t *testing.T) {
 // after-insert trigger never fired to populate documents_fts, leaving the
 // new doc invisible to ListDocuments(Query=...).
 func TestCreateDocument_IsSearchableImmediately(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 
@@ -1996,6 +2039,7 @@ func TestCreateDocument_IsSearchableImmediately(t *testing.T) {
 // BUG-812). Before the fix, /documents?q=foo&tag=bar returned all docs
 // matching "foo" regardless of tag.
 func TestListDocuments_FTS_TagFilter(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 
@@ -2036,6 +2080,7 @@ func TestListDocuments_FTS_TagFilter(t *testing.T) {
 // /documents?q=foo&pinned=true used to ignore the pin bit when the FTS
 // branch took over. Documents analog of BUG-812.
 func TestListDocuments_FTS_PinnedFilter(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 
@@ -2079,6 +2124,7 @@ func TestListDocuments_FTS_PinnedFilter(t *testing.T) {
 // routing/guard has to short-circuit before binding.
 // See BUG-818 / Codex follow-up.
 func TestFTS_WhitespaceOnlyQuery_DoesNotCrash(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -2104,6 +2150,7 @@ func TestFTS_WhitespaceOnlyQuery_DoesNotCrash(t *testing.T) {
 // produces the second leg of the OR-combined PG FTS query (raw +
 // hyphen-as-space). See internal/store/search.go.
 func TestSanitizePGFTSQuery(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name string
 		in   string
@@ -2131,6 +2178,7 @@ func TestSanitizePGFTSQuery(t *testing.T) {
 // double quotes so SQLite FTS5 treats special characters as literals. See
 // internal/store/search.go and BUG-818.
 func TestSanitizeFTSQuery(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name string
 		in   string
@@ -2167,6 +2215,7 @@ func TestSanitizeFTSQuery(t *testing.T) {
 // items, must narrow the result to only the matching item.
 
 func TestListItems_FTS_TagFilter(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -2207,6 +2256,7 @@ func TestListItems_FTS_TagFilter(t *testing.T) {
 }
 
 func TestListItems_FTS_ParentIDFilter(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -2239,6 +2289,7 @@ func TestListItems_FTS_ParentIDFilter(t *testing.T) {
 }
 
 func TestListItems_FTS_AssignedUserFilter(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -2273,6 +2324,7 @@ func TestListItems_FTS_AssignedUserFilter(t *testing.T) {
 }
 
 func TestListItems_FTS_AgentRoleFilter(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -2320,6 +2372,7 @@ func TestListItems_FTS_AgentRoleFilter(t *testing.T) {
 }
 
 func TestListItems_FTS_FieldFilter(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -2390,6 +2443,7 @@ func TestListItems_FTS_FieldFilter(t *testing.T) {
 }
 
 func TestItemLinkDefaultType(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -2412,6 +2466,7 @@ func TestItemLinkDefaultType(t *testing.T) {
 // --- Workspace-Global Item Numbering Tests ---
 
 func TestItemNumbersAreWorkspaceGlobal(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	tasks := createTestCollection(t, s, ws.ID, "Tasks")
@@ -2438,6 +2493,7 @@ func TestItemNumbersAreWorkspaceGlobal(t *testing.T) {
 }
 
 func TestMoveItemPreservesNumber(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	tasks := createTestCollection(t, s, ws.ID, "Tasks")
@@ -2466,6 +2522,7 @@ func TestMoveItemPreservesNumber(t *testing.T) {
 }
 
 func TestOldRefResolvesAfterMove(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	plans := createTestCollection(t, s, ws.ID, "Plans")
@@ -2515,6 +2572,7 @@ func TestOldRefResolvesAfterMove(t *testing.T) {
 }
 
 func TestWorkspaceNumberingIsolation(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws1 := createTestWorkspace(t, s, "Workspace 1")
 	ws2 := createTestWorkspace(t, s, "Workspace 2")
@@ -2534,6 +2592,7 @@ func TestWorkspaceNumberingIsolation(t *testing.T) {
 }
 
 func TestItemVersionCreation(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -2565,6 +2624,7 @@ func TestItemVersionCreation(t *testing.T) {
 // no version anchoring the reverse-patch chain (and losing the restore's undo
 // point).
 func TestItemVersionForceBypassesThrottle(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -2640,6 +2700,7 @@ func TestItemVersionForceBypassesThrottle(t *testing.T) {
 }
 
 func TestWorkspaceHasAgentActivity(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Connect Banner")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -2753,6 +2814,7 @@ func TestWorkspaceHasAgentActivity(t *testing.T) {
 // filtering, has_agent_activity reflected the whole workspace regardless
 // of caller visibility.
 func TestWorkspaceHasAgentActivityVisibility(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Visibility")
 	visibleColl := createTestCollection(t, s, ws.ID, "Visible")
@@ -2828,6 +2890,7 @@ func TestWorkspaceHasAgentActivityVisibility(t *testing.T) {
 // We compare both helpers side by side so a future regression on
 // either path fails this test loudly.
 func TestGuestVisibleResourcesIncludeDeleted_SurfacesTombstones(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	user := createTestUser(t, s, "guest@example.com", "Guest", "password123")
 	ws := createTestWorkspace(t, s, "Test")
@@ -2906,6 +2969,7 @@ func stringInSlice(xs []string, want string) bool {
 // migration transaction so every row ends up with a strictly
 // unique seq.
 func TestMigrateItemFieldValues_PerRowUniqueSeq(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -2957,6 +3021,7 @@ func TestMigrateItemFieldValues_PerRowUniqueSeq(t *testing.T) {
 // mechanic the local-first read model relies on for delta sync
 // (PLAN-1343 / TASK-1352).
 func TestItemSeqMonotonic(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -3031,6 +3096,7 @@ func TestItemSeqMonotonic(t *testing.T) {
 // affect another workspace's monotonic floor (DOC-1342 design
 // decision #1).
 func TestItemSeqWorkspaceScoped(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws1 := createTestWorkspace(t, s, "WS1")
 	ws2 := createTestWorkspace(t, s, "WS2")
@@ -3058,6 +3124,7 @@ func TestItemSeqWorkspaceScoped(t *testing.T) {
 // store init), so this test inserts a fresh batch and confirms each
 // row's seq is non-zero and unique within the workspace.
 func TestItemSeqBackfillNonZero(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")

--- a/internal/store/items_title_validation_test.go
+++ b/internal/store/items_title_validation_test.go
@@ -48,6 +48,7 @@ func asInvalidTitle(t *testing.T, err error) *InvalidItemTitleError {
 }
 
 func TestItemTitle_CreateRefuses(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "TitleCreate")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -83,6 +84,7 @@ func TestItemTitle_CreateRefuses(t *testing.T) {
 // measured UpdateItem(target, {Title: ""}) returning err = nil and the item's
 // title becoming empty, while the create path refused the same input.
 func TestItemTitle_UpdateRefusesEmpty(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "TitleUpdateEmpty")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -118,6 +120,7 @@ func TestItemTitle_UpdateRefusesEmpty(t *testing.T) {
 // the handler's generic error arm. Both dialects now refuse it the same way,
 // with a typed validation error rather than a driver error.
 func TestItemTitle_UpdateRefusesOverlong(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "TitleUpdateLong")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -138,6 +141,7 @@ func TestItemTitle_UpdateRefusesOverlong(t *testing.T) {
 // bound whose accepted side is untested can be tightened by accident and
 // nothing fails.
 func TestItemTitle_BoundaryIsInclusive(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "TitleBoundary")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -165,6 +169,7 @@ func TestItemTitle_BoundaryIsInclusive(t *testing.T) {
 // storing the raw one would leave the row holding something the validator never
 // saw. Both doors must persist what they checked.
 func TestItemTitle_StoresTheNormalizedValue(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "TitleNormalize")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -202,6 +207,7 @@ func TestItemTitle_StoresTheNormalizedValue(t *testing.T) {
 // stored title predates the bound must stay editable; only a genuine rename is
 // a write-time door.
 func TestItemTitle_GrandfathersLegacyRows(t *testing.T) {
+	t.Parallel()
 	// RUNS ON BOTH DIALECTS. It used to skip on Postgres, on the stated ground
 	// that a legacy over-bound title implies a slug past the btree index-tuple
 	// cap — which is true of BUG-2804's 2 MiB fixture and FALSE of this one
@@ -254,6 +260,7 @@ func TestItemTitle_GrandfathersLegacyRows(t *testing.T) {
 // that would turn restoring a legacy archive into a hard failure for data this
 // product already accepted.
 func TestImportWorkspace_CoercesTitles(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	owner, err := s.CreateUser(models.UserCreate{
 		Name:     "Owner",
@@ -442,6 +449,7 @@ func highEntropySlug(n int) string {
 // The failure mode is the whole import aborting — the opposite of the
 // coerce-and-continue policy the title coercion exists to honour.
 func TestImportWorkspace_TruncatedSlugCollidesWithALaterVerbatimSlug(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	owner, err := s.CreateUser(models.UserCreate{
 		Name: "Owner", Email: "slug-collision-owner@example.com", Password: "passw0rd!",
@@ -545,6 +553,7 @@ func TestImportWorkspace_TruncatedSlugCollidesWithALaterVerbatimSlug(t *testing.
 // comparing only the NORMALIZED form makes that false for exactly the rows the
 // exemption exists for.
 func TestItemTitle_GrandfathersAVerbatimEchoOfAWhitespaceTitle(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "TitleEchoGrandfather")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -598,6 +607,7 @@ func TestItemTitle_GrandfathersAVerbatimEchoOfAWhitespaceTitle(t *testing.T) {
 // this disjunct survived the rest of the suite, which is why the case is
 // pinned separately rather than folded into the test above.
 func TestItemTitle_GrandfathersAWriteThatNormalizesToTheStoredTitle(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "TitleNormalizedEcho")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -627,6 +637,7 @@ func TestItemTitle_GrandfathersAWriteThatNormalizesToTheStoredTitle(t *testing.T
 // to protect legacy rows. No error is returned in that version, which is why
 // the assertion has to be on the stored bytes.
 func TestItemTitle_GrandfatheredWriteCannotMintAnEmptyTitle(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "TitleNoMintEmpty")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -673,6 +684,7 @@ func TestItemTitle_GrandfatheredWriteCannotMintAnEmptyTitle(t *testing.T) {
 // (The earlier grandfathering tests all derive the slug from the title, which
 // is exactly why they could not see this.)
 func TestItemTitle_GrandfatheredEchoDoesNotMoveTheSlug(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "TitleEchoSlug")
 	col := createTestCollection(t, s, ws.ID, "Tasks")

--- a/internal/store/items_version_seq_test.go
+++ b/internal/store/items_version_seq_test.go
@@ -28,6 +28,7 @@ import (
 //   - ListItemVersionsResolved reconstructs the correct pre-update content
 //     for each row — which only holds if the newest→oldest walk is ordered.
 func TestItemVersionSeqBreaksSameSecondTies(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Version Seq Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")

--- a/internal/store/items_versions_page_test.go
+++ b/internal/store/items_versions_page_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestListItemVersionsPage_ReturnsUnresolvedRows(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws, err := s.CreateWorkspace(models.WorkspaceCreate{Name: "Versions WS"})
 	if err != nil {
@@ -100,6 +101,7 @@ func TestListItemVersionsPage_ReturnsUnresolvedRows(t *testing.T) {
 }
 
 func TestListItemVersionsPage_LimitTakesTheNewest(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws, err := s.CreateWorkspace(models.WorkspaceCreate{Name: "Versions WS 2"})
 	if err != nil {

--- a/internal/store/items_views_jsonb_test.go
+++ b/internal/store/items_views_jsonb_test.go
@@ -31,6 +31,7 @@ import (
 // The store-layer coercion normalizes "" → "{}" / "[]" before the
 // UPDATE reaches the database.
 func TestItemsViewsJSONB_UpdateItemCoercesEmptyStringFields(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "JSONBCoerce")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -56,6 +57,7 @@ func TestItemsViewsJSONB_UpdateItemCoercesEmptyStringFields(t *testing.T) {
 // TestItemsViewsJSONB_UpdateViewCoercesEmptyStringConfig exercises the
 // IDEA-1486 floor at views.go:152.
 func TestItemsViewsJSONB_UpdateViewCoercesEmptyStringConfig(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "ViewCoerce")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -88,6 +90,7 @@ func TestItemsViewsJSONB_UpdateViewCoercesEmptyStringConfig(t *testing.T) {
 // shape default. Mirrors the IDEA-1488 log-and-coerce policy: legacy
 // bundles don't fail-stop on one bad row.
 func TestItemsViewsJSONB_ImportWorkspaceCoercesEmptyAndMalformed(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	owner, err := s.CreateUser(models.UserCreate{
 		Email:    "owner-import@example.com",
@@ -254,6 +257,7 @@ func jsonEqualString(a, b string) bool {
 // rebuild forgets to recreate an index or the FTS triggers don't
 // re-attach to the renamed items table.
 func TestItemsViewsJSONB_SQLiteRebuildPreservesIndexesAndTriggers(t *testing.T) {
+	t.Parallel()
 	if os.Getenv("PAD_TEST_POSTGRES_URL") != "" {
 		t.Skip("SQLite-specific schema-introspection test")
 	}
@@ -352,6 +356,7 @@ func TestItemsViewsJSONB_SQLiteRebuildPreservesIndexesAndTriggers(t *testing.T) 
 // schema level on SQLite (driven by the table-rebuild from migration
 // 056). This is the load-bearing invariant the IDEA-1486 floor adds.
 func TestItemsViewsJSONB_SQLiteRebuildRejectsNullFieldsAfterMigration(t *testing.T) {
+	t.Parallel()
 	if os.Getenv("PAD_TEST_POSTGRES_URL") != "" {
 		t.Skip("SQLite-specific test; Postgres counterpart uses ALTER COLUMN SET NOT NULL")
 	}
@@ -375,6 +380,7 @@ func TestItemsViewsJSONB_SQLiteRebuildRejectsNullFieldsAfterMigration(t *testing
 // TestItemsViewsJSONB_SQLiteRebuildRejectsNullConfigAfterMigration is
 // the views.config counterpart to the items NULL-reject test.
 func TestItemsViewsJSONB_SQLiteRebuildRejectsNullConfigAfterMigration(t *testing.T) {
+	t.Parallel()
 	if os.Getenv("PAD_TEST_POSTGRES_URL") != "" {
 		t.Skip("SQLite-specific test")
 	}
@@ -397,6 +403,7 @@ func TestItemsViewsJSONB_SQLiteRebuildRejectsNullConfigAfterMigration(t *testing
 // Verifies the ALTER COLUMN ... SET NOT NULL from pgmigrations/035 + 036
 // actually rejects NULL writes.
 func TestItemsViewsJSONB_PostgresRejectsNullFieldsAfterMigration(t *testing.T) {
+	t.Parallel()
 	if os.Getenv("PAD_TEST_POSTGRES_URL") == "" {
 		t.Skip("PAD_TEST_POSTGRES_URL not set")
 	}
@@ -442,6 +449,7 @@ func TestItemsViewsJSONB_PostgresRejectsNullFieldsAfterMigration(t *testing.T) {
 // repeated application (DROP TABLE IF EXISTS items_new; backfill UPDATEs
 // are WHERE x IS NULL; index/trigger DROPs use IF EXISTS).
 func TestItemsViewsJSONB_SQLiteRebuildIsIdempotent(t *testing.T) {
+	t.Parallel()
 	if os.Getenv("PAD_TEST_POSTGRES_URL") != "" {
 		t.Skip("SQLite-specific idempotency test")
 	}
@@ -479,6 +487,7 @@ func TestItemsViewsJSONB_SQLiteRebuildIsIdempotent(t *testing.T) {
 // INSERT…SELECT, the FK metadata re-resolves to the renamed table by
 // name and existing links remain valid.
 func TestItemsViewsJSONB_ItemLinksRoundTripAfterRebuild(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "LinkRoundTrip")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -520,6 +529,7 @@ func TestItemsViewsJSONB_ItemLinksRoundTripAfterRebuild(t *testing.T) {
 // seeding below is the actual ship-breaker scenario; without the
 // widened WHERE clause, the migration aborts.
 func TestItemsViewsJSONB_SQLiteBackfillRepairsMalformedShapes(t *testing.T) {
+	t.Parallel()
 	if os.Getenv("PAD_TEST_POSTGRES_URL") != "" {
 		t.Skip("SQLite-specific (json_valid / json_type)")
 	}
@@ -749,6 +759,7 @@ func TestItemsViewsJSONB_SQLiteBackfillRepairsMalformedShapes(t *testing.T) {
 // required, a primitive). Codex R2 P1: the original NULL-only WHERE
 // would have left wrong-shape rows in place.
 func TestItemsViewsJSONB_PostgresBackfillRepairsMalformedShapes(t *testing.T) {
+	t.Parallel()
 	pgURL := os.Getenv("PAD_TEST_POSTGRES_URL")
 	if pgURL == "" {
 		t.Skip("PAD_TEST_POSTGRES_URL not set")
@@ -818,6 +829,7 @@ func TestItemsViewsJSONB_PostgresBackfillRepairsMalformedShapes(t *testing.T) {
 // design decision D2, the virtual table is NOT dropped — only the
 // three triggers are.)
 func TestItemsViewsJSONB_ItemsFTSVirtualTableExists(t *testing.T) {
+	t.Parallel()
 	if os.Getenv("PAD_TEST_POSTGRES_URL") != "" {
 		t.Skip("SQLite-specific (items_fts is a SQLite FTS5 virtual table)")
 	}

--- a/internal/store/limits_test.go
+++ b/internal/store/limits_test.go
@@ -13,6 +13,7 @@ import (
 //   - With 2 workspaces (below cap): Allowed=true, Current=2
 //   - After inserting a 3rd workspace (at cap): Allowed=false, Current=3
 func TestCheckUserLimit_WorkspacesFreeTier(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	owner := createTestUser(t, s, "owner@example.com", "Owner", "s3cret")
@@ -80,6 +81,7 @@ func TestCheckUserLimit_WorkspacesFreeTier(t *testing.T) {
 // TestCheckUserLimit_WorkspacesFreeWithOverride confirms that a per-user
 // plan_overrides JSON entry raises the cap above the default 3.
 func TestCheckUserLimit_WorkspacesFreeWithOverride(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	owner := createTestUser(t, s, "override@example.com", "Override", "s3cret")
@@ -115,6 +117,7 @@ func TestCheckUserLimit_WorkspacesFreeWithOverride(t *testing.T) {
 // TestCheckUserLimit_WorkspacesProUnlimited confirms that pro-plan users
 // are always allowed regardless of workspace count.
 func TestCheckUserLimit_WorkspacesProUnlimited(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	owner := createTestUser(t, s, "pro@example.com", "Pro", "s3cret")

--- a/internal/store/mcp_audit_test.go
+++ b/internal/store/mcp_audit_test.go
@@ -50,6 +50,7 @@ func auditUser(t *testing.T, s *Store, email string) string {
 }
 
 func TestInsertMCPAuditEntry_RequiredFields(t *testing.T) {
+	t.Parallel()
 	s := newAuditTestStore(t)
 	uid := auditUser(t, s, "req-fields@example.com")
 
@@ -75,6 +76,7 @@ func TestInsertMCPAuditEntry_RequiredFields(t *testing.T) {
 }
 
 func TestInsertMCPAuditEntry_RoundTrip(t *testing.T) {
+	t.Parallel()
 	s := newAuditTestStore(t)
 	uid := auditUser(t, s, "roundtrip@example.com")
 	wsID := "" // workspace nullable; leave empty so the column is NULL
@@ -123,6 +125,7 @@ func TestInsertMCPAuditEntry_RoundTrip(t *testing.T) {
 }
 
 func TestInsertMCPAuditEntry_NullableFieldsPopulated(t *testing.T) {
+	t.Parallel()
 	s := newAuditTestStore(t)
 	uid := auditUser(t, s, "nullable@example.com")
 	// Need an actual workspace row for the FK on workspace_id
@@ -162,6 +165,7 @@ func TestInsertMCPAuditEntry_NullableFieldsPopulated(t *testing.T) {
 }
 
 func TestListMCPAuditByUser_OrderingAndPagination(t *testing.T) {
+	t.Parallel()
 	s := newAuditTestStore(t)
 	uid := auditUser(t, s, "ordering@example.com")
 	base := time.Now().UTC().Truncate(time.Second)
@@ -213,6 +217,7 @@ func TestListMCPAuditByUser_OrderingAndPagination(t *testing.T) {
 }
 
 func TestListMCPAuditByConnection_FiltersByOwner(t *testing.T) {
+	t.Parallel()
 	s := newAuditTestStore(t)
 	alice := auditUser(t, s, "alice@example.com")
 	bob := auditUser(t, s, "bob@example.com")
@@ -249,6 +254,7 @@ func TestListMCPAuditByConnection_FiltersByOwner(t *testing.T) {
 }
 
 func TestMCPConnectionStatsForUser_LastUsedAndCalls30d(t *testing.T) {
+	t.Parallel()
 	s := newAuditTestStore(t)
 	uid := auditUser(t, s, "stats@example.com")
 
@@ -327,6 +333,7 @@ func TestMCPConnectionStatsForUser_LastUsedAndCalls30d(t *testing.T) {
 }
 
 func TestSweepMCPAuditOlderThan_DeletesOldRowsOnly(t *testing.T) {
+	t.Parallel()
 	s := newAuditTestStore(t)
 	uid := auditUser(t, s, "sweep@example.com")
 	now := time.Now().UTC()
@@ -368,6 +375,7 @@ func TestSweepMCPAuditOlderThan_DeletesOldRowsOnly(t *testing.T) {
 }
 
 func TestListAllMCPAudit_ReturnsAcrossUsers(t *testing.T) {
+	t.Parallel()
 	s := newAuditTestStore(t)
 	a := auditUser(t, s, "all-a@example.com")
 	b := auditUser(t, s, "all-b@example.com")

--- a/internal/store/migration_atomicity_test.go
+++ b/internal/store/migration_atomicity_test.go
@@ -24,6 +24,7 @@ import (
 // partially-mutated schema — exactly the data-loss window described in
 // the IDEA's "Problem" section.
 func TestMigrationAtomicity_FailedSQLite_RollsBackPartialDDLAndBookkeeping(t *testing.T) {
+	t.Parallel()
 	if os.Getenv("PAD_TEST_POSTGRES_URL") != "" {
 		t.Skip("SQLite-specific atomicity test; Postgres has its own counterpart below")
 	}
@@ -79,6 +80,7 @@ INSERT INTO no_such_table_xyz (id) VALUES ('boom');
 // positive control: a normal multi-statement migration commits both the
 // DDL and the schema_migrations row together.
 func TestMigrationAtomicity_SuccessfulSQLite_RecordsBookkeeping(t *testing.T) {
+	t.Parallel()
 	if os.Getenv("PAD_TEST_POSTGRES_URL") != "" {
 		t.Skip("SQLite-specific")
 	}
@@ -130,6 +132,7 @@ CREATE TABLE atomic_ok_t2 (id TEXT PRIMARY KEY);
 // drops parent_t and recreates it; without FK-off this would fail
 // because child_t still references it.
 func TestMigrationAtomicity_PragmaForeignKeysLifted(t *testing.T) {
+	t.Parallel()
 	if os.Getenv("PAD_TEST_POSTGRES_URL") != "" {
 		t.Skip("SQLite-specific (PRAGMA semantics)")
 	}
@@ -216,6 +219,7 @@ PRAGMA foreign_keys = ON;
 
 // TestExtractPragmas validates the lifter in isolation.
 func TestExtractPragmas(t *testing.T) {
+	t.Parallel()
 	in := `-- header comment
 PRAGMA foreign_keys = OFF;
 CREATE TABLE x (id TEXT);
@@ -247,6 +251,7 @@ PRAGMA foreign_keys = ON;
 // is the Postgres counterpart to the SQLite atomicity test. It only
 // runs when PAD_TEST_POSTGRES_URL is set.
 func TestMigrationAtomicity_FailedPostgres_RollsBackPartialDDLAndBookkeeping(t *testing.T) {
+	t.Parallel()
 	pgURL := os.Getenv("PAD_TEST_POSTGRES_URL")
 	if pgURL == "" {
 		t.Skip("PAD_TEST_POSTGRES_URL not set")
@@ -304,6 +309,7 @@ INSERT INTO no_such_table_xyz (id) VALUES ('boom');
 // post-failure FK check is deterministically against the same physical
 // connection that ran the failed migration.
 func TestMigrationAtomicity_FailedSQLite_RestoresForeignKeysOnError(t *testing.T) {
+	t.Parallel()
 	if os.Getenv("PAD_TEST_POSTGRES_URL") != "" {
 		t.Skip("SQLite-specific (PRAGMA foreign_keys is a SQLite construct)")
 	}

--- a/internal/store/migration_guard_test.go
+++ b/internal/store/migration_guard_test.go
@@ -1,5 +1,23 @@
 package store
 
+// TASK-2900: NO TEST IN THIS FILE MAY CALL t.Parallel().
+//
+// Every one of them touches a package-level EXPORTED global —
+// store.AllowSchemaAhead and store.BinaryVersion — and restores it in a
+// t.Cleanup. Under t.Parallel that mutation window is open across every
+// concurrently-running test, and the restore fires while they are still in
+// flight: AllowSchemaAhead=true would silently disarm the schema-ahead guard
+// for whoever else is running, which is the assertion two of these tests exist
+// to make.
+//
+// Found by codex, NOT by my own sweep, and the reason is worth recording: my
+// global-mutator grep was `^var [a-z]`, which finds unexported package vars and
+// silently skips exported ones. The instrument asked "which unexported globals
+// exist" while the claim it was carrying was "which globals exist". Third
+// instance today of a grep narrower than the claim resting on it.
+//
+// TestMigrationGuardTestsStaySerial enforces this file-wide.
+
 import (
 	"os"
 	"path/filepath"

--- a/internal/store/moved_out_test.go
+++ b/internal/store/moved_out_test.go
@@ -11,6 +11,7 @@ import (
 // moved-out tombstone so the caller's local cache evicts it. The move
 // is recorded durably in item_collection_moves by MoveItem itself.
 func TestListMovedOutSince(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "MovedOutTest")
 	schema := `{"fields":[{"key":"status","type":"select","options":["open","done"],"default":"open"}]}`
@@ -105,6 +106,7 @@ func TestListMovedOutSince(t *testing.T) {
 // seq. An item that moved out early but then churned in the hidden
 // collection (high current seq) must not be dropped past the limit.
 func TestListMovedOutSince_PaginatesByMoveSeq(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "MovedOutPaging")
 	schema := `{"fields":[{"key":"status","type":"select","options":["open","done"],"default":"open"}]}`

--- a/internal/store/non_terminal_filter_test.go
+++ b/internal/store/non_terminal_filter_test.go
@@ -12,6 +12,7 @@ import (
 // CUSTOM status vocabularies (todo / drafting / scheduled) show their open
 // items instead of being hidden behind a hardcoded global allowlist.
 func TestListItems_NonTerminalFilter(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "NonTerminalFilter")
 

--- a/internal/store/nul_native_pg_test.go
+++ b/internal/store/nul_native_pg_test.go
@@ -22,6 +22,7 @@ import (
 // It runs against the RAW driver deliberately — no guard in the path — so what
 // is measured is Postgres's own verdict, not ours reflected back.
 func TestNativePostgresAgreesWithTheCorpus(t *testing.T) {
+	t.Parallel()
 	dsn := os.Getenv("PAD_TEST_POSTGRES_URL")
 	if dsn == "" {
 		t.Skip("PAD_TEST_POSTGRES_URL not set; the native-Postgres leg needs a real server")

--- a/internal/store/nul_repair_differential_test.go
+++ b/internal/store/nul_repair_differential_test.go
@@ -26,6 +26,7 @@ import (
 
 // TestLayerAAcceptsEveryRepairedCorpusValue — the driver guard.
 func TestLayerAAcceptsEveryRepairedCorpusValue(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "RepairLayerA")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -58,6 +59,7 @@ func TestLayerAAcceptsEveryRepairedCorpusValue(t *testing.T) {
 // raw handle so what is measured is the DATABASE's verdict rather than Layer
 // A's reflected back.
 func TestLayerBAcceptsEveryRepairedCorpusValue(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	if s.dialect.Driver() != DriverSQLite {
 		t.Skip("Layer B is SQLite-only")
@@ -116,6 +118,7 @@ func TestLayerBAcceptsEveryRepairedCorpusValue(t *testing.T) {
 // PostgreSQL's own parser. That claim is only discharged by putting the
 // repaired values in front of a real Postgres.
 func TestNativePostgresAcceptsEveryRepairedCorpusValue(t *testing.T) {
+	t.Parallel()
 	dsn := os.Getenv("PAD_TEST_POSTGRES_URL")
 	if dsn == "" {
 		t.Skip("PAD_TEST_POSTGRES_URL not set; the native-Postgres leg needs a real server")

--- a/internal/store/nulcolumns_test.go
+++ b/internal/store/nulcolumns_test.go
@@ -21,6 +21,7 @@ import (
 // add the column to nulColumns (with its class) or to nulExcluded (with the
 // reason). Do not delete the test.
 func TestNULColumnCensus(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	if s.dialect.Driver() != DriverSQLite {
 		t.Skip("census runs against the SQLite schema; Layer B is SQLite-only (Postgres refuses natively)")
@@ -194,6 +195,7 @@ func TestNULColumnCensus(t *testing.T) {
 // TestNULColumnListIsWellFormed checks the list itself before anything is
 // generated from it.
 func TestNULColumnListIsWellFormed(t *testing.T) {
+	t.Parallel()
 	seen := map[string]bool{}
 	var jsonN, textN int
 	for _, c := range NULProtectedColumns() {
@@ -287,6 +289,7 @@ func isDerivedTable(name string) bool {
 // having done it once and it staying done. A new *_by column fails here the day
 // it is added.
 func TestAttributionColumnsAreAllProtected(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	if s.dialect.Driver() != DriverSQLite {
 		t.Skip("schema census runs against SQLite")

--- a/internal/store/nulguard_test.go
+++ b/internal/store/nulguard_test.go
@@ -31,6 +31,7 @@ import (
 // whether anything binds TEXT to it, or text to any other column as []byte,
 // then add it below.
 func TestBinaryColumnCensus(t *testing.T) {
+	t.Parallel()
 	want := map[string]bool{"item_yjs_updates.update_data": true}
 
 	// One pattern per dialect spelling, applied to the raw migration text so
@@ -111,6 +112,7 @@ func TestBinaryColumnCensus(t *testing.T) {
 // covers the predicate. What this asserts is that a value reaching the driver
 // is refused there, whichever of the four receivers carried it.
 func TestWriteGuardRefusesTheCorpus(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "NulGuard")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -182,6 +184,7 @@ func models_ItemUpdateFields(v string) (u models.ItemUpdate)  { u.Fields = &v; r
 // RETURNING statement, so it keeps guarding the path against the day someone
 // adds the next one.
 func TestWriteGuardCoversTheQueryPath(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "NulGuardQueryPath")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -240,6 +243,7 @@ func TestWriteGuardCoversTheQueryPath(t *testing.T) {
 // rather than borrowing one: what is under test is the ROUTE, and it must stay
 // covered when the next prepared statement does carry text.
 func TestWriteGuardCoversPreparedStatements(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "NulGuardPrepared")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -308,6 +312,7 @@ func TestWriteGuardCoversPreparedStatements(t *testing.T) {
 // means the guard gained real column knowledge, and the case should move into
 // textguard.Corpus where every layer is held to it.
 func TestStoreOverRefusalsStillOverRefuse(t *testing.T) {
+	t.Parallel()
 	// NOT a skip, for the same reason as KnownGaps: an empty slice would let
 	// someone delete the record of a divergence and see green (codex round 2).
 	const wantOverRefusals = 1
@@ -349,6 +354,7 @@ func TestStoreOverRefusalsStillOverRefuse(t *testing.T) {
 // So the property is pinned rather than reasoned about: for every optional
 // interface the wrapper varies over, wrapped and base must agree exactly.
 func TestWrapperAdvertisesExactlyWhatTheBaseDoes(t *testing.T) {
+	t.Parallel()
 	if err := registerGuardedDrivers(); err != nil {
 		t.Fatalf("register: %v", err)
 	}
@@ -468,6 +474,7 @@ func TestWrapperAdvertisesExactlyWhatTheBaseDoes(t *testing.T) {
 // internal/store/wiki_links.go binds sql.NullString today, so this is a live
 // parameter shape rather than a constructed one.
 func TestWriteGuardSeesThroughDriverValuer(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "ValuerGuard")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -518,6 +525,7 @@ func TestWriteGuardSeesThroughDriverValuer(t *testing.T) {
 // the guard ever runs. That made it pass for the wrong reason by default
 // (codex round 3), and these do not depend on which driver is present.
 func TestWriteGuardResolvesValuerOnce(t *testing.T) {
+	t.Parallel()
 	t.Run("typed-nil valuer binds NULL instead of panicking", func(t *testing.T) {
 		args := []driver.NamedValue{{Ordinal: 1, Value: (*sql.NullString)(nil)}}
 		if err := normalizeAndCheck(args); err != nil {

--- a/internal/store/nulscan_test.go
+++ b/internal/store/nulscan_test.go
@@ -48,6 +48,7 @@ func plantLegacyRows(t *testing.T, s *Store, plant func(raw *sql.DB)) {
 // TestScanNULFindsThePlantedPopulation drives every shape the counter has to
 // tell apart, including the two it must NOT report.
 func TestScanNULFindsThePlantedPopulation(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	if s.dialect.Driver() != DriverSQLite {
 		t.Skip("the scan is SQLite-only; Postgres cannot hold the state")
@@ -167,6 +168,7 @@ func TestScanNULFindsThePlantedPopulation(t *testing.T) {
 // repair the database satisfies the invariant, and the values that were never
 // violating are byte-identical.
 func TestRepairNULRepairsThePopulationAndIsIdempotent(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	if s.dialect.Driver() != DriverSQLite {
 		t.Skip("SQLite only")
@@ -250,6 +252,7 @@ func TestRepairNULRepairsThePopulationAndIsIdempotent(t *testing.T) {
 // an existing row — silently merging two opt-out records, which in this table
 // means somebody starts receiving mail again.
 func TestRepairNULRefusesToRewriteAPrimaryKey(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	if s.dialect.Driver() != DriverSQLite {
 		t.Skip("SQLite only")
@@ -295,6 +298,7 @@ func TestRepairNULRefusesToRewriteAPrimaryKey(t *testing.T) {
 // TestScanNULOnPostgresSaysWhyItDidNotLook guards the one thing a zero report
 // must never be mistaken for.
 func TestScanNULOnPostgresSaysWhyItDidNotLook(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	if s.dialect.Driver() == DriverSQLite {
 		t.Skip("this leg is about the Postgres arm")
@@ -330,6 +334,7 @@ func mustExec(t *testing.T, db *sql.DB, query string, args ...any) {
 // round. If this fails, update the comment rather than the numbers here: the
 // list is the source and the comment is the copy.
 func TestScanCostFiguresMatchTheList(t *testing.T) {
+	t.Parallel()
 	const (
 		wantTotal = 131
 		wantJSON  = 24
@@ -363,6 +368,7 @@ func TestScanCostFiguresMatchTheList(t *testing.T) {
 // id-addressed rows, and a leg that never exercises the rowid path would let
 // that binding break without a failure.
 func TestRepairNULAddressesARowidOnlyTable(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	if s.dialect.Driver() != DriverSQLite {
 		t.Skip("SQLite only")
@@ -427,6 +433,7 @@ func TestRepairNULAddressesARowidOnlyTable(t *testing.T) {
 // Verified to fail against the unfixed code: the scan returned
 // `scan activities.actor row: sql: Scan error ... converting NULL to string`.
 func TestScanNULSurvivesANullWorkspaceID(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	if s.dialect.Driver() != DriverSQLite {
 		t.Skip("SQLite only")
@@ -492,6 +499,7 @@ func TestScanNULSurvivesANullWorkspaceID(t *testing.T) {
 // platform_settings is the fixture because its key IS its primary key and is
 // NOT in the protected list, while its `value` column is: exactly the shape.
 func TestRepairNULSkipsARowItCannotAddress(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	if s.dialect.Driver() != DriverSQLite {
 		t.Skip("SQLite only")
@@ -562,6 +570,7 @@ func TestRepairNULSkipsARowItCannotAddress(t *testing.T) {
 // direction, and the same reason, as textguard's TestKnownGapsStillGap. See
 // also TestSuspectsCollapseWhenBUG2812Lands, which names what to delete.
 func TestScanNULInheritsTheRecordedKnownGaps(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	if s.dialect.Driver() != DriverSQLite {
 		t.Skip("SQLite only")
@@ -611,6 +620,7 @@ func TestScanNULInheritsTheRecordedKnownGaps(t *testing.T) {
 // decides. This test pins that both LAND in the suspect list and neither lands
 // in the violations, which is what makes the preflight's oracle reachable.
 func TestScanNULReportsSuspectsSeparately(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	if s.dialect.Driver() != DriverSQLite {
 		t.Skip("SQLite only")
@@ -680,6 +690,7 @@ func TestScanNULReportsSuspectsSeparately(t *testing.T) {
 // a repair broad enough to catch the shadowed value must still leave a value
 // that merely writes ABOUT the escape byte-identical.
 func TestRepairSuspectFixesOnlyTheFatalShape(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	if s.dialect.Driver() != DriverSQLite {
 		t.Skip("SQLite only")
@@ -762,6 +773,7 @@ func TestRepairSuspectFixesOnlyTheFatalShape(t *testing.T) {
 // Nothing would otherwise tell anyone. This fails at that moment and says what
 // to remove.
 func TestSuspectsCollapseWhenBUG2812Lands(t *testing.T) {
+	t.Parallel()
 	shadowed := `{"a":"` + textguard.EscNUL + `","a":"clean"}`
 
 	if textguard.ParameterRefused(shadowed, true) {

--- a/internal/store/nulsuspect_pg_test.go
+++ b/internal/store/nulsuspect_pg_test.go
@@ -22,6 +22,7 @@ import (
 // package). A wrong assumption on either half fails in the worst direction —
 // silently accepting a value the migration will choke on.
 func TestDestinationOracleClassifiesRealPostgresErrors(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	if s.dialect.Driver() != DriverPostgres {
 		t.Skip("the destination oracle needs a real PostgreSQL (set PAD_TEST_POSTGRES_URL)")
@@ -112,6 +113,7 @@ func TestDestinationOracleClassifiesRealPostgresErrors(t *testing.T) {
 // A CLOSED POOL rather than a fabricated error string, so what is measured is
 // what pgx actually produces when the database cannot be reached.
 func TestDestinationOracleFailsClosedOnAnUnusableConnection(t *testing.T) {
+	t.Parallel()
 	dsn := os.Getenv("PAD_TEST_POSTGRES_URL")
 	if dsn == "" {
 		t.Skip("needs a real PostgreSQL (set PAD_TEST_POSTGRES_URL)")
@@ -164,6 +166,7 @@ func TestDestinationOracleFailsClosedOnAnUnusableConnection(t *testing.T) {
 // TestDestinationOracleFailsClosedOnAnUnusableConnection. Neither half is
 // assumed alone.
 func TestClassifyDestinationErrorTreatsOperationalCodesAsUnverified(t *testing.T) {
+	t.Parallel()
 	pgxish := func(code, text string) error {
 		return errors.New("ERROR: " + text + " (SQLSTATE " + code + ")")
 	}
@@ -208,6 +211,7 @@ func TestClassifyDestinationErrorTreatsOperationalCodesAsUnverified(t *testing.T
 
 // TestSQLStateExtractionEdges covers the parser the classification rests on.
 func TestSQLStateExtractionEdges(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name string
 		err  error
@@ -256,6 +260,7 @@ func TestSQLStateExtractionEdges(t *testing.T) {
 // Reflection over the struct is the maintainable version of the question: every
 // slice section, plus the workspace row itself, must map to a listed table.
 func TestMigratedTablesCoversTheExport(t *testing.T) {
+	t.Parallel()
 	// Section field name -> the table it is read from. Adding a section to
 	// WorkspaceExport fails the loop below until it is named here AND in
 	// MigratedTables, which is the point.

--- a/internal/store/nultriggers_gen_test.go
+++ b/internal/store/nultriggers_gen_test.go
@@ -18,6 +18,7 @@ import (
 // list disagree, and the right response is usually to fix whichever is wrong —
 // regenerate only after deciding the LIST is right.
 func TestGenerateNULTriggerMigration(t *testing.T) {
+	t.Parallel()
 	if os.Getenv("GEN_NUL_TRIGGERS") == "" {
 		t.Skip("generator; run with GEN_NUL_TRIGGERS=1 after changing nulcolumns.go")
 	}

--- a/internal/store/nultriggers_test.go
+++ b/internal/store/nultriggers_test.go
@@ -26,6 +26,7 @@ import (
 // If this passes while Layer A's tests also pass, the invariant has moved from
 // being a property of our code to being a property of the data.
 func TestNULTriggersRefuseAnUnguardedWriter(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	if s.dialect.Driver() != DriverSQLite {
 		t.Skip("Layer B is SQLite-only; Postgres refuses natively")
@@ -146,6 +147,7 @@ func TestNULTriggersRefuseAnUnguardedWriter(t *testing.T) {
 // TestGenerateNULTriggerMigration. If the FILE is right, the list is wrong and
 // regenerating would erase the evidence.
 func TestNULTriggersMatchTheList(t *testing.T) {
+	t.Parallel()
 	committed, err := os.ReadFile("migrations/" + nulTriggerMigration)
 	if err != nil {
 		t.Fatalf("read migration: %v", err)
@@ -190,6 +192,7 @@ func TestNULTriggersMatchTheList(t *testing.T) {
 // exercise this is to classify the driver error directly and, separately, to
 // prove an unguarded write produces a message the classifier recognises.
 func TestTriggerRefusalIsIndistinguishableFromLayerA(t *testing.T) {
+	t.Parallel()
 	// WHY THERE IS NO END-TO-END LEG HERE, stated rather than faked.
 	//
 	// Codex round 2 was right that testing classifyTriggerRefusal with a
@@ -317,6 +320,7 @@ func TestTriggerRefusalIsIndistinguishableFromLayerA(t *testing.T) {
 // enforcers, which is what licenses two enforcement layers to coexist — the
 // property DOC-2823 named as the deliverable rather than the guard itself.
 func TestLayerBAgreesWithTheCorpus(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	if s.dialect.Driver() != DriverSQLite {
 		t.Skip("Layer B is SQLite-only")
@@ -395,6 +399,7 @@ func execRaw(db *sql.DB, q string, args ...any) error {
 // This simulates the rebuild by dropping the triggers, then runs the same
 // re-assertion path startup uses.
 func TestNULTriggersSurviveATableRebuild(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	if s.dialect.Driver() != DriverSQLite {
 		t.Skip("Layer B is SQLite-only")
@@ -590,6 +595,7 @@ func openFakeGuarded(t *testing.T) *sql.DB {
 // use, which is the closest reachable analogue of a corrupt or partially
 // restored database.
 func TestNULTriggerRestorationFailsLoudlyOnAQueryError(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	if s.dialect.Driver() != DriverSQLite {
 		t.Skip("Layer B is SQLite-only")
@@ -621,6 +627,7 @@ func TestNULTriggerRestorationFailsLoudlyOnAQueryError(t *testing.T) {
 // edit can ABORT legitimate writes, and the check that is supposed to notice
 // would report the database fine forever.
 func TestNULTriggerRestorationRemovesStrays(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	if s.dialect.Driver() != DriverSQLite {
 		t.Skip("Layer B is SQLite-only")

--- a/internal/store/oauth_connections_backfill_test.go
+++ b/internal/store/oauth_connections_backfill_test.go
@@ -109,6 +109,7 @@ func seedBackfillRefresh(t *testing.T, s *Store, requestID, clientID, subject st
 }
 
 func TestBackfillOAuthConnections_EmptyDatabase(t *testing.T) {
+	t.Parallel()
 	s := newBackfillTestStore(t)
 	res, err := s.BackfillOAuthConnections()
 	if err != nil {
@@ -120,6 +121,7 @@ func TestBackfillOAuthConnections_EmptyDatabase(t *testing.T) {
 }
 
 func TestBackfillOAuthConnections_PreTASK952_WildcardSemantic(t *testing.T) {
+	t.Parallel()
 	s := newBackfillTestStore(t)
 	uid := seedBackfillUser(t, s, "pre-952@example.com")
 	client := seedBackfillClient(t, s, "Pre-952 Client")
@@ -155,6 +157,7 @@ func TestBackfillOAuthConnections_PreTASK952_WildcardSemantic(t *testing.T) {
 }
 
 func TestBackfillOAuthConnections_Wildcard(t *testing.T) {
+	t.Parallel()
 	s := newBackfillTestStore(t)
 	uid := seedBackfillUser(t, s, "wildcard@example.com")
 	client := seedBackfillClient(t, s, "Wildcard Client")
@@ -176,6 +179,7 @@ func TestBackfillOAuthConnections_Wildcard(t *testing.T) {
 }
 
 func TestBackfillOAuthConnections_ExplicitList(t *testing.T) {
+	t.Parallel()
 	s := newBackfillTestStore(t)
 	uid := seedBackfillUser(t, s, "explicit@example.com")
 	client := seedBackfillClient(t, s, "Explicit Client")
@@ -214,6 +218,7 @@ func TestBackfillOAuthConnections_ExplicitList(t *testing.T) {
 }
 
 func TestBackfillOAuthConnections_UnresolvedSlugIsCounted(t *testing.T) {
+	t.Parallel()
 	s := newBackfillTestStore(t)
 	uid := seedBackfillUser(t, s, "unresolved@example.com")
 	client := seedBackfillClient(t, s, "Unresolved Client")
@@ -238,6 +243,7 @@ func TestBackfillOAuthConnections_UnresolvedSlugIsCounted(t *testing.T) {
 }
 
 func TestBackfillOAuthConnections_NewestRowDrivesShape(t *testing.T) {
+	t.Parallel()
 	s := newBackfillTestStore(t)
 	uid := seedBackfillUser(t, s, "rotation@example.com")
 	client := seedBackfillClient(t, s, "Rotation Client")
@@ -267,6 +273,7 @@ func TestBackfillOAuthConnections_NewestRowDrivesShape(t *testing.T) {
 }
 
 func TestBackfillOAuthConnections_RefreshOnlyChain(t *testing.T) {
+	t.Parallel()
 	s := newBackfillTestStore(t)
 	uid := seedBackfillUser(t, s, "refresh-only@example.com")
 	client := seedBackfillClient(t, s, "Refresh Client")
@@ -295,6 +302,7 @@ func TestBackfillOAuthConnections_RefreshOnlyChain(t *testing.T) {
 // session.Extra payload is frozen reference data, not a source of
 // truth the backfill keeps reconciling against.
 func TestBackfillOAuthConnections_DoesNotResurrectRemovedWorkspace(t *testing.T) {
+	t.Parallel()
 	s := newBackfillTestStore(t)
 	uid := seedBackfillUser(t, s, "resurrect@example.com")
 	client := seedBackfillClient(t, s, "Resurrect Client")
@@ -357,6 +365,7 @@ func TestBackfillOAuthConnections_DoesNotResurrectRemovedWorkspace(t *testing.T)
 // the test exercises the same rollback path any other error would
 // trigger (network glitch, FK violation, etc.).
 func TestBackfillOAuthConnections_AtomicOnMidLoopFailure(t *testing.T) {
+	t.Parallel()
 	s := newBackfillTestStore(t)
 	uid := seedBackfillUser(t, s, "atomic@example.com")
 	client := seedBackfillClient(t, s, "Atomic Client")
@@ -399,6 +408,7 @@ func TestBackfillOAuthConnections_AtomicOnMidLoopFailure(t *testing.T) {
 }
 
 func TestBackfillOAuthConnections_Idempotent(t *testing.T) {
+	t.Parallel()
 	s := newBackfillTestStore(t)
 	uid := seedBackfillUser(t, s, "idem@example.com")
 	client := seedBackfillClient(t, s, "Idem Client")

--- a/internal/store/oauth_connections_test.go
+++ b/internal/store/oauth_connections_test.go
@@ -63,6 +63,7 @@ func seedWorkspaceForConn(t *testing.T, s *Store, name string) (id, slug string)
 }
 
 func TestOAuthConnections_CreateGetRoundTrip(t *testing.T) {
+	t.Parallel()
 	s := newOAuthConnTestStore(t)
 	u, err := s.CreateUser(models.UserCreate{
 		Email: "conn-create@example.com", Name: "C", Password: "pw-create-12345",
@@ -98,6 +99,7 @@ func TestOAuthConnections_CreateGetRoundTrip(t *testing.T) {
 }
 
 func TestOAuthConnections_GetMissingReturnsSentinel(t *testing.T) {
+	t.Parallel()
 	s := newOAuthConnTestStore(t)
 	_, err := s.GetOAuthConnection("nope")
 	if !errors.Is(err, ErrOAuthConnectionNotFound) {
@@ -106,6 +108,7 @@ func TestOAuthConnections_GetMissingReturnsSentinel(t *testing.T) {
 }
 
 func TestOAuthConnectionAccess_NoRowFallsBack(t *testing.T) {
+	t.Parallel()
 	s := newOAuthConnTestStore(t)
 	got, err := s.GetOAuthConnectionAccess("never-existed")
 	if err != nil {
@@ -120,6 +123,7 @@ func TestOAuthConnectionAccess_NoRowFallsBack(t *testing.T) {
 }
 
 func TestOAuthConnectionAccess_WildcardSkipsJoin(t *testing.T) {
+	t.Parallel()
 	s := newOAuthConnTestStore(t)
 	u, _ := s.CreateUser(models.UserCreate{
 		Email: "wc@example.com", Name: "W", Password: "pw-wild-12345",
@@ -152,6 +156,7 @@ func TestOAuthConnectionAccess_WildcardSkipsJoin(t *testing.T) {
 }
 
 func TestOAuthConnectionAccess_ExplicitListReturnsSortedSlugs(t *testing.T) {
+	t.Parallel()
 	s := newOAuthConnTestStore(t)
 	u, _ := s.CreateUser(models.UserCreate{
 		Email: "ex@example.com", Name: "E", Password: "pw-exp-12345",
@@ -188,6 +193,7 @@ func TestOAuthConnectionAccess_ExplicitListReturnsSortedSlugs(t *testing.T) {
 }
 
 func TestOAuthConnections_AddWorkspaceIdempotent(t *testing.T) {
+	t.Parallel()
 	s := newOAuthConnTestStore(t)
 	u, _ := s.CreateUser(models.UserCreate{
 		Email: "idem@example.com", Name: "I", Password: "pw-idem-12345",
@@ -214,6 +220,7 @@ func TestOAuthConnections_AddWorkspaceIdempotent(t *testing.T) {
 }
 
 func TestOAuthConnections_RemoveWorkspaceIdempotent(t *testing.T) {
+	t.Parallel()
 	s := newOAuthConnTestStore(t)
 	u, _ := s.CreateUser(models.UserCreate{
 		Email: "rem@example.com", Name: "R", Password: "pw-rem-12345",
@@ -241,6 +248,7 @@ func TestOAuthConnections_RemoveWorkspaceIdempotent(t *testing.T) {
 }
 
 func TestOAuthConnections_RenameAndScopeFlagsRequireExistingRow(t *testing.T) {
+	t.Parallel()
 	s := newOAuthConnTestStore(t)
 	if err := s.RenameConnection("ghost", "anything"); !errors.Is(err, ErrOAuthConnectionNotFound) {
 		t.Errorf("Rename missing: got %v, want ErrOAuthConnectionNotFound", err)
@@ -251,6 +259,7 @@ func TestOAuthConnections_RenameAndScopeFlagsRequireExistingRow(t *testing.T) {
 }
 
 func TestOAuthConnections_RenameAndScopeFlagsTouchUpdatedAt(t *testing.T) {
+	t.Parallel()
 	s := newOAuthConnTestStore(t)
 	u, _ := s.CreateUser(models.UserCreate{
 		Email: "u@example.com", Name: "U", Password: "pw-upd-12345",
@@ -279,6 +288,7 @@ func TestOAuthConnections_RenameAndScopeFlagsTouchUpdatedAt(t *testing.T) {
 }
 
 func TestOAuthConnections_DeleteCascadesJoinTable(t *testing.T) {
+	t.Parallel()
 	s := newOAuthConnTestStore(t)
 	u, _ := s.CreateUser(models.UserCreate{
 		Email: "del@example.com", Name: "D", Password: "pw-del-12345",

--- a/internal/store/oauth_test.go
+++ b/internal/store/oauth_test.go
@@ -61,6 +61,7 @@ func newTestRequest(clientID, signature, requestID string) models.OAuthRequest {
 // ------------------------------------------------------------
 
 func TestOAuth_ClientCRUD(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	created, err := s.CreateOAuthClient(models.OAuthClientCreate{
@@ -102,6 +103,7 @@ func TestOAuth_ClientCRUD(t *testing.T) {
 }
 
 func TestOAuth_GetOAuthClient_NotFound(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	_, err := s.GetOAuthClient("does-not-exist")
 	if !errors.Is(err, ErrOAuthNotFound) {
@@ -117,6 +119,7 @@ func TestOAuth_GetOAuthClient_NotFound(t *testing.T) {
 // DELETE CASCADE on the migration) so its blast radius stays
 // obvious to future readers.
 func TestOAuth_DeleteOAuthClient_CascadesDependentRows(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	c := newTestClient(t, s)
 
@@ -161,6 +164,7 @@ func TestOAuth_DeleteOAuthClient_CascadesDependentRows(t *testing.T) {
 }
 
 func TestOAuth_DeleteOAuthClient_Idempotent(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	c := newTestClient(t, s)
 	if err := s.DeleteOAuthClient(c.ID); err != nil {
@@ -178,6 +182,7 @@ func TestOAuth_DeleteOAuthClient_Idempotent(t *testing.T) {
 }
 
 func TestOAuth_CreateClient_EmptySlicesNormalize(t *testing.T) {
+	t.Parallel()
 	// nil / empty slices must round-trip as empty (non-nil) so
 	// callers can range without nil-checking. Pinning this prevents
 	// a regression where Postgres's JSONB column returns null for
@@ -217,6 +222,7 @@ func TestOAuth_CreateClient_EmptySlicesNormalize(t *testing.T) {
 // ------------------------------------------------------------
 
 func TestOAuth_AuthorizationCode_CRUDAndInvalidate(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	c := newTestClient(t, s)
 
@@ -255,6 +261,7 @@ func TestOAuth_AuthorizationCode_CRUDAndInvalidate(t *testing.T) {
 }
 
 func TestOAuth_GetAuthorizationCode_NotFound(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	_, err := s.GetAuthorizationCode("nope")
 	if !errors.Is(err, ErrOAuthNotFound) {
@@ -263,6 +270,7 @@ func TestOAuth_GetAuthorizationCode_NotFound(t *testing.T) {
 }
 
 func TestOAuth_InvalidateAuthorizationCode_Idempotent(t *testing.T) {
+	t.Parallel()
 	// Invalidating an absent / already-invalid row must not error.
 	// fosite's contract is "make it invalid"; our store doesn't
 	// distinguish "wasn't there" from "was already invalid".
@@ -277,6 +285,7 @@ func TestOAuth_InvalidateAuthorizationCode_Idempotent(t *testing.T) {
 // ------------------------------------------------------------
 
 func TestOAuth_AccessToken_CRUDAndDelete(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	c := newTestClient(t, s)
 
@@ -307,6 +316,7 @@ func TestOAuth_AccessToken_CRUDAndDelete(t *testing.T) {
 // Verifies the count tracks insertions, ignores inactive rows, and
 // returns 0 when the table is empty.
 func TestOAuth_CountActiveOAuthAccessTokens(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	c := newTestClient(t, s)
 
@@ -356,6 +366,7 @@ func TestOAuth_CountActiveOAuthAccessTokens(t *testing.T) {
 // the original issuance time gives the right "lifetime of this grant"
 // signal.
 func TestOAuth_OldestAccessTokenIssuedAtByRequestID(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	c := newTestClient(t, s)
 
@@ -407,6 +418,7 @@ func TestOAuth_OldestAccessTokenIssuedAtByRequestID(t *testing.T) {
 // ------------------------------------------------------------
 
 func TestOAuth_RefreshToken_CRUD(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	c := newTestClient(t, s)
 
@@ -429,6 +441,7 @@ func TestOAuth_RefreshToken_CRUD(t *testing.T) {
 }
 
 func TestOAuth_RotateRefreshToken_RevokesEntireGrant(t *testing.T) {
+	t.Parallel()
 	// Per fosite's reference MemoryStore.RotateRefreshToken
 	// (storage/memory.go:497-504), rotation revokes BOTH the refresh
 	// family AND the access family for the grant's request_id, then
@@ -491,6 +504,7 @@ func TestOAuth_RotateRefreshToken_RevokesEntireGrant(t *testing.T) {
 }
 
 func TestOAuth_RevokeRefreshTokenFamily_RevokesEntireChain(t *testing.T) {
+	t.Parallel()
 	// The OAuth 2.1 BCP §4.14 "revoke the whole family on a replayed
 	// refresh" rule. fosite triggers this when GetRefreshToken on a
 	// previously-rotated (inactive) row signals replay.
@@ -531,6 +545,7 @@ func TestOAuth_RevokeRefreshTokenFamily_RevokesEntireChain(t *testing.T) {
 }
 
 func TestOAuth_RevokeAccessTokenFamily_RevokesEntireChain(t *testing.T) {
+	t.Parallel()
 	// Symmetric to RevokeRefreshTokenFamily — fosite revokes both
 	// access and refresh families when the user clicks "log out
 	// everywhere" or POSTs /oauth/revoke (sub-PR D).
@@ -561,6 +576,7 @@ func TestOAuth_RevokeAccessTokenFamily_RevokesEntireChain(t *testing.T) {
 // ------------------------------------------------------------
 
 func TestOAuth_PKCE_CRUD(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	c := newTestClient(t, s)
 
@@ -605,6 +621,7 @@ func TestOAuth_PKCE_CRUD(t *testing.T) {
 // readable as active. Without the fix, GetAccessToken would return
 // ErrOAuthInactiveToken here.
 func TestOAuth_Insert_AlwaysActive(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	c := newTestClient(t, s)
 
@@ -668,6 +685,7 @@ func TestOAuth_Insert_AlwaysActive(t *testing.T) {
 }
 
 func TestOAuth_Insert_RejectsEmptyRequiredFields(t *testing.T) {
+	t.Parallel()
 	// The store-level guards exist as defense in depth — fosite's
 	// adapter in sub-PR B will populate these fields, but the SQL
 	// schema's NOT NULL constraints would otherwise produce

--- a/internal/store/parent_link_concurrency_test.go
+++ b/internal/store/parent_link_concurrency_test.go
@@ -50,6 +50,7 @@ func countParentLinks(t *testing.T, s *Store, itemID string) int {
 //
 // The invariant asserted: for every pair, A->B and B->A must NEVER both exist.
 func TestSetParentLink_ConcurrentOpposingNoCycle(t *testing.T) {
+	t.Parallel()
 	requirePostgresForConcurrency(t)
 
 	s := testStore(t)
@@ -127,6 +128,7 @@ func TestSetParentLink_ConcurrentOpposingNoCycle(t *testing.T) {
 // re-reads the old parent under the child lock before detaching, so it always
 // detaches from (and holds the lock for) the child's real current parent.
 func TestSetParentLink_ConcurrentReparentSingleParent(t *testing.T) {
+	t.Parallel()
 	requirePostgresForConcurrency(t)
 
 	s := testStore(t)
@@ -223,6 +225,7 @@ func parentChainCycles(t *testing.T, s *Store, startID string, maxHops int) bool
 // Invariant asserted: after both goroutines finish, NO node's parent chain
 // forms a cycle, and the two closing edges never BOTH exist.
 func TestSetParentLink_ConcurrentNHopNoCycle(t *testing.T) {
+	t.Parallel()
 	requirePostgresForConcurrency(t)
 
 	s := testStore(t)
@@ -311,6 +314,7 @@ func TestSetParentLink_ConcurrentNHopNoCycle(t *testing.T) {
 // shared workspace cycle lock and CreateItemLink's own cycle check rejects the
 // loser, so A→B→C→D→A can't form across the two APIs.
 func TestCreateItemLink_ConcurrentNHopNoCycle(t *testing.T) {
+	t.Parallel()
 	requirePostgresForConcurrency(t)
 
 	s := testStore(t)
@@ -383,6 +387,7 @@ func TestCreateItemLink_ConcurrentNHopNoCycle(t *testing.T) {
 // and the cycle walk (which follows one arbitrary parent per source) could miss
 // a cycle. Dialect-agnostic: the invariant holds on SQLite and Postgres alike.
 func TestCreateItemLink_ParentSingleParentAndCycle(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")

--- a/internal/store/permissions_test.go
+++ b/internal/store/permissions_test.go
@@ -53,6 +53,7 @@ func setupPermissionTest(t *testing.T) (*Store, *models.Workspace, *models.User,
 }
 
 func TestVisibleCollectionIDs_AllAccess(t *testing.T) {
+	t.Parallel()
 	s, ws, _, member := setupPermissionTest(t)
 
 	// Default: member has "all" access
@@ -66,6 +67,7 @@ func TestVisibleCollectionIDs_AllAccess(t *testing.T) {
 }
 
 func TestVisibleCollectionIDs_SpecificAccess(t *testing.T) {
+	t.Parallel()
 	s, ws, _, member := setupPermissionTest(t)
 
 	// Get collection IDs
@@ -109,6 +111,7 @@ func TestVisibleCollectionIDs_SpecificAccess(t *testing.T) {
 }
 
 func TestVisibleCollectionIDs_SystemCollectionsAlwaysVisible(t *testing.T) {
+	t.Parallel()
 	s, ws, _, member := setupPermissionTest(t)
 
 	colls, _ := s.ListCollections(ws.ID)
@@ -142,6 +145,7 @@ func TestVisibleCollectionIDs_SystemCollectionsAlwaysVisible(t *testing.T) {
 }
 
 func TestVisibleCollectionIDs_NonMember(t *testing.T) {
+	t.Parallel()
 	s, ws, _, _ := setupPermissionTest(t)
 
 	// Create a user who is NOT a member
@@ -161,6 +165,7 @@ func TestVisibleCollectionIDs_NonMember(t *testing.T) {
 }
 
 func TestSetMemberCollectionAccess_ReplaceGrants(t *testing.T) {
+	t.Parallel()
 	s, ws, _, member := setupPermissionTest(t)
 
 	colls, _ := s.ListCollections(ws.ID)
@@ -192,6 +197,7 @@ func TestSetMemberCollectionAccess_ReplaceGrants(t *testing.T) {
 }
 
 func TestSetMemberCollectionAccess_BackToAll(t *testing.T) {
+	t.Parallel()
 	s, ws, _, member := setupPermissionTest(t)
 
 	colls, _ := s.ListCollections(ws.ID)
@@ -233,6 +239,7 @@ func TestSetMemberCollectionAccess_BackToAll(t *testing.T) {
 }
 
 func TestListItems_FilteredByCollectionIDs(t *testing.T) {
+	t.Parallel()
 	s, ws, _, _ := setupPermissionTest(t)
 
 	colls, _ := s.ListCollections(ws.ID)
@@ -283,6 +290,7 @@ func TestListItems_FilteredByCollectionIDs(t *testing.T) {
 }
 
 func TestCollectionAccess_DefaultIsAll(t *testing.T) {
+	t.Parallel()
 	s, ws, _, member := setupPermissionTest(t)
 
 	m, err := s.GetWorkspaceMember(ws.ID, member.ID)
@@ -295,6 +303,7 @@ func TestCollectionAccess_DefaultIsAll(t *testing.T) {
 }
 
 func TestIsSystemCollection(t *testing.T) {
+	t.Parallel()
 	s, ws, _, _ := setupPermissionTest(t)
 
 	colls, _ := s.ListCollections(ws.ID)

--- a/internal/store/relation_referents_test.go
+++ b/internal/store/relation_referents_test.go
@@ -49,6 +49,7 @@ func relationFixture(t *testing.T, s *Store) (*models.Workspace, *models.Collect
 }
 
 func TestResolveRelationReferents_AcceptsIDAndRefAndCanonicalises(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws, _, _, red := relationFixture(t, s)
 
@@ -71,6 +72,7 @@ func TestResolveRelationReferents_AcceptsIDAndRefAndCanonicalises(t *testing.T) 
 }
 
 func TestResolveRelationReferents_RejectsUnresolvableValues(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws, _, cars, _ := relationFixture(t, s)
 	// A live item in the WRONG collection, and a live item in ANOTHER
@@ -138,6 +140,7 @@ func TestResolveRelationReferents_RejectsUnresolvableValues(t *testing.T) {
 }
 
 func TestResolveRelationReferents_LeavesNonWritesAlone(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws, _, _, _ := relationFixture(t, s)
 
@@ -167,6 +170,7 @@ func TestResolveRelationReferents_LeavesNonWritesAlone(t *testing.T) {
 }
 
 func TestResolveRelationReferents_SoftDeletedTargetDoesNotResolve(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws, colors, _, _ := relationFixture(t, s)
 	gone := createTestItem(t, s, ws.ID, colors.ID, "Retired Blue", "")
@@ -189,6 +193,7 @@ func TestResolveRelationReferents_SoftDeletedTargetDoesNotResolve(t *testing.T) 
 }
 
 func TestResolveRelationReferents_TargetCollectionProblems(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws, _, _, red := relationFixture(t, s)
 
@@ -218,6 +223,7 @@ func TestResolveRelationReferents_TargetCollectionProblems(t *testing.T) {
 }
 
 func TestResolveRelationReferents_IsDeterministicAndBatched(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws, _, _, _ := relationFixture(t, s)
 	// Two relation fields, both broken, both aimed at the same collection.
@@ -256,6 +262,7 @@ func TestResolveRelationReferents_IsDeterministicAndBatched(t *testing.T) {
 // --- Migrate doors (PLAN-2857 U1, lead ruling: provenance, not door) ---
 
 func TestMigrateRelationReferents_SameWorkspaceKeepsWhatResolves(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws, _, _, red := relationFixture(t, s)
 
@@ -276,6 +283,7 @@ func TestMigrateRelationReferents_SameWorkspaceKeepsWhatResolves(t *testing.T) {
 }
 
 func TestMigrateRelationReferents_SameWorkspaceDropsWhatDoesNot(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws, _, _, _ := relationFixture(t, s)
 
@@ -302,6 +310,7 @@ func TestMigrateRelationReferents_SameWorkspaceDropsWhatDoesNot(t *testing.T) {
 }
 
 func TestMigrateRelationReferents_CrossWorkspaceDropsEveryCarriedRelation(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws, _, _, red := relationFixture(t, s)
 
@@ -326,6 +335,7 @@ func TestMigrateRelationReferents_CrossWorkspaceDropsEveryCarriedRelation(t *tes
 }
 
 func TestMigrateRelationReferents_SuppliedOverrideRefusesOnEitherMode(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws, _, _, red := relationFixture(t, s)
 
@@ -390,6 +400,7 @@ func carriedFrom(fields map[string]any) map[string]any {
 // corruption this whole unit exists to stop, reached through the parser rather
 // than through the lookup.
 func TestResolveRelationReferents_OverflowingRefDoesNotResolve(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws, _, _, red := relationFixture(t, s)
 
@@ -436,6 +447,7 @@ func TestResolveRelationReferents_OverflowingRefDoesNotResolve(t *testing.T) {
 // byte-identical output for the junk rows. The control is the only leg whose
 // expected output DIFFERS from its input.
 func TestImportWorkspace_CarriesUnresolvableRelationValues(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	owner, err := s.CreateUser(models.UserCreate{
 		Name:     "Owner",
@@ -588,6 +600,7 @@ func TestImportWorkspace_CarriesUnresolvableRelationValues(t *testing.T) {
 // assertion could not fail for this reason — which is how the defect went
 // unexamined: the fixture was engineered around it instead of at it.
 func TestImportWorkspace_UnresolvableRelationValueSurvivesAPrefixCollision(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	owner, err := s.CreateUser(models.UserCreate{
 		Name: "Owner", Email: "prefix-collision-owner@example.com", Password: "passw0rd!",

--- a/internal/store/reminder_workspace_constraint_test.go
+++ b/internal/store/reminder_workspace_constraint_test.go
@@ -43,6 +43,7 @@ func reminderConstraintFixture(t *testing.T, s *Store) (item *models.Item, ownWo
 // forbid — testing through it would assert that a correct writer writes
 // correctly, which is the thing already true before the migration.
 func TestReminderWorkspaceMustMatchItem(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	item, own, other := reminderConstraintFixture(t, s)
 	ts := now()
@@ -72,6 +73,7 @@ func TestReminderWorkspaceMustMatchItem(t *testing.T) {
 // can drop ON DELETE CASCADE without anything else noticing, and a reminder
 // for a deleted item is a notification nobody can act on (085's rationale).
 func TestReminderCascadeSurvivesTheCompositeKey(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	item, own, _ := reminderConstraintFixture(t, s)
 
@@ -114,6 +116,7 @@ func TestReminderCascadeSurvivesTheCompositeKey(t *testing.T) {
 // against the real items table. The one hand-written piece is the pre-086
 // item_reminders shape, copied from 085.
 func TestMigration086DropsPreExistingDisagreeingRows(t *testing.T) {
+	t.Parallel()
 	if os.Getenv("PAD_TEST_POSTGRES_URL") != "" {
 		t.Skip("SQLite rebuild path; the Postgres half of 086 is a DELETE + ADD CONSTRAINT")
 	}
@@ -235,6 +238,7 @@ func TestMigration086DropsPreExistingDisagreeingRows(t *testing.T) {
 // both, and the untested half is the one that would fail a deployment's
 // startup.
 func TestMigration063DropsPreExistingDisagreeingRows(t *testing.T) {
+	t.Parallel()
 	if os.Getenv("PAD_TEST_POSTGRES_URL") == "" {
 		t.Skip("Postgres half of IDEA-2883; the SQLite rebuild has its own test")
 	}
@@ -323,6 +327,7 @@ func TestMigration063DropsPreExistingDisagreeingRows(t *testing.T) {
 // handle a case no other test reaches, and an untested branch that only runs
 // on a database nobody has is worse than no branch at all.
 func TestMigration063DropsEveryLegacyItemIdConstraint(t *testing.T) {
+	t.Parallel()
 	if os.Getenv("PAD_TEST_POSTGRES_URL") == "" {
 		t.Skip("Postgres-only: the DO block has no SQLite counterpart (the rebuild replaces the FK wholesale)")
 	}

--- a/internal/store/reminders_pg_test.go
+++ b/internal/store/reminders_pg_test.go
@@ -56,6 +56,7 @@ func firePathPGStore(t *testing.T) (*Store, string, string, string) {
 }
 
 func TestFireOneReminderBlocksOnAnArchivingWorkspace(t *testing.T) {
+	t.Parallel()
 	s, wsID, _, id := firePathPGStore(t)
 
 	tx, err := s.db.Begin()
@@ -96,6 +97,7 @@ func TestFireOneReminderBlocksOnAnArchivingWorkspace(t *testing.T) {
 }
 
 func TestFireOneReminderBlocksOnAnArchivingItem(t *testing.T) {
+	t.Parallel()
 	s, wsID, itemID, id := firePathPGStore(t)
 
 	tx, err := s.db.Begin()

--- a/internal/store/reminders_test.go
+++ b/internal/store/reminders_test.go
@@ -50,6 +50,7 @@ func nowTS() string { return time.Now().UTC().Format(time.RFC3339) }
 // future reminder and not the past one — both halves of this test go red, and
 // asserting only on the fired one would have let the flip through.
 func TestFireDueRemindersFiresOnlyArrivedReminders(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -96,6 +97,7 @@ func TestFireDueRemindersFiresOnlyArrivedReminders(t *testing.T) {
 // leaves fired_at set with no event — the reminder is retired and nobody is
 // ever told, which is the silent failure this test exists to make loud.
 func TestFireDueRemindersWritesOutboxEvent(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -154,6 +156,7 @@ func TestFireDueRemindersWritesOutboxEvent(t *testing.T) {
 // MUTANT: dropping `AND fired_at IS NULL` from the fire UPDATE makes the
 // second tick re-fire and write a second event.
 func TestFireDueRemindersIsIdempotentAcrossTicks(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -191,6 +194,7 @@ func TestFireDueRemindersIsIdempotentAcrossTicks(t *testing.T) {
 // MUTANT: dropping the RowsAffected check makes the loser return a reminder
 // and emit a duplicate event.
 func TestFireOneReminderArbitratesAStaleCandidate(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -229,6 +233,7 @@ func TestFireOneReminderArbitratesAStaleCandidate(t *testing.T) {
 // acknowledged — a state the lifecycle has no name for, and one that would
 // make the reminder invisible on the poll surface after it fires again.
 func TestRearmClearsBothFireMarks(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -284,6 +289,7 @@ func TestRearmClearsBothFireMarks(t *testing.T) {
 // MUTANT: dropping `AND fired_at IS NOT NULL` from the ack UPDATE makes the
 // first assertion pass an acked-but-never-fired row.
 func TestAckRequiresAFiredReminder(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -355,6 +361,7 @@ func TestAckRequiresAFiredReminder(t *testing.T) {
 // MUTANT: dropping `i.workspace_id = ?` from the INSERT's SELECT accepts the
 // row and both halves of this test fail.
 func TestCreateReminderRefusesAnotherWorkspacesItem(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	wsA := createTestWorkspace(t, s, "A")
 	wsB := createTestWorkspace(t, s, "B")
@@ -388,6 +395,7 @@ func TestCreateReminderRefusesAnotherWorkspacesItem(t *testing.T) {
 //
 // MUTANT: dropping `i.deleted_at IS NULL` from the INSERT accepts it.
 func TestCreateReminderRefusesASoftDeletedItem(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -412,6 +420,7 @@ func TestCreateReminderRefusesASoftDeletedItem(t *testing.T) {
 // surface forever; dropping `fired_at IS NOT NULL` shows a reminder before its
 // time.
 func TestPendingRemindersAreFiredAndUnacked(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -458,6 +467,7 @@ func TestPendingRemindersAreFiredAndUnacked(t *testing.T) {
 // the lexicographic comparison then fires it against an RFC3339 clock string
 // at a moment nobody chose.
 func TestReminderRejectsANonInstant(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -485,6 +495,7 @@ func TestReminderRejectsANonInstant(t *testing.T) {
 // reminder then fires nine hours late — a silent, timezone-shaped error with
 // nothing in the row to show why.
 func TestReminderNormalizesToUTC(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -504,6 +515,7 @@ func TestReminderNormalizesToUTC(t *testing.T) {
 //
 // MUTANT: dropping `AND workspace_id = ?` returns the other workspace's row.
 func TestGetReminderIsWorkspaceScoped(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	wsA := createTestWorkspace(t, s, "A")
 	wsB := createTestWorkspace(t, s, "B")
@@ -524,6 +536,7 @@ func TestGetReminderIsWorkspaceScoped(t *testing.T) {
 // nothing to say; the FK is what makes that structural rather than a cleanup
 // job somebody has to remember to write.
 func TestReminderCascadesWithItsItem(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -559,6 +572,7 @@ func TestReminderCascadesWithItsItem(t *testing.T) {
 // MUTANT: dropping `AND i.deleted_at IS NULL` from the candidate query starves
 // the live reminder and this fails.
 func TestSoftDeletedItemsDoNotOccupyTheBatch(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -611,6 +625,7 @@ func TestSoftDeletedItemsDoNotOccupyTheBatch(t *testing.T) {
 //
 // MUTANT: `continue` back to `return fired, err` and the third id never runs.
 func TestOneBrokenReminderDoesNotBlockTheRest(t *testing.T) {
+	t.Parallel()
 	var attempted []string
 	fired, err := fireEachReminder([]string{"a", "b", "c"}, nowTS(),
 		func(id, _ string) (*models.Reminder, error) {
@@ -638,6 +653,7 @@ func TestOneBrokenReminderDoesNotBlockTheRest(t *testing.T) {
 // TestEveryReminderFailingIsStillReported is the negative control for the
 // aggregation: with nothing fired, the error is the only signal there was one.
 func TestEveryReminderFailingIsStillReported(t *testing.T) {
+	t.Parallel()
 	fired, err := fireEachReminder([]string{"a", "b"}, nowTS(),
 		func(string, string) (*models.Reminder, error) { return nil, errors.New("boom") })
 	if len(fired) != 0 {
@@ -653,6 +669,7 @@ func TestEveryReminderFailingIsStillReported(t *testing.T) {
 // reporting the loser as an error would make every multi-instance tick log
 // spurious failures.
 func TestSkippedRemindersAreNotErrors(t *testing.T) {
+	t.Parallel()
 	fired, err := fireEachReminder([]string{"a", "b"}, nowTS(),
 		func(id, _ string) (*models.Reminder, error) {
 			if id == "a" {
@@ -679,6 +696,7 @@ func TestSkippedRemindersAreNotErrors(t *testing.T) {
 // MUTANT: replace NormalizeInstant's round-up with Truncate and the first case
 // stores ...00Z.
 func TestFractionalSecondsRoundUp(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -708,6 +726,7 @@ func TestFractionalSecondsRoundUp(t *testing.T) {
 // STRING being right is only interesting because of what the tick does with
 // it. Asserting the column alone would not catch a comparison that ignored it.
 func TestAFractionalReminderDoesNotFireEarly(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -749,6 +768,7 @@ func TestAFractionalReminderDoesNotFireEarly(t *testing.T) {
 //
 // MUTANT: drop `AND remind_at <= ?` from the fire UPDATE and this fires.
 func TestARearmedReminderIsNotFiredByAnInFlightPass(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -804,6 +824,7 @@ func TestARearmedReminderIsNotFiredByAnInFlightPass(t *testing.T) {
 // MUTANT: remove the LIMIT and both the window and the truncation flag are
 // wrong.
 func TestPendingRemindersAreBounded(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -864,6 +885,7 @@ func TestPendingRemindersAreBounded(t *testing.T) {
 //
 // MUTANT: delete the guard and this returns every pending reminder.
 func TestEmptyScopeSeesNothing(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -912,6 +934,7 @@ func TestEmptyScopeSeesNothing(t *testing.T) {
 // MUTANT: drop `AND w.deleted_at IS NULL` from the candidate query and the
 // deleted workspace's reminder fires.
 func TestSoftDeletedWorkspacesDoNotFire(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	live := createTestWorkspace(t, s, "Live")
 	gone := createTestWorkspace(t, s, "Gone")
@@ -969,6 +992,7 @@ func TestSoftDeletedWorkspacesDoNotFire(t *testing.T) {
 // query rather than a user-visible symptom — the same reason the fire-side
 // filter is not enough on its own.
 func TestPendingRemindersHideASoftDeletedWorkspace(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Gone")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -1014,6 +1038,7 @@ func TestPendingRemindersHideASoftDeletedWorkspace(t *testing.T) {
 // MUTANT: drop the reminder block from either ExportWorkspace or
 // ImportWorkspace and this fails.
 func TestRemindersRoundTripThroughExport(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	owner := createTestUser(t, s, "reminder-export@test.com", "Export Owner", "password123")
 	src := createTestWorkspace(t, s, "Reminder Export")
@@ -1099,6 +1124,7 @@ func TestRemindersRoundTripThroughExport(t *testing.T) {
 // mark, the instant, or either half of reminderFireable — and the
 // corresponding row fails while the others stay green.
 func TestFirePathInvariant(t *testing.T) {
+	t.Parallel()
 	for _, tc := range []struct {
 		name string
 		// invalidate makes the scanned candidate no longer fireable, standing
@@ -1183,6 +1209,7 @@ func TestFirePathInvariant(t *testing.T) {
 // control. Every case above asserts that nothing happens, so all four would
 // pass against a build that never fires anything at all.
 func TestFirePathInvariantFiresWhenNothingChanged(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Invariant")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -1224,6 +1251,7 @@ func TestFirePathInvariantFiresWhenNothingChanged(t *testing.T) {
 //
 // MUTANT: scan into a plain int and this fails.
 func TestPendingRemindersSurviveALegacyItemNumber(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Legacy")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -1269,6 +1297,7 @@ func TestPendingRemindersSurviveALegacyItemNumber(t *testing.T) {
 //
 // MUTANT: drop the JOIN's deleted_at filter and the export carries 2.
 func TestExportSkipsRemindersForSoftDeletedItems(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	src := createTestWorkspace(t, s, "Partial")
 	col := createTestCollection(t, s, src.ID, "Tasks")
@@ -1304,6 +1333,7 @@ func TestExportSkipsRemindersForSoftDeletedItems(t *testing.T) {
 // MUTANT: insert rm.RemindAt instead of the normalized value and the offset
 // value is stored verbatim.
 func TestImportNormalizesRemindAt(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	owner := createTestUser(t, s, "import-norm@test.com", "Import Norm", "password123")
 	src := createTestWorkspace(t, s, "Import Norm")
@@ -1365,6 +1395,7 @@ func TestImportNormalizesRemindAt(t *testing.T) {
 // MUTANT: gate on `itemMap[...] != ""` instead of insertedItems, or restore
 // the fatal return, and the import fails.
 func TestOrphanedItemDoesNotAbortTheImport(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	owner := createTestUser(t, s, "orphan-import@test.com", "Orphan Import", "password123")
 	src := createTestWorkspace(t, s, "Orphan Source")
@@ -1424,6 +1455,7 @@ func TestOrphanedItemDoesNotAbortTheImport(t *testing.T) {
 // MUTANT: assign ackedAt unconditionally and the imported row comes back
 // neither armed nor pending.
 func TestImportRefusesAckWithoutFire(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	owner := createTestUser(t, s, "ackfire@test.com", "Ack Fire", "password123")
 	src := createTestWorkspace(t, s, "Ack Fire")
@@ -1491,6 +1523,7 @@ func TestImportRefusesAckWithoutFire(t *testing.T) {
 // there; dropping reminderOwned from GetReminder or ListRemindersForItem
 // surfaces it through B. Each site has its own assertion below.
 func TestAReminderWhoseWorkspaceDisagreesWithItsItemIsInert(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	wsA := createTestWorkspace(t, s, "A")
 	wsB := createTestWorkspace(t, s, "B")

--- a/internal/store/report_layouts_test.go
+++ b/internal/store/report_layouts_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestReportLayout_SaveGetUpsert(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u, err := s.CreateUser(models.UserCreate{Name: "Lay", Email: "lay@example.com"})
 	if err != nil {
@@ -65,6 +66,7 @@ func TestReportLayout_SaveGetUpsert(t *testing.T) {
 }
 
 func TestReportLayout_IsolatedPerUserAndWorkspace(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	a, _ := s.CreateUser(models.UserCreate{Name: "A", Email: "a@example.com"})
 	b, _ := s.CreateUser(models.UserCreate{Name: "B", Email: "b@example.com"})

--- a/internal/store/reports_test.go
+++ b/internal/store/reports_test.go
@@ -28,6 +28,7 @@ func collCount(list []ReportCollectionCount, slug string) int {
 }
 
 func TestGetReport_ThroughputAndTotals(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	wsID, colID := newTransitionTestWorkspace(t, s)
 
@@ -73,6 +74,7 @@ func TestGetReport_ThroughputAndTotals(t *testing.T) {
 }
 
 func TestGetReport_NegativeTerminalNotCompleted(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	wsID, colID := newTransitionTestWorkspace(t, s)
 	item := createTestItem(t, s, wsID, colID, "Doomed idea", "")
@@ -96,6 +98,7 @@ func TestGetReport_NegativeTerminalNotCompleted(t *testing.T) {
 }
 
 func TestGetReport_StatusDistribution(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	wsID, colID := newTransitionTestWorkspace(t, s)
 	createTestItem(t, s, wsID, colID, "open1", "")
@@ -121,6 +124,7 @@ func TestGetReport_StatusDistribution(t *testing.T) {
 }
 
 func TestGetReport_CollectionFilter(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	wsID, tasksID := newTransitionTestWorkspace(t, s)
 	bugs := createTestCollection(t, s, wsID, "Bugs")
@@ -141,6 +145,7 @@ func TestGetReport_CollectionFilter(t *testing.T) {
 }
 
 func TestGetReport_SoftDeletedExcludedFromCompleted(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	wsID, colID := newTransitionTestWorkspace(t, s)
 	item := createTestItem(t, s, wsID, colID, "ship then delete", "")
@@ -170,6 +175,7 @@ func TestGetReport_SoftDeletedExcludedFromCompleted(t *testing.T) {
 }
 
 func TestGetReport_ScopeToVisibleExcludesHidden(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	wsID, tasksID := newTransitionTestWorkspace(t, s)
 	secret := createTestCollection(t, s, wsID, "Secret")
@@ -204,6 +210,7 @@ func TestGetReport_ScopeToVisibleExcludesHidden(t *testing.T) {
 }
 
 func TestGetReport_NonStatusDoneField(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u, _ := s.CreateUser(models.UserCreate{Name: "H", Email: "h@example.com"})
 	ws, _ := s.CreateWorkspace(models.WorkspaceCreate{Name: "Hiring", Slug: "hiring", OwnerID: u.ID})
@@ -236,6 +243,7 @@ func TestGetReport_NonStatusDoneField(t *testing.T) {
 }
 
 func TestGetReport_ExcludesOutOfWindow(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	wsID, colID := newTransitionTestWorkspace(t, s)
 	old := createTestItem(t, s, wsID, colID, "ancient", "")
@@ -256,6 +264,7 @@ func TestGetReport_ExcludesOutOfWindow(t *testing.T) {
 }
 
 func TestGetReport_DayWindowBucketsByHour(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	wsID, _ := newTransitionTestWorkspace(t, s)
 	rep, err := s.GetReport(wsID, ReportOptions{Window: "day", Now: time.Now().UTC()})
@@ -280,6 +289,7 @@ func backdateItem(t *testing.T, s *Store, itemID string, hoursAgo float64) {
 }
 
 func TestGetReport_CycleTime(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	wsID, colID := newTransitionTestWorkspace(t, s)
 	item := createTestItem(t, s, wsID, colID, "slow task", "")
@@ -304,6 +314,7 @@ func TestGetReport_CycleTime(t *testing.T) {
 }
 
 func TestGetReport_WIPAndAging(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	wsID, colID := newTransitionTestWorkspace(t, s)
 	a := createTestItem(t, s, wsID, colID, "old open", "")
@@ -344,6 +355,7 @@ func collDurMedian(list []ReportDuration, slug string) float64 {
 }
 
 func TestPercentile(t *testing.T) {
+	t.Parallel()
 	if got := percentile(nil, 0.5); got != 0 {
 		t.Errorf("empty percentile = %v, want 0", got)
 	}
@@ -360,6 +372,7 @@ func TestPercentile(t *testing.T) {
 }
 
 func TestGetReport_EmptyScopeWellFormedJSON(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	wsID, _ := newTransitionTestWorkspace(t, s)
 	// Empty visible set → no collections in scope (early-return path).
@@ -383,6 +396,7 @@ func TestGetReport_EmptyScopeWellFormedJSON(t *testing.T) {
 }
 
 func TestGetReport_OffsetShiftsWindow(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	wsID, colID := newTransitionTestWorkspace(t, s)
 	createTestItem(t, s, wsID, colID, "recent", "") // created ~now
@@ -422,6 +436,7 @@ func TestGetReport_OffsetShiftsWindow(t *testing.T) {
 }
 
 func TestReportSnapshotAsOf(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	wsID, colID := newTransitionTestWorkspace(t, s) // tasks; "done" is a default terminal
 	item := createTestItem(t, s, wsID, colID, "historical", "")
@@ -514,6 +529,7 @@ func TestReportSnapshotAsOf(t *testing.T) {
 }
 
 func TestGetReport_CompletedItems(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	wsID, colID := newTransitionTestWorkspace(t, s)
 	a := createTestItem(t, s, wsID, colID, "Ship A", "")
@@ -569,6 +585,7 @@ func TestGetReport_CompletedItems(t *testing.T) {
 }
 
 func TestGetReport_CompletedItemsRespectsCurrentCollectionVisibility(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u, _ := s.CreateUser(models.UserCreate{Name: "V", Email: "v@example.com"})
 	ws, _ := s.CreateWorkspace(models.WorkspaceCreate{Name: "Vis", Slug: "vis", OwnerID: u.ID})
@@ -611,6 +628,7 @@ func TestGetReport_CompletedItemsRespectsCurrentCollectionVisibility(t *testing.
 }
 
 func TestReportSnapshotAsOf_SameSecondSeqTiebreak(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	wsID, colID := newTransitionTestWorkspace(t, s)
 	item := createTestItem(t, s, wsID, colID, "flipper", "")
@@ -651,6 +669,7 @@ func TestReportSnapshotAsOf_SameSecondSeqTiebreak(t *testing.T) {
 }
 
 func TestBackfillStatusTransitions_SeedSeqBelowHop(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	wsID, colID := newTransitionTestWorkspace(t, s)
 	item := createTestItem(t, s, wsID, colID, "create-and-change", "")
@@ -699,6 +718,7 @@ func TestBackfillStatusTransitions_SeedSeqBelowHop(t *testing.T) {
 }
 
 func TestGetReport_DisabledConventionNotCompleted(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u, err := s.CreateUser(models.UserCreate{Name: "C", Email: "c@example.com"})
 	if err != nil {

--- a/internal/store/search_quality_test.go
+++ b/internal/store/search_quality_test.go
@@ -13,6 +13,7 @@ import (
 // runs the same queries against each, and reports ranking differences.
 // This test requires PAD_TEST_POSTGRES_URL to be set — otherwise it skips.
 func TestSearchQualityComparison(t *testing.T) {
+	t.Parallel()
 	pgURL := os.Getenv("PAD_TEST_POSTGRES_URL")
 	if pgURL == "" {
 		t.Skip("PAD_TEST_POSTGRES_URL not set — skipping search quality comparison")
@@ -189,6 +190,7 @@ func containsTitle(results []ItemSearchResult, title string, topN int) bool {
 
 // TestSearchEdgeCases tests tricky search scenarios on both backends.
 func TestSearchEdgeCases(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	ws := createTestWorkspace(t, s, "search-edge")

--- a/internal/store/sessions_test.go
+++ b/internal/store/sessions_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestSessionCreateAndValidate(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u := createTestUser(t, s, "test@test.com", "Test", "password123")
 
@@ -50,6 +51,7 @@ func TestSessionCreateAndValidate(t *testing.T) {
 }
 
 func TestSessionInvalidToken(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	session, err := s.ValidateSession("padsess_invalidtoken")
@@ -62,6 +64,7 @@ func TestSessionInvalidToken(t *testing.T) {
 }
 
 func TestSessionExpired(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u := createTestUser(t, s, "test@test.com", "Test", "password123")
 
@@ -82,6 +85,7 @@ func TestSessionExpired(t *testing.T) {
 }
 
 func TestSessionDelete(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u := createTestUser(t, s, "test@test.com", "Test", "password123")
 
@@ -101,6 +105,7 @@ func TestSessionDelete(t *testing.T) {
 }
 
 func TestDeleteUserSessions(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u := createTestUser(t, s, "test@test.com", "Test", "password123")
 
@@ -122,6 +127,7 @@ func TestDeleteUserSessions(t *testing.T) {
 }
 
 func TestCleanExpiredSessions(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u := createTestUser(t, s, "test@test.com", "Test", "password123")
 
@@ -143,6 +149,7 @@ func TestCleanExpiredSessions(t *testing.T) {
 }
 
 func TestSessionBindingMetadata(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u := createTestUser(t, s, "test@test.com", "Test", "password123")
 
@@ -174,6 +181,7 @@ func TestSessionBindingMetadata(t *testing.T) {
 }
 
 func TestWorkspaceMemberCRUD(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test Workspace")
 	u := createTestUser(t, s, "test@test.com", "Test User", "password123")
@@ -241,6 +249,7 @@ func TestWorkspaceMemberCRUD(t *testing.T) {
 }
 
 func TestGetUserWorkspaces(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws1 := createTestWorkspace(t, s, "Workspace A")
 	ws2 := createTestWorkspace(t, s, "Workspace B")
@@ -261,6 +270,7 @@ func TestGetUserWorkspaces(t *testing.T) {
 }
 
 func TestWorkspaceMemberNotFound(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 
@@ -281,6 +291,7 @@ func TestWorkspaceMemberNotFound(t *testing.T) {
 // Ensure createTestUser helper is usable from other test files
 // by verifying it works correctly with the workspace member pattern
 func TestCreateTestUserHelper(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u := createTestUser(t, s, "helper@test.com", "Helper", "pass")
 
@@ -324,6 +335,7 @@ func setSessionTimes(t *testing.T, s *Store, userID string, expiresAt, createdAt
 }
 
 func TestRenewSessionExtendsWhenStale(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u := createTestUser(t, s, "renew@test.com", "Renew", "password123")
 
@@ -353,6 +365,7 @@ func TestRenewSessionExtendsWhenStale(t *testing.T) {
 }
 
 func TestRenewSessionSkipsWhenFresh(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u := createTestUser(t, s, "fresh@test.com", "Fresh", "password123")
 
@@ -372,6 +385,7 @@ func TestRenewSessionSkipsWhenFresh(t *testing.T) {
 }
 
 func TestRenewSessionRespectsMaxLifetime(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u := createTestUser(t, s, "cap@test.com", "Cap", "password123")
 
@@ -399,6 +413,7 @@ func TestRenewSessionRespectsMaxLifetime(t *testing.T) {
 }
 
 func TestRenewSessionLegacyZeroTTLNotRenewed(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u := createTestUser(t, s, "legacy@test.com", "Legacy", "password123")
 

--- a/internal/store/status_transitions_test.go
+++ b/internal/store/status_transitions_test.go
@@ -60,6 +60,7 @@ func newTransitionTestWorkspace(t *testing.T, s *Store) (workspaceID, collection
 }
 
 func TestStatusTransition_CapturedOnStatusChange(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	wsID, colID := newTransitionTestWorkspace(t, s)
 	item := createTestItem(t, s, wsID, colID, "Do a thing", "")
@@ -85,6 +86,7 @@ func TestStatusTransition_CapturedOnStatusChange(t *testing.T) {
 }
 
 func TestStatusTransition_MultiHopEachRecorded(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	wsID, colID := newTransitionTestWorkspace(t, s)
 	item := createTestItem(t, s, wsID, colID, "Multi", "")
@@ -115,6 +117,7 @@ func TestStatusTransition_MultiHopEachRecorded(t *testing.T) {
 }
 
 func TestStatusTransition_NoHopWhenStatusUnchanged(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	wsID, colID := newTransitionTestWorkspace(t, s)
 	item := createTestItem(t, s, wsID, colID, "Title only", "")
@@ -136,6 +139,7 @@ func TestStatusTransition_NoHopWhenStatusUnchanged(t *testing.T) {
 // Finding 2: every created item gets a create-time "entered initial status"
 // seed row so it has an "entered status" timestamp.
 func TestStatusTransition_CreateSeed(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	wsID, colID := newTransitionTestWorkspace(t, s)
 	item := createTestItem(t, s, wsID, colID, "Fresh", "") // status defaults to open
@@ -156,6 +160,7 @@ func TestStatusTransition_CreateSeed(t *testing.T) {
 // Finding 2: an item created directly in a terminal value must still get a
 // create-seed row so reports can count it as a completion.
 func TestStatusTransition_CreateInTerminalStatus(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	wsID, colID := newTransitionTestWorkspace(t, s)
 	item, err := s.CreateItem(wsID, colID, models.ItemCreate{Title: "Born done", Fields: `{"status":"done"}`})
@@ -172,6 +177,7 @@ func TestStatusTransition_CreateInTerminalStatus(t *testing.T) {
 // Finding 1: collections that designate a non-status select field as their
 // done field (BoardGroupBy) must record transitions on THAT field.
 func TestStatusTransition_NonStatusDoneField(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u, err := s.CreateUser(models.UserCreate{Name: "Hank", Email: "hank@example.com"})
 	if err != nil {
@@ -213,6 +219,7 @@ func TestStatusTransition_NonStatusDoneField(t *testing.T) {
 }
 
 func TestStatusTransition_CapturedOnMoveWithStatusOverride(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	wsID, srcColID := newTransitionTestWorkspace(t, s)
 	dstCol := createTestCollection(t, s, wsID, "Done Bucket")
@@ -239,6 +246,7 @@ func TestStatusTransition_CapturedOnMoveWithStatusOverride(t *testing.T) {
 }
 
 func TestStatusTransition_NoHopOnMoveWithoutStatusChange(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	wsID, srcColID := newTransitionTestWorkspace(t, s)
 	dstCol := createTestCollection(t, s, wsID, "Other Bucket")
@@ -256,6 +264,7 @@ func TestStatusTransition_NoHopOnMoveWithoutStatusChange(t *testing.T) {
 // A hard delete of an item must cascade to its status_transitions rows
 // (FK ON DELETE CASCADE), or the delete would fail the FK constraint.
 func TestStatusTransition_CascadesOnHardDelete(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	wsID, colID := newTransitionTestWorkspace(t, s)
 	item := createTestItem(t, s, wsID, colID, "Doomed", "") // seeds a create-row
@@ -272,6 +281,7 @@ func TestStatusTransition_CascadesOnHardDelete(t *testing.T) {
 }
 
 func TestParseFieldChange(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		in       string
 		key      string
@@ -297,6 +307,7 @@ func TestParseFieldChange(t *testing.T) {
 }
 
 func TestBackfillStatusTransitions(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	wsID, colID := newTransitionTestWorkspace(t, s)
 	item := createTestItem(t, s, wsID, colID, "Historical", "")
@@ -361,6 +372,7 @@ func TestBackfillStatusTransitions(t *testing.T) {
 }
 
 func TestStatusTransition_RecordsStatusClear(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	wsID, colID := newTransitionTestWorkspace(t, s)
 	item := createTestItem(t, s, wsID, colID, "clearable", "") // status open

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -516,6 +516,7 @@ func TestSQLiteConcurrentWritersNoBusy(t *testing.T) {
 }
 
 func TestNewStore(t *testing.T) {
+	t.Parallel()
 	if os.Getenv("PAD_TEST_POSTGRES_URL") != "" {
 		t.Skip("skipping SQLite-specific test when running against PostgreSQL")
 	}
@@ -534,6 +535,7 @@ func TestNewStore(t *testing.T) {
 }
 
 func TestNewStorePostgres(t *testing.T) {
+	t.Parallel()
 	pgURL := os.Getenv("PAD_TEST_POSTGRES_URL")
 	if pgURL == "" {
 		t.Skip("PAD_TEST_POSTGRES_URL not set, skipping PostgreSQL test")
@@ -553,6 +555,7 @@ func TestNewStorePostgres(t *testing.T) {
 // --- Workspace Tests ---
 
 func TestWorkspaceCRUD(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	// Create
@@ -622,6 +625,7 @@ func TestWorkspaceCRUD(t *testing.T) {
 // of workspaces.updated_at and MAX(items.updated_at), so the freshness
 // signal answers "where is work happening?".
 func TestListWorkspaces_UpdatedAtReflectsItemActivity(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	ws, err := s.CreateWorkspace(models.WorkspaceCreate{Name: "Active"})
@@ -686,6 +690,7 @@ func TestListWorkspaces_UpdatedAtReflectsItemActivity(t *testing.T) {
 // must surface item activity as its effective UpdatedAt, not just the
 // workspace row mtime.
 func TestGetUserWorkspaces_MemberFreshness(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	ws, err := s.CreateWorkspace(models.WorkspaceCreate{Name: "Member-WS"})
@@ -911,6 +916,7 @@ func TestGetUserWorkspaces_MemberSpecificAccessFreshnessLimitedToVisibleItems(t 
 }
 
 func TestWorkspaceUniqueSlug(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	ws1, _ := s.CreateWorkspace(models.WorkspaceCreate{Name: "Test"})
@@ -925,6 +931,7 @@ func TestWorkspaceUniqueSlug(t *testing.T) {
 }
 
 func TestWorkspaceSettingsHydrateStructuredContext(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	settings, err := models.SerializeWorkspaceSettings(&models.WorkspaceSettings{
@@ -980,6 +987,7 @@ func TestWorkspaceSettingsHydrateStructuredContext(t *testing.T) {
 // --- Document Tests ---
 
 func TestDocumentCRUD(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 
@@ -1058,6 +1066,7 @@ func TestDocumentCRUD(t *testing.T) {
 }
 
 func TestDocumentListFilters(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 
@@ -1087,6 +1096,7 @@ func TestDocumentListFilters(t *testing.T) {
 }
 
 func TestVersionCreation(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 
@@ -1122,6 +1132,7 @@ func TestVersionCreation(t *testing.T) {
 }
 
 func TestVersionCreationActorChange(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 
@@ -1142,6 +1153,7 @@ func TestVersionCreationActorChange(t *testing.T) {
 }
 
 func TestVersionNotCreatedWithoutContentChange(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 
@@ -1158,6 +1170,7 @@ func TestVersionNotCreatedWithoutContentChange(t *testing.T) {
 }
 
 func TestDocumentLinkRename(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 
@@ -1178,6 +1191,7 @@ func TestDocumentLinkRename(t *testing.T) {
 }
 
 func TestFTSSearch(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	s.SeedDefaultCollections(ws.ID)
@@ -1206,6 +1220,7 @@ func TestFTSSearch(t *testing.T) {
 }
 
 func TestFTSSearchScoped(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws1 := createTestWorkspace(t, s, "Workspace 1")
 	ws2 := createTestWorkspace(t, s, "Workspace 2")
@@ -1245,6 +1260,7 @@ func TestFTSSearchScoped(t *testing.T) {
 }
 
 func TestSearchCollectionFilter(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	s.SeedDefaultCollections(ws.ID)
@@ -1298,6 +1314,7 @@ func TestSearchCollectionFilter(t *testing.T) {
 }
 
 func TestSearchFieldFilters(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	s.SeedDefaultCollections(ws.ID)
@@ -1359,6 +1376,7 @@ func TestSearchFieldFilters(t *testing.T) {
 }
 
 func TestSearchCollectionAndFieldFilters(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	s.SeedDefaultCollections(ws.ID)
@@ -1397,6 +1415,7 @@ func TestSearchCollectionAndFieldFilters(t *testing.T) {
 }
 
 func TestSearchPagination(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	s.SeedDefaultCollections(ws.ID)
@@ -1477,6 +1496,7 @@ func TestSearchPagination(t *testing.T) {
 }
 
 func TestSearchSorting(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	s.SeedDefaultCollections(ws.ID)
@@ -1523,6 +1543,7 @@ func TestSearchSorting(t *testing.T) {
 }
 
 func TestSearchFacets(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	s.SeedDefaultCollections(ws.ID)
@@ -1584,6 +1605,7 @@ func TestSearchFacets(t *testing.T) {
 }
 
 func TestActivity(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	doc := createTestDoc(t, s, ws.ID, "Doc", "content")
@@ -1630,6 +1652,7 @@ func TestActivity(t *testing.T) {
 // item with that item_number. This lets the search palette double as a quick
 // "go to item N" jump. See BUG-910.
 func TestSearch_BareNumericQueryFindsItemByNumber(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	s.SeedDefaultCollections(ws.ID)
@@ -1707,6 +1730,7 @@ func TestSearch_BareNumericQueryFindsItemByNumber(t *testing.T) {
 // later pages. With the FTS WHERE-clause exclusion, the item appears
 // exactly once and Total counts it exactly once.
 func TestSearch_BareNumericQueryDedupsAgainstFTS(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	s.SeedDefaultCollections(ws.ID)
@@ -1762,6 +1786,7 @@ func TestSearch_BareNumericQueryDedupsAgainstFTS(t *testing.T) {
 // direct hits on page 0 ignoring `limit`, and not skip them entirely on
 // page 1.
 func TestSearch_BareNumericQueryPaginatesAcrossWorkspaces(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws1 := createTestWorkspace(t, s, "WS One")
 	ws2 := createTestWorkspace(t, s, "WS Two")
@@ -1853,6 +1878,7 @@ func TestSearch_BareNumericQueryPaginatesAcrossWorkspaces(t *testing.T) {
 
 // TestParseItemNumber covers the helper that gates the bare-numeric search path.
 func TestParseItemNumber(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		in  string
 		num int
@@ -1880,6 +1906,7 @@ func TestParseItemNumber(t *testing.T) {
 }
 
 func TestSlugify(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		input    string
 		expected string

--- a/internal/store/stripe_events_test.go
+++ b/internal/store/stripe_events_test.go
@@ -11,6 +11,7 @@ import (
 // retries can re-run the handler. A bug that made unmark a no-op (e.g.
 // wrong WHERE clause) would break this invariant.
 func TestUnmarkStripeEventProcessed_RoundTrip(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	// Mark a fresh event.
@@ -124,6 +125,7 @@ func TestUnmarkStripeEventProcessed_StaleTokenIsNoOp(t *testing.T) {
 // event that was already cleaned up; a hard error in that case would mask
 // real problems in the sidecar logs.
 func TestUnmarkStripeEventProcessed_MissingRow(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	unmarked, err := s.UnmarkStripeEventProcessed("evt_never_marked", "2025-01-01T00:00:00Z")
@@ -140,6 +142,7 @@ func TestUnmarkStripeEventProcessed_MissingRow(t *testing.T) {
 // already rejects at the HTTP layer, but the store method is exported
 // and called in tests, so defensive empty-input rejection matters.
 func TestUnmarkStripeEventProcessed_RejectsEmptyID(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	_, err := s.UnmarkStripeEventProcessed("", "2025-01-01T00:00:00Z")
@@ -153,6 +156,7 @@ func TestUnmarkStripeEventProcessed_RejectsEmptyID(t *testing.T) {
 // race-protection contract falls back to "delete by event_id alone", which
 // is exactly the unsafe shape the composite key exists to prevent.
 func TestUnmarkStripeEventProcessed_RejectsEmptyProcessedAt(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	_, err := s.UnmarkStripeEventProcessed("evt_missing_token", "")

--- a/internal/store/tags_test.go
+++ b/internal/store/tags_test.go
@@ -21,6 +21,7 @@ func createTaggedItem(t *testing.T, s *Store, wsID, collID, title, tags string) 
 }
 
 func TestListWorkspaceTags(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Tags WS")
 	ideas := createTestCollection(t, s, ws.ID, "Ideas")

--- a/internal/store/timeline_pagination_test.go
+++ b/internal/store/timeline_pagination_test.go
@@ -50,6 +50,7 @@ func timelineFixture(t *testing.T, s *Store) (*models.Item, []models.Comment) {
 }
 
 func TestListCommentsBeforeTime_NoCursor(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	item, comments := timelineFixture(t, s)
 
@@ -69,6 +70,7 @@ func TestListCommentsBeforeTime_NoCursor(t *testing.T) {
 }
 
 func TestListCommentsBeforeTime_WithCursor(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	item, comments := timelineFixture(t, s)
 
@@ -92,6 +94,7 @@ func TestListCommentsBeforeTime_WithCursor(t *testing.T) {
 // rows whose created_at equals that second — equivalent to the legacy
 // "before=now,beforeID=\xff" semantics that BUG-1086 broke.
 func TestListCommentsBeforeTime_SameSecondCursor(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "SameSecond")
 	coll := createTestCollection(t, s, ws.ID, "Tasks")
@@ -121,6 +124,7 @@ func TestListCommentsBeforeTime_SameSecondCursor(t *testing.T) {
 }
 
 func TestListCommentsBeforeTime_LimitRespected(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	item, _ := timelineFixture(t, s)
 
@@ -134,6 +138,7 @@ func TestListCommentsBeforeTime_LimitRespected(t *testing.T) {
 }
 
 func TestListDocumentActivityBeforeTime_NoCursor(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Activity")
 	doc := createTestDoc(t, s, ws.ID, "Doc", "content")

--- a/internal/store/totp_test.go
+++ b/internal/store/totp_test.go
@@ -13,6 +13,7 @@ func hashCode(code string) string {
 }
 
 func TestTOTPSetupAndEnable(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u := createTestUser(t, s, "test@test.com", "Test", "password123")
 
@@ -56,6 +57,7 @@ func TestTOTPSetupAndEnable(t *testing.T) {
 }
 
 func TestTOTPEnableSecretMismatch(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u := createTestUser(t, s, "test@test.com", "Test", "password123")
 
@@ -75,6 +77,7 @@ func TestTOTPEnableSecretMismatch(t *testing.T) {
 }
 
 func TestTOTPDisable(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u := createTestUser(t, s, "test@test.com", "Test", "password123")
 
@@ -106,6 +109,7 @@ func TestTOTPDisable(t *testing.T) {
 }
 
 func TestConsumeRecoveryCode(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u := createTestUser(t, s, "test@test.com", "Test", "password123")
 
@@ -153,6 +157,7 @@ func TestConsumeRecoveryCode(t *testing.T) {
 }
 
 func TestUserFieldsSurviveTOTP(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u := createTestUser(t, s, "test@test.com", "Test", "password123")
 

--- a/internal/store/trait_dedupe_test.go
+++ b/internal/store/trait_dedupe_test.go
@@ -107,6 +107,7 @@ func declaringConvention(t *testing.T, s *Store, workspaceID string) []string {
 // the declaration every time. Measured 8/8 before this shipped; the point of
 // the test is that it is not 7/8.
 func TestDedupeKeepsTheCollectionTheUserWroteIn(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws, _, dupID := duplicateTraitFixture(t, s, "Dedupe User Wrote", true)
 
@@ -146,6 +147,7 @@ func TestDedupeKeepsTheCollectionTheUserWroteIn(t *testing.T) {
 // one does and that the log says the choice was arbitrary rather than dressing
 // it up as age.
 func TestDedupeReportsAnArbitraryTieAsArbitrary(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws, _, _ := duplicateTraitFixture(t, s, "Dedupe Arbitrary Tie", false)
 	if got := declaringConvention(t, s, ws.ID); len(got) != 2 {
@@ -199,6 +201,7 @@ func TestDedupeReportsAnArbitraryTieAsArbitrary(t *testing.T) {
 // Raw SQL on purpose — the API gate refuses this too, so going through it
 // would assert that the gate works rather than that the constraint does.
 func TestTraitUniquenessIsEnforcedByTheDatabase(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Trait Uniqueness")
 	if err := s.SeedCollectionsFromTemplate(ws.ID, "startup"); err != nil {
@@ -234,6 +237,7 @@ func TestTraitUniquenessIsEnforcedByTheDatabase(t *testing.T) {
 // have failed on it — which is precisely the failure the de-dup pass exists to
 // prevent, so it would have surfaced as a broken upgrade rather than a test.
 func TestDedupeStripsEveryDeclarationALoserHolds(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Dedupe Both Declarations")
 	if err := s.SeedCollectionsFromTemplate(ws.ID, "startup"); err != nil {
@@ -306,6 +310,7 @@ func TestDedupeStripsEveryDeclarationALoserHolds(t *testing.T) {
 // blob. Every other reader treats malformed traits as declaring nothing, and
 // the guard makes these two agree with that rather than being fatal.
 func TestMalformedTraitsDoNotBreakTheInvariant(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Malformed Traits")
 	if err := s.SeedCollectionsFromTemplate(ws.ID, "startup"); err != nil {
@@ -371,6 +376,7 @@ func TestMalformedTraitsDoNotBreakTheInvariant(t *testing.T) {
 // minted before the transaction opened; BUG-2892 moved it inside. That changed
 // what a failure COSTS, not whether this de-duplication is needed.
 func TestImportDeduplicatesAConflictingArchive(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	owner := createTestUser(t, s, "importdedupe@test.com", "Owner", "password123")
 	ws := createTestWorkspace(t, s, "Import Dedupe Source")
@@ -446,6 +452,7 @@ func TestImportDeduplicatesAConflictingArchive(t *testing.T) {
 // So the pass has to run on the traits each collection will ACTUALLY be
 // inserted with, not on the ones the bundle carries.
 func TestImportDeduplicatesAfterCanonicalInference(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	owner := createTestUser(t, s, "inferdedupe@test.com", "Owner", "password123")
 	ws := createTestWorkspace(t, s, "Infer Dedupe Source")
@@ -517,6 +524,7 @@ func TestImportDeduplicatesAfterCanonicalInference(t *testing.T) {
 // the partial unique indexes exclude it (`AND deleted_at IS NULL`), and
 // stripping it would edit data the operator archived rather than deleted.
 func TestImportKeepsTheLiveDeclarationWhenAnArchivedCollectionSharesIt(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	owner := createTestUser(t, s, "archivedtrait@test.com", "Owner", "password123")
 	ws := createTestWorkspace(t, s, "Archived Trait Source")
@@ -608,6 +616,7 @@ func TestImportKeepsTheLiveDeclarationWhenAnArchivedCollectionSharesIt(t *testin
 // SQLite only. Postgres takes no snapshot — backups there are the operator's
 // pg_dump/PITR job — so on that dialect there is no ordering to pin.
 func TestTheSnapshotIsTakenBeforeTheRepairWrites(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	if s.dialect.Driver() != DriverSQLite {
 		t.Skip("no pre-migration snapshot on Postgres; the ordering this pins does not exist there")

--- a/internal/store/users_email_verified_test.go
+++ b/internal/store/users_email_verified_test.go
@@ -66,6 +66,7 @@ func insertLegacyUnverifiedUser(t *testing.T, s *Store, email string) string {
 // self-host account is write-locked on deploy. Runs the real migration DML
 // against pre-existing NULL rows (both dialects via make test-pg).
 func TestEmailVerifiedBackfill(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	legacy := []string{
@@ -110,6 +111,7 @@ func TestEmailVerifiedBackfill(t *testing.T) {
 // CreateUser yields a VERIFIED user, and only an explicit Unverified request
 // (the future cloud self-serve branch) produces an unverified one.
 func TestCreateUserEmailVerifiedDefault(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	// Default: verified.
@@ -139,6 +141,7 @@ func TestCreateUserEmailVerifiedDefault(t *testing.T) {
 
 // TestCreateOAuthUserVerified covers DR-3's "OAuth = verified" rule.
 func TestCreateOAuthUserVerified(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u, err := s.CreateOAuthUser("oauth@example.com", "OAuth User", "https://example.com/a.png")
 	if err != nil {
@@ -154,6 +157,7 @@ func TestCreateOAuthUserVerified(t *testing.T) {
 // SearchUsers. Missing the second breaks the admin user list at runtime with a
 // column/target mismatch, which a compile check would NOT catch.
 func TestEmailVerifiedBothScanPaths(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	verified := createTestUser(t, s, "scanverified@example.com", "V", "password123")
@@ -188,6 +192,7 @@ func TestEmailVerifiedBothScanPaths(t *testing.T) {
 // ListUsers scanUser path also surfaces the field (defensive; scanUser is
 // shared, but ListUsers is the admin-facing bulk reader).
 func TestListUsersEmailVerified(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	for i := 0; i < 3; i++ {
 		createTestUser(t, s, fmt.Sprintf("list%d@example.com", i), "L", "password123")

--- a/internal/store/users_metrics_test.go
+++ b/internal/store/users_metrics_test.go
@@ -10,6 +10,7 @@ import (
 // TestGetUserMetrics covers the three engagement metrics from T1547:
 // days_since_write, writes_7d, collections_touched_30d.
 func TestGetUserMetrics(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	alice := createTestUser(t, s, "alice@example.com", "Alice", "password123")
 	ws, err := s.CreateWorkspace(models.WorkspaceCreate{Name: "Acme", Slug: "acme", OwnerID: alice.ID})
@@ -73,6 +74,7 @@ func TestGetUserMetrics(t *testing.T) {
 // TestGetUserMetricsEmptyUser ensures a user with no activity returns
 // zero counts and a nil days_since_write rather than an error.
 func TestGetUserMetricsEmptyUser(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u := createTestUser(t, s, "fresh@example.com", "Fresh", "password123")
 	m, err := s.GetUserMetrics(u.ID)

--- a/internal/store/users_test.go
+++ b/internal/store/users_test.go
@@ -21,6 +21,7 @@ func createTestUser(t *testing.T, s *Store, email, name, password string) *model
 }
 
 func TestUserCRUD(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	// Create
@@ -104,6 +105,7 @@ func TestUserCRUD(t *testing.T) {
 }
 
 func TestUserCreateAdmin(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	u, err := s.CreateUser(models.UserCreate{
@@ -121,6 +123,7 @@ func TestUserCreateAdmin(t *testing.T) {
 }
 
 func TestUserDuplicateEmail(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	_, err := s.CreateUser(models.UserCreate{
@@ -139,6 +142,7 @@ func TestUserDuplicateEmail(t *testing.T) {
 }
 
 func TestValidatePassword(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	createTestUser(t, s, "test@test.com", "Test", "correctpassword")
@@ -172,6 +176,7 @@ func TestValidatePassword(t *testing.T) {
 }
 
 func TestListUsers(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	createTestUser(t, s, "a@test.com", "Alice", "pass1")
@@ -187,6 +192,7 @@ func TestListUsers(t *testing.T) {
 }
 
 func TestUserCount(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	count, _ := s.UserCount()
@@ -204,6 +210,7 @@ func TestUserCount(t *testing.T) {
 }
 
 func TestCountBillingAggregates(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	now := time.Now().UTC()
 	cutoff := now.Add(-30 * 24 * time.Hour)
@@ -256,6 +263,7 @@ func TestCountBillingAggregates(t *testing.T) {
 // over no-workspace wins over inactive wins over active. Documented in the
 // admin user list contract (PLAN-1542 / TASK-1544).
 func TestComputeAdminUserStatus(t *testing.T) {
+	t.Parallel()
 	recent := time.Now().UTC().Add(-1 * time.Hour).Format(time.RFC3339)
 	old := time.Now().UTC().Add(-60 * 24 * time.Hour).Format(time.RFC3339)
 	cases := []struct {
@@ -288,6 +296,7 @@ func TestComputeAdminUserStatus(t *testing.T) {
 // sort/filter knobs route to the right rows. Single end-to-end test against
 // a multi-user fixture; finer-grained assertions are split into subtests.
 func TestSearchUsersAggregations(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	// Three users:

--- a/internal/store/users_totp_step_test.go
+++ b/internal/store/users_totp_step_test.go
@@ -12,6 +12,7 @@ const totpStepTestSecret = "JBSWY3DPEHPK3PXP" // canonical base32 test secret
 // the same (or an older) step is rejected, and a fresh higher step succeeds
 // and advances the stored value.
 func TestConsumeTOTPStep_SingleUse(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u := createTestUser(t, s, "totp@example.com", "TOTP User", "password123")
 	if err := s.SetTOTPSecret(u.ID, totpStepTestSecret); err != nil {
@@ -68,6 +69,7 @@ func TestConsumeTOTPStep_SingleUse(t *testing.T) {
 // disable/re-enroll racing an in-flight login) does NOT advance the watermark,
 // so it can't spuriously lock out the freshly-enrolled authenticator.
 func TestConsumeTOTPStep_SecretMismatch(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u := createTestUser(t, s, "mismatch@example.com", "Mismatch User", "password123")
 	if err := s.SetTOTPSecret(u.ID, "SECRETAAAAAAAAAA"); err != nil {
@@ -98,6 +100,7 @@ func TestConsumeTOTPStep_SecretMismatch(t *testing.T) {
 // when the secret changes (BUG-2054 Codex follow-up): a time-step counter from
 // an old secret must not reject a freshly-enrolled authenticator's codes.
 func TestTOTPStep_ResetOnSecretChange(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	stepIsSet := func(userID string) bool {
@@ -148,6 +151,7 @@ func TestTOTPStep_ResetOnSecretChange(t *testing.T) {
 // claim the SAME step, exactly one wins — the compare-and-set closes the
 // concurrent-replay window.
 func TestConsumeTOTPStep_ConcurrentCAS(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u := createTestUser(t, s, "race@example.com", "Race User", "password123")
 	if err := s.SetTOTPSecret(u.ID, totpStepTestSecret); err != nil {

--- a/internal/store/webhooks_test.go
+++ b/internal/store/webhooks_test.go
@@ -34,6 +34,7 @@ func newWebhookTestWorkspace(t *testing.T, s *Store) string {
 // must be encrypted in the DB, round-trip to plaintext on read (so the
 // dispatcher can sign), and that plaintext must produce a valid HMAC.
 func TestWebhookSecret_EncryptedAtRest(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	key := make([]byte, 32)
 	if _, err := rand.Read(key); err != nil {
@@ -88,6 +89,7 @@ func TestWebhookSecret_EncryptedAtRest(t *testing.T) {
 // TestWebhookSecret_ListRoundTrips confirms ListWebhooks also decrypts the
 // secret for internal/dispatch use.
 func TestWebhookSecret_ListRoundTrips(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	key := make([]byte, 32)
 	rand.Read(key)
@@ -118,6 +120,7 @@ func TestWebhookSecret_ListRoundTrips(t *testing.T) {
 // pre-encryption plaintext row (inserted before a key was configured) still
 // signs correctly, and BackfillEncryptWebhookSecrets encrypts it in place.
 func TestWebhookSecret_BackfillEncryptsPlaintext(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	wsID := newWebhookTestWorkspace(t, s)
 
@@ -186,6 +189,7 @@ func insertRawWebhook(t *testing.T, s *Store, wsID, secret string) string {
 // marker must be encrypted by the one-time migration (first run encrypts every
 // pre-encryption value) and round-trip on read.
 func TestWebhookSecret_MigratesEncPrefixedLegacyPlaintext(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	wsID := newWebhookTestWorkspace(t, s)
 
@@ -231,6 +235,7 @@ func TestWebhookSecret_MigratesEncPrefixedLegacyPlaintext(t *testing.T) {
 // wrong key (which would corrupt the secret). Steady-state skips "enc:" rows and
 // a wrong key surfaces as a loud decrypt error instead.
 func TestWebhookSecret_DoesNotRewrapCiphertextOnKeyChange(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	wsID := newWebhookTestWorkspace(t, s)
 

--- a/internal/store/wiki_links_test.go
+++ b/internal/store/wiki_links_test.go
@@ -14,6 +14,7 @@ import (
 // backlinks for the target item. End-to-end coverage of the write
 // path → resolver → GetBacklinks read path.
 func TestWikiLinks_CreateItemIndexesRefs(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -48,6 +49,7 @@ func TestWikiLinks_CreateItemIndexesRefs(t *testing.T) {
 // on UpdateItem: changing the body to remove a [[]] removes its
 // backlink row, and adding a new [[]] adds a row.
 func TestWikiLinks_UpdateItemReplacesIndex(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -83,6 +85,7 @@ func TestWikiLinks_UpdateItemReplacesIndex(t *testing.T) {
 // items) doesn't trigger this — the rows persist but GetBacklinks
 // filters via items.deleted_at IS NULL on the source.
 func TestWikiLinks_DeleteItemCascadesOutboundRows(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -110,6 +113,7 @@ func TestWikiLinks_DeleteItemCascadesOutboundRows(t *testing.T) {
 // ref/title in its own body shouldn't appear in its own "Mentioned
 // in" panel (PLAN-1593 behavior decision).
 func TestWikiLinks_SelfLinkHidden(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -136,6 +140,7 @@ func TestWikiLinks_SelfLinkHidden(t *testing.T) {
 // table even though it can't be queried via the target-id index.
 // Feeds the future broken-links report.
 func TestWikiLinks_BrokenRefPersisted(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -161,6 +166,7 @@ func TestWikiLinks_BrokenRefPersisted(t *testing.T) {
 // Display-side dedupe is the renderer's job; storage keeps every
 // occurrence so future "show me where" features can highlight each.
 func TestWikiLinks_RepeatedRefStoresMultipleRows(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -197,6 +203,7 @@ func TestWikiLinks_RepeatedRefStoresMultipleRows(t *testing.T) {
 // counterpart to the parser test: a fenced block with [[REF]] inside
 // must NOT produce a backlink row. Parser exclusion proven end-to-end.
 func TestWikiLinks_CodeBlocksExcludedAtIndexTime(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -223,6 +230,7 @@ func TestWikiLinks_CodeBlocksExcludedAtIndexTime(t *testing.T) {
 // produces the same final state. The first call populates rows; the
 // second short-circuits via the EXISTS check and inserts nothing new.
 func TestWikiLinks_BackfillIdempotent(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -264,6 +272,7 @@ func TestWikiLinks_BackfillIdempotent(t *testing.T) {
 // rows. Empty override → display_text=”, no override → display_text
 // IS NULL.
 func TestWikiLinks_EmptyDisplayDistinct(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -333,6 +342,7 @@ func TestWikiLinks_EmptyDisplayDistinct(t *testing.T) {
 // extend both edges to rune boundaries so the snippet is always
 // valid UTF-8. Codex round-8 P3.
 func TestWikiLinks_SnippetIsValidUTF8(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -365,6 +375,7 @@ func TestWikiLinks_SnippetIsValidUTF8(t *testing.T) {
 // indexer behavior have to agree, otherwise users see broken silent
 // data divergence.
 func TestWikiLinks_MixedCaseRefIndexed(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -410,6 +421,7 @@ func TestWikiLinks_MixedCaseRefIndexed(t *testing.T) {
 //     [src3, src1] (newest-first), NOT [src3] (which would be the
 //     bug — hidden src2 silently consuming a slot).
 func TestWikiLinks_VisibilityAwarePagination(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	visible := createTestCollection(t, s, ws.ID, "Visible")
@@ -485,6 +497,7 @@ func TestWikiLinks_VisibilityAwarePagination(t *testing.T) {
 // rows from B. The bad-pagination version returned 0 or 1 depending
 // on how the hidden rows interleaved.
 func TestWikiLinks_ItemGrantPagination(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	a := createTestCollection(t, s, ws.ID, "A")
@@ -554,6 +567,7 @@ func refOf(item *models.Item) string {
 // `[[Title]]` in a source's body produces a backlink for the target
 // when the target's title matches (case-insensitive).
 func TestWikiLinks_TitleFormIndexed(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -579,6 +593,7 @@ func TestWikiLinks_TitleFormIndexed(t *testing.T) {
 // writes `[[project goals]]` must still resolve to an item titled
 // "Project Goals".
 func TestWikiLinks_TitleFormCaseInsensitive(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -601,6 +616,7 @@ func TestWikiLinks_TitleFormCaseInsensitive(t *testing.T) {
 //     the row to point at it — backlinks resolve on next query without
 //     waiting for a content rewrite or a backfill run.
 func TestWikiLinks_BrokenTitlePersistedThenResolved(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -627,6 +643,7 @@ func TestWikiLinks_BrokenTitlePersistedThenResolved(t *testing.T) {
 // index rows refresh, (c) "who mentions me?" still finds them under
 // the new title.
 func TestWikiLinks_TitleRenameCascadesContentAndBacklinks(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -682,6 +699,7 @@ func TestWikiLinks_TitleRenameCascadesContentAndBacklinks(t *testing.T) {
 // case) both index via target_item_id, so without alias-aware /
 // case-insensitive rewrite, the trailing re-parse drops them.
 func TestWikiLinks_TitleRenameCascadesAliasedForms(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -736,6 +754,7 @@ func TestWikiLinks_TitleRenameCascadesAliasedForms(t *testing.T) {
 // because no item is literally titled "tasks/Setup"; stage 2 (split
 // fallback) finds the item titled "Setup" in collection "tasks".
 func TestWikiLinks_CollectionQualifiedTitleResolved(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks") // slug = "tasks"
@@ -756,6 +775,7 @@ func TestWikiLinks_CollectionQualifiedTitleResolved(t *testing.T) {
 // and looks up by collection slug. If we split first, the wrong item
 // would resolve.
 func TestWikiLinks_FullKeyTitleBeatsQualifiedSplit(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks") // slug = "tasks"
@@ -788,6 +808,7 @@ func TestWikiLinks_FullKeyTitleBeatsQualifiedSplit(t *testing.T) {
 // stale while the renderer's full-body interpretation would resolve
 // the link correctly.
 func TestWikiLinks_BrokenPipeInBodyRetargetsOnLiteralArrival(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -812,6 +833,7 @@ func TestWikiLinks_BrokenPipeInBodyRetargetsOnLiteralArrival(t *testing.T) {
 // different item or fail to resolve at all, leaving a backlink the
 // UI shows but the index can't surface.
 func TestWikiLinks_LiteralPipeInTitleResolves(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -832,6 +854,7 @@ func TestWikiLinks_LiteralPipeInTitleResolves(t *testing.T) {
 // kicks in (title="A", display="B"). The candidate-order in
 // replaceWikiLinks tries full body first, then falls through.
 func TestWikiLinks_LiteralPipeInTitleFallsThroughToSplit(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -855,6 +878,7 @@ func TestWikiLinks_LiteralPipeInTitleFallsThroughToSplit(t *testing.T) {
 // Stage 3 (literal-arrival retarget) is gated to titles containing
 // `/` for exactly this reason.
 func TestWikiLinks_SecondItemSameTitleDoesNotStealBacklinks(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -895,6 +919,7 @@ func TestWikiLinks_SecondItemSameTitleDoesNotStealBacklinks(t *testing.T) {
 // Without the stage-1 NULL-constraint drop, the index would stay
 // stale until the source's content was rewritten.
 func TestWikiLinks_LiteralTitleArrivalRetargetsQualifiedFallback(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks") // slug = "tasks"
@@ -926,6 +951,7 @@ func TestWikiLinks_LiteralTitleArrivalRetargetsQualifiedFallback(t *testing.T) {
 // should resolve when an existing item gets renamed TO "New Title".
 // No content rewrite needed; only the target_item_id flip.
 func TestWikiLinks_TitleRenameResolvesPreExistingBrokenRows(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -953,6 +979,7 @@ func TestWikiLinks_TitleRenameResolvesPreExistingBrokenRows(t *testing.T) {
 // the cascade. Cheap path that paid nothing pre-Phase-2a should pay
 // nothing now either.
 func TestWikiLinks_TitleRenameNoChangeIsNoOp(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -983,6 +1010,7 @@ func TestWikiLinks_TitleRenameNoChangeIsNoOp(t *testing.T) {
 // renderer drift apart. Self-link visibility filtering happens at
 // GetBacklinks query time, so the panel still hides it.
 func TestWikiLinks_TitleRenameRewritesSelfReferences(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -1026,6 +1054,7 @@ func TestWikiLinks_TitleRenameRewritesSelfReferences(t *testing.T) {
 // literally titled " TASK-5 " (with spaces) must resolve via the
 // fallback when no real TASK-5 ref exists.
 func TestWikiLinks_RefShapedWithWhitespaceFallsThroughToTitle(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks") // prefix "TASKS"
@@ -1056,6 +1085,7 @@ func TestWikiLinks_RefShapedWithWhitespaceFallsThroughToTitle(t *testing.T) {
 // index that keeps pointing at deleted A means GetBacklinks(B)
 // misses the link the UI would actually render to B.
 func TestWikiLinks_SoftDeletedTargetRetargetsOnNewItem(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -1089,6 +1119,7 @@ func TestWikiLinks_SoftDeletedTargetRetargetsOnNewItem(t *testing.T) {
 // corrupting the B link. Position-based per-row cascade fixes this
 // — only the brackets whose wl row resolves to A get rewritten.
 func TestWikiLinks_CascadeDoesNotCorruptLiteralPipeNeighbor(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -1145,6 +1176,7 @@ func TestWikiLinks_CascadeDoesNotCorruptLiteralPipeNeighbor(t *testing.T) {
 // index must too. Without the fallback, GetBacklinks would never
 // find the backlink even though the renderer renders the link.
 func TestWikiLinks_RefShapedFallsThroughToTitle(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks") // prefix "TASKS"
@@ -1176,6 +1208,7 @@ func TestWikiLinks_RefShapedFallsThroughToTitle(t *testing.T) {
 // stale `[[Old Title]]` would otherwise go broken. Covered by
 // TestWikiLinks_TitleRenameRewritesSelfReferences.
 func TestWikiLinks_TitleAndContentRenameLeavesUserContentVerbatim(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -1221,6 +1254,7 @@ func TestWikiLinks_TitleAndContentRenameLeavesUserContentVerbatim(t *testing.T) 
 // i.e. rows resolved via stage-2 qualified fallback to a different
 // item, not via stage-1 to a literal twin.
 func TestWikiLinks_DuplicateSlashTitleNoTheft(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -1282,6 +1316,7 @@ func createChildItem(t *testing.T, s *Store, workspaceID, collectionID, parentID
 // already listed in the Child Items section above. Symmetric with
 // the long-standing self-link suppression.
 func TestWikiLinks_ChildMentionOfParentSuppressed(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -1333,6 +1368,7 @@ func TestWikiLinks_ChildMentionOfParentSuppressed(t *testing.T) {
 // the parent relationship from item_links directly, so the caller
 // doesn't need to pass parent context through the visibility shape.
 func TestWikiLinks_ParentMentionOnChildPageSuppressed(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -1370,6 +1406,7 @@ func TestWikiLinks_ParentMentionOnChildPageSuppressed(t *testing.T) {
 // cross-references — they aren't implied by any other UI surface, so
 // they must still appear in "Mentioned in".
 func TestWikiLinks_SiblingMentionsNotSuppressed(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -1405,6 +1442,7 @@ func TestWikiLinks_SiblingMentionsNotSuppressed(t *testing.T) {
 // match, no suppression — but the test pins the behavior in case
 // a future refactor inverts the predicate.
 func TestWikiLinks_OrphanBacklinksUnaffected(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -1437,6 +1475,7 @@ func TestWikiLinks_OrphanBacklinksUnaffected(t *testing.T) {
 // change reroutes the filter back through items.parent_id, this
 // test will catch it.
 func TestWikiLinks_SuppressionUsesItemLinksNotParentIDColumn(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -1503,6 +1542,7 @@ func TestWikiLinks_SuppressionUsesItemLinksNotParentIDColumn(t *testing.T) {
 // duplicate. The suppression filter uses childLinkTypeSQL() to
 // stay in lockstep with the canonical inclusion rule.
 func TestWikiLinks_SuppressionCoversImplementsChildLinkType(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -1553,6 +1593,7 @@ func TestWikiLinks_SuppressionCoversImplementsChildLinkType(t *testing.T) {
 // suppression filter consults both storage mechanisms so neither
 // write path can leave the duplication visible.
 func TestWikiLinks_SuppressionFallsBackToItemsParentIDColumn(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -1634,6 +1675,7 @@ func TestWikiLinks_SuppressionFallsBackToItemsParentIDColumn(t *testing.T) {
 // for the GetBacklinks/CountBacklinks lockstep that the
 // handlers_backlinks.go same-ws/cross-ws math depends on.
 func TestWikiLinks_PaginationStableAfterSuppression(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")

--- a/internal/store/wiki_links_xws_test.go
+++ b/internal/store/wiki_links_xws_test.go
@@ -12,6 +12,7 @@ import (
 // A surfaces the cross-ws source — provided the requester has
 // visibility into workspace B. PLAN-1593 / TASK-1597.
 func TestWikiLinks_CrossWorkspaceRefIndexedAndQueryable(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	user := createTestUser(t, s, "alice@example.com", "Alice", "password123")
 
@@ -62,6 +63,7 @@ func TestWikiLinks_CrossWorkspaceRefIndexedAndQueryable(t *testing.T) {
 // enumerates only workspaces the requester has access to via
 // GetUserWorkspaces.
 func TestWikiLinks_CrossWorkspaceNonMemberDoesNotSee(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	owner := createTestUser(t, s, "owner@example.com", "Owner", "password123")
@@ -106,6 +108,7 @@ func TestWikiLinks_CrossWorkspaceNonMemberDoesNotSee(t *testing.T) {
 // other collections in B. Mirrors the same-ws Phase 1 visibility
 // model — Codex round-1/2 P1 — across the cross-ws boundary.
 func TestWikiLinks_CrossWorkspaceGuestSeesGrantedCollectionOnly(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	owner := createTestUser(t, s, "owner@example.com", "Owner", "password123")
@@ -163,6 +166,7 @@ func TestWikiLinks_CrossWorkspaceGuestSeesGrantedCollectionOnly(t *testing.T) {
 // target. This is the cross-ws equivalent of
 // TestWikiLinks_ItemGrantPagination from Phase 1.
 func TestWikiLinks_CrossWorkspaceGuestItemGrantOnlyVisible(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	owner := createTestUser(t, s, "owner@example.com", "Owner", "password123")
@@ -213,6 +217,7 @@ func TestWikiLinks_CrossWorkspaceGuestItemGrantOnlyVisible(t *testing.T) {
 // any wsID). Documents the broken-link semantics consistent with the
 // renderer's resolver-route 404 path.
 func TestWikiLinks_CrossWorkspaceUnknownSlugBroken(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	user := createTestUser(t, s, "alice@example.com", "Alice", "password123")
 	ws := createTestWorkspace(t, s, "Workspace A")
@@ -243,6 +248,7 @@ func TestWikiLinks_CrossWorkspaceUnknownSlugBroken(t *testing.T) {
 // SourceWorkspaceSlug so the renderer can route the link to the
 // foreign workspace. Same-ws rows leave it empty.
 func TestWikiLinks_CrossWorkspaceSourceWorkspaceSlugPopulated(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	user := createTestUser(t, s, "alice@example.com", "Alice", "password123")
 
@@ -290,6 +296,7 @@ func TestWikiLinks_CrossWorkspaceSourceWorkspaceSlugPopulated(t *testing.T) {
 // same-ws query requires target_item_id (workspace_ref leaves it
 // NULL) and the cross-ws query skips the target workspace.
 func TestWikiLinks_CrossWorkspaceSameWorkspaceQualifiedNormalized(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	user := createTestUser(t, s, "alice@example.com", "Alice", "password123")
 	ws := createTestWorkspace(t, s, "Test")
@@ -327,6 +334,7 @@ func TestWikiLinks_CrossWorkspaceSameWorkspaceQualifiedNormalized(t *testing.T) 
 // fallback; the index must match or it creates ghost backlinks the
 // UI doesn't render.
 func TestWikiLinks_SameWorkspaceQualifiedRefNoTitleFallback(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	user := createTestUser(t, s, "alice@example.com", "Alice", "password123")
 	ws := createTestWorkspace(t, s, "Test")
@@ -366,6 +374,7 @@ func TestWikiLinks_SameWorkspaceQualifiedRefNoTitleFallback(t *testing.T) {
 // Without this fix, an admin querying for backlinks misses cross-ws
 // links from any workspace they're not explicitly a member of.
 func TestWikiLinks_CrossWorkspaceAdminSeesAllWorkspaces(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	owner := createTestUser(t, s, "owner@example.com", "Owner", "password123")
@@ -429,6 +438,7 @@ func TestWikiLinks_CrossWorkspaceAdminSeesAllWorkspaces(t *testing.T) {
 // match — otherwise the bearer-admin's grant elsewhere becomes a
 // side-channel into a workspace they can't open directly.
 func TestWikiLinks_CrossWorkspaceBearerAdminGrantOnlyWorkspaceFiltered(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	owner := createTestUser(t, s, "owner@example.com", "Owner", "password123")
@@ -492,6 +502,7 @@ func TestWikiLinks_CrossWorkspaceBearerAdminGrantOnlyWorkspaceFiltered(t *testin
 // visible even via bearer auth — the gate's job is to suppress the
 // PLATFORM admin role, not membership-based access.
 func TestWikiLinks_CrossWorkspaceBearerAdminSeesMemberWorkspaces(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	admin, err := s.CreateUser(models.UserCreate{
@@ -533,6 +544,7 @@ func TestWikiLinks_CrossWorkspaceBearerAdminSeesMemberWorkspaces(t *testing.T) {
 // fallback by item_number; cross-ws resolves at query time so the
 // query SQL has the OR-LIKE fallback inline.
 func TestWikiLinks_CrossWorkspaceRefNumberFallback(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	user := createTestUser(t, s, "alice@example.com", "Alice", "password123")
 
@@ -594,6 +606,7 @@ func TestWikiLinks_CrossWorkspaceRefNumberFallback(t *testing.T) {
 // `[]string{"*"}` → wildcard consent.
 // Explicit list → strict slug match.
 func TestWikiLinks_CrossWorkspaceTokenAllowListFilters(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	user := createTestUser(t, s, "alice@example.com", "Alice", "password123")
 
@@ -651,6 +664,7 @@ func TestWikiLinks_CrossWorkspaceTokenAllowListFilters(t *testing.T) {
 // guest. Each case asserts the (fullCollIDs, grantedItemIDs) shape
 // against the documented contract. PLAN-1593 / TASK-1597.
 func TestResolveBacklinksVisibility_RoleMatrix(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	owner := createTestUser(t, s, "owner@example.com", "Owner", "password123")
 	ws := createTestWorkspace(t, s, "Test")

--- a/internal/store/workspace_members_admin_detail_test.go
+++ b/internal/store/workspace_members_admin_detail_test.go
@@ -15,6 +15,7 @@ import (
 // And verifies all six aggregations land correctly.
 // PLAN-1542 / TASK-1545.
 func TestGetUserWorkspacesDetailed(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	owner := createTestUser(t, s, "owner@example.com", "Owner", "password123")
 	guest := createTestUser(t, s, "guest@example.com", "Guest", "password123")

--- a/internal/store/workspace_purge_test.go
+++ b/internal/store/workspace_purge_test.go
@@ -211,6 +211,7 @@ func (s *Store) totalChildRows(t *testing.T, sw seededWorkspace) int {
 // completely untouched (no over-purge). mcp_audit_log is de-identified
 // (workspace_id nulled) rather than deleted.
 func TestPurgeWorkspaceData_RemovesAllChildDataNoOrphans(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u, err := s.CreateUser(models.UserCreate{Email: "owner@test.com", Name: "Owner", Password: "correct-horse-battery-staple"})
 	if err != nil {
@@ -270,6 +271,7 @@ func TestPurgeWorkspaceData_RemovesAllChildDataNoOrphans(t *testing.T) {
 // guard: PurgeWorkspaceData must refuse to touch a workspace that is not
 // soft-deleted, even if handed its ID directly — no child row is removed.
 func TestPurgeWorkspaceData_RefusesLiveWorkspace(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u, err := s.CreateUser(models.UserCreate{Email: "live@test.com", Name: "Live", Password: "correct-horse-battery-staple"})
 	if err != nil {
@@ -294,6 +296,7 @@ func TestPurgeWorkspaceData_RefusesLiveWorkspace(t *testing.T) {
 // workspace soft-deleted just past the cutoff is eligible; one deleted
 // just inside the window and a live workspace are NOT.
 func TestListPurgeableWorkspaces_Boundary(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u, err := s.CreateUser(models.UserCreate{Email: "b@test.com", Name: "B", Password: "correct-horse-battery-staple"})
 	if err != nil {

--- a/internal/store/workspaces_source_test.go
+++ b/internal/store/workspaces_source_test.go
@@ -12,6 +12,7 @@ import (
 // (or as a "sql: expected N destination arguments" failure) rather than at
 // runtime.
 func TestWorkspaceSourcePersisted(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 
 	cli, err := s.CreateWorkspace(models.WorkspaceCreate{Name: "Agent WS", Source: "cli"})

--- a/internal/store/workspaces_test.go
+++ b/internal/store/workspaces_test.go
@@ -13,6 +13,7 @@ import (
 // collections underneath are never touched, just transitively hidden.
 // RestoreWorkspace clears deleted_at and everything comes back intact.
 func TestRestoreWorkspace_ResurfacesIntact(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u, err := s.CreateUser(models.UserCreate{Email: "owner@test.com", Name: "Owner", Password: "correct-horse-battery-staple"})
 	if err != nil {
@@ -80,6 +81,7 @@ func TestRestoreWorkspace_ResurfacesIntact(t *testing.T) {
 // idempotent-ish 404 semantics: restoring a live workspace, restoring
 // twice, and restoring an unknown slug all return sql.ErrNoRows.
 func TestRestoreWorkspace_ErrNoRowsWhenNothingToRestore(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	u, err := s.CreateUser(models.UserCreate{Email: "owner@test.com", Name: "Owner", Password: "correct-horse-battery-staple"})
 	if err != nil {
@@ -119,6 +121,7 @@ func TestRestoreWorkspace_ErrNoRowsWhenNothingToRestore(t *testing.T) {
 // window boundary (29d IN, 31d OUT — the inverse of the purge boundary),
 // owner-scoping, live exclusion, and most-recently-deleted ordering.
 func TestListDeletedWorkspaces_WindowAndOwnerScope(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	owner, err := s.CreateUser(models.UserCreate{Email: "owner@test.com", Name: "Owner", Password: "correct-horse-battery-staple"})
 	if err != nil {

--- a/internal/store/yjs_updates_test.go
+++ b/internal/store/yjs_updates_test.go
@@ -9,6 +9,7 @@ import (
 // TestYjsUpdatesAppendAndLoad verifies AppendYjsUpdate returns monotonic
 // IDs and LoadYjsUpdatesSince filters strictly above the cursor.
 func TestYjsUpdatesAppendAndLoad(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -77,6 +78,7 @@ func TestYjsUpdatesAppendAndLoad(t *testing.T) {
 // schemaVersion. We do this in Go rather than relying on the NOT NULL
 // constraint so callers fail fast with a clear error message.
 func TestYjsUpdatesValidation(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -105,6 +107,7 @@ func TestYjsUpdatesValidation(t *testing.T) {
 // TestYjsUpdatesPrune removes only rows older than the cutoff for the
 // given item, leaving newer rows + other items untouched.
 func TestYjsUpdatesPrune(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
@@ -155,6 +158,7 @@ func TestYjsUpdatesPrune(t *testing.T) {
 // op-log rows when their parent item is deleted. Without this, item
 // deletion would leave orphaned binary blobs on disk indefinitely.
 func TestYjsUpdatesCascadeOnItemDelete(t *testing.T) {
+	t.Parallel()
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 	col := createTestCollection(t, s, ws.ID, "Tasks")


### PR DESCRIPTION
> **The SQLite leg was CPU-bound and serial** — 154.9s of CPU inside 185.6s of wall on eight cores, which is 0.84 cores. Unlike the Postgres leg there was no setup cost to reclaim (the gap between package wall-clock and the sum of its tests measured *minus* 1.4s) and no fat test beyond one 48s outlier. The only lever left was the seven idle cores.

`t.Parallel()` on **844 of 906** tests. Every test in this package builds its own isolated store — a SQLite file copy, or since `6f8b6eb9` a Postgres clone — so it shares no database with any other.

## Results

Medians on a quiet box, three SQLite repeats and two Postgres:

| | before | after | |
|---|---|---|---|
| SQLite wall | 185.6s | **111.0s** | **−40%** |
| Postgres wall | 224.4s | **121.2s** | −46% (**495.8s → 121.2s, −76%** since `6f8b6eb9`) |
| `-race` wall | 2006.3s | **1365.0s** | −32% |

**The cost, not folded into the win.** SQLite CPU rose 154.9s → **159.9s, +3.2%**. That is contention overhead, it is real, and it is paid by whoever else is on the box: this change moves **wall**, it does not remove work. A pre-registered prediction that CPU would stay within ~1% is **falsified** by that number, though only just.

*That figure is itself a correction.* An earlier draft reported +10.4%, from **one** run taken while another seat was working the box. Three quiet repeats put the median at +3.2% — the published number overstated the cost by more than three times. The direction survived and the magnitude did not, which is the case for repeating a figure you intend to publish as a **cost** as carefully as one you intend to publish as a win.

Postgres binary CPU is flat to slightly down (63.9s → 63.1s), which fits the mechanism rather than contradicting it: that leg was 82% waiting, so parallelism fills idle time instead of competing for cycles.

**Variance changed shape**, which matters for anyone measuring this package later: the parallel leg's repeat spread is **5.9%** (106.7 / 111.0 / 113.2) against **0.7%** for the serial leg it replaces. Scheduling decides which tests share a core, so a future before/after here needs repeats per side — the serial suite never did.

## Why `-race` was measured

Not for completeness — it was a **risk**. CI's `Go` job runs `go test -race -timeout=45m ./...` and already takes ~42 minutes; the race detector serialises heavily, so parallelism could plausibly have made that leg slower and pushed CI toward its own timeout. Measured against the template-only tree: **2006s → 1365s**. The risk is closed in the good direction.

## Exclusions — 62 tests, each for a mechanism

| count | why |
|---|---|
| 19 | files measuring **allocations** (`runtime.ReadMemStats`) — process-global counters, so a concurrent test's allocations land in the measurement. Excluded by *file*: the hazard is the process. |
| 23 | tests measuring **elapsed time** — wall-clock under contention is not the wall-clock the assertion was written against. |
| 7 | `migration_guard_test.go`, every test of which mutates the **exported** globals `AllowSchemaAhead` / `BinaryVersion`. |
| 1 | `TestUpdateDocument_CascadeExhaustionRollsBackTheWholeRename`, which mutates the **unexported** `cascadeRewriteAttempts`. |
| 3 | the template mechanism tests, which assert on package-level counters. |
| 16 | already had `t.Parallel()`. |

**Excluding a test is a real remedy here, not a hope**, and the reason is a Go semantic worth naming: a top-level test that calls `t.Parallel()` is *held* and resumed only after the sequential pass finishes, so every excluded test still runs alone in a quiet process.

That is **measured, not assumed**. A probe with serial mutators either side of eight parallel observers, 300ms windows, including a serial test declared *after* the parallel ones: **zero observations** of the mutation. Parallel tests are deferred past every serial test regardless of declaration order.

## Two exclusions my own sweep missed — same shape twice

**First**, before shipping. I recorded that this package had "no per-test global setters", having grepped `t.Setenv` / `os.Setenv` / `Set*ForTesting` — all genuinely zero. The counts were true and the conclusion was false: that sweep asked whether a test changes the **environment**, while the claim it carried was whether a test changes anything **global**. Found by a different question — grep the package's own non-test `var` declarations, then grep the tests for each name.

**Second**, found by review as a P1, not by me. That grep was `^var [a-z]`. It finds *unexported* package vars and silently skips exported ones, so it never saw `AllowSchemaAhead` or `BinaryVersion`. `AllowSchemaAhead = true` leaking across parallel tests would have disarmed the schema-ahead guard for everything running concurrently — which is the property two of those very tests exist to assert.

**The fix that caught the first miss was itself too narrow to catch the second.** That is the argument for enforcing the invariant in code rather than trusting the sweep that produced it.

## The guards

`TestCascadeExhaustionStaysSerial` (function-scoped) and `TestMigrationGuardTestsStaySerial` (file-scoped). Both:

- **fail closed** — a missing file or renamed function is a failure, not a pass;
- anchor the identifier **end**, so a `...V2` rename cannot slip past a prefix match;
- **strip line comments**, so the explanatory comment naming `t.Parallel()` can neither satisfy nor trip them;
- carry a **positive control** that the scan can see a real `t.Parallel()` elsewhere — a guard that cannot find what it is looking for proves nothing by its silence;
- are **mutation-controlled in both directions**: green as written, red when `t.Parallel()` is added.

A comment saying "must not call `t.Parallel()`" protects nobody against the next sweep — this repository just ran one that touched 844 test functions.

## Verification

| instrument | result |
|---|---|
| SQLite parallel ×4 | exit 0, zero failures |
| Postgres parallel ×3 | exit 0, zero failures |
| `-race -timeout=45m` | exit 0, **zero data races** |
| baseline `-race` (counterfactual) | exit 0 |

**A false alarm not filed as a finding:** my first `-race` run exited 1 with zero `--- FAIL` lines and zero data races — the shape that reads as a pass to anything counting FAIL lines. The log said `panic: test timed out after 10m0s`. That was the *invocation*: I omitted `-timeout`, and `ci.yml` already carries a comment explaining the explicit timeout exists because Go's default is too low. I ran a command CI does not run and nearly filed its result as a finding about the change.

## Known bound, not a solved problem

The test container's `max_connections` is 100, each store sets `MaxOpenConns(25)`, and `-parallel` defaults to GOMAXPROCS — so on an eight-core box the worst case permits 200. Three Postgres runs showed no `53300 too many clients`, but the arithmetic still allows it on a larger box or a heavier test. That belongs here as a bound rather than as an absence of observed failures.

## Diff shape

**844 insertions, zero deletions, zero modifications** across 100 files, plus the two guard tests and the exclusion banner. Every added line is a `t.Parallel()` call, which makes "no test was weakened" checkable by inspection rather than only by my outcome-set comparison.

Closes TASK-2900.

https://claude.ai/code/session_01HeChkgZVYb3NTgTcckF5KR
