### PR TITLE
fix(store): a relation value pointing at an orphaned item is carried, not rewritten into a minted id (BUG-2895)

### DIFF
--- a/internal/store/export.go
+++ b/internal/store/export.go
@@ -737,6 +737,33 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 		insertedItems[newItemID] = true
 	}
 
+	// The remap map for relation FIELD VALUES, filtered to items that actually
+	// landed (BUG-2895). itemMap holds an entry for every item in the bundle
+	// INCLUDING orphans — see the note where it is built, which explains why it
+	// has to — so remapping a field value through it rewrites a reference to an
+	// orphan into the id that orphan WOULD have received: an id that names no
+	// row here and has never identified anything anywhere.
+	//
+	// That is worse than leaving it alone. TASK-2878's carry rule imports an
+	// unresolvable relation value VERBATIM precisely so nothing is invented:
+	// the source id is evidence a human or a repair tool can act on, and
+	// ImportWorkspace runs no MigrateRelationReferents pass afterwards to
+	// re-examine what this writes.
+	//
+	// This is the same correction BUG-2884 made for parent_id, arriving late
+	// because every site that one fixed writes a FOREIGN KEY and the database
+	// objected. This one writes into a JSON blob, so nothing objected.
+	//
+	// KEY SPACES DIFFER and getting it backwards is silent in both directions:
+	// itemMap is oldID -> newID, insertedItems is keyed by NEW id. The test is
+	// on the VALUE.
+	insertedItemMap := make(map[string]string, len(insertedItems))
+	for oldID, newItemID := range itemMap {
+		if insertedItems[newItemID] {
+			insertedItemMap[oldID] = newItemID
+		}
+	}
+
 	// Second pass: remap parent_id and relation fields (now all items exist).
 	// Use the coerced first-pass fields value as the remap input so a
 	// malformed-and-coerced row doesn't get its coercion clobbered by the
@@ -755,8 +782,9 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 		if !ok {
 			fieldsInput = it.Fields // defensive — should always be populated by first pass
 		}
-		// Remap relation fields now that ALL items are mapped
-		fields := remapFieldIDs(fieldsInput, itemMap, collMap)
+		// Remap relation fields now that all INSERTED items are mapped
+		// (BUG-2895 — see insertedItemMap above for why it is not itemMap).
+		fields := remapFieldIDs(fieldsInput, insertedItemMap)
 		parentID := resolveImportParent(it.ParentID, itemMap, insertedItems)
 		_, err := tx.Exec(s.q(`UPDATE items SET fields = ?, parent_id = NULLIF(?, '') WHERE id = ?`),
 			fields, parentID, newItemID)
