### PR TITLE
fix(server,store): both workspace mint doors enforce their preconditions from one place (BUG-2809)

### DIFF
--- a/cmd/pad/cmd_db.go
+++ b/cmd/pad/cmd_db.go
@@ -456,7 +456,10 @@ Steps:
 				stats := fmt.Sprintf("%d collections, %d items, %d comments",
 					len(data.Collections), len(data.Items), len(data.Comments))
 
-				if _, err := dstStore.ImportWorkspace(data, "", ""); err != nil {
+				// Empty source: this is an operator-run copy of an existing
+				// workspace, not a creation surface, and inventing "cli"
+				// here would relabel every migrated workspace's origin.
+				if _, err := dstStore.ImportWorkspace(data, "", "", ""); err != nil {
 					fmt.Fprintf(os.Stderr, "  ERROR importing %s: %v (skipping)\n", ws.Slug, err)
 					continue
 				}

--- a/internal/server/handlers_import_bundle.go
+++ b/internal/server/handlers_import_bundle.go
@@ -100,7 +100,7 @@ func (s *Server) effectiveBlobMaxBytes() int64 {
 // for the operator to inspect. Orphan GC will eventually reclaim any
 // blob whose row insertion failed — the upload-handler's "blob may be
 // orphan on disk" comment applies here too.
-func (s *Server) handleImportWorkspaceBundle(w http.ResponseWriter, r *http.Request) {
+func (s *Server) handleImportWorkspaceBundle(w http.ResponseWriter, r *http.Request, mint workspaceMintAuth) {
 	if s.attachments == nil {
 		writeError(w, http.StatusServiceUnavailable, "attachments_disabled",
 			"Attachment storage is not configured on this server")
@@ -122,7 +122,6 @@ func (s *Server) handleImportWorkspaceBundle(w http.ResponseWriter, r *http.Requ
 	defer gz.Close()
 
 	newName := r.URL.Query().Get("name")
-	userID := currentUserID(r)
 
 	// The bundle door gets the same --repair-nul treatment as the JSON one:
 	// a gzip import is the same import reached by a different Content-Type,
@@ -130,7 +129,7 @@ func (s *Server) handleImportWorkspaceBundle(w http.ResponseWriter, r *http.Requ
 	// different answers is how one of them keeps being forgotten.
 	repair := &nulRepairTally{Enabled: wantsNULRepair(r)}
 
-	ws, err := s.importBundle(r.Context(), gz, newName, userID, repair)
+	ws, err := s.importBundle(r.Context(), gz, newName, mint, repair)
 	if err != nil {
 		// Errors from importBundle are already shaped with status hints —
 		// surface as 400 unless the underlying error wraps an http hint.
@@ -184,10 +183,10 @@ func (s *Server) handleImportWorkspaceBundle(w http.ResponseWriter, r *http.Requ
 	// Mirror the JSON-import path's owner-attachment so the workspace
 	// shows up under the importer's account — including its error posture:
 	// not fatal (BUG-2715), but not discarded either.
-	if userID != "" {
-		if err := s.store.AddWorkspaceMember(ws.ID, userID, "owner"); err != nil {
+	if mint.OwnerID != "" {
+		if err := s.store.AddWorkspaceMember(ws.ID, mint.OwnerID, "owner"); err != nil {
 			slog.Error("bundle imported but importer was not added as owner",
-				"workspace_id", ws.ID, "user_id", userID, "error", err)
+				"workspace_id", ws.ID, "user_id", mint.OwnerID, "error", err)
 		}
 	}
 	repair.SetHeader(w)
@@ -213,7 +212,12 @@ func (s *Server) handleImportWorkspaceBundle(w http.ResponseWriter, r *http.Requ
 // Split out from the handler so tests can drive it with a tar.Reader
 // over an in-memory bundle and assert on the resulting state without
 // a live HTTP server.
-func (s *Server) importBundle(ctx context.Context, r io.Reader, newName, ownerID string, repair *nulRepairTally) (*models.Workspace, error) {
+func (s *Server) importBundle(ctx context.Context, r io.Reader, newName string, mint workspaceMintAuth, repair *nulRepairTally) (*models.Workspace, error) {
+	// The bundle door is the SECOND body shape behind the import route, and
+	// it mints through the same store call, so it takes the same mint
+	// context the JSON path does rather than re-deriving owner and source
+	// from the request down here (BUG-2809).
+	ownerID := mint.OwnerID
 	tr := tar.NewReader(r)
 	blobCap := s.effectiveBlobMaxBytes()
 
@@ -302,7 +306,20 @@ func (s *Server) importBundle(ctx context.Context, r io.Reader, newName, ownerID
 					message: "Bundle pad-export.json could not be decoded: " + err.Error(),
 				}
 			}
-			ws, err = s.store.ImportWorkspace(&export, newName, ownerID)
+			// The payload-shaped preconditions, from the same place the
+			// JSON doors call — same rule, this door's own envelope
+			// (400 bad_bundle rather than 400 bad_request).
+			effectiveName := export.Workspace.Name
+			if newName != "" {
+				effectiveName = newName
+			}
+			if verr := validateWorkspaceMintPayload(effectiveName, &export.Workspace.Settings); verr != nil {
+				return nil, &importStatusError{
+					status: http.StatusBadRequest, code: "bad_bundle",
+					message: "Bundle pad-export.json is not importable: " + verr.Error(),
+				}
+			}
+			ws, err = s.store.ImportWorkspace(&export, newName, ownerID, mint.Source)
 			if err != nil {
 				return nil, fmt.Errorf("import workspace: %w", err)
 			}

--- a/internal/server/handlers_workspace_mint_parity_test.go
+++ b/internal/server/handlers_workspace_mint_parity_test.go
@@ -1,0 +1,220 @@
+package server
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// BUG-2809: the two workspace-mint doors — POST /workspaces and
+// POST /workspaces/import, the latter with a tar.gz body shape behind it —
+// enforce the same preconditions, from one place.
+//
+// Two had already diverged and been fixed one at a time, each found by a
+// reviewer rather than by the door that lacked it: the OAuth consent grant
+// (IDEA-2756) and the user-scoped plan limit (BUG-2793). This file pins the
+// remainder so a third cannot be found the same way.
+//
+// The empty-name leg is a live defect, not a symmetry argument. Measured on
+// the unfixed tip: an import with no workspace name CREATED a workspace with
+// `name="" slug=""`, and a second one landed on slug `"-2"` — the first had
+// taken the empty slug, which is a routing key, globally.
+
+func mintTestUser(t *testing.T, srv *Server, email string) *models.User {
+	t.Helper()
+	u, err := srv.store.CreateUser(models.UserCreate{
+		Email: email, Name: "Mint", Password: "correct-horse-battery-staple", Role: "member",
+	})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	return u
+}
+
+func importJSON(t *testing.T, srv *Server, path string, export *models.WorkspaceExport, sessionToken string) *httptest.ResponseRecorder {
+	t.Helper()
+	return doRequestWithCookie(srv, "POST", path, export, sessionToken)
+}
+
+// THE LIVE DEFECT: an import with no effective name is refused, rather than
+// minting a workspace whose slug is the empty string.
+func TestImportWorkspace_EmptyNameIsRefused(t *testing.T) {
+	t.Parallel()
+	srv := testServer(t)
+	mintTestUser(t, srv, "mint-empty@example.com")
+	tok := loginUser(t, srv, "mint-empty@example.com", "correct-horse-battery-staple")
+
+	rr := importJSON(t, srv, "/api/v1/workspaces/import", &models.WorkspaceExport{
+		Version: 1, ExportedAt: "2026-09-07T00:00:00Z",
+		Workspace: models.WorkspaceExportMeta{Name: "", Slug: ""},
+	}, tok)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("import with an empty workspace name: got %d, want 400; body=%s", rr.Code, rr.Body.String())
+	}
+	// The CREATE door's own answer to the same input, so the two doors are
+	// pinned to one message and not merely to one status.
+	if got := errorCode(t, rr); got != "bad_request" {
+		t.Errorf("error code = %q, want bad_request; body=%s", got, rr.Body.String())
+	}
+}
+
+// CONTROL — the check is on the EFFECTIVE name. A bundle with no name is
+// importable when ?name= supplies one, because that override is what
+// becomes the slug. Without this leg the rule above is indistinguishable
+// from "reject any bundle whose payload name is empty", which would break a
+// legitimate rename-on-import.
+func TestImportWorkspace_EmptyNameRescuedByOverride(t *testing.T) {
+	t.Parallel()
+	srv := testServer(t)
+	mintTestUser(t, srv, "mint-override@example.com")
+	tok := loginUser(t, srv, "mint-override@example.com", "correct-horse-battery-staple")
+
+	rr := importJSON(t, srv, "/api/v1/workspaces/import?name=Renamed+On+Import", &models.WorkspaceExport{
+		Version: 1, ExportedAt: "2026-09-07T00:00:00Z",
+		Workspace: models.WorkspaceExportMeta{Name: "", Slug: ""},
+	}, tok)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("import with ?name= override: got %d, want 201; body=%s", rr.Code, rr.Body.String())
+	}
+	var ws models.Workspace
+	parseJSON(t, rr, &ws)
+	if ws.Slug == "" {
+		t.Fatalf("import produced an EMPTY SLUG despite the override; ws=%+v", ws)
+	}
+}
+
+// Malformed settings answer 400 at both doors. The store normalizes too, so
+// this never reached the database — but a store failure surfaces as 500
+// `import_failed`, and the create door answers 400 for the same input. Same
+// input, same answer, whichever door it arrives at.
+func TestImportWorkspace_MalformedSettingsIs400NotA500(t *testing.T) {
+	t.Parallel()
+	srv := testServer(t)
+	mintTestUser(t, srv, "mint-settings@example.com")
+	tok := loginUser(t, srv, "mint-settings@example.com", "correct-horse-battery-staple")
+
+	rr := importJSON(t, srv, "/api/v1/workspaces/import", &models.WorkspaceExport{
+		Version: 1, ExportedAt: "2026-09-07T00:00:00Z",
+		Workspace: models.WorkspaceExportMeta{Name: "Bad Settings", Slug: "bad-settings", Settings: "not-json"},
+	}, tok)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("import with malformed settings: got %d, want 400; body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+// An imported workspace is ATTRIBUTED, the same way a created one is
+// (BUG-1557). It previously got no source at all, so the dashboard could not
+// tell an imported workspace's origin from a web-created one's.
+func TestImportWorkspace_AttributesTheCreationSurface(t *testing.T) {
+	t.Parallel()
+	srv := testServer(t)
+	mintTestUser(t, srv, "mint-source@example.com")
+	tok := loginUser(t, srv, "mint-source@example.com", "correct-horse-battery-staple")
+
+	rr := importJSON(t, srv, "/api/v1/workspaces/import", &models.WorkspaceExport{
+		Version: 1, ExportedAt: "2026-09-07T00:00:00Z",
+		Workspace: models.WorkspaceExportMeta{Name: "Attributed", Slug: "attributed"},
+	}, tok)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("import: got %d, want 201; body=%s", rr.Code, rr.Body.String())
+	}
+	var ws models.Workspace
+	parseJSON(t, rr, &ws)
+
+	stored, err := srv.store.GetWorkspaceBySlug(ws.Slug)
+	if err != nil {
+		t.Fatalf("GetWorkspaceBySlug: %v", err)
+	}
+	// A cookie-session caller is "web" on the create door; the import door
+	// now derives it from the same helper rather than leaving it empty.
+	if stored.Source != "web" {
+		t.Errorf("imported workspace source = %q, want %q — an import over a cookie session is a web mint", stored.Source, "web")
+	}
+}
+
+// The BUNDLE door is the second body shape behind the same route and mints
+// through the same store call, so it answers the same way — in its own
+// envelope (`bad_bundle`), which is the reason the shared step returns an
+// error instead of writing one.
+func TestImportBundle_EmptyNameIsRefused(t *testing.T) {
+	t.Parallel()
+	srv, _ := testServerWithAttachments(t)
+	mintTestUser(t, srv, "mint-bundle@example.com")
+	tok := loginUser(t, srv, "mint-bundle@example.com", "correct-horse-battery-staple")
+
+	export := models.WorkspaceExport{
+		Version: 1, ExportedAt: "2026-09-07T00:00:00Z",
+		Workspace: models.WorkspaceExportMeta{Name: "", Slug: ""},
+	}
+	payload, err := json.Marshal(export)
+	if err != nil {
+		t.Fatalf("marshal export: %v", err)
+	}
+
+	var buf bytes.Buffer
+	gzw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gzw)
+	if err := tw.WriteHeader(&tar.Header{Name: "pad-export.json", Mode: 0o644, Size: int64(len(payload))}); err != nil {
+		t.Fatalf("write header: %v", err)
+	}
+	if _, err := tw.Write(payload); err != nil {
+		t.Fatalf("write export: %v", err)
+	}
+	tw.Close()
+	gzw.Close()
+
+	req := httptest.NewRequest("POST", "/api/v1/workspaces/import", bytes.NewReader(buf.Bytes()))
+	req.Header.Set("Content-Type", "application/gzip")
+	req.RemoteAddr = "192.0.2.1:1234"
+	req.AddCookie(&http.Cookie{Name: "pad_session", Value: tok})
+	const testCSRF = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	req.AddCookie(&http.Cookie{Name: "pad_csrf", Value: testCSRF})
+	req.Header.Set("X-CSRF-Token", testCSRF)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("bundle import with an empty workspace name: got %d, want 400; body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+// CONTROL — the create door still refuses an empty name after the
+// refactor. The rule moved into a shared function; a mutant that drops the
+// call from the create side must not pass because the import side kept it.
+func TestCreateWorkspace_EmptyNameStillRefused(t *testing.T) {
+	t.Parallel()
+	srv := testServer(t)
+	mintTestUser(t, srv, "mint-create@example.com")
+	tok := loginUser(t, srv, "mint-create@example.com", "correct-horse-battery-staple")
+
+	rr := doRequestWithCookie(srv, "POST", "/api/v1/workspaces", map[string]any{"name": ""}, tok)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("create with an empty name: got %d, want 400; body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+// CONTROL — an ordinary import still works. Every refusal above is
+// meaningless if the door refuses everything.
+func TestImportWorkspace_OrdinaryImportStillWorks(t *testing.T) {
+	t.Parallel()
+	srv := testServer(t)
+	mintTestUser(t, srv, "mint-ok@example.com")
+	tok := loginUser(t, srv, "mint-ok@example.com", "correct-horse-battery-staple")
+
+	rr := importJSON(t, srv, "/api/v1/workspaces/import", &models.WorkspaceExport{
+		Version: 1, ExportedAt: "2026-09-07T00:00:00Z",
+		Workspace: models.WorkspaceExportMeta{Name: "Ordinary", Slug: "ordinary"},
+	}, tok)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("ordinary import: got %d, want 201; body=%s", rr.Code, rr.Body.String())
+	}
+}

--- a/internal/server/handlers_workspaces.go
+++ b/internal/server/handlers_workspaces.go
@@ -380,9 +380,11 @@ func (s *Server) requireWorkspaceCreationConsent(w http.ResponseWriter, r *http.
 }
 
 func (s *Server) handleCreateWorkspace(w http.ResponseWriter, r *http.Request) {
-	// Consent gate first — before decoding the body, so a refusal never
+	// Every precondition that does not need the body, from the one place
+	// both mint doors call (BUG-2809). Before decoding, so a refusal never
 	// depends on body validity and cannot be probed by shape.
-	if !s.requireWorkspaceCreationConsent(w, r) {
+	mint, ok := s.beginWorkspaceMint(w, r)
+	if !ok {
 		return
 	}
 
@@ -392,35 +394,30 @@ func (s *Server) handleCreateWorkspace(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if input.Name == "" {
-		writeError(w, http.StatusBadRequest, "bad_request", "Name is required")
+	// The payload-shaped preconditions, from that same place.
+	if err := validateWorkspaceMintPayload(input.Name, &input.Settings); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
 		return
 	}
+	// Context is a create-only input concept (an export carries none), so it
+	// stays here rather than in the shared step. Settings are already
+	// normalized above, which is what this call would otherwise redo.
 	if err := normalizeWorkspaceInput(&input); err != nil {
 		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
 		return
 	}
 
-	// Attribute the creation surface AUTHORITATIVELY from the request's auth
-	// shape — never from the request body (WorkspaceCreate.Source is
-	// `json:"-"` for exactly this reason). CLI and Remote MCP callers
-	// present a bearer token / api-token context => "cli"; cookie-session
-	// web callers => "web". A cli/mcp origin is what tells the dashboard an
-	// agent is already connected right after `pad init`, so a web client
-	// must not be able to spoof it to suppress the connect-agent/onboarding
-	// prompts (BUG-1557).
-	_, input.Source = actorFromRequest(r)
-
-	// Set owner to the authenticated user
-	if userID := currentUserID(r); userID != "" {
-		input.OwnerID = userID
-	}
-
-	// Enforce workspace count limit (user-scoped)
-	if userID := currentUserID(r); userID != "" {
-		if !s.enforceUserPlanLimit(w, userID, "workspaces") {
-			return
-		}
+	// Attribution and ownership come from beginWorkspaceMint, which derived
+	// both AUTHORITATIVELY from the request's auth shape — never from the
+	// request body (WorkspaceCreate.Source is `json:"-"` for exactly this
+	// reason). A cli/mcp origin is what tells the dashboard an agent is
+	// already connected right after `pad init`, so a web client must not be
+	// able to spoof it to suppress the connect-agent/onboarding prompts
+	// (BUG-1557). The import door now gets the same value from the same
+	// place, which it previously got not at all.
+	input.Source = mint.Source
+	if mint.OwnerID != "" {
+		input.OwnerID = mint.OwnerID
 	}
 
 	ws, err := s.store.CreateWorkspace(input)
@@ -801,57 +798,31 @@ func (s *Server) handleExportWorkspace(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleImportWorkspace(w http.ResponseWriter, r *http.Request) {
-	// Consent gate — import is workspace creation through a second door
-	// (store.ImportWorkspace calls CreateWorkspace), so the same
-	// may_create_workspaces grant decides it. Ruled with the create-side
-	// gate on IDEA-2756. It sits ABOVE the Content-Type dispatch so it
-	// covers the tar.gz bundle path too — handleImportWorkspaceBundle is
-	// reachable only from here, so this is its only door — and above
-	// either body read, so a refused caller never uploads anything. The
-	// two reads have different bounds (the JSON path's 64 MiB
-	// decodeJSONWithLimit, the bundle path's own configurable and much
-	// larger limit); the gate precedes both, which is the property that
-	// matters here.
+	// Every pre-body precondition, from the one place both mint doors call
+	// (BUG-2809). This used to be two gates written out here, each added
+	// separately after a reviewer found the create door had it and this one
+	// did not: the OAuth consent grant (IDEA-2756) and the user-scoped plan
+	// limit (BUG-2793).
 	//
-	// Reachability, stated precisely because the create-side gate's is
-	// different: NO OAuth-bound caller can reach this handler today. The
-	// OAuth identity is stashed only by MCPBearerAuth, which is mounted
-	// on /mcp alone, so an OAuth connection reaches an /api/v1 handler
-	// only through the in-process MCP dispatcher — and its route table
-	// has no `workspace import` action. This gate is therefore correct
-	// but currently unexercised in production: it exists so that adding
-	// that action later cannot silently reopen the door, which is the
-	// failure mode a create-only fix would have left armed.
-	if !s.requireWorkspaceCreationConsent(w, r) {
+	// The PLACEMENT is the load-bearing part rather than the call. It sits
+	// ABOVE the Content-Type dispatch, so the tar.gz bundle path is covered
+	// by this same line rather than needing its own, and above either body
+	// read, so a refused caller never uploads anything. The two reads have
+	// different bounds (the JSON path's 64 MiB decodeJSONWithLimit, the
+	// bundle path's own configurable and much larger limit); the gate
+	// precedes both.
+	//
+	// Reachability of the consent half, stated precisely because the create
+	// door's is different: NO OAuth-bound caller can reach this handler
+	// today. The OAuth identity is stashed only by MCPBearerAuth, mounted on
+	// /mcp alone, so an OAuth connection reaches an /api/v1 handler only
+	// through the in-process MCP dispatcher — and its route table has no
+	// `workspace import` action. The gate is correct but currently
+	// unexercised in production: it exists so that adding that action later
+	// cannot silently reopen the door.
+	mint, ok := s.beginWorkspaceMint(w, r)
+	if !ok {
 		return
-	}
-
-	// Plan limit — the SECOND gate on workspace creation this door used to
-	// skip (BUG-2793). An import mints a workspace through the same
-	// store.CreateWorkspace, so a user at their plan's limit could exceed it
-	// by exporting any workspace and importing it back.
-	//
-	// Dave's day-63 ruling: an import IS a new workspace and counts, with no
-	// exemption for re-importing something you previously owned — export
-	// provenance is not trustworthy enough to gate billing on, and the
-	// at-limit case that deserves relief (undoing a delete) is served by the
-	// restore endpoint, which does not mint anything.
-	//
-	// Placed here for the same two reasons as the consent gate above it, and
-	// the placement is the load-bearing part rather than the call: ABOVE the
-	// Content-Type dispatch, so the tar.gz bundle path is covered by the same
-	// line rather than needing its own, and above either body read, so a
-	// refused caller never uploads. Self-hosted is unaffected —
-	// enforceUserPlanLimit returns true when cloudMode is off.
-	//
-	// The `userID != ""` guard mirrors the create side exactly. It is not
-	// defensive padding: a legacy workspace token resolves no user, and
-	// charging an unattributable import against nobody's plan is not a
-	// limit, it is a crash waiting for a nil.
-	if userID := currentUserID(r); userID != "" {
-		if !s.enforceUserPlanLimit(w, userID, "workspaces") {
-			return
-		}
 	}
 
 	// Content-Type dispatch:
@@ -870,7 +841,10 @@ func (s *Server) handleImportWorkspace(w http.ResponseWriter, r *http.Request) {
 	}
 	ct = strings.ToLower(strings.TrimSpace(ct))
 	if ct == "application/gzip" || ct == "application/x-gzip" || ct == "application/x-tar" {
-		s.handleImportWorkspaceBundle(w, r)
+		// mint travels as an ARGUMENT rather than on the Server: it is
+		// per-request state, and the two things it carries (owner, source)
+		// are exactly the two a concurrent request would differ on.
+		s.handleImportWorkspaceBundle(w, r, mint)
 		return
 	}
 
@@ -907,10 +881,26 @@ func (s *Server) handleImportWorkspace(w http.ResponseWriter, r *http.Request) {
 	// Optional: override workspace name via query param
 	newName := r.URL.Query().Get("name")
 
-	// Set the authenticated user as owner so the imported workspace is
-	// accessible and has correct owner_username for URL routing.
-	userID := currentUserID(r)
-	ws, err := s.store.ImportWorkspace(&data, newName, userID)
+	// The payload-shaped preconditions, from the same place the create door
+	// calls (BUG-2809). The EFFECTIVE name is checked — the override when
+	// one was given, the bundle's own otherwise — because that is what
+	// becomes the slug, and an empty name slugifies to an EMPTY SLUG, which
+	// is a routing key. Measured before the fix: the first such import took
+	// the empty slug and a second landed on "-2".
+	effectiveName := data.Workspace.Name
+	if newName != "" {
+		effectiveName = newName
+	}
+	if verr := validateWorkspaceMintPayload(effectiveName, &data.Workspace.Settings); verr != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", verr.Error())
+		return
+	}
+
+	// Owner and source both come from the mint context resolved above, so
+	// an imported workspace is attributed the same way a created one is
+	// (BUG-1557 — import previously got no source at all).
+	userID := mint.OwnerID
+	ws, err := s.store.ImportWorkspace(&data, newName, userID, mint.Source)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "import_failed", err.Error())
 		return

--- a/internal/server/workspace_mint.go
+++ b/internal/server/workspace_mint.go
@@ -1,0 +1,119 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// Workspace minting has TWO doors — handleCreateWorkspace and
+// handleImportWorkspace, the latter with a second body shape behind it
+// (handleImportWorkspaceBundle) — and both reach store.CreateWorkspace.
+// Every precondition one enforces, the other must enforce, FROM HERE
+// (BUG-2809).
+//
+// The record is why this exists rather than a note asking people to
+// remember: two preconditions diverged and were fixed one at a time, each
+// found by a reviewer rather than by the door that lacked it — the OAuth
+// consent grant (IDEA-2756) and the user-scoped workspace plan limit
+// (BUG-2793). A third divergence was live when this landed: import
+// accepted an empty workspace name, and an empty name slugifies to an
+// EMPTY SLUG, which is a routing key. Measured on that tip: the first such
+// import took the empty slug and a second one landed on "-2".
+//
+// The preconditions split by WHEN they can run, and that split is
+// load-bearing rather than tidy:
+//
+//   - beginWorkspaceMint runs BEFORE the body is read, so a refused caller
+//     never uploads a bundle, and so a refusal cannot be probed by body
+//     shape. It also resolves the two things a mint is attributed with.
+//   - validateWorkspaceMintPayload runs AFTER, because its subject is the
+//     payload. It returns an error rather than writing one: the JSON doors
+//     answer 400 `bad_request` and the bundle door answers 400 `bad_bundle`
+//     through importStatusError, so the RULE is shared and the envelope
+//     stays each door's own.
+
+// workspaceMintAuth carries what a mint door resolves from the REQUEST, as
+// opposed to from its payload. Both fields are authoritative here and must
+// never be read from a request body: Source decides UI affordances
+// (BUG-1557) and OwnerID decides who the workspace belongs to.
+type workspaceMintAuth struct {
+	// OwnerID is the authenticated user, or "" for a caller TokenAuth
+	// admits with no resolved user (a legacy workspace token, or the
+	// fresh-install window). See the quota note in beginWorkspaceMint.
+	OwnerID string
+	// Source is derived from the auth shape: "cli" for bearer/api-token
+	// callers, "web" for cookie sessions.
+	Source string
+}
+
+// beginWorkspaceMint runs every precondition that does not need the body,
+// and returns false having already written the response when one refuses.
+//
+// Call it FIRST in any handler that mints a workspace — above the body
+// read, and for the import door above the Content-Type dispatch, so one
+// line covers both body shapes.
+func (s *Server) beginWorkspaceMint(w http.ResponseWriter, r *http.Request) (workspaceMintAuth, bool) {
+	// Consent: the OAuth connection's may_create_workspaces grant
+	// (IDEA-2756). First, so a refusal never depends on body validity.
+	if !s.requireWorkspaceCreationConsent(w, r) {
+		return workspaceMintAuth{}, false
+	}
+
+	userID := currentUserID(r)
+
+	// Plan limit, user-scoped (BUG-2793). An import IS a new workspace and
+	// counts, with no exemption for re-importing something you previously
+	// owned — export provenance is not trustworthy enough to gate billing
+	// on, and the at-limit case that deserves relief (undoing a delete) is
+	// served by the restore endpoint, which mints nothing.
+	//
+	// The `userID != ""` guard is not defensive padding: a legacy workspace
+	// token resolves no user, and charging an unattributable mint against
+	// nobody's plan is not a limit. Whether such a caller should be able to
+	// mint an UNOWNED workspace at all is a live question on BUG-2809's
+	// trail, deliberately not decided here — this function preserves the
+	// behaviour both doors already had rather than changing it under cover
+	// of a refactor.
+	if userID != "" {
+		if !s.enforceUserPlanLimit(w, userID, "workspaces") {
+			return workspaceMintAuth{}, false
+		}
+	}
+
+	_, source := actorFromRequest(r)
+	return workspaceMintAuth{OwnerID: userID, Source: source}, true
+}
+
+// errWorkspaceNameRequired is the empty-name refusal, exported as a value so
+// a door can tell it from a settings failure without matching on prose.
+var errWorkspaceNameRequired = errors.New("Name is required")
+
+// validateWorkspaceMintPayload enforces the preconditions whose subject is
+// the payload, and NORMALIZES the settings in place when they are valid.
+//
+// name is the EFFECTIVE name — for an import that is the ?name= override
+// when one was given, otherwise the bundle's own — because the effective
+// name is what becomes the slug.
+//
+// settings is a pointer so a valid blob is written back normalized; pass
+// nil when the door has no settings to offer. Rejecting malformed settings
+// HERE is what makes the two doors agree on the status code: the store
+// normalizes too (createWorkspaceQ), but a store error surfaces as 500
+// import_failed, and caller-supplied malformed JSON is a 400 on the create
+// door. Same input, same answer, whichever door it arrives at.
+func validateWorkspaceMintPayload(name string, settings *string) error {
+	if name == "" {
+		return errWorkspaceNameRequired
+	}
+	if settings != nil && *settings != "" {
+		normalized, err := models.NormalizeWorkspaceSettings(*settings)
+		if err != nil {
+			return fmt.Errorf("invalid settings JSON: %w", err)
+		}
+		*settings = normalized
+	}
+	return nil
+}

--- a/internal/store/collection_traits_backfill_test.go
+++ b/internal/store/collection_traits_backfill_test.go
@@ -265,7 +265,7 @@ func TestImportLegacyArchiveInfersTraits(t *testing.T) {
 		t.Fatal("control leg failed: export carried no conventions collection to strip")
 	}
 
-	imported, err := s.ImportWorkspace(exp, "legacy-archive-target", owner.ID)
+	imported, err := s.ImportWorkspace(exp, "legacy-archive-target", owner.ID, "")
 	if err != nil {
 		t.Fatalf("ImportWorkspace: %v", err)
 	}
@@ -364,7 +364,7 @@ func TestImportDoesNotOverrideSurvivingTraits(t *testing.T) {
 		}
 	}
 
-	imported, err := s.ImportWorkspace(exp, "custom-traits-target", owner.ID)
+	imported, err := s.ImportWorkspace(exp, "custom-traits-target", owner.ID, "")
 	if err != nil {
 		t.Fatalf("ImportWorkspace: %v", err)
 	}

--- a/internal/store/collections_test.go
+++ b/internal/store/collections_test.go
@@ -558,7 +558,7 @@ func TestExportImportRoundTripWithEmptyStringSettings(t *testing.T) {
 		exp.Collections[i].Settings = ""
 	}
 
-	imported, err := s.ImportWorkspace(exp, "round-trip-import-target", owner.ID)
+	imported, err := s.ImportWorkspace(exp, "round-trip-import-target", owner.ID, "")
 	if err != nil {
 		t.Fatalf("ImportWorkspace error (IDEA-1484 import-side coercion regression): %v", err)
 	}

--- a/internal/store/export.go
+++ b/internal/store/export.go
@@ -353,7 +353,13 @@ func resolveImportParent(exportedParentID string, itemMap map[string]string, ins
 // ImportWorkspace imports a workspace from an exported data structure.
 // It creates a new workspace with regenerated IDs, remapping all references.
 // If newName is non-empty, it overrides the workspace name and slug.
-func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ownerID string) (*models.Workspace, error) {
+// source is the creation-surface attribution, derived by the CALLER from
+// the request's auth shape exactly as the create door derives it (BUG-1557,
+// BUG-2809). It is a parameter rather than a field on the export because an
+// export carries no source: a bundle says what the workspace WAS, and where
+// this copy is being minted from is a fact about this request. Operator
+// callers outside HTTP pass "".
+func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ownerID string, source string) (*models.Workspace, error) {
 	if data.Version != 1 {
 		return nil, fmt.Errorf("unsupported export version: %d", data.Version)
 	}
@@ -398,6 +404,7 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 		Description: data.Workspace.Description,
 		Settings:    data.Workspace.Settings,
 		OwnerID:     ownerID,
+		Source:      source,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create workspace: %w", err)

--- a/internal/store/export_soft_deleted_collection_test.go
+++ b/internal/store/export_soft_deleted_collection_test.go
@@ -130,7 +130,7 @@ func TestRoundTripPreservesItemsUnderSoftDeletedCollection(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ExportWorkspace: %v", err)
 	}
-	imported, err := s.ImportWorkspace(exp, "round-trip-2884-target", owner.ID)
+	imported, err := s.ImportWorkspace(exp, "round-trip-2884-target", owner.ID, "")
 	if err != nil {
 		t.Fatalf("ImportWorkspace: %v", err)
 	}
@@ -211,7 +211,7 @@ func TestRoundTripPreservesDependentsUnderSoftDeletedCollection(t *testing.T) {
 			len(exp.Comments), len(exp.ItemVersions), len(exp.Reminders))
 	}
 
-	imported, err := s.ImportWorkspace(exp, "dependents-2884-target", owner.ID)
+	imported, err := s.ImportWorkspace(exp, "dependents-2884-target", owner.ID, "")
 	if err != nil {
 		t.Fatalf("ImportWorkspace: %v", err)
 	}
@@ -306,7 +306,7 @@ func TestImportRoutingIgnoresSoftDeletedCollections(t *testing.T) {
 	t.Cleanup(func() { slog.SetDefault(prev) })
 	slog.SetDefault(slog.New(&recordCapturingHandler{records: &captured}))
 
-	imported, err := s.ImportWorkspace(exp, "routing-2884-target", owner.ID)
+	imported, err := s.ImportWorkspace(exp, "routing-2884-target", owner.ID, "")
 	if err != nil {
 		t.Fatalf("ImportWorkspace: %v", err)
 	}
@@ -382,7 +382,7 @@ func TestLegacyBundleWithoutDeletedAtImportsLive(t *testing.T) {
 		exp.Collections[i].DeletedAt = "" // as a pre-BUG-2884 archive decodes
 	}
 
-	imported, err := s.ImportWorkspace(exp, "legacy-2884-target", owner.ID)
+	imported, err := s.ImportWorkspace(exp, "legacy-2884-target", owner.ID, "")
 	if err != nil {
 		t.Fatalf("ImportWorkspace: %v", err)
 	}
@@ -580,7 +580,7 @@ func TestImportSurvivesOrphanedItemDependents(t *testing.T) {
 				}
 			}
 
-			imported, err := s.ImportWorkspace(exp, "orphan-"+tc.name+"-2884-target", owner.ID)
+			imported, err := s.ImportWorkspace(exp, "orphan-"+tc.name+"-2884-target", owner.ID, "")
 			if err != nil {
 				t.Fatalf("a bundle with one orphaned item carrying a %s aborted the whole import: %v", tc.name, err)
 			}
@@ -663,7 +663,7 @@ func TestImportDoesNotInferTraitsForArchivedCollections(t *testing.T) {
 		t.Fatal("control leg failed: the bundle carries no conventions collection")
 	}
 
-	imported, err := s.ImportWorkspace(exp, "inference-2884-target", owner.ID)
+	imported, err := s.ImportWorkspace(exp, "inference-2884-target", owner.ID, "")
 	if err != nil {
 		t.Fatalf("ImportWorkspace: %v", err)
 	}
@@ -794,7 +794,7 @@ func TestImportSurvivesOrphanedParent(t *testing.T) {
 		t.Fatalf("control leg failed: parent sorts after child (%d > %d), so the first pass never resolves it", parentIdx, childIdx)
 	}
 
-	imported, err := s.ImportWorkspace(exp, "orphan-parent-2884-target", owner.ID)
+	imported, err := s.ImportWorkspace(exp, "orphan-parent-2884-target", owner.ID, "")
 	if err != nil {
 		t.Fatalf("a live item whose parent is orphaned aborted the whole import: %v", err)
 	}
@@ -856,7 +856,7 @@ func TestImportSurvivesDuplicateLinks(t *testing.T) {
 	dup.ID = dup.ID + "-dup"
 	exp.ItemLinks = append(exp.ItemLinks, dup)
 
-	imported, err := s.ImportWorkspace(exp, "duplicate-links-2884-target", owner.ID)
+	imported, err := s.ImportWorkspace(exp, "duplicate-links-2884-target", owner.ID, "")
 	if err != nil {
 		t.Fatalf("a bundle carrying one duplicated link aborted the whole import: %v", err)
 	}

--- a/internal/store/import_workspace_husk_test.go
+++ b/internal/store/import_workspace_husk_test.go
@@ -81,7 +81,7 @@ func TestImportWorkspaceFailureLeavesNoWorkspace(t *testing.T) {
 	t.Parallel()
 	s := testStore(t)
 
-	ws, err := s.ImportWorkspace(failingImportBundle("Husk Probe", "husk-probe"), "", "")
+	ws, err := s.ImportWorkspace(failingImportBundle("Husk Probe", "husk-probe"), "", "", "")
 	if err == nil {
 		t.Fatalf("ImportWorkspace succeeded on a bundle with two collections sharing a slug; got workspace %+v", ws)
 	}
@@ -110,11 +110,11 @@ func TestImportWorkspaceRetryKeepsOriginalSlug(t *testing.T) {
 	t.Parallel()
 	s := testStore(t)
 
-	if _, err := s.ImportWorkspace(failingImportBundle("Retry Probe", "retry-slug"), "", ""); err == nil {
+	if _, err := s.ImportWorkspace(failingImportBundle("Retry Probe", "retry-slug"), "", "", ""); err == nil {
 		t.Fatal("ImportWorkspace succeeded on the deliberately-broken bundle; the retry leg proves nothing")
 	}
 
-	ws, err := s.ImportWorkspace(validImportBundle("Retry Probe", "retry-slug"), "", "")
+	ws, err := s.ImportWorkspace(validImportBundle("Retry Probe", "retry-slug"), "", "", "")
 	if err != nil {
 		t.Fatalf("retry with the corrected bundle failed: %v", err)
 	}

--- a/internal/store/items_title_validation_test.go
+++ b/internal/store/items_title_validation_test.go
@@ -327,7 +327,7 @@ func TestImportWorkspace_CoercesTitles(t *testing.T) {
 		},
 	}
 
-	ws, err := s.ImportWorkspace(export, "Legacy Archive Target", owner.ID)
+	ws, err := s.ImportWorkspace(export, "Legacy Archive Target", owner.ID, "")
 	if err != nil {
 		t.Fatalf("ImportWorkspace must SUCCEED on a legacy bundle, not refuse it: %v", err)
 	}
@@ -491,7 +491,7 @@ func TestImportWorkspace_TruncatedSlugCollidesWithALaterVerbatimSlug(t *testing.
 		},
 	}
 
-	ws, err := s.ImportWorkspace(export, "Collide Target", owner.ID)
+	ws, err := s.ImportWorkspace(export, "Collide Target", owner.ID, "")
 	if err != nil {
 		t.Fatalf("a slug collision created by OUR truncation must be resolved, not abort the import: %v", err)
 	}

--- a/internal/store/items_views_jsonb_test.go
+++ b/internal/store/items_views_jsonb_test.go
@@ -186,7 +186,7 @@ func TestItemsViewsJSONB_ImportWorkspaceCoercesEmptyAndMalformed(t *testing.T) {
 		},
 	}
 
-	ws, err := s.ImportWorkspace(export, "Imported Coerce", owner.ID)
+	ws, err := s.ImportWorkspace(export, "Imported Coerce", owner.ID, "")
 	if err != nil {
 		t.Fatalf("ImportWorkspace: %v", err)
 	}

--- a/internal/store/relation_referents_test.go
+++ b/internal/store/relation_referents_test.go
@@ -520,7 +520,7 @@ func TestImportWorkspace_CarriesUnresolvableRelationValues(t *testing.T) {
 		},
 	}
 
-	ws, err := s.ImportWorkspace(export, "Relation Archive Target", owner.ID)
+	ws, err := s.ImportWorkspace(export, "Relation Archive Target", owner.ID, "")
 	if err != nil {
 		t.Fatalf("ImportWorkspace must SUCCEED on a bundle carrying unresolvable relation values, not refuse it: %v", err)
 	}
@@ -654,7 +654,7 @@ func TestImportWorkspace_UnresolvableRelationValueSurvivesAPrefixCollision(t *te
 		},
 	}
 
-	ws, err := s.ImportWorkspace(export, "Prefix Archive Target", owner.ID)
+	ws, err := s.ImportWorkspace(export, "Prefix Archive Target", owner.ID, "")
 	if err != nil {
 		t.Fatalf("ImportWorkspace: %v", err)
 	}
@@ -790,7 +790,7 @@ func TestImportWorkspace_DoesNotMintIDsForOrphanRelationReferents(t *testing.T) 
 		},
 	}
 
-	ws, err := s.ImportWorkspace(export, "Orphan Relation Target", owner.ID)
+	ws, err := s.ImportWorkspace(export, "Orphan Relation Target", owner.ID, "")
 	if err != nil {
 		t.Fatalf("ImportWorkspace: %v", err)
 	}

--- a/internal/store/reminders_test.go
+++ b/internal/store/reminders_test.go
@@ -1065,7 +1065,7 @@ func TestRemindersRoundTripThroughExport(t *testing.T) {
 		t.Fatalf("export carried %d reminders, want 3", len(exp.Reminders))
 	}
 
-	dst, err := s.ImportWorkspace(exp, "reminder-export-target", owner.ID)
+	dst, err := s.ImportWorkspace(exp, "reminder-export-target", owner.ID, "")
 	if err != nil {
 		t.Fatalf("ImportWorkspace: %v", err)
 	}
@@ -1357,7 +1357,7 @@ func TestImportNormalizesRemindAt(t *testing.T) {
 		CreatedAt: exp.Reminders[0].CreatedAt, UpdatedAt: exp.Reminders[0].UpdatedAt,
 	})
 
-	dst, err := s.ImportWorkspace(exp, "import-norm-target", owner.ID)
+	dst, err := s.ImportWorkspace(exp, "import-norm-target", owner.ID, "")
 	if err != nil {
 		t.Fatalf("ImportWorkspace: %v", err)
 	}
@@ -1420,7 +1420,7 @@ func TestOrphanedItemDoesNotAbortTheImport(t *testing.T) {
 		CreatedAt: exp.Items[0].CreatedAt, UpdatedAt: exp.Items[0].UpdatedAt,
 	})
 
-	dst, err := s.ImportWorkspace(exp, "orphan-import-target", owner.ID)
+	dst, err := s.ImportWorkspace(exp, "orphan-import-target", owner.ID, "")
 	if err != nil {
 		t.Fatalf("one orphaned item aborted the whole import: %v", err)
 	}
@@ -1471,7 +1471,7 @@ func TestImportRefusesAckWithoutFire(t *testing.T) {
 	exp.Reminders[0].AckedAt = "2026-01-01T00:00:00Z"
 	exp.Reminders[0].FiredAt = ""
 
-	dst, err := s.ImportWorkspace(exp, "ack-fire-target", owner.ID)
+	dst, err := s.ImportWorkspace(exp, "ack-fire-target", owner.ID, "")
 	if err != nil {
 		t.Fatalf("ImportWorkspace: %v", err)
 	}

--- a/internal/store/trait_dedupe_test.go
+++ b/internal/store/trait_dedupe_test.go
@@ -408,7 +408,7 @@ func TestImportDeduplicatesAConflictingArchive(t *testing.T) {
 	dupe.Traits = convTraits
 	exp.Collections = append(exp.Collections, dupe)
 
-	imported, err := s.ImportWorkspace(exp, "import-dedupe-target", owner.ID)
+	imported, err := s.ImportWorkspace(exp, "import-dedupe-target", owner.ID, "")
 	if err != nil {
 		t.Fatalf("an archive carrying a duplicate declaration failed to import: %v", err)
 	}
@@ -486,7 +486,7 @@ func TestImportDeduplicatesAfterCanonicalInference(t *testing.T) {
 	rival.Traits = convTraits
 	exp.Collections = append(exp.Collections, rival)
 
-	imported, err := s.ImportWorkspace(exp, "infer-dedupe-target", owner.ID)
+	imported, err := s.ImportWorkspace(exp, "infer-dedupe-target", owner.ID, "")
 	if err != nil {
 		t.Fatalf("import failed on an archive whose duplicate only appears after inference: %v", err)
 	}
@@ -561,7 +561,7 @@ func TestImportKeepsTheLiveDeclarationWhenAnArchivedCollectionSharesIt(t *testin
 	archived.DeletedAt = "2026-01-02T03:04:05Z"
 	exp.Collections = append([]models.CollectionExport{archived}, exp.Collections...)
 
-	imported, err := s.ImportWorkspace(exp, "archived-trait-target", owner.ID)
+	imported, err := s.ImportWorkspace(exp, "archived-trait-target", owner.ID, "")
 	if err != nil {
 		t.Fatalf("import failed with an archived collection sharing a declaration: %v", err)
 	}


### PR DESCRIPTION
Closes BUG-2809. Files BUG-2914 for the one inventory item that is not this unit's.

## Why

`handleCreateWorkspace` and `handleImportWorkspace` mint the same thing through the same `store.CreateWorkspace` and enforced preconditions in two places. Two had already diverged and been fixed one at a time, each found by a reviewer rather than by the door that lacked it — the OAuth consent grant (IDEA-2756) and the user-scoped plan limit (BUG-2793). A third was live.

## The shared place

`internal/server/workspace_mint.go`, split by WHEN a precondition can run:

- **`beginWorkspaceMint`** — everything that does not need the body: consent, plan limit, and the owner/source attributions. Before the body read, so a refused caller never uploads a bundle and a refusal cannot be probed by body shape; above the Content-Type dispatch, so one line covers both body shapes.
- **`validateWorkspaceMintPayload`** — the payload-shaped rules. Returns an error rather than writing one, because the JSON doors answer `400 bad_request` and the bundle door answers `400 bad_bundle` through `importStatusError`. Shared rule, each door's own envelope.

Callers: `handleCreateWorkspace`, `handleImportWorkspace`, `importBundle`. The mint context reaches the bundle path as an **argument**, not on the `Server` — per-request state, and the two things it carries are exactly what two concurrent requests would differ on.

## The inventory

| item | disposition |
|---|---|
| 1. empty name | **live defect, fixed** |
| 2. settings normalization | **premise corrected**, status divergence fixed |
| 3. source attribution | **fixed** |
| 4. userless callers | **measured, filed as BUG-2914, doors unchanged** |

**1 — measured before writing anything.** An import with no workspace name *created* a workspace with `name="" slug=""`, and a second landed on slug `"-2"`: the first had taken the empty slug, globally, and a slug is a routing key. Both import doors now refuse it, checking the EFFECTIVE name (the `?name=` override when given, the bundle's own otherwise) since that is what becomes the slug. A control leg covers the override, or the rule would be indistinguishable from "reject any bundle whose payload name is empty" and would break rename-on-import.

**2 — the item's premise was wrong.** Malformed settings never reached the store unnormalized: `createWorkspaceQ` calls `NormalizeWorkspaceSettings` itself and refuses (`settings:"not-json"` → `create workspace: normalize workspace settings: invalid character 'o'`). What diverged was the STATUS — create answers 400, import answered **500 `import_failed`** because every store error maps that way. The shared payload step makes both 400. `Context` stays create-only: an export carries none, so applying it on import would be inventing input.

**3** — `store.ImportWorkspace` takes a `source` parameter, derived by the caller from the request's auth shape exactly as create derives it. A parameter rather than an export field, deliberately: a bundle says what the workspace WAS, and where this copy is minted from is a fact about this request. `pad db migrate-to-pg` passes `""` — a copy, not a creation surface; inventing `"cli"` would relabel every migrated workspace's origin.

**4** — deliberately unchanged. `beginWorkspaceMint` preserves the `userID != ""` guard exactly as both doors had it rather than changing behaviour under cover of a refactor. Measurement and ruling on BUG-2914.

## Mutants — five, each verified to COMPILE first

| mutant | detected by |
|---|---|
| JSON import door skips the payload check | empty-name + malformed-settings legs |
| bundle door skips it | bundle empty-name leg |
| check the payload name instead of the effective name | the `?name=` override control |
| import passes `""` for source | attribution leg |
| create door skips the payload check | create empty-name control |

Two of these initially did not compile (`declared and not used: effectiveName`), and `go test` answers a build failure with `FAIL <pkg> [build failed]` — which in a filtered run reads exactly like detection. That is a **false DETECTED**, the mirror of the false SURVIVED, and it is worse because it ends the check rather than extending it. Re-run with the orphaned variable kept alive; every row above is `BUILD OK` followed by a named test failure.

## Scope of the signature change

`store.ImportWorkspace` gained a fourth parameter, which touched 27 test call sites (mechanical, `""`) and the one operator caller.

https://claude.ai/code/session_01HeChkgZVYb3NTgTcckF5KR
