### PR TITLE
fix(web): the durable item cache's cursor never moves backward, and a refused batch stamps no epoch (TASK-2906)

### DIFF
--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -130,6 +130,17 @@ class WorkspaceState {
 	// on that evidence is the silent adopt this change exists to prevent — see
 	// `ensureAccessScope`.
 	cacheRead = $state(false);
+	// Did the last projection/access resync's authoritative snapshot actually
+	// REACH the durable cache? (TASK-2906, review round 2.) `persistReplace` can
+	// decline — its cursor lost a race to another tab, or storage failed — and
+	// when it does the durable rows still describe the OLD scope while RAM has
+	// moved on. `ensureAccessScope` must not then stamp the new epoch onto disk
+	// on that resync's behalf: an epoch is a claim about the rowset it was
+	// fetched with, and adopting one over a rowset that was never replaced makes
+	// the cache agree with the server about a scope it does not hold — the
+	// silent adopt IDEA-2898 exists to prevent, arriving through a different
+	// door. Starts true: with no resync yet there is no unconfirmed snapshot.
+	durableSnapshotCommitted = $state(true);
 
 	// `scopeEpoch` bumps every time a projection resync installs a new
 	// authoritative snapshot (i.e. the scope changed). Reconcile loops capture
@@ -316,6 +327,31 @@ function rebuildSearchIndex(ws: string, state: WorkspaceState): void {
 	localSearch.rebuild(ws, state.items.values());
 }
 
+/**
+ * The access epoch a DELTA may stamp on the durable cache (TASK-2906 round 3).
+ *
+ * `state.accessEpoch` is what RAM believes, and after a REFUSED `persistReplace`
+ * that belief is true of RAM and false of disk: the resync adopted the new epoch
+ * while the durable rows were left describing the old scope. A delta advancing
+ * the cursor would then carry the new epoch onto those rows and make the cache
+ * agree with the server about a scope it does not hold — the same silent adopt
+ * the joined-resync stamp was taught to skip, one door along. Skipping is not
+ * available here, because the delta's rows and cursor must still land.
+ *
+ * So the delta writes NULL instead, which is not a gap but the accurate
+ * statement: a null baseline over a populated cache means "cannot know what this
+ * was authorised for", and `ensureAccessScope` already reads it as a resync. It
+ * clears itself — the next `persistReplace` that commits records the real epoch
+ * and flips the flag back.
+ *
+ * One function rather than the expression written at each `persistDelta` call,
+ * because a rule applied at one door and not its sibling is how this unit's
+ * previous two rounds each went.
+ */
+function durableEpochFor(state: WorkspaceState): string | null {
+	return state.durableSnapshotCommitted ? state.accessEpoch : null;
+}
+
 async function resyncProjectionScope(
 	ws: string,
 	state: WorkspaceState,
@@ -475,7 +511,7 @@ async function resyncProjectionScope(
 		// hydrate.
 		if (state.generation !== generation) return;
 		const snapshot = [...state.items.values()];
-		await persistReplace(
+		state.durableSnapshotCommitted = await persistReplace(
 			userId,
 			ws,
 			snapshot,
@@ -884,8 +920,10 @@ export const localIndex = {
 						resp.includes_unparented_metadata,
 						// The baseline this snapshot established, so the durable
 						// meta row records the scope its rows were fetched under
-						// (IDEA-2898).
-						state.accessEpoch,
+						// (IDEA-2898) — unless a refused snapshot has left the
+						// durable rows describing an older scope, in which case
+						// see durableEpochFor (TASK-2906).
+						durableEpochFor(state),
 					).catch(
 						() => undefined,
 					);
@@ -1120,7 +1158,7 @@ export const localIndex = {
 			toPersist,
 			newCursor,
 			includesUnparentedMetadata,
-			state.accessEpoch,
+			durableEpochFor(state),
 			toRemove,
 		).catch(
 			() => undefined,
@@ -1155,7 +1193,11 @@ export const localIndex = {
 				// Same joined-resync case as below.
 				if (state.accessEpoch === null) {
 					state.accessEpoch = accessEpoch;
-					await persistAccessEpoch(state.userId, ws, accessEpoch, null);
+					// Only when the resync's snapshot actually landed durably —
+					// see `durableSnapshotCommitted` (TASK-2906 round 2).
+					if (state.durableSnapshotCommitted) {
+						await persistAccessEpoch(state.userId, ws, accessEpoch, null);
+					}
 				}
 				return true;
 			}
@@ -1204,7 +1246,19 @@ export const localIndex = {
 			// and resync again — every reload, for a scope that has not changed
 			// since. The started-resync path has no such gap, because its
 			// fallback is applied BEFORE the persist that happens inside it.
-			await persistAccessEpoch(state.userId, ws, accessEpoch, beforeResync);
+			// ...AND ONLY IF THAT RESYNC'S SNAPSHOT REACHED DISK (TASK-2906
+			// round 2). The compare-and-set below is honest about the row it
+			// patches but cannot see whether the `persistReplace` it is
+			// finishing on behalf of committed. When that write was declined —
+			// a cursor that lost the race to another tab, or a storage failure —
+			// the durable rows still describe the OLD scope, and stamping the
+			// new epoch over them would leave a cache that agrees with the
+			// server about a scope it does not hold, with nothing left to
+			// notice. Skipping keeps the stale baseline on disk, which is
+			// exactly the disagreement that makes the next hydrate resync.
+			if (state.durableSnapshotCommitted) {
+				await persistAccessEpoch(state.userId, ws, accessEpoch, beforeResync);
+			}
 		}
 		return true;
 	},

--- a/web/src/lib/stores/localIndexAccessEpochWiring.svelte.test.ts
+++ b/web/src/lib/stores/localIndexAccessEpochWiring.svelte.test.ts
@@ -29,7 +29,11 @@ const persistence = vi.hoisted(() => ({
 	})),
 	persistDelta: vi.fn(async () => undefined),
 	persistRemovals: vi.fn(async () => undefined),
-	persistReplace: vi.fn(async () => undefined),
+	// Returns the durable-commit signal IDEA-2898's caller now reads (TASK-2906
+	// round 2): true = the snapshot reached disk. Default it to the committing
+	// case so these epoch-argument assertions keep testing what they name; the
+	// refusal case gets its own test below.
+	persistReplace: vi.fn(async () => true),
 	persistAccessEpoch: vi.fn(async () => undefined),
 	persistRetag: vi.fn(async () => undefined),
 	persistUpserts: vi.fn(async () => undefined),
@@ -149,6 +153,63 @@ describe('IDEA-2898 — what the resync hands on', () => {
 		expect(args[3]).toBe('e1');
 	});
 
+	it('does NOT stamp the told epoch on disk when the joined resync\u2019s snapshot was refused', async () => {
+		// TASK-2906 round 2. The compare-and-set above is honest about the row
+		// it patches but cannot see whether the `persistReplace` it is
+		// finishing on behalf of committed. Since TASK-2906 that write can be
+		// declined — its cursor lost the race to another tab — and then the
+		// durable rows still describe the OLD scope. Stamping the new epoch
+		// over them leaves a cache that AGREES with the server about a scope it
+		// does not hold, so neither a hydrate nor another tab's poll ever
+		// notices the revoked rows again: the silent adopt IDEA-2898 exists to
+		// prevent, arriving through a different door.
+		persistence.persistReplace.mockResolvedValueOnce(
+			false as unknown as Awaited<ReturnType<typeof persistence.persistReplace>>,
+		);
+		persistence.hydrate.mockResolvedValueOnce({
+			items: [row('cached', 1, 'kept')],
+			cursor: '1',
+			includesUnparentedMetadata: false,
+			accessEpoch: 'e1',
+			durableRead: true,
+			retags: {},
+		} as unknown as Awaited<ReturnType<typeof persistence.hydrate>>);
+		vi.spyOn(api.items, 'changes').mockResolvedValue({
+			changes: [],
+			cursor: '1',
+			includes_unparented_metadata: false,
+			access_epoch: 'e1',
+		});
+		await localIndex.bootstrap(ws, { userId: null });
+		persistence.persistAccessEpoch.mockClear();
+
+		let releaseSnapshot: (() => void) | undefined;
+		vi.spyOn(api.items, 'listIndex').mockReturnValue(
+			new Promise((resolve) => {
+				releaseSnapshot = () =>
+					resolve({
+						items: [row('cached', 1, 'kept')],
+						total: 1,
+						cursor: '1',
+						includes_unparented_metadata: false,
+						// No access_epoch, so the joined caller's fallback is the
+						// only thing that could move the baseline — exactly the
+						// path the round-2 finding walked.
+					});
+			}) as unknown as ReturnType<typeof api.items.listIndex>,
+		);
+		const first = localIndex.ensureProjectionScope(ws, true);
+		const joined = localIndex.ensureAccessScope(ws, 'e2');
+		releaseSnapshot?.();
+		await Promise.all([first, joined]);
+
+		// RAM still adopts it — this session has the new scope and re-resyncing
+		// it would loop. Only the DURABLE stamp is withheld, and withholding it
+		// is what leaves the disagreement that makes the next hydrate resync.
+		expect(localIndex.accessEpochFor(ws)).toBe('e2');
+		expect(persistence.persistAccessEpoch).not.toHaveBeenCalled();
+	});
+
 	it('persists the told epoch after a joined resync on a NULL baseline too', async () => {
 		// The same durable-repair as above, on the other branch. A populated
 		// cache with no recorded baseline resyncs by design; if that resync is
@@ -197,6 +258,53 @@ describe('IDEA-2898 — what the resync hands on', () => {
 		expect(nullBranchArgs[2]).toBe('told');
 		// The baseline being repaired on this branch is the ABSENT one.
 		expect(nullBranchArgs[3]).toBeNull();
+	});
+
+	it('withholds the durable stamp on the NULL-baseline branch too when the snapshot was refused', async () => {
+		// TASK-2906 round 2, second door. The guard belongs on BOTH branches for
+		// the same reason the stamp does, and a mutation run found this one
+		// unguarded-and-untested while its sibling above was covered — which is
+		// the failure the sibling test's own comment already warns about, one
+		// change later.
+		persistence.persistReplace.mockResolvedValueOnce(
+			false as unknown as Awaited<ReturnType<typeof persistence.persistReplace>>,
+		);
+		persistence.hydrate.mockResolvedValueOnce({
+			items: [row('cached', 1, 'kept')],
+			cursor: '1',
+			includesUnparentedMetadata: false,
+			accessEpoch: null,
+			durableRead: true,
+			retags: {},
+		} as unknown as Awaited<ReturnType<typeof persistence.hydrate>>);
+		vi.spyOn(api.items, 'changes').mockResolvedValue({
+			changes: [],
+			cursor: '1',
+			includes_unparented_metadata: false,
+		});
+		let releaseSnapshot: (() => void) | undefined;
+		vi.spyOn(api.items, 'listIndex').mockReturnValue(
+			new Promise((resolve) => {
+				releaseSnapshot = () =>
+					resolve({
+						items: [row('cached', 1, 'kept')],
+						total: 1,
+						cursor: '1',
+						includes_unparented_metadata: false,
+					});
+			}) as unknown as ReturnType<typeof api.items.listIndex>,
+		);
+		await localIndex.bootstrap(ws, { userId: null });
+		expect(localIndex.accessEpochFor(ws)).toBeNull();
+
+		persistence.persistAccessEpoch.mockClear();
+		const first = localIndex.ensureProjectionScope(ws, true);
+		const joined = localIndex.ensureAccessScope(ws, 'told');
+		releaseSnapshot?.();
+		await Promise.all([first, joined]);
+
+		expect(localIndex.accessEpochFor(ws)).toBe('told');
+		expect(persistence.persistAccessEpoch).not.toHaveBeenCalled();
 	});
 
 	it('does NOT adopt when the durable read FAILED, only when it answered', async () => {
@@ -272,6 +380,54 @@ describe('IDEA-2898 — what the resync hands on', () => {
 		expect(persistence.persistDelta).toHaveBeenCalled();
 		const args = persistence.persistDelta.mock.calls.at(-1) as unknown[];
 		expect(args[5]).toBe('e1');
+	});
+
+	it('hands persistDelta a NULL baseline while a refused snapshot is unrepaired', async () => {
+		// TASK-2906 round 3. Skipping the joined stamp is not enough on its own:
+		// RAM has adopted the new epoch, and the very next delta advances the
+		// cursor and carries that epoch onto durable rows the refused snapshot
+		// never replaced. The delta cannot be skipped — its rows and cursor must
+		// land — so it writes NULL, which is the accurate claim ("cannot know
+		// what this was authorised for") and the one `ensureAccessScope`
+		// already resyncs on.
+		persistence.persistReplace.mockResolvedValueOnce(
+			false as unknown as Awaited<ReturnType<typeof persistence.persistReplace>>,
+		);
+		persistence.hydrate.mockResolvedValueOnce({
+			items: [row('cached', 1, 'kept')],
+			cursor: '1',
+			includesUnparentedMetadata: false,
+			accessEpoch: 'e1',
+			durableRead: true,
+			retags: {},
+		} as unknown as Awaited<ReturnType<typeof persistence.hydrate>>);
+		vi.spyOn(api.items, 'changes').mockResolvedValue({
+			changes: [],
+			cursor: '1',
+			includes_unparented_metadata: false,
+			access_epoch: 'e1',
+		});
+		vi.spyOn(api.items, 'listIndex').mockResolvedValue({
+			items: [row('cached', 1, 'kept')],
+			total: 1,
+			cursor: '1',
+			includes_unparented_metadata: false,
+			access_epoch: 'e2',
+		} as unknown as Awaited<ReturnType<typeof api.items.listIndex>>);
+		await localIndex.bootstrap(ws, { userId: null });
+		await localIndex.ensureAccessScope(ws, 'e2');
+		expect(localIndex.accessEpochFor(ws)).toBe('e2');
+
+		persistence.persistDelta.mockClear();
+		localIndex.applyDelta(ws, [], '501', false);
+
+		expect(persistence.persistDelta).toHaveBeenCalled();
+		const args = persistence.persistDelta.mock.calls.at(-1) as unknown[];
+		// RAM keeps 'e2' — this session genuinely has the new scope. Only the
+		// DURABLE claim is withheld, and withholding it is what makes the next
+		// hydrate resync instead of adopting rows nobody replaced.
+		expect(args[5]).toBeNull();
+		expect(localIndex.accessEpochFor(ws)).toBe('e2');
 	});
 
 	it('writes the PRESERVED baseline to IDB when a resync snapshot carries no epoch', async () => {

--- a/web/src/lib/stores/localIndexPersistence.ts
+++ b/web/src/lib/stores/localIndexPersistence.ts
@@ -200,6 +200,114 @@ async function raiseTombstone(
 }
 
 /**
+ * Is `cursor` BEHIND the cursor already recorded in `meta.sync`? (TASK-2906.)
+ *
+ * The durable cursor is the claim that every change at or below it is already
+ * reflected in the durable rows. Two functions write that FIELD — `persistDelta`
+ * and `persistReplace` — and until this gate both `put` a freshly built
+ * `MetaRow` unconditionally, so the cursor was LAST-WRITER-WINS while every
+ * other value this cache holds was already ordered (rows arbitrate on `seq`
+ * through `resolveRowWrite`, tombstones on `Math.max` through
+ * `raiseTombstone`). `persistAccessEpoch` also writes the `sync` ROW, but it
+ * carries the stored cursor across unchanged, so it is not a third writer of
+ * the position.
+ *
+ * WHY A REGRESSION IS NOT MERELY WASTEFUL. A cursor that is too LOW only costs
+ * a replay, which is why this looked harmless. It is not, because nothing keeps
+ * it low until the replay happens: a behind tab lowers the cursor to 400 over
+ * rows another tab had current to 500, and then that other tab's next ordinary
+ * delta writes 501 — leaving the cache claiming 501 while the rows are missing
+ * every change in 401..500, with nothing left that will ever replay them. The
+ * regression alone is recoverable; the regression followed by an unrelated
+ * advance is not, and the advance is the next ordinary event.
+ *
+ * A SNAPSHOT'S POSITION IS NEVER LEGITIMATELY BEHIND. `/items-index` returns
+ * `max(workspace MAX(seq) read before the list, MAX(returned rows.seq))`, and
+ * that floor is workspace-global — unfiltered by visibility and by soft-delete.
+ * Every cursor the workspace has issued is therefore at or below its max seq at
+ * issue time, and seq is strictly monotonic per workspace. So a `persistReplace`
+ * whose cursor is behind is a STALE RESPONSE that landed late, not a resync
+ * legitimately pinning the cursor for replay — that pin is about the resyncing
+ * tab's own RAM position, where a regression is safe because the merge keeps the
+ * newer row per id and a replayed range is idempotent. See TASK-2906
+ * checkpoint 2 for the measurement.
+ *
+ * BUT POSITION IS ALL A BEHIND CURSOR SETTLES (review round 1). A snapshot that
+ * is behind in position can still be strictly NEWER IN SCOPE — an access
+ * revocation writes no item, so the epoch changes while the cursor does not, and
+ * such a snapshot can lose the position race to an unrelated mutation in another
+ * tab. Refusing it therefore does drop a true statement, and the reason that is
+ * survivable is the refusal being WHOLE: the durable epoch stays at the OLD
+ * value, so the disagreement that drives the repair is still on disk. Any
+ * hydrate of this cache reads the stale baseline and resyncs; and the tab that
+ * WON the position race reads the changed epoch on its own next
+ * `/items-changes` response — which carries the live-grant fingerprint even when
+ * it carries no changes — and resyncs from a cursor that is not behind. Writing
+ * the epoch while withholding the cursor would look like a kinder refusal and is
+ * the one thing that would break this: it erases the signal and leaves the
+ * revoked rows with nothing left to notice them.
+ *
+ * ORDERING PRECISION — and why this does NOT go through `seqFromCursor`
+ * (review round 2). Both sides of THIS comparison are cursors, which travel as
+ * opaque decimal strings and are unrounded until something calls `Number` on
+ * them, so an exact compare here is meaningful and is what `compareCursors`
+ * does. The lossiness of `ItemIndexRow.seq` — a JSON `number`, already rounded
+ * at parse — bounds the ROW comparisons in `resolveRowWrite` and the tombstone
+ * stamps in `raiseTombstone`, which is a different pair of values; reasoning
+ * from that pair to this one was the first draft's mistake. `seqFromCursor`
+ * stays as it is because a tombstone stamp is persisted as a `number` and has
+ * to be one.
+ *
+ * The caller drops the WHOLE batch on true, rows included. A delta's rows and
+ * its cursor are one statement, so writing the rows while withholding the
+ * cursor would break it in half — and unlike the epoch case that reasoning came
+ * from, dropping it whole costs nothing here: everything a behind batch carries
+ * is already covered by the claim the stored cursor makes. The batch is
+ * superseded, not refused, so no caller is owed a signal or a resync.
+ */
+async function cursorIsBehind(
+	metaStore: { get(key: string): Promise<unknown> },
+	cursor: string,
+): Promise<boolean> {
+	const stored = (await metaStore.get('sync')) as MetaRow | undefined;
+	// No stored cursor: nothing to be behind. Equal is not behind — the rows are
+	// a restatement at the same position, and refusing one would drop rows a
+	// cold snapshot may hold that the other writer's cache does not.
+	if (!stored) return false;
+	return compareCursors(cursor, stored.cursor) < 0;
+}
+
+/**
+ * Order two cursors EXACTLY (TASK-2906, review round 2). Cursors are opaque
+ * decimal strings on the wire, so comparing them through `Number` ties any pair
+ * that differs only above 2^53 — and a tie reads as "not behind", which is the
+ * direction that lets a stale batch through.
+ *
+ * Canonical non-negative decimals compare by digit count and then
+ * lexicographically, which is exact at any magnitude and needs no BigInt.
+ * Anything else — an empty string, a non-numeric value, a sign, a fractional
+ * part — falls back to `seqFromCursor`'s `Number` reading so malformed input
+ * behaves exactly as it did before this function existed rather than acquiring
+ * a new meaning here.
+ *
+ * Returns <0 when `a` is behind `b`, 0 when equal, >0 when ahead.
+ */
+function compareCursors(a: string, b: string): number {
+	if (!DECIMAL_CURSOR.test(a) || !DECIMAL_CURSOR.test(b)) {
+		return seqFromCursor(a) - seqFromCursor(b);
+	}
+	// Strip leading zeros so "007" and "7" compare equal by length as well as
+	// by digits; the guard keeps a lone "0" intact.
+	const x = a.replace(/^0+(?=\d)/, '');
+	const y = b.replace(/^0+(?=\d)/, '');
+	if (x.length !== y.length) return x.length - y.length;
+	return x < y ? -1 : x > y ? 1 : 0;
+}
+
+/** A canonical non-negative decimal cursor — the only shape the server emits. */
+const DECIMAL_CURSOR = /^\d+$/;
+
+/**
  * Open the workspace's IDB database for the given user, creating
  * object stores on first run. Cached so subsequent calls reuse the
  * connection. Returns null on any storage failure — callers must
@@ -519,6 +627,15 @@ export async function persistDelta(
 		const tx = db.transaction(['items', 'meta', 'tombstones'], 'readwrite');
 		const itemsStore = tx.objectStore('items');
 		const tombstones = tx.objectStore('tombstones');
+		const metaStore = tx.objectStore('meta');
+		// CURSOR ORDERING GATE (TASK-2906). Read the stored cursor BEFORE any
+		// write is issued in this transaction, so a behind batch lands nothing
+		// at all — see cursorIsBehind for why the whole batch goes, not just
+		// the cursor.
+		if (await cursorIsBehind(metaStore, cursor)) {
+			await tx.done.catch(() => undefined);
+			return;
+		}
 		// Same policy as persistUpserts (resolveRowWrite): the race runs in both
 		// directions, so a delta must not overwrite a row that is already NEWER
 		// in the cache, and a tombstone must refuse a stale resurrection.
@@ -543,7 +660,7 @@ export async function persistDelta(
 			itemsStore.delete(id).catch(() => undefined);
 			await raiseTombstone(tombstones, id, deletedAtSeq);
 		}
-		tx.objectStore('meta')
+		metaStore
 			.put({
 				key: 'sync',
 				cursor,
@@ -589,13 +706,36 @@ export async function persistReplace(
 	cursor: string,
 	includesUnparentedMetadata: boolean,
 	accessEpoch: string | null,
-): Promise<void> {
-	if (!isSupported()) return;
+): Promise<boolean> {
+	// TRUE means "nothing durable can now contradict this snapshot" — the same
+	// reading `HydrateResult.durableRead` uses, and the reason an unsupported
+	// IndexedDB answers true: with no durable cache in the picture there is no
+	// stale rowset for an adopted epoch to describe. FALSE means this call did
+	// not put the snapshot on disk, and is deliberately the answer when the
+	// database could not even be OPENED — that failure cannot prove a cache is
+	// absent, and between "no cache" and "a cache I could not replace" only the
+	// second is safe to assume. See the caller notes in
+	// `localIndex.ensureAccessScope` and `durableEpochFor` for why the
+	// difference is load-bearing (review rounds 2 and 3).
+	if (!isSupported()) return true;
 	const db = await open(userId, ws);
-	if (!db) return;
+	if (!db) return false;
 	try {
 		const tx = db.transaction(['items', 'meta', 'tombstones'], 'readwrite');
 		const itemsStore = tx.objectStore('items');
+		const metaStore = tx.objectStore('meta');
+		// CURSOR ORDERING GATE (TASK-2906), before the clear below issues. A
+		// replace whose cursor is behind is a stale response that landed late,
+		// not a legitimate pin; letting it through clears rows another tab had
+		// current and regresses the cursor over them. Refusing keeps rows this
+		// snapshot's scope no longer grants — an accepted cost, recorded on the
+		// TASK-2906 trail: it adds no exposure the cache did not already carry
+		// one moment earlier, and refusing the epoch ALONG WITH the rows is what
+		// keeps the repair alive — see cursorIsBehind's scope paragraph.
+		if (await cursorIsBehind(metaStore, cursor)) {
+			await tx.done.catch(() => undefined);
+			return false;
+		}
 		// Queued before the puts; IDB executes requests against a store in
 		// issue order, so the clear always lands first.
 		itemsStore.clear().catch(() => undefined);
@@ -605,7 +745,6 @@ export async function persistReplace(
 		// both overlays so a stale tombstone can't refuse a legitimate row and a
 		// stale retag can't regress a newer slug on the next hydrate.
 		tx.objectStore('tombstones').clear().catch(() => undefined);
-		const metaStore = tx.objectStore('meta');
 		metaStore.delete('retags').catch(() => undefined);
 		for (const row of rows) {
 			itemsStore.put(row).catch(() => undefined);
@@ -620,8 +759,10 @@ export async function persistReplace(
 			} satisfies MetaRow)
 			.catch(() => undefined);
 		await tx.done;
+		return true;
 	} catch {
 		/* swallow — best-effort cache */
+		return false;
 	}
 }
 

--- a/web/src/lib/stores/localIndexPersistenceCursorOrdering.idb.test.ts
+++ b/web/src/lib/stores/localIndexPersistenceCursorOrdering.idb.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect } from 'vitest';
+import type { ItemIndexRow } from '$lib/types';
+import { loadPersistence, rawItem, rawItems } from '../../test/idbHarness';
+
+/**
+ * TASK-2906 (PLAN-2903 item 2) — the durable cursor never moves backward, and
+ * a batch whose position is behind it is dropped whole.
+ *
+ * The cursor was the one value this cache wrote without ordering: rows already
+ * arbitrate on `seq` through `resolveRowWrite` and tombstones through
+ * `raiseTombstone`'s `Math.max`, while `persistDelta` and `persistReplace` each
+ * `put` a freshly built meta row unconditionally. See TASK-2906 checkpoints 1
+ * and 2 for the writer table and the two traps.
+ *
+ * These are sequential calls through the real module, which is how this file's
+ * siblings pin the PLAN-2636 races: IDB serializes the transactions, so
+ * ordering the calls IS the cross-tab interleaving.
+ */
+
+function row(id: string, seq: number): ItemIndexRow {
+	return { id, seq, collection_slug: 'c' } as unknown as ItemIndexRow;
+}
+
+async function cursorOf(
+	mod: Awaited<ReturnType<typeof loadPersistence>>,
+	userId: string | null,
+	ws: string,
+): Promise<string> {
+	return (await mod.hydrate(userId, ws)).cursor;
+}
+
+describe('TASK-2906 — the durable cursor never moves backward', () => {
+	it('refuses a delta whose cursor is behind the stored one, cursor and rows together', async () => {
+		const U = null;
+		const WS = 'ws-2906-delta-behind';
+		const mod = await loadPersistence();
+		const { persistDelta } = mod;
+
+		// The ahead tab.
+		await persistDelta(U, WS, [row('a', 500)], '500', false, null);
+		// The behind tab's late delta. Its row would be a fresh INSERT — the id
+		// is not stored, so `resolveRowWrite` has no seq and no tombstone to
+		// refuse it with, and only the cursor can say it is stale.
+		await persistDelta(U, WS, [row('late', 300)], '300', false, null);
+
+		expect(await cursorOf(mod, U, WS)).toBe('500');
+		expect(await rawItem(U, WS, 'late')).toBeUndefined();
+	});
+
+	it('refuses a replace whose cursor is behind, keeping the ahead tab’s rows uncleared', async () => {
+		const U = null;
+		const WS = 'ws-2906-replace-behind';
+		const mod = await loadPersistence();
+		const { persistDelta, persistReplace } = mod;
+
+		await persistDelta(U, WS, [row('a', 500), row('b', 500)], '500', false, null);
+		// A stale snapshot that was computed before the ahead tab advanced and
+		// landed after it. A replace CLEARS the items store, so letting it
+		// through would drop `b` as well as regress the cursor.
+		await persistReplace(U, WS, [row('a', 400)], '400', false, null);
+
+		expect(await cursorOf(mod, U, WS)).toBe('500');
+		const ids = (await rawItems(U, WS)).map((r) => r.id).sort();
+		expect(ids).toEqual(['a', 'b']);
+		expect((await rawItem(U, WS, 'a'))?.seq).toBe(500);
+	});
+
+	it('does not reinsert a row the ahead tab’s resync removed', async () => {
+		const U = null;
+		const WS = 'ws-2906-no-resurrect';
+		const mod = await loadPersistence();
+		const { persistDelta, persistReplace } = mod;
+
+		// Both rows visible under the old scope.
+		await persistDelta(U, WS, [row('keep', 250), row('revoked', 250)], '250', false, 'e1');
+		// The ahead tab resyncs under a narrowed scope: `revoked` is absent from
+		// the authoritative snapshot, and the replace also clears tombstones —
+		// which is exactly why no tombstone is left to refuse the reinsert.
+		await persistReplace(U, WS, [row('keep', 500)], '500', false, 'e2');
+		expect(await rawItem(U, WS, 'revoked')).toBeUndefined();
+
+		// The behind tab never learned about the narrowing and replays its own
+		// delta carrying the revoked row.
+		await persistDelta(U, WS, [row('revoked', 250)], '300', false, 'e1');
+
+		expect(await rawItem(U, WS, 'revoked')).toBeUndefined();
+		expect(await cursorOf(mod, U, WS)).toBe('500');
+	});
+
+	it('keeps the rows a regressed cursor would strand once the ahead tab advances again', async () => {
+		const U = null;
+		const WS = 'ws-2906-loss-path';
+		const mod = await loadPersistence();
+		const { persistDelta, persistReplace } = mod;
+
+		// This is the case that makes a regression more than wasteful. A cursor
+		// that is too LOW only costs a replay — but nothing keeps it low: the
+		// ahead tab's next ordinary delta advances it past the gap, and then
+		// nothing will ever replay the window the replace cleared.
+		await persistDelta(U, WS, [row('a', 500), row('b', 500)], '500', false, null);
+		await persistReplace(U, WS, [row('a', 400)], '400', false, null);
+		await persistDelta(U, WS, [row('c', 501)], '501', false, null);
+
+		expect(await cursorOf(mod, U, WS)).toBe('501');
+		// Without the gate the cursor still reads 501 here — `b` is what tells
+		// the two builds apart, so assert the row, not just the position.
+		expect(await rawItem(U, WS, 'b')).toBeDefined();
+		const ids = (await rawItems(U, WS)).map((r) => r.id).sort();
+		expect(ids).toEqual(['a', 'b', 'c']);
+	});
+
+	it('leaves the OLD epoch on disk when it refuses a behind snapshot carrying a new one', async () => {
+		const U = null;
+		const WS = 'ws-2906-refusal-keeps-repair-signal';
+		const mod = await loadPersistence();
+		const { persistDelta, persistReplace } = mod;
+
+		// A behind cursor settles POSITION, not SCOPE. A revocation writes no
+		// item, so a snapshot can be strictly newer in scope while losing the
+		// position race to an unrelated mutation in another tab (review round 1).
+		await persistDelta(U, WS, [row('a', 500), row('revoked', 500)], '501', false, 'e1');
+		await persistReplace(U, WS, [row('a', 500)], '500', false, 'e2');
+
+		const after = await mod.hydrate(U, WS);
+		// The refusal has to be WHOLE. Writing the epoch while withholding the
+		// cursor would look like the kinder refusal and is the one thing that
+		// breaks the repair: a durable `e2` agrees with the server, so no
+		// hydrate and no ahead tab would ever notice the revoked row again.
+		expect(after.accessEpoch).toBe('e1');
+		expect(after.cursor).toBe('501');
+		expect(await rawItem(U, WS, 'revoked')).toBeDefined();
+	});
+
+	it('accepts a batch at the SAME cursor — equal is not behind', async () => {
+		const U = null;
+		const WS = 'ws-2906-equal';
+		const mod = await loadPersistence();
+		const { persistDelta } = mod;
+
+		await persistDelta(U, WS, [row('a', 500)], '500', false, null);
+		// A second tab restating the same position with a row the first lacked
+		// (a cold snapshot is exactly this shape). Refusing it would drop rows
+		// for no ordering reason, so the gate is strictly-behind, not
+		// at-or-behind.
+		await persistDelta(U, WS, [row('b', 500)], '500', false, null);
+
+		expect(await rawItem(U, WS, 'b')).toBeDefined();
+		expect(await cursorOf(mod, U, WS)).toBe('500');
+	});
+
+	it('orders cursors that differ only above 2^53, where Number ties', async () => {
+		const U = null;
+		const WS = 'ws-2906-precision';
+		const mod = await loadPersistence();
+		const { persistDelta } = mod;
+
+		// Both of these are the same IEEE double. Comparing through `Number`
+		// makes them tie, and a tie reads as "not behind" — the direction that
+		// lets a stale batch through (review round 2).
+		await persistDelta(U, WS, [row('a', 1)], '9007199254740993', false, null);
+		await persistDelta(U, WS, [row('behind', 2)], '9007199254740992', false, null);
+
+		expect(await cursorOf(mod, U, WS)).toBe('9007199254740993');
+		expect(await rawItem(U, WS, 'behind')).toBeUndefined();
+	});
+
+	it('reports whether the snapshot reached disk, so the caller can tell a refusal from a commit', async () => {
+		const U = null;
+		const WS = 'ws-2906-replace-reports';
+		const mod = await loadPersistence();
+		const { persistDelta, persistReplace } = mod;
+
+		// The return value is what stops `ensureAccessScope` stamping a new
+		// access epoch onto a rowset that was never replaced.
+		expect(await persistReplace(U, WS, [row('a', 1)], '10', false, 'e1')).toBe(true);
+		await persistDelta(U, WS, [row('b', 20)], '20', false, 'e1');
+		expect(await persistReplace(U, WS, [row('a', 1)], '15', false, 'e2')).toBe(false);
+	});
+
+	it('accepts the first write, when there is no stored cursor to be behind', async () => {
+		const U = null;
+		const WS = 'ws-2906-first-write';
+		const mod = await loadPersistence();
+		const { persistReplace } = mod;
+
+		// An absent meta row is not a cursor of 0 that everything ties with —
+		// it is no claim at all, and the first write must land.
+		await persistReplace(U, WS, [row('a', 7)], '7', false, null);
+
+		expect(await cursorOf(mod, U, WS)).toBe('7');
+		expect(await rawItem(U, WS, 'a')).toBeDefined();
+	});
+});


### PR DESCRIPTION
Second unit of [[PLAN-2903]] (the plan's item 2, "cursor ordering"), split from IDEA-2898. Closes the half TASK-2906 names: **the durable cursor never moves backward, and a batch whose position is behind it lands nothing.**

## The defect

The durable cursor was the one value this cache wrote without ordering. Rows already arbitrate on `seq` (`resolveRowWrite`) and tombstones on `Math.max` (`raiseTombstone`), while `persistDelta` and `persistReplace` each `put` a freshly built meta row unconditionally — last-writer-wins, so a behind tab lowered it.

A low cursor only costs a replay, which is why this read as harmless. **Nothing keeps it low until the replay happens:**

1. Tab A ahead — durable rows current to seq 500, cursor `"500"`.
2. Tab B (RAM at 400) resyncs; `persistReplace` clears the items store and writes cursor `"400"`. Still self-consistent — a hydrate here would replay 401..500.
3. Tab A's next ordinary delta writes cursor `"501"`.

The cache now claims 501 while the rows are missing every change in 401..500, and nothing will ever replay them.

## The measurement that changed the shape

The unit's own checkpoint 1 flagged a trap: *a resync legitimately PINS the cursor, so a naive gate may refuse the write the resync exists to make*. **Measured false.** `/items-index` returns `max(workspace MAX(seq) read before the list, MAX(returned rows.seq))`, and that floor is workspace-global — unfiltered by visibility and by soft-delete. Every cursor the workspace has issued is at or below its max seq at issue time, so a behind snapshot is a **stale response that landed late**, not a pin. The pin is about the resyncing tab's own RAM position, where regression is safe (the merge keeps the newer row per id; a replayed range is idempotent).

## What lands

Both writers read the stored cursor before issuing any write in their existing transaction and drop the **whole batch** when the incoming cursor is strictly behind — rows included, since a delta's rows and its cursor are one statement. Equal is not behind.

Position is all a behind cursor settles, though, and that is where the review rounds went. A revocation writes no item, so a snapshot can be strictly newer in **scope** while losing the position race. Refusing it drops a true statement; what makes that survivable is the refusal being whole — the durable epoch stays old, so the disagreement that drives the repair is still on disk. That argument then has to survive the two doors that write the epoch with no snapshot behind them:

- **`ensureAccessScope` joining a resync** stamps the told epoch on that resync's behalf without seeing whether its `persistReplace` committed. Both stamping branches now skip on a refusal.
- **the next ordinary delta** would carry RAM's adopted epoch onto rows the refused snapshot never replaced. A delta cannot be skipped, so it writes `null` — the accurate claim, and the one `ensureAccessScope` already resyncs on. Self-clearing.

Both read one signal (`persistReplace`'s new boolean) through one helper. The hazard predates this change (a storage failure or the generation guard reaches it too); a refusable write makes it routine.

Cursors are ordered **exactly** rather than through `Number`, which ties any pair differing only above 2^53 — and a tie reads as "not behind", the direction that lets a stale batch through.

## Scope — what this does NOT close

`persistReplace`'s documented residual names a stale **`persistUpserts`** from another tab. That carries no cursor, and gating it on the row's own `seq` would refuse the optimistic-reorder path that passes `seq: undefined` deliberately. That arm stays with PLAN-2903. F2 is **not** fully closed, said after measuring rather than either way.

## Gates

| Gate | Result |
|---|---|
| `npx vite build` | ✅ built |
| `go build ./...` | ✅ (no Go files changed) |
| `npm run check` (svelte-check) | ✅ 1101 files, **0 errors**, 6 pre-existing warnings |
| `npx vitest run` (full web suite) | ✅ **2173 passed** |
| `npm run check:tiptap-pins` | ✅ |
| `make lint` / `go test ./...` / `make test-pg` | N/A — no Go or store SQL in the diff |
| Codex | 3 rounds; round 3's remaining P2 fixed in code, not argued away |

**Twelve new tests, ten of which fail against the unfixed source** (measured by running them against `main`'s copies of both files); the two that pass are boundary guards, not regressions.

**Mutation matrix — eleven mutants, ten killed.** Gate removed from each writer; behind widened to at-or-behind; absent meta row treated as behind; the kinder refusal that keeps the cursor while adopting the new epoch; the exact compare degraded back to `Number`; the commit signal ignored in each of the two stamping branches and in the delta helper; `persistReplace` always reporting success. Two survived a first run and were answered differently: the null-baseline branch was genuinely untested and now has its own test, while the cold-path delta site is **unreachable** with the flag false (`hasCache = reentry || cacheIsPopulated` gates that branch, only a post-resync state can be false, and `reset()` restores the default) — an equivalent mutant, kept uniform deliberately. A non-compiling negative control scores BUILD-FAIL rather than SURVIVED.

TASK-2906 · PLAN-2903

https://claude.ai/code/session_01Xk9M5UVPdc84xL5E1mZkm8