@@ -1004,6 +1032,17 @@ func (s *Store) rebuildFTSForWorkspace(wsID string) {
 // remapFieldIDs replaces old UUIDs in a JSON fields string with their new IDs.
 // This handles relation fields (e.g. parent: "uuid") without needing to parse the schema.
 //
+// itemMap must contain ONLY items the import actually inserted (BUG-2895). An id
+// absent from it is left verbatim, which is the carry posture TASK-2878 defines
+// for an unresolvable relation value; an id this function invents is not
+// unresolvable, it is fabricated, and nothing downstream re-examines it.
+//
+// The collMap parameter this used to take was never read — a relation field's
+// VALUE names an item, and the collection a relation targets is carried in the
+// SCHEMA as a slug, not as an id in the blob (see retargetRelationFieldsTx).
+// Dropped rather than left, because an unread parameter reads as a claim that
+// collection ids are remapped here.
+//
 // IDEA-1486: empty-string input is normalized to "{}". Centralizing the
 // contract here keeps future callers safe by default — any UPDATE that
 // writes the result back into items.fields is guaranteed to satisfy the
@@ -1013,7 +1052,7 @@ func (s *Store) rebuildFTSForWorkspace(wsID string) {
 // invalid JSON on SQLite and (post-migration) would have already 500'd
 // on the first-pass INSERT on Postgres if not for the import-boundary
 // coercion above.
-func remapFieldIDs(fieldsJSON string, itemMap, collMap map[string]string) string {
+func remapFieldIDs(fieldsJSON string, itemMap map[string]string) string {
 	if fieldsJSON == "" {
 		return "{}"
 	}

--- a/internal/store/relation_referents_test.go
+++ b/internal/store/relation_referents_test.go
@@ -686,3 +686,164 @@ func TestImportWorkspace_UnresolvableRelationValueSurvivesAPrefixCollision(t *te
 			"the remap has stopped working", got, want)
 	}
 }
+
+// A relation value pointing at an ORPHANED item is carried verbatim, not
+// rewritten into an id that names no row (BUG-2895).
+//
+// itemMap holds an entry for every item in the bundle INCLUDING orphans —
+// items whose collection the bundle does not carry — because the entry is
+// written before the orphan skip and parent resolution inside the same loop
+// reads it for items the loop has not reached. Passing that map to
+// remapFieldIDs rewrote an orphan-pointing relation value into the id the
+// orphan WOULD have received: an id that names no row here and has never
+// identified anything in any workspace.
+//
+// That is strictly worse than dangling. TASK-2878's carry rule imports an
+// unresolvable value VERBATIM so the source id survives as evidence a human or
+// a repair tool can act on; a fabricated id destroys the information that the
+// value was ever resolvable, and ImportWorkspace runs no
+// MigrateRelationReferents pass afterwards to re-examine it.
+//
+// This is the JSON-blob twin of BUG-2884's parent_id fix. Every site that one
+// corrected writes a FOREIGN KEY, so the database objected and the sweep found
+// them; this one writes into a blob, so nothing objected and it shipped.
+//
+// The bundle is hand-built because ExportWorkspace cannot produce an orphan —
+// which is the population the carry rule exists for: hand-edited, foreign, and
+// pre-BUG-2884 archives.
+//
+// MUTANT: pass itemMap instead of insertedItemMap at the remapFieldIDs call and
+// the orphan leg fails with a fresh UUID. Delete the second-pass remap entirely
+// and the CONTROL leg fails — that leg is the reason "carried verbatim" here
+// cannot be satisfied by "never processed", which produces byte-identical
+// output for the orphan leg alone.
+func TestImportWorkspace_DoesNotMintIDsForOrphanRelationReferents(t *testing.T) {
+	t.Parallel()
+	s := testStore(t)
+	owner, err := s.CreateUser(models.UserCreate{
+		Name:     "Owner",
+		Email:    "relation-orphan-owner@example.com",
+		Password: "passw0rd!",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	// No id here is a prefix of another: a partial rewrite (codex round 17's
+	// defect, fixed) would otherwise fail these assertions for the wrong reason.
+	const (
+		liveColorID   = "old-color-alpha"
+		orphanColorID = "old-color-omega" // an ITEM in the bundle, collection absent
+		relationField = "color"
+	)
+
+	export := &models.WorkspaceExport{
+		Version:    1,
+		ExportedAt: "2026-09-07T00:00:00Z",
+		Workspace: models.WorkspaceExportMeta{
+			Name: "Orphan Relation Archive",
+			Slug: "orphan-relation-archive",
+		},
+		Collections: []models.CollectionExport{
+			{
+				ID: "old-coll-colors", Name: "Colors", Slug: "colors", Prefix: "COLO",
+				Schema:    `{"fields":[{"key":"status","type":"select","options":["open","done"],"default":"open","required":true}]}`,
+				CreatedAt: "2026-09-07T00:00:00Z", UpdatedAt: "2026-09-07T00:00:00Z",
+			},
+			{
+				ID: "old-coll-cars", Name: "Cars", Slug: "cars", Prefix: "CAR",
+				Schema:    `{"fields":[{"key":"status","type":"select","options":["open","done"],"default":"open","required":true},{"key":"color","type":"relation","collection":"colors"}]}`,
+				CreatedAt: "2026-09-07T00:00:00Z", UpdatedAt: "2026-09-07T00:00:00Z",
+			},
+			// "old-coll-hues" is deliberately ABSENT — that is what orphans the
+			// item below.
+		},
+		Items: []models.ItemExport{
+			{
+				ID: liveColorID, CollectionID: "old-coll-colors",
+				Title: "Red", Slug: "red",
+				Fields: `{}`, Tags: `[]`,
+				CreatedAt: "2026-09-07T00:00:00Z", UpdatedAt: "2026-09-07T00:00:00Z",
+			},
+			{
+				// THE ORPHAN: its collection is not in the bundle, so the import
+				// skips it — while still writing its itemMap entry.
+				ID: orphanColorID, CollectionID: "old-coll-hues",
+				Title: "Orphaned Hue", Slug: "orphaned-hue",
+				Fields: `{}`, Tags: `[]`,
+				CreatedAt: "2026-09-07T00:00:00Z", UpdatedAt: "2026-09-07T00:00:00Z",
+			},
+			{
+				// CONTROL: resolves inside the bundle, MUST come out rewritten.
+				ID: "old-car-resolvable", CollectionID: "old-coll-cars",
+				Title: "Resolvable", Slug: "resolvable",
+				Fields: `{"color":"` + liveColorID + `"}`, Tags: `[]`,
+				CreatedAt: "2026-09-07T00:00:00Z", UpdatedAt: "2026-09-07T00:00:00Z",
+			},
+			{
+				// THE SUBJECT: points at the orphan.
+				ID: "old-car-orphan-ref", CollectionID: "old-coll-cars",
+				Title: "Orphan Referent", Slug: "orphan-referent",
+				Fields: `{"color":"` + orphanColorID + `"}`, Tags: `[]`,
+				CreatedAt: "2026-09-07T00:00:00Z", UpdatedAt: "2026-09-07T00:00:00Z",
+			},
+		},
+	}
+
+	ws, err := s.ImportWorkspace(export, "Orphan Relation Target", owner.ID)
+	if err != nil {
+		t.Fatalf("ImportWorkspace: %v", err)
+	}
+
+	items, err := s.ListItems(ws.ID, models.ItemListParams{})
+	if err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+	byTitle := map[string]models.Item{}
+	for _, it := range items {
+		byTitle[it.Title] = it
+	}
+
+	// FIXTURE CHECK: the orphan really was orphaned. Without this the test
+	// could pass on a build that imported it, where the value would be
+	// legitimately resolvable and nothing under test would be exercised.
+	if _, imported := byTitle["Orphaned Hue"]; imported {
+		t.Fatalf("the orphan IMPORTED, so this fixture no longer orphans anything; titles=%v", byTitle)
+	}
+	red, ok := byTitle["Red"]
+	if !ok {
+		t.Fatalf("the relation target did not import; the control below would be meaningless. titles=%v", byTitle)
+	}
+
+	relationValue := func(title string) (any, bool) {
+		t.Helper()
+		it, ok := byTitle[title]
+		if !ok {
+			t.Fatalf("item %q did not import", title)
+		}
+		var fields map[string]any
+		if err := json.Unmarshal([]byte(it.Fields), &fields); err != nil {
+			t.Fatalf("item %q has an unreadable fields blob %q: %v", title, it.Fields, err)
+		}
+		v, present := fields[relationField]
+		return v, present
+	}
+
+	// CONTROL: the remap ran at all.
+	got, present := relationValue("Resolvable")
+	if !present {
+		t.Fatalf("the resolvable relation value was DROPPED")
+	}
+	if got != red.ID {
+		t.Fatalf("resolvable relation is %v, want the imported target's id %q; the remap did not run, so the orphan assertion below proves nothing", got, red.ID)
+	}
+
+	// THE RULE: the orphan-pointing value is carried verbatim.
+	got, present = relationValue("Orphan Referent")
+	if !present {
+		t.Fatalf("import DROPPED a relation value pointing at an orphan; the ruling is that it carries")
+	}
+	if got != orphanColorID {
+		t.Fatalf("import rewrote an orphan-pointing relation value to %v — an id that names no row in any workspace — want it carried verbatim as %q", got, orphanColorID)
+	}
+}


### PR DESCRIPTION
Closes BUG-2895.

## The defect

`ImportWorkspace`'s second pass handed `remapFieldIDs` the unfiltered `itemMap`. That map holds an entry for **every** item in the bundle **including orphans** — items whose collection the bundle does not carry — because the entry is written before the orphan skip and parent resolution inside the same loop reads it for items the loop has not reached yet.

So a relation field pointing at an orphan was rewritten to the id that orphan *would* have received: an id that names no row in the destination and has never identified anything in any workspace.

Measured on the filing:

```
source orphan id : 89affc62-163a-4077-8649-06d0ca6e2ee7
imported fields  : {"related":"37b09d3f-19c7-409d-ab36-d3efbc51713b"}
```

## Why it is worse than dangling

TASK-2878's carry rule imports an unresolvable relation value **verbatim** precisely so nothing is invented. The source id is evidence — it says "this pointed at that item over there", which a human or a repair tool can act on. A fabricated id destroys the information that the value was ever resolvable, and `ImportWorkspace` runs no `MigrateRelationReferents` pass afterwards to re-examine what it wrote.

## The fix

Filter the map to items that actually landed, once, before the second pass. Same correction BUG-2884 made for `parent_id`; it arrives separately because every site that unit fixed writes a FOREIGN KEY, so the database objected and the sweep found them. This one writes into a JSON blob, so nothing objected.

Also drops `remapFieldIDs`' `collMap` parameter, which was never read. A relation's target collection travels in the SCHEMA as a slug, not as an id in the fields blob, so an unread parameter there reads as a claim that collection ids are remapped.

## Population and boundary

- `itemMap` has **eight** consumers inside `ImportWorkspace`; seven already check `insertedItems` and this call was the eighth. Re-verified at this tip, and independently enumerated by an outside review round that reached the same eight.
- `collMap` needs no equivalent: the collections loop has no `continue`, so every collection either INSERTs or the import returns an error, and no `collMap` entry can name a row that does not exist.
- Repo-wide, `remapFieldIDs` has one caller. The one other place ids are rewritten into text — `attachments_copy_plan.go` — already classifies unresolvable refs and leaves them literal.
- **Search boundary:** `internal/store`.

## Test and mutants

`TestImportWorkspace_DoesNotMintIDsForOrphanRelationReferents`. The bundle is hand-built because `ExportWorkspace` cannot produce an orphan — which is the population the carry rule exists for: hand-edited, foreign, and pre-BUG-2884 archives.

| mutant | observed |
|---|---|
| restore the defect (pass `itemMap`) | FAIL — orphan leg gets a fresh UUID |
| delete the second-pass remap | FAIL — control leg, on this test and the sibling carry test |
| filter on the wrong key space (`insertedItems[oldID]`) | FAIL — control leg, map comes out empty |

Under the first mutant the pre-existing `TestImportWorkspace_CarriesUnresolvableRelationValues` stays **green**: its unresolvable ids are absent from the bundle, so they are absent from `itemMap` too. No existing test used an id that was IN the map but NOT inserted, which is why this shipped.

The test carries two legs beyond the rule: a fixture check that the orphan did NOT import (otherwise the value would be legitimately resolvable and nothing under test is exercised), and a control asserting the resolvable value WAS rewritten (otherwise "carried verbatim" is satisfied by "never processed").

https://claude.ai/code/session_01HeChkgZVYb3NTgTcckF5KR
