### PR TITLE
fix(web): a reconcile loop cannot report catch-up for a verdict a resync overtook (TASK-2909)

### DIFF
--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -130,11 +130,25 @@ class WorkspaceState {
 	// on that evidence is the silent adopt this change exists to prevent — see
 	// `ensureAccessScope`.
 	cacheRead = $state(false);
-	// Did the last projection/access resync's authoritative snapshot actually
-	// REACH the durable cache? (TASK-2906, review round 2.) `persistReplace` can
-	// decline — its cursor lost a race to another tab, or storage failed — and
-	// when it does the durable rows still describe the OLD scope while RAM has
-	// moved on. `ensureAccessScope` must not then stamp the new epoch onto disk
+	// Does the durable cache reflect the MOST RECENT authoritative snapshot this
+	// session installed in RAM? (TASK-2906 round 2; widened by TASK-2909.)
+	//
+	// Read it as a statement about the two stores AGREEING, not as the return
+	// value of the last `persistReplace` call. `resyncProjectionScope` clears it
+	// the moment it installs a snapshot in RAM and sets it again from the
+	// persist result, so it is false for the whole window in between.
+	//
+	// TWO CONSUMERS, AND `markCaughtUp` IS NOT ONE OF THEM: `durableEpochFor`,
+	// which stops vouching for the epoch while this is false, and
+	// `ensureAccessScope`, which skips its durable stamp on the same evidence.
+	// The ASK is deliberately not conditioned on it — see `markCaughtUp` for why
+	// requiring disk there is a wedge rather than a guard. A resync that never
+	// installs anything (the fetch threw, or the generation changed before the
+	// snapshot was applied) leaves this alone, because RAM and IDB still agree.
+	//
+	// `persistReplace` can decline — its cursor lost a race to another tab, or
+	// storage failed — and when it does the durable rows still describe the OLD
+	// scope while RAM has moved on. `ensureAccessScope` must not then stamp the new epoch onto disk
 	// on that resync's behalf: an epoch is a claim about the rowset it was
 	// fetched with, and adopting one over a rowset that was never replaced makes
 	// the cache agree with the server about a scope it does not hold — the
@@ -142,13 +156,49 @@ class WorkspaceState {
 	// door. Starts true: with no resync yet there is no unconfirmed snapshot.
 	durableSnapshotCommitted = $state(true);
 
-	// `scopeEpoch` bumps every time a projection resync installs a new
-	// authoritative snapshot (i.e. the scope changed). Reconcile loops capture
-	// it before each `/items-changes` request and refuse to treat a response
-	// that raced a concurrent resync as caught-up — otherwise a stale in-flight
-	// delta could clear `pendingResync` without validating the pinned cursor
-	// (Codex P2 round 8). Not persisted; a session-local ordering token.
+	// `scopeEpoch` bumps every time a projection resync STARTS installing a new
+	// authoritative snapshot (i.e. the scope changed). Its consumer is the
+	// optimistic-write fence in `upsert`: a mutation captures it when the
+	// request is issued, and a write authorised under a superseded scope is
+	// refused on return. Not persisted; a session-local ordering token.
+	//
+	// RECONCILE LOOPS DO NOT USE THIS — they use `resyncSeq` below (TASK-2909).
+	// They did until then, which is what made a settle bump here look free: it
+	// would have answered their question and silently broken this one, refusing
+	// writes issued after the new snapshot was already installed.
 	scopeEpoch = 0;
+
+	// `resyncSeq` bumps when a resync SETTLES, and exists so a reconcile loop can
+	// ask "did a resync overlap my request", which `scopeEpoch` cannot answer
+	// (TASK-2909, review rounds 2 and 3).
+	//
+	// Settle only — an entry bump was written first and is redundant, which a
+	// mutation run showed by surviving its removal. A request that started
+	// before the resync mismatches after the settle bump; one that started
+	// during it is refused by the in-flight check while the resync runs and by
+	// the same settle bump afterwards. A second bump would be a second
+	// definition of "a resync happened" with nothing extra to say.
+	//
+	// KNOWN LIMIT, older than this counter: it is per-state and restarts at
+	// zero, so a `reset()` between a loop's capture and its response gives the
+	// REPLACEMENT state a matching token by coincidence. `resetGenerationFor`
+	// is the value that survives a reset and the loops do not yet capture it.
+	// Filed as IDEA-2913 rather than fixed here — the scope epoch this replaced
+	// had the same gap, so it is not this unit's to close.
+	//
+	// A separate counter rather than bumping `scopeEpoch` twice, which was the
+	// first shape and was wrong: `scopeEpoch` is ALSO the fence `upsert` uses to
+	// reject an optimistic write authorised under a superseded scope, and a
+	// settle bump made it reject writes issued AFTER the new snapshot was
+	// already installed — a user's create returning successfully and never
+	// reaching the store. One counter for two questions looked like thrift and
+	// was an overload; the questions differ, so the counters do.
+	//
+	// Reconcile loops capture this at the top of each iteration and hand it back
+	// when they report catch-up. Any capture taken during a resync mismatches
+	// afterwards, so a response computed against the pre-snapshot cursor cannot
+	// clear the ask however late it arrives.
+	resyncSeq = 0;
 
 	// `fencedIds` holds item ids the most recent resync DROPPED (absent from the
 	// authoritative snapshot — hidden by a downgrade or deleted). `upsert`
@@ -338,18 +388,55 @@ function rebuildSearchIndex(ws: string, state: WorkspaceState): void {
  * the joined-resync stamp was taught to skip, one door along. Skipping is not
  * available here, because the delta's rows and cursor must still land.
  *
- * So the delta writes NULL instead, which is not a gap but the accurate
- * statement: a null baseline over a populated cache means "cannot know what this
- * was authorised for", and `ensureAccessScope` already reads it as a resync. It
- * clears itself — the next `persistReplace` that commits records the real epoch
- * and flips the flag back.
+ * So the delta DECLINES TO VOUCH: it passes `undefined`, which `persistDelta`
+ * reads as "carry the stored epoch" (TASK-2909 review round 1 P2 — an explicit
+ * null, which this shipped as, could commit after a replace and clobber the
+ * epoch that replace had just recorded). The carried value keeps the durable
+ * epoch agreeing with the durable ROWS, which is what makes the SERVER's next
+ * epoch disagree with it and trigger a resync. It clears itself — the next
+ * `persistReplace` that commits records the real epoch and flips the flag back.
+ *
+ * The repair is a LATER one, not an in-session one: it fires on the next
+ * hydrate, or on the next response whose epoch disagrees. Nothing here repairs
+ * the durable cache at the moment the replace is refused.
  *
  * One function rather than the expression written at each `persistDelta` call,
  * because a rule applied at one door and not its sibling is how this unit's
  * previous two rounds each went.
  */
-function durableEpochFor(state: WorkspaceState): string | null {
-	return state.durableSnapshotCommitted ? state.accessEpoch : null;
+/**
+ * Clear the "this workspace still owes a replay" ask, if it may be cleared
+ * (TASK-2909).
+ *
+ * ONE definition, two callers: the public `markCaughtUp` (used by reconcile
+ * loops that own their own catch-up) and `bootstrap`'s internal loop. They used
+ * to hold the decision separately, so a condition added to one did not reach
+ * the other.
+ *
+ * Both doors pass the token their own loop captured at request time; this helper
+ * owns the whole decision, so a condition added here reaches both.
+ */
+function clearAskIfSettled(ws: string, state: WorkspaceState, token: number): void {
+	// The response was computed against the cursor as it stood when the request
+	// started. A resync that overlapped it pinned the cursor since, so the
+	// verdict is stale — however late it arrives, and whether or not anything is
+	// still in flight now.
+	if (state.resyncSeq !== token) return;
+	// ...and the still-running case, which the token alone cannot catch: the
+	// counter only moves when a resync SETTLES, so a response that arrives while
+	// one is mid-flight still carries a matching token.
+	if (projectionResyncs.has(ws)) return;
+	state.pendingResync = false;
+}
+
+function durableEpochFor(state: WorkspaceState): string | null | undefined {
+	// `undefined` is CARRY THE STORED EPOCH, not "no epoch" — see persistDelta's
+	// param doc. Writing an explicit null here (TASK-2906's first shape) is
+	// unsafe during the window between a resync installing its snapshot in RAM
+	// and `persistReplace` resolving: a delta committing after that replace
+	// would clobber the epoch it had just correctly recorded, and the next boot
+	// would pay a full snapshot to rediscover it (review round 1 P2).
+	return state.durableSnapshotCommitted ? state.accessEpoch : undefined;
 }
 
 async function resyncProjectionScope(
@@ -485,6 +572,16 @@ async function resyncProjectionScope(
 			state.items.set(next.id, next);
 		}
 		state.cursor = resp.cursor;
+		// FROM HERE, RAM AND DISK DISAGREE UNTIL `persistReplace` SAYS OTHERWISE
+		// (TASK-2909). Every exit below this line — the generation guard, a
+		// refused replace, or simply the time the transaction takes — leaves the
+		// durable cache describing the PREVIOUS snapshot, and both readers of
+		// this flag need to know that: a delta must not stamp RAM's epoch onto
+		// rows nobody replaced (`durableEpochFor`), and a joined caller must not
+		// stamp it on the resync's behalf (`ensureAccessScope`). Setting it only
+		// from the persist RESULT left it carrying the previous resync's verdict
+		// across this whole window — which the persist-await test pins.
+		state.durableSnapshotCommitted = false;
 		state.bootstrapState = 'ready';
 		// Server rows carry the live collection slug — a rename recorded
 		// pre-snapshot is already reflected, and re-applying it later could
@@ -534,6 +631,25 @@ async function resyncProjectionScope(
 		await promise;
 	} finally {
 		if (projectionResyncs.get(ws) === promise) projectionResyncs.delete(ws);
+		// BUMP THE OVERLAP COUNTER ON SETTLE (TASK-2909, review rounds 2-3).
+		//
+		// This is the ONLY bump. A reconcile loop captures the counter when its
+		// `/items-changes` request starts, so bumping here makes every capture
+		// taken before or during this resync mismatch once it finishes — which
+		// is exactly the set of responses whose verdict the pinned cursor has
+		// overtaken. The remaining case, a response that returns while this
+		// resync is still running, has not reached this line yet and is refused
+		// by `clearAskIfSettled`'s in-flight check instead.
+		//
+		// An entry bump was written first and removed: a mutation run showed it
+		// survived removal, and reading it again there was nothing it could say
+		// that these two do not already say between them. A second bump would
+		// have been a second definition of "a resync happened" to keep in step
+		// with the first.
+		//
+		// Only the STARTER reaches this: joined callers return the pending
+		// promise above and never enter the try.
+		state.resyncSeq += 1;
 	}
 }
 
@@ -732,12 +848,16 @@ export const localIndex = {
 						// advance, give up after 50 and let the user's
 						// next visit retry.
 						let caughtUp = false;
+						// Captured per ITERATION but declared out here, because
+						// the clear below belongs to whichever iteration
+						// concluded catch-up (TASK-2909 review round 3).
+						let reconcileToken = state.resyncSeq;
 						for (let i = 0; i < 50; i++) {
-							const epochBefore = state.scopeEpoch;
+							reconcileToken = state.resyncSeq;
 							const since = state.cursor;
 							const delta = await api.items.changes(ws, since);
 							if (isStale()) return;
-							if (state.scopeEpoch !== epochBefore) {
+							if (state.resyncSeq !== reconcileToken) {
 								// A concurrent resync (another caller) installed a
 								// new snapshot + pinned cursor while this request
 								// was in flight. This response predates it, so it
@@ -808,7 +928,14 @@ export const localIndex = {
 						// rows; we don't expect to hit this in practice
 						// but it's the difference between "stale
 						// forever" and "next visit retries".
-						if (caughtUp) state.pendingResync = false;
+						// Through the same guard as `markCaughtUp`, not a
+						// second copy of the decision (TASK-2909 review round
+						// 1). This loop cleared the flag directly, which meant
+						// every condition added to the public entry point
+						// silently did not apply here — the fourth time in
+						// PLAN-2903 that a rule landed at one door and not its
+						// sibling.
+						if (caughtUp) clearAskIfSettled(ws, state, reconcileToken);
 					} catch (err) {
 						if (isStale()) return;
 						// 401 (unauthorized — session expired) and 403
@@ -1557,8 +1684,10 @@ export const localIndex = {
 	 * `since`) — mirroring exactly what `bootstrap()`'s loop already does
 	 * for the path it owns.
 	 *
-	 * `epoch` MUST be the `scopeEpochFor(ws)` the caller captured at (or
-	 * reconfirmed immediately before) the point it decided "caught up" —
+	 * The argument MUST be the `reconcileTokenFor(ws)` the caller captured when
+	 * it ISSUED the request it is reporting on — not one read at (or
+	 * reconfirmed immediately before) the point it decided "caught up", because
+	 * the staleness this guards against is decided at request time (TASK-2909) —
 	 * the same value already threaded through these reconcile loops as
 	 * `epochBefore`. SSE, periodic sync, and `bootstrap()` can all trigger
 	 * reconciliations concurrently; without this check, one caller's stale
@@ -1573,21 +1702,70 @@ export const localIndex = {
 	 *
 	 * No-op for an unhydrated workspace.
 	 */
-	markCaughtUp(ws: string, epoch: number): void {
+	markCaughtUp(ws: string, token: number): void {
 		const state = workspaces.get(ws);
 		if (!state) return;
-		if (state.scopeEpoch !== epoch) return;
-		state.pendingResync = false;
+		// WHAT THE TOKEN MUST BE, AND WHAT IT IS NOT (TASK-2909).
+		//
+		// `token` is the caller's `reconcileTokenFor(ws)` captured when it
+		// ISSUED the request it is now reporting on. Not a scope epoch — those
+		// fence optimistic WRITES and say nothing about resync overlap — and not
+		// a value read at the moment of reporting, because the staleness this
+		// guards against is decided at request time, not at clear time.
+		//
+		// `clearAskIfSettled` compares it against `resyncSeq`, which bumps when
+		// a resync SETTLES, and additionally refuses while one is outstanding.
+		// Between them they cover both ways a response can be overtaken: one
+		// that returns while the resync is still running (the counter has not
+		// moved yet — the in-flight check catches it) and one that returns after
+		// it settled (nothing is in flight — the bumped counter catches it).
+		// Both were computed against the PRE-snapshot cursor, so once the resync
+		// pins the cursor their verdict is not merely early, it is stale. That is
+		// also why the refusal is not deferred and re-applied: applying it later
+		// would apply a verdict the snapshot invalidated. The caller's next
+		// trigger re-polls from the pinned cursor and clears honestly.
+		//
+		// DISK IS NOT A CONDITION, deliberately (review round 1). An earlier
+		// version also refused while `durableSnapshotCommitted` was false. That
+		// buys no repair and costs a wedge: `pendingResyncFor` gates a
+		// destructive decision (TASK-2099 / PLAN-2095 DR-2), and a persistently
+		// refused replace or a failing IndexedDB `open()` would make the flag
+		// un-clearable for the session. The refused case is repaired through a
+		// channel that does not touch this flag — `durableEpochFor` stops
+		// vouching for the epoch, so the durable baseline stops agreeing with
+		// the server and the next hydrate resyncs. PLAN-2903 item 3's "nothing
+		// retries" was true when written and stopped being true at TASK-2906;
+		// the premise correction is on that plan's trail.
+		clearAskIfSettled(ws, state, token);
 	},
 
 	/**
-	 * Current projection-scope epoch — bumped each time a resync installs a
-	 * new authoritative snapshot. A reconcile loop captures it before an
-	 * `/items-changes` request and, if it differs when the request returns, a
-	 * concurrent resync landed: the response predates the new pinned cursor and
-	 * must not be treated as a clean catch-up (Codex P2 round 8). Returns 0 for
-	 * an unhydrated workspace.
+	 * Current projection-scope epoch — bumped when a resync STARTS installing a
+	 * new authoritative snapshot. Captured by a caller issuing an optimistic
+	 * MUTATION and handed back to `upsert`, which refuses a write authorised
+	 * under a superseded scope. Returns 0 for an unhydrated workspace.
+	 *
+	 * Reconcile loops want `reconcileTokenFor` instead (TASK-2909): this value
+	 * cannot say whether a resync overlapped a request, and giving it that
+	 * second meaning broke the write fence.
 	 */
+	/**
+	 * The token a reconcile loop captures when it starts an `/items-changes`
+	 * request and hands back to `markCaughtUp` (TASK-2909).
+	 *
+	 * Distinct from `scopeEpochFor`, which answers "was my optimistic write
+	 * authorised under the current scope" and must NOT change when a resync
+	 * merely finishes persisting — a settle bump there rejected user writes
+	 * issued after the new snapshot was already installed (review round 3).
+	 * This one changes when a resync SETTLES, which is what makes a capture
+	 * taken before or during that resync detectably stale afterwards; the
+	 * mid-flight case is covered by the in-flight check in `clearAskIfSettled`
+	 * rather than by this counter. Returns 0 for an unhydrated workspace.
+	 */
+	reconcileTokenFor(ws: string): number {
+		return workspaces.get(ws)?.resyncSeq ?? 0;
+	},
+
 	scopeEpochFor(ws: string): number {
 		return workspaces.get(ws)?.scopeEpoch ?? 0;
 	},
@@ -1607,8 +1785,13 @@ export const localIndex = {
 	 * workspace — capturing this before the request and requiring it unchanged
 	 * afterwards is what distinguishes "still the state I was authorized
 	 * against" from "a fresh state that has coincidentally reached the same
-	 * numbers". `scopeEpochFor` answers the resync question and this answers
-	 * the identity one; a write-back needs both (TASK-2877).
+	 * numbers". `reconcileTokenFor` answers the resync-overlap question and this
+	 * answers the identity one; a write-back needs both (TASK-2877). Still true
+	 * after TASK-2909, and sharper: a reset between a reconcile loop's capture
+	 * and its response gives the REPLACEMENT state a token starting from zero,
+	 * so the token alone cannot tell a stale response from a fresh one across a
+	 * reset. That gap is older than the token (the scope epoch it replaced had
+	 * it too) and is filed rather than fixed here.
 	 */
 	resetGenerationFor(ws: string): number {
 		return resetGenerations.get(ws) ?? 0;

--- a/web/src/lib/stores/localIndexAccessEpochWiring.svelte.test.ts
+++ b/web/src/lib/stores/localIndexAccessEpochWiring.svelte.test.ts
@@ -382,14 +382,21 @@ describe('IDEA-2898 — what the resync hands on', () => {
 		expect(args[5]).toBe('e1');
 	});
 
-	it('hands persistDelta a NULL baseline while a refused snapshot is unrepaired', async () => {
+	it('hands persistDelta the CARRY-OVER marker while a refused snapshot is unrepaired', async () => {
 		// TASK-2906 round 3. Skipping the joined stamp is not enough on its own:
 		// RAM has adopted the new epoch, and the very next delta advances the
-		// cursor and carries that epoch onto durable rows the refused snapshot
-		// never replaced. The delta cannot be skipped — its rows and cursor must
-		// land — so it writes NULL, which is the accurate claim ("cannot know
-		// what this was authorised for") and the one `ensureAccessScope`
-		// already resyncs on.
+		// cursor and would carry that epoch onto durable rows the refused
+		// snapshot never replaced. The delta cannot be skipped — its rows and
+		// cursor must land — so it declines to vouch for the epoch at all.
+		//
+		// It passes `undefined` (CARRY THE STORED EPOCH) rather than the
+		// explicit `null` this shipped as: the caller also cannot vouch during
+		// the window between a resync installing its snapshot and
+		// `persistReplace` resolving, and a null committing after that replace
+		// would clobber the epoch it had just recorded (TASK-2909 review round 1
+		// P2). Carrying the stored value keeps the epoch agreeing with the ROWS
+		// it describes, which is what makes the server's next epoch disagree and
+		// trigger the resync.
 		persistence.persistReplace.mockResolvedValueOnce(
 			false as unknown as Awaited<ReturnType<typeof persistence.persistReplace>>,
 		);
@@ -426,7 +433,7 @@ describe('IDEA-2898 — what the resync hands on', () => {
 		// RAM keeps 'e2' — this session genuinely has the new scope. Only the
 		// DURABLE claim is withheld, and withholding it is what makes the next
 		// hydrate resync instead of adopting rows nobody replaced.
-		expect(args[5]).toBeNull();
+		expect(args[5]).toBeUndefined();
 		expect(localIndex.accessEpochFor(ws)).toBe('e2');
 	});
 

--- a/web/src/lib/stores/localIndexPersistence.ts
+++ b/web/src/lib/stores/localIndexPersistence.ts
@@ -265,16 +265,19 @@ async function raiseTombstone(
  * is already covered by the claim the stored cursor makes. The batch is
  * superseded, not refused, so no caller is owed a signal or a resync.
  */
-async function cursorIsBehind(
-	metaStore: { get(key: string): Promise<unknown> },
-	cursor: string,
-): Promise<boolean> {
-	const stored = (await metaStore.get('sync')) as MetaRow | undefined;
+function cursorIsBehind(stored: MetaRow | undefined, cursor: string): boolean {
 	// No stored cursor: nothing to be behind. Equal is not behind — the rows are
 	// a restatement at the same position, and refusing one would drop rows a
 	// cold snapshot may hold that the other writer's cache does not.
 	if (!stored) return false;
 	return compareCursors(cursor, stored.cursor) < 0;
+}
+
+/** Read the `sync` meta row, or undefined when this cache has never synced. */
+async function readSyncRow(metaStore: {
+	get(key: string): Promise<unknown>;
+}): Promise<MetaRow | undefined> {
+	return (await metaStore.get('sync')) as MetaRow | undefined;
 }
 
 /**
@@ -617,7 +620,28 @@ export async function persistDelta(
 	rows: ItemIndexRow[],
 	cursor: string,
 	includesUnparentedMetadata: boolean,
-	accessEpoch: string | null,
+	/**
+	 * The scope this batch was fetched under, or `undefined` for CARRY THE
+	 * STORED EPOCH (TASK-2909, review round 1 P2).
+	 *
+	 * TASK-2906 had the caller write an explicit `null` — "cannot know what this
+	 * was authorised for" — whenever it could not vouch for the epoch, which is
+	 * true at the instant the delta is built but is not safe to WRITE: the
+	 * caller cannot vouch during the whole window between a resync installing
+	 * its snapshot in RAM and `persistReplace` resolving, and a delta whose
+	 * transaction commits after that replace would overwrite the epoch the
+	 * replace had just correctly recorded. The next boot then reads a null
+	 * baseline over a populated cache and pays a full snapshot to rediscover
+	 * what this session already knew.
+	 *
+	 * Carrying the stored value instead is both safer and more accurate. If the
+	 * replace committed, its epoch survives. If it was refused, the stored
+	 * epoch still describes the stored ROWS — the two agree, which is the one
+	 * property the cache needs — and it is the SERVER's next epoch that
+	 * disagrees with it and triggers the resync. Either way the repair happens;
+	 * this way it does not also fire when nothing changed.
+	 */
+	accessEpoch: string | null | undefined,
 	removeIds: string[] = [],
 ): Promise<void> {
 	if (!isSupported()) return;
@@ -628,11 +652,12 @@ export async function persistDelta(
 		const itemsStore = tx.objectStore('items');
 		const tombstones = tx.objectStore('tombstones');
 		const metaStore = tx.objectStore('meta');
-		// CURSOR ORDERING GATE (TASK-2906). Read the stored cursor BEFORE any
+		// CURSOR ORDERING GATE (TASK-2906). Read the stored row BEFORE any
 		// write is issued in this transaction, so a behind batch lands nothing
 		// at all — see cursorIsBehind for why the whole batch goes, not just
-		// the cursor.
-		if (await cursorIsBehind(metaStore, cursor)) {
+		// the cursor. The same read supplies the epoch carry-over below.
+		const storedMeta = await readSyncRow(metaStore);
+		if (cursorIsBehind(storedMeta, cursor)) {
 			await tx.done.catch(() => undefined);
 			return;
 		}
@@ -666,7 +691,8 @@ export async function persistDelta(
 				cursor,
 				schemaVersion: LOCAL_INDEX_SCHEMA_VERSION,
 				includesUnparentedMetadata,
-				accessEpoch,
+				// `undefined` means CARRY THE STORED EPOCH — see the param doc.
+				accessEpoch: accessEpoch === undefined ? (storedMeta?.accessEpoch ?? null) : accessEpoch,
 			} satisfies MetaRow)
 			.catch(() => undefined);
 		await tx.done;
@@ -732,7 +758,7 @@ export async function persistReplace(
 		// TASK-2906 trail: it adds no exposure the cache did not already carry
 		// one moment earlier, and refusing the epoch ALONG WITH the rows is what
 		// keeps the repair alive — see cursorIsBehind's scope paragraph.
-		if (await cursorIsBehind(metaStore, cursor)) {
+		if (cursorIsBehind(await readSyncRow(metaStore), cursor)) {
 			await tx.done.catch(() => undefined);
 			return false;
 		}

--- a/web/src/lib/stores/localIndexPersistenceCursorOrdering.idb.test.ts
+++ b/web/src/lib/stores/localIndexPersistenceCursorOrdering.idb.test.ts
@@ -131,6 +131,39 @@ describe('TASK-2906 — the durable cursor never moves backward', () => {
 		expect(await rawItem(U, WS, 'revoked')).toBeDefined();
 	});
 
+	it('carries the stored epoch when the delta declines to vouch for one (TASK-2909)', async () => {
+		const U = null;
+		const WS = 'ws-2909-carry-epoch';
+		const mod = await loadPersistence();
+		const { persistReplace, persistDelta, hydrate } = mod;
+
+		await persistReplace(U, WS, [row('a', 1)], '10', false, 'e1');
+		// `undefined` is CARRY THE STORED EPOCH, and it is distinct from an
+		// explicit null: a delta that cannot vouch for the epoch must not
+		// clobber one a replace has just correctly recorded, which is reachable
+		// because the caller cannot vouch for the whole window between a resync
+		// installing its snapshot and the replace resolving.
+		await persistDelta(U, WS, [row('b', 20)], '20', false, undefined);
+
+		const after = await hydrate(U, WS);
+		expect(after.accessEpoch).toBe('e1');
+		expect(after.cursor).toBe('20');
+	});
+
+	it('still writes an explicit null when the caller passes one', async () => {
+		const U = null;
+		const WS = 'ws-2909-explicit-null';
+		const mod = await loadPersistence();
+		const { persistReplace, persistDelta, hydrate } = mod;
+
+		// The carry-over must not swallow a deliberate "no baseline" — an older
+		// server sends no epoch at all, and that absence has to reach disk.
+		await persistReplace(U, WS, [row('a', 1)], '10', false, 'e1');
+		await persistDelta(U, WS, [row('b', 20)], '20', false, null);
+
+		expect((await hydrate(U, WS)).accessEpoch).toBeNull();
+	});
+
 	it('accepts a batch at the SAME cursor — equal is not behind', async () => {
 		const U = null;
 		const WS = 'ws-2906-equal';

--- a/web/src/lib/stores/localIndexResyncSettled.svelte.test.ts
+++ b/web/src/lib/stores/localIndexResyncSettled.svelte.test.ts
@@ -1,0 +1,455 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { api } from '$lib/api/client';
+import type { ItemIndexRow } from '$lib/types';
+
+/**
+ * TASK-2909 (PLAN-2903 item 3) — nothing reports the resync settled until the
+ * write it was waiting on has committed.
+ *
+ * `markCaughtUp`'s `scopeEpoch` guard answers "has a resync landed since I
+ * looked". It cannot answer "has the resync I am inside of finished", because
+ * the epoch is bumped at the START of a resync — so a reconcile loop that
+ * captures it AFTER the bump matches happily while the snapshot is still in
+ * flight or was refused on disk, and clears the ask over a cache that has not
+ * been written. See TASK-2909 checkpoint 1 for the per-exit table these tests
+ * are one-per-row of.
+ *
+ * Mocked persistence, like its sibling wiring file: in jsdom IDB is
+ * unsupported and the real calls are no-ops, so the durable half has to be
+ * asserted at the boundary.
+ */
+
+const persistence = vi.hoisted(() => ({
+	hydrate: vi.fn(async () => ({
+		items: [],
+		cursor: '0',
+		includesUnparentedMetadata: null,
+		accessEpoch: null,
+		durableRead: true,
+		retags: {},
+	})),
+	persistDelta: vi.fn(async () => undefined),
+	persistRemovals: vi.fn(async () => undefined),
+	persistReplace: vi.fn(async () => true),
+	persistAccessEpoch: vi.fn(async () => undefined),
+	persistRetag: vi.fn(async () => undefined),
+	persistUpserts: vi.fn(async () => undefined),
+	wipe: vi.fn(async () => undefined),
+}));
+vi.mock('./localIndexPersistence', () => persistence);
+
+const { localIndex } = await import('./localIndex.svelte');
+
+const ws = 'resync-settled';
+
+function row(id: string, seq: number, collection = 'kept'): ItemIndexRow {
+	return {
+		id,
+		seq,
+		title: `Title ${id}`,
+		collection_slug: collection,
+		created_at: '2026-01-01T00:00:00Z',
+		updated_at: '2026-01-01T00:00:00Z',
+	} as ItemIndexRow;
+}
+
+/** A cold bootstrap that leaves the workspace ready with one row. */
+async function boot(): Promise<void> {
+	vi.spyOn(api.items, 'listIndex').mockResolvedValueOnce({
+		items: [row('cached', 1)],
+		total: 1,
+		cursor: '1',
+		includes_unparented_metadata: false,
+		access_epoch: 'e1',
+	} as unknown as Awaited<ReturnType<typeof api.items.listIndex>>);
+	vi.spyOn(api.items, 'changes').mockResolvedValue({
+		changes: [],
+		cursor: '1',
+		includes_unparented_metadata: false,
+		access_epoch: 'e1',
+	});
+	await localIndex.bootstrap(ws, { userId: null });
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	for (const fn of Object.values(persistence)) fn.mockClear();
+	persistence.persistReplace.mockImplementation(async () => true);
+	localIndex.reset(ws);
+});
+
+describe('TASK-2909 — the ask outlives an unwritten resync', () => {
+	it('clears the ask when the resync COMMITTED (E4) — the flag must not just wedge', async () => {
+		await boot();
+		vi.spyOn(api.items, 'listIndex').mockResolvedValue({
+			items: [row('cached', 1)],
+			total: 1,
+			cursor: '1',
+			includes_unparented_metadata: true,
+			access_epoch: 'e2',
+		} as unknown as Awaited<ReturnType<typeof api.items.listIndex>>);
+		await localIndex.ensureProjectionScope(ws, true);
+		expect(localIndex.pendingResyncFor(ws)).toBe(true);
+
+		localIndex.markCaughtUp(ws, localIndex.reconcileTokenFor(ws));
+		expect(localIndex.pendingResyncFor(ws)).toBe(false);
+	});
+
+	it('bootstrap\u2019s own loop obeys the same guard as markCaughtUp', async () => {
+		// Review round 1 P1b: that loop cleared the flag directly, so every
+		// condition added to the public entry point silently did not reach it —
+		// the fourth time in PLAN-2903 a rule landed at one door and not its
+		// sibling. Reproduced by starting a resync from ANOTHER driver while
+		// bootstrap's loop is between its delta response and its clear, which is
+		// what the `changes` side effect below does deterministically.
+		persistence.hydrate.mockResolvedValueOnce({
+			items: [row('cached', 1)],
+			cursor: '1',
+			includesUnparentedMetadata: false,
+			accessEpoch: 'e1',
+			durableRead: true,
+			retags: {},
+		} as unknown as Awaited<ReturnType<typeof persistence.hydrate>>);
+		// Never resolves: the concurrent resync stays in flight past the clear.
+		vi.spyOn(api.items, 'listIndex').mockReturnValue(
+			new Promise(() => {}) as unknown as ReturnType<typeof api.items.listIndex>,
+		);
+		vi.spyOn(api.items, 'changes').mockImplementation(async () => {
+			// A second driver's resync, started but not awaited here.
+			void localIndex.ensureProjectionScope(ws, true);
+			return {
+				changes: [],
+				cursor: '1',
+				// MATCHES, so bootstrap's own ensureProjectionScope is a no-op
+				// and does not await the resync away before the clear.
+				includes_unparented_metadata: false,
+				access_epoch: 'e1',
+			};
+		});
+
+		await localIndex.bootstrap(ws, { userId: null });
+
+		expect(localIndex.pendingResyncFor(ws)).toBe(true);
+	});
+
+	it('a delta during the persistReplace await does not vouch for the epoch', async () => {
+		// The install-point clear of `durableSnapshotCommitted` earns its place
+		// here and only here. The two generation guards have no await between
+		// them, so the snapshot install is synchronous and the early-return
+		// window is unreachable; what IS reachable is the persist await, during
+		// which the flag would otherwise still carry the PREVIOUS resync's
+		// verdict and let a delta stamp RAM's epoch onto rows this replace has
+		// not written yet.
+		await boot();
+		let settleReplace: ((v: boolean) => void) | undefined;
+		persistence.persistReplace.mockImplementation(
+			() =>
+				new Promise<boolean>((resolve) => {
+					settleReplace = resolve;
+				}) as unknown as ReturnType<typeof persistence.persistReplace>,
+		);
+		vi.spyOn(api.items, 'listIndex').mockResolvedValue({
+			items: [row('cached', 1)],
+			total: 1,
+			cursor: '1',
+			includes_unparented_metadata: true,
+			access_epoch: 'e2',
+		} as unknown as Awaited<ReturnType<typeof api.items.listIndex>>);
+
+		const inFlight = localIndex.ensureProjectionScope(ws, true);
+		await Promise.resolve();
+		await Promise.resolve();
+
+		persistence.persistDelta.mockClear();
+		localIndex.applyDelta(ws, [], '2', true);
+		const args = persistence.persistDelta.mock.calls.at(-1) as unknown[];
+		expect(args[5]).toBeUndefined();
+
+		settleReplace?.(true);
+		await inFlight;
+	});
+
+	it('an optimistic write issued after the snapshot installed is NOT fenced (round 3 P2)', async () => {
+		// The counter split earns its place here. `scopeEpoch` is also the fence
+		// `upsert` uses to reject a write authorised under a superseded scope,
+		// so bumping it when a resync merely FINISHES PERSISTING rejected writes
+		// issued after the new snapshot was already installed: a create that the
+		// server accepted would never reach the store, and the field editing it
+		// would never see its own result. Two questions, two counters.
+		await boot();
+		let settleReplace: ((v: boolean) => void) | undefined;
+		persistence.persistReplace.mockImplementation(
+			() =>
+				new Promise<boolean>((resolve) => {
+					settleReplace = resolve;
+				}) as unknown as ReturnType<typeof persistence.persistReplace>,
+		);
+		vi.spyOn(api.items, 'listIndex').mockResolvedValue({
+			items: [row('cached', 1)],
+			total: 1,
+			cursor: '1',
+			includes_unparented_metadata: true,
+			access_epoch: 'e2',
+		} as unknown as Awaited<ReturnType<typeof api.items.listIndex>>);
+
+		const inFlight = localIndex.ensureProjectionScope(ws, true);
+		await Promise.resolve();
+		await Promise.resolve();
+
+		// The scope the write is authorised under is the one now installed.
+		const authorisedUnder = localIndex.scopeEpochFor(ws);
+		settleReplace?.(true);
+		await inFlight;
+
+		localIndex.upsert(ws, row('created', 9), authorisedUnder);
+		expect(
+			localIndex.getAll(ws, { includeArchived: true }).some((r) => r.id === 'created'),
+		).toBe(true);
+	});
+
+	it('bootstrap refuses the clear when a resync settles during its post-delta awaits', async () => {
+		// Review round 3 P1, and the interleaving matters: the resync must
+		// settle AFTER bootstrap's own epoch re-check and BEFORE its clear, or
+		// the loop simply re-polls and the test proves nothing. The first
+		// version of this test hit the 50-iteration cap instead — it passed, and
+		// a mutant that read a fresh token at the clear survived it, which is
+		// how the wrong reason showed up.
+		//
+		// So: the `changes` mock STARTS a resync without awaiting it, and the
+		// loop's own no-op access/projection checks are where it settles.
+		persistence.hydrate.mockResolvedValueOnce({
+			items: [row('cached', 1)],
+			cursor: '1',
+			includesUnparentedMetadata: false,
+			accessEpoch: 'e1',
+			durableRead: true,
+			retags: {},
+		} as unknown as Awaited<ReturnType<typeof persistence.hydrate>>);
+		vi.spyOn(api.items, 'listIndex').mockResolvedValue({
+			items: [row('cached', 1)],
+			total: 1,
+			cursor: '1',
+			includes_unparented_metadata: false,
+			access_epoch: 'e1',
+		} as unknown as Awaited<ReturnType<typeof api.items.listIndex>>);
+		let call = 0;
+		vi.spyOn(api.items, 'changes').mockImplementation(async () => {
+			call += 1;
+			if (call === 2) {
+				// A DIFFERENT driver's resync runs to completion while this
+				// request is outstanding. By the time the response is read the
+				// resync has settled — so the in-flight check sees nothing —
+				// and the token bootstrap captured at the top of THIS iteration
+				// is stale. Only comparing that captured value catches it.
+				await localIndex.ensureAccessScope(ws, 'e2');
+			}
+			if (call === 1) {
+				// Advance the cursor so iteration 1 is NOT caught up and the
+				// loop runs again — otherwise it clears on the first pass and
+				// the interleaving below never happens.
+				return {
+					changes: [row('cached', 2) as unknown as never],
+					cursor: '2',
+					includes_unparented_metadata: false,
+					access_epoch: 'e1',
+				};
+			}
+			return {
+				changes: [],
+				cursor: '2',
+				// Matches what the concurrent resync installed, so neither
+				// ensure* fires and the loop actually reaches its clear.
+				includes_unparented_metadata: true,
+				access_epoch: 'e2',
+			};
+		});
+
+		await localIndex.bootstrap(ws, { userId: null });
+
+		expect(localIndex.pendingResyncFor(ws)).toBe(true);
+	});
+
+	it('does not CONSUME the settled signal — the next delta still stamps the real epoch', async () => {
+		await boot();
+		vi.spyOn(api.items, 'listIndex').mockResolvedValue({
+			items: [row('cached', 1)],
+			total: 1,
+			cursor: '1',
+			includes_unparented_metadata: true,
+			access_epoch: 'e2',
+		} as unknown as Awaited<ReturnType<typeof api.items.listIndex>>);
+		await localIndex.ensureProjectionScope(ws, true);
+
+		localIndex.markCaughtUp(ws, localIndex.reconcileTokenFor(ws));
+		expect(localIndex.pendingResyncFor(ws)).toBe(false);
+
+		// The guard READS the settled state; it must not spend it. Asserting
+		// that a second `markCaughtUp` still clears proves nothing — the ask is
+		// already clear, so the assertion passes either way (it did, and the
+		// mutant survived it). The observable that discriminates is the OTHER
+		// reader of the same flag: `durableEpochFor` turns a delta's epoch into
+		// null the moment the flag goes false, so a clear that consumed the
+		// signal would silently downgrade every subsequent delta to "cannot know
+		// what this was authorised for" and buy a full resync on the next reload.
+		persistence.persistDelta.mockClear();
+		localIndex.applyDelta(ws, [], '2', true);
+		expect(persistence.persistDelta).toHaveBeenCalled();
+		const args = persistence.persistDelta.mock.calls.at(-1) as unknown[];
+		expect(args[5]).toBe('e2');
+	});
+
+	it('DOES clear the ask when the replace was refused — the repair is not this flag (E5)', async () => {
+		await boot();
+		persistence.persistReplace.mockImplementation(
+			async () => false as unknown as Awaited<ReturnType<typeof persistence.persistReplace>>,
+		);
+		vi.spyOn(api.items, 'listIndex').mockResolvedValue({
+			items: [row('cached', 1)],
+			total: 1,
+			cursor: '1',
+			includes_unparented_metadata: true,
+			access_epoch: 'e2',
+		} as unknown as Awaited<ReturnType<typeof api.items.listIndex>>);
+		await localIndex.ensureProjectionScope(ws, true);
+
+		// The plan called this the defect. It names a real state, but its implied
+		// harm — "nothing retries" — stopped being true at TASK-2906, and
+		// holding the ask here would buy no repair while costing a wedge:
+		// `pendingResyncFor` gates a destructive decision, and a storage failure
+		// would make it permanently un-clearable (review round 1 P1).
+		localIndex.markCaughtUp(ws, localIndex.reconcileTokenFor(ws));
+		expect(localIndex.pendingResyncFor(ws)).toBe(false);
+
+		// The repair lives in the epoch channel instead: the session stops
+		// vouching for the durable baseline, so the delta carries it over rather
+		// than asserting a scope disk does not hold.
+		persistence.persistDelta.mockClear();
+		localIndex.applyDelta(ws, [], '2', true);
+		const args = persistence.persistDelta.mock.calls.at(-1) as unknown[];
+		expect(args[5]).toBeUndefined();
+	});
+
+	it('does NOT clear the ask while the resync is still IN FLIGHT (the E2 window)', async () => {
+		await boot();
+		let release: (() => void) | undefined;
+		vi.spyOn(api.items, 'listIndex').mockReturnValue(
+			new Promise((resolve) => {
+				release = () =>
+					resolve({
+						items: [row('cached', 1)],
+						total: 1,
+						cursor: '1',
+						includes_unparented_metadata: true,
+						access_epoch: 'e2',
+					} as unknown as Awaited<ReturnType<typeof api.items.listIndex>>);
+			}) as unknown as ReturnType<typeof api.items.listIndex>,
+		);
+
+		const inFlight = localIndex.ensureProjectionScope(ws, true);
+		// The epoch is bumped at the START of a resync, so a loop capturing it
+		// HERE matches the guard and would have cleared the ask over a cache
+		// nothing has written yet.
+		const epochDuring = localIndex.reconcileTokenFor(ws);
+		localIndex.markCaughtUp(ws, epochDuring);
+		expect(localIndex.pendingResyncFor(ws)).toBe(true);
+
+		release?.();
+		await inFlight;
+		// ...and once it has landed, the same call is allowed through.
+		localIndex.markCaughtUp(ws, localIndex.reconcileTokenFor(ws));
+		expect(localIndex.pendingResyncFor(ws)).toBe(false);
+	});
+
+	it('still clears the ask when the resync never INSTALLED anything (E3, the fetch threw)', async () => {
+		await boot();
+		vi.spyOn(api.items, 'listIndex').mockRejectedValue(new Error('network'));
+		await expect(localIndex.ensureProjectionScope(ws, true)).rejects.toThrow('network');
+
+		// RAM and disk still agree — the snapshot was never applied — so the
+		// hold has nothing to protect, and over-holding has its own cost:
+		// `pendingResyncFor` gates a destructive decision (TASK-2099), and a
+		// flag that can only ever be set is a wedge.
+		localIndex.markCaughtUp(ws, localIndex.reconcileTokenFor(ws));
+		expect(localIndex.pendingResyncFor(ws)).toBe(false);
+	});
+
+	it('a caller JOINING a refused resync is bound by the same answer as the starter', async () => {
+		await boot();
+		persistence.persistReplace.mockImplementation(
+			async () => false as unknown as Awaited<ReturnType<typeof persistence.persistReplace>>,
+		);
+		let release: (() => void) | undefined;
+		vi.spyOn(api.items, 'listIndex').mockReturnValue(
+			new Promise((resolve) => {
+				release = () =>
+					resolve({
+						items: [row('cached', 1)],
+						total: 1,
+						cursor: '1',
+						includes_unparented_metadata: true,
+						access_epoch: 'e2',
+					} as unknown as Awaited<ReturnType<typeof api.items.listIndex>>);
+			}) as unknown as ReturnType<typeof api.items.listIndex>,
+		);
+
+		// Resyncs dedupe per workspace: the second caller gets the first's
+		// promise, so it never sees the persist result directly. It must still
+		// be bound by it.
+		const started = localIndex.ensureProjectionScope(ws, true);
+		const joined = localIndex.ensureAccessScope(ws, 'e2');
+		release?.();
+		await Promise.all([started, joined]);
+
+		// Same answer as the starter gets — the point is that joining does not
+		// produce a DIFFERENT verdict, not that the verdict is a hold.
+		localIndex.markCaughtUp(ws, localIndex.reconcileTokenFor(ws));
+		expect(localIndex.pendingResyncFor(ws)).toBe(false);
+	});
+
+	it('a capture that OVERLAPPED the resync stays refused; a fresh one clears at once', async () => {
+		// The lead's hold — a refusal must not outlive its resync — plus review
+		// round 2's P1, which showed the first version answered it at the wrong
+		// moment. A loop that captured the epoch during a resync and whose
+		// `/items-changes` response arrives AFTER that resync settles computed
+		// its answer against the PRE-snapshot cursor. `projectionResyncs` no
+		// longer holds the promise by then, so an in-flight check at clear time
+		// cannot see the overlap; the epoch changing at BOTH ends of a resync
+		// can, because any capture taken during one then mismatches.
+		//
+		// So the refusal is scoped to the stale VERDICT, not to the caller and
+		// not to the workspace: the very next poll captures a fresh epoch and
+		// clears immediately, which is what keeps this a guard rather than a
+		// wedge.
+		await boot();
+		let release: (() => void) | undefined;
+		vi.spyOn(api.items, 'listIndex').mockReturnValue(
+			new Promise((resolve) => {
+				release = () =>
+					resolve({
+						items: [row('cached', 1)],
+						total: 1,
+						cursor: '1',
+						includes_unparented_metadata: true,
+						access_epoch: 'e2',
+					} as unknown as Awaited<ReturnType<typeof api.items.listIndex>>);
+			}) as unknown as ReturnType<typeof api.items.listIndex>,
+		);
+
+		const inFlight = localIndex.ensureProjectionScope(ws, true);
+		const capturedDuring = localIndex.reconcileTokenFor(ws);
+		localIndex.markCaughtUp(ws, capturedDuring);
+		expect(localIndex.pendingResyncFor(ws)).toBe(true);
+
+		release?.();
+		await inFlight;
+
+		// The delayed response lands. Its verdict predates the pinned cursor and
+		// must not clear the ask, even though nothing is in flight any more.
+		localIndex.markCaughtUp(ws, capturedDuring);
+		expect(localIndex.pendingResyncFor(ws)).toBe(true);
+
+		// ...and the loop's next poll, capturing now, clears without ceremony.
+		localIndex.markCaughtUp(ws, localIndex.reconcileTokenFor(ws));
+		expect(localIndex.pendingResyncFor(ws)).toBe(false);
+	});
+});

--- a/web/src/lib/stores/localIndexUnparented.svelte.test.ts
+++ b/web/src/lib/stores/localIndexUnparented.svelte.test.ts
@@ -233,7 +233,7 @@ describe('localIndex.markCaughtUp', () => {
 		await localIndex.ensureProjectionScope(ws, false);
 		expect(localIndex.pendingResyncFor(ws)).toBe(true);
 
-		localIndex.markCaughtUp(ws, localIndex.scopeEpochFor(ws));
+		localIndex.markCaughtUp(ws, localIndex.reconcileTokenFor(ws));
 		expect(localIndex.pendingResyncFor(ws)).toBe(false);
 	});
 
@@ -245,7 +245,10 @@ describe('localIndex.markCaughtUp', () => {
 	it('does NOT clear a pending resync when a newer resync has landed under a different epoch', async () => {
 		localIndex.upsert(ws, row('scoped', 1, true));
 		localIndex.applyDelta(ws, [], '1', true);
-		const staleEpoch = localIndex.scopeEpochFor(ws);
+		// The RECONCILE TOKEN, which is what `markCaughtUp` compares since
+		// TASK-2909 — `scopeEpochFor` kept its own meaning as the fence for
+		// optimistic writes.
+		const staleEpoch = localIndex.reconcileTokenFor(ws);
 
 		vi.spyOn(api.items, 'listIndex').mockResolvedValueOnce({
 			items: [row('scoped', 1)],
@@ -255,7 +258,7 @@ describe('localIndex.markCaughtUp', () => {
 		});
 		await localIndex.ensureProjectionScope(ws, false);
 		expect(localIndex.pendingResyncFor(ws)).toBe(true);
-		expect(localIndex.scopeEpochFor(ws)).toBeGreaterThan(staleEpoch);
+		expect(localIndex.reconcileTokenFor(ws)).toBeGreaterThan(staleEpoch);
 
 		// A caller that captured the epoch BEFORE this resync landed tries
 		// to confirm catch-up — its confirmation predates the newer resync

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -1090,10 +1090,16 @@
 	async function deltaSync(ws: string): Promise<boolean> {
 		try {
 			for (let i = 0; i < 50; i++) {
-				const epochBefore = localIndex.scopeEpochFor(ws);
+				// The overlap token, not the scope epoch: this loop needs to know
+				// whether a resync overlapped its request, and `scopeEpochFor` is
+				// the fence for optimistic WRITES and must not carry that meaning
+				// (TASK-2909 review round 3). Captured HERE, when the request is
+				// issued — the staleness it guards against is decided then, not
+				// when the response is read.
+				const tokenBefore = localIndex.reconcileTokenFor(ws);
 				const since = localIndex.cursorFor(ws);
 				const delta = await api.items.changes(ws, since);
-				if (localIndex.scopeEpochFor(ws) !== epochBefore) {
+				if (localIndex.reconcileTokenFor(ws) !== tokenBefore) {
 					// A concurrent resync installed a new snapshot + pinned
 					// cursor while this request was in flight; the response
 					// predates it. Re-poll from the new cursor rather than
@@ -1131,7 +1137,7 @@
 					// epoch above — so a differently-scoped resync that
 					// lands concurrently after this point isn't silently
 					// stomped (Codex review round 5).
-					localIndex.markCaughtUp(ws, epochBefore);
+					localIndex.markCaughtUp(ws, tokenBefore);
 					return true;
 				}
 				localIndex.applyDelta(
@@ -1142,7 +1148,7 @@
 				);
 				if (delta.cursor === since) {
 					deltaSyncFailed = false;
-					localIndex.markCaughtUp(ws, epochBefore);
+					localIndex.markCaughtUp(ws, tokenBefore);
 					return true;
 				}
 			}


### PR DESCRIPTION
Third unit of [[PLAN-2903]], covering the plan's item 3 (and confirming item 4 needs no change).

## The defect

`markCaughtUp` clears `pendingResync` — the "this workspace still owes a replay" ask — under a `scopeEpoch` equality guard. That guard answers *"has a resync landed since I looked"*. It cannot answer *"has the resync I am inside of finished"*, because `scopeEpoch` is bumped at the **start** of a resync, before the network await. A reconcile loop that captures it after the bump matches happily while the snapshot is still in flight.

The sharper reason it matters: a loop reaching its catch-up during the fetch concluded it against the **pre-snapshot cursor**. Once the resync pins the cursor, that conclusion is *stale*, not merely early — which is also why the refusal is not deferred and re-applied later. The loop's own next trigger re-polls from the pinned cursor and clears honestly.

The recon table (checkpoint 1) enumerates all five exits — joined, both generation guards, the throw, and normal completion in its committed and refused forms — with what RAM, IDB and the ask hold at each.

## What changed

- **One helper, two doors.** `bootstrap`'s reconcile loop had its own copy of the clear, so every condition added to the public entry point silently did not reach it. Fourth time in this plan that a rule landed at one door and not its sibling — caught by review this time rather than by the next unit.
- **The in-flight condition only.** See below.
- **Carry-over epoch** (round 1 P2): a delta that cannot vouch for the epoch passes `undefined` (CARRY THE STORED EPOCH) rather than the explicit `null` TASK-2906 shipped. It reuses the meta row already read for the cursor gate, so it costs no extra IDB request.

## What this deliberately does NOT do

The first version also refused to clear while `durableSnapshotCommitted` was false. **That is a wedge.** `pendingResyncFor` gates a destructive decision (TASK-2099 / PLAN-2095 DR-2), and a persistently refused replace — or a failing IndexedDB `open()` — would make the flag un-clearable for the whole session. It also buys no repair: the refused case self-heals through a channel that does not touch this flag.

PLAN-2903 item 3's *"nothing retries"* was true when written and stopped being true at TASK-2906. That premise correction is recorded on the plan's trail and ratified.

**Item 4** needs no change — IDEA-2898's joined branch already writes the told epoch durably and TASK-2906 made that write conditional. Pinned by the existing wiring test rather than re-tested.

## Gates

| Gate | Result |
|---|---|
| `npx vite build` | ✅ built |
| `go build ./...` | ✅ (no Go files changed) |
| `npm run check` | ✅ 1101 files, **0 errors**, 6 pre-existing warnings |
| `npx vitest run` | ✅ **2184 passed** |
| `make lint` / `go test ./...` / `make test-pg` | N/A — no Go or store SQL in the diff |
| Codex | **4 rounds: 2 / 1 / 2 / 0 findings in the change**, all fixed in code |

**The mutation matrix is the instrument here, not a count against `main`** — most new tests call an accessor `main` does not have, so they would fail there for the wrong reason and that number would be worth nothing. Of the two IDB tests, one fails against `main` behaviourally and one is a guard passing on both.

**Mutation matrix — nine mutants, eight killed.** In-flight guard dropped; the token guard dropped; no settle bump; a settle bump on `scopeEpoch` as well (the fenced-write regression); bootstrap clearing directly again; `durableEpochFor` nulling instead of carrying; no clear at the RAM install point; `persistDelta` ignoring the carry-over. Negative control scores BUILD-FAIL.

The ninth — bootstrap reading a fresh token at its clear rather than the captured one — **is equivalent**, correcting what an earlier revision of this PR asserted: once `caughtUp` is set there is no further await before the clear, and any resync met on the way makes the loop `continue`. Three attempts at a discriminating test failed for that reason, and the attempts kept implying the conclusion I had not written down.

Two other mutants survived first runs and were answered with **tests rather than equivalence arguments** — both arguments reached for turned out to be wrong. One test in this file passed for the **wrong reason** (the 50-iteration cap, not the guard) until a mutant exposed it.

## What this does not close

**IDEA-2913**, filed rather than folded in: the reconcile token is per-state and restarts at zero, so a `reset()` between a loop's capture and its response hands the replacement state a matching token by coincidence — an ABA. `resetGenerationFor` is the value that survives a reset and the loops do not capture it. This **predates the unit** (the scope epoch the token replaced had the same gap), so closing it is a deliberate unit rather than a rider on one whose property is about ordering within a single state. Recorded in the code as a known limit.

TASK-2909 · PLAN-2903

https://claude.ai/code/session_01Xk9M5UVPdc84xL5E1mZkm8
