### PR TITLE
fix(web): the reconcile token outlives the state it counts, so a verdict cannot cross a reset (IDEA-2913)

### DIFF
--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -162,43 +162,13 @@ class WorkspaceState {
 	// request is issued, and a write authorised under a superseded scope is
 	// refused on return. Not persisted; a session-local ordering token.
 	//
-	// RECONCILE LOOPS DO NOT USE THIS — they use `resyncSeq` below (TASK-2909).
+	// RECONCILE LOOPS DO NOT USE THIS — they use the module-level
+	// `reconcileTokens` map (TASK-2909; moved out of the state by IDEA-2913).
 	// They did until then, which is what made a settle bump here look free: it
 	// would have answered their question and silently broken this one, refusing
 	// writes issued after the new snapshot was already installed.
 	scopeEpoch = 0;
 
-	// `resyncSeq` bumps when a resync SETTLES, and exists so a reconcile loop can
-	// ask "did a resync overlap my request", which `scopeEpoch` cannot answer
-	// (TASK-2909, review rounds 2 and 3).
-	//
-	// Settle only — an entry bump was written first and is redundant, which a
-	// mutation run showed by surviving its removal. A request that started
-	// before the resync mismatches after the settle bump; one that started
-	// during it is refused by the in-flight check while the resync runs and by
-	// the same settle bump afterwards. A second bump would be a second
-	// definition of "a resync happened" with nothing extra to say.
-	//
-	// KNOWN LIMIT, older than this counter: it is per-state and restarts at
-	// zero, so a `reset()` between a loop's capture and its response gives the
-	// REPLACEMENT state a matching token by coincidence. `resetGenerationFor`
-	// is the value that survives a reset and the loops do not yet capture it.
-	// Filed as IDEA-2913 rather than fixed here — the scope epoch this replaced
-	// had the same gap, so it is not this unit's to close.
-	//
-	// A separate counter rather than bumping `scopeEpoch` twice, which was the
-	// first shape and was wrong: `scopeEpoch` is ALSO the fence `upsert` uses to
-	// reject an optimistic write authorised under a superseded scope, and a
-	// settle bump made it reject writes issued AFTER the new snapshot was
-	// already installed — a user's create returning successfully and never
-	// reaching the store. One counter for two questions looked like thrift and
-	// was an overload; the questions differ, so the counters do.
-	//
-	// Reconcile loops capture this at the top of each iteration and hand it back
-	// when they report catch-up. Any capture taken during a resync mismatches
-	// afterwards, so a response computed against the pre-snapshot cursor cannot
-	// clear the ask however late it arrives.
-	resyncSeq = 0;
 
 	// `fencedIds` holds item ids the most recent resync DROPPED (absent from the
 	// authoritative snapshot — hidden by a downgrade or deleted). `upsert`
@@ -248,6 +218,40 @@ const workspaces = new SvelteMap<string, WorkspaceState>();
 const resetGenerations = new Map<string, number>();
 
 /**
+ * Per-workspace reconcile token — the value a reconcile loop captures when it
+ * ISSUES an `/items-changes` request and hands back when it reports catch-up
+ * (TASK-2909, moved out of `WorkspaceState` by IDEA-2913).
+ *
+ * It bumps on exactly two events, and they are the two ways a verdict computed
+ * against the cursor as the caller saw it can be overtaken:
+ *
+ *   - a projection resync SETTLES, having pinned the cursor;
+ *   - the workspace's rows are DROPPED (`markWorkspaceDropped`).
+ *
+ * OUTSIDE `workspaces`, for the same reason `resetGenerations` is (TASK-2877):
+ * `reset()` deletes that entry, so any counter living on the state object
+ * restarts at zero and a response issued against the OLD state finds a matching
+ * value on the replacement. That is an ABA — the counter returns to a value the
+ * caller had seen, by way of a different object — and no per-state value can
+ * close it, because "unchanged" and "reset back to zero" are the same number.
+ *
+ * ONE counter rather than making callers capture this AND `resetGenerationFor`:
+ * two values to compare is two values to keep in step, and the door that forgets
+ * the second one is the next lapse. The question both would answer is a single
+ * question — "is the state I measured still the state I am reporting to" — so it
+ * gets a single value. Its readers are the reconcile path and
+ * nothing else — `clearAskIfSettled`, the two loops, and the
+ * `reconcileTokenFor` accessor they capture through — verified by grep before
+ * the move, which is what makes moving it safe here and was not true of
+ * `scopeEpoch`.
+ */
+const reconcileTokens = new Map<string, number>();
+
+function bumpReconcileToken(ws: string): void {
+	reconcileTokens.set(ws, (reconcileTokens.get(ws) ?? 0) + 1);
+}
+
+/**
  * Record that a workspace's rows are gone. EVERY path that drops them calls
  * this — `reset()`, which deletes the whole state entry, and `bootstrap()`'s
  * 401/403 branch, which clears the rows in place. Two call sites rather than
@@ -257,6 +261,12 @@ const resetGenerations = new Map<string, number>();
  */
 function markWorkspaceDropped(ws: string): void {
 	resetGenerations.set(ws, (resetGenerations.get(ws) ?? 0) + 1);
+	// A drop invalidates any reconcile verdict in flight just as a settled
+	// resync does — the rows the response was computed against are gone
+	// (IDEA-2913). Bumping HERE rather than in `reset()` inherits this helper's
+	// guarantee of being the single funnel every drop path calls, which
+	// `localIndexResetGeneration.svelte.test.ts` already enforces.
+	bumpReconcileToken(ws);
 }
 
 const inflight = new Map<string, Promise<void>>();
@@ -421,7 +431,7 @@ function clearAskIfSettled(ws: string, state: WorkspaceState, token: number): vo
 	// started. A resync that overlapped it pinned the cursor since, so the
 	// verdict is stale — however late it arrives, and whether or not anything is
 	// still in flight now.
-	if (state.resyncSeq !== token) return;
+	if ((reconcileTokens.get(ws) ?? 0) !== token) return;
 	// ...and the still-running case, which the token alone cannot catch: the
 	// counter only moves when a resync SETTLES, so a response that arrives while
 	// one is mid-flight still carries a matching token.
@@ -649,7 +659,7 @@ async function resyncProjectionScope(
 		//
 		// Only the STARTER reaches this: joined callers return the pending
 		// promise above and never enter the try.
-		state.resyncSeq += 1;
+		bumpReconcileToken(ws);
 	}
 }
 
@@ -851,13 +861,13 @@ export const localIndex = {
 						// Captured per ITERATION but declared out here, because
 						// the clear below belongs to whichever iteration
 						// concluded catch-up (TASK-2909 review round 3).
-						let reconcileToken = state.resyncSeq;
+						let reconcileToken = reconcileTokens.get(ws) ?? 0;
 						for (let i = 0; i < 50; i++) {
-							reconcileToken = state.resyncSeq;
+							reconcileToken = reconcileTokens.get(ws) ?? 0;
 							const since = state.cursor;
 							const delta = await api.items.changes(ws, since);
 							if (isStale()) return;
-							if (state.resyncSeq !== reconcileToken) {
+							if ((reconcileTokens.get(ws) ?? 0) !== reconcileToken) {
 								// A concurrent resync (another caller) installed a
 								// new snapshot + pinned cursor while this request
 								// was in flight. This response predates it, so it
@@ -1713,8 +1723,9 @@ export const localIndex = {
 		// a value read at the moment of reporting, because the staleness this
 		// guards against is decided at request time, not at clear time.
 		//
-		// `clearAskIfSettled` compares it against `resyncSeq`, which bumps when
-		// a resync SETTLES, and additionally refuses while one is outstanding.
+		// `clearAskIfSettled` compares it against the module-level reconcile
+		// token, which bumps when a resync SETTLES and when the workspace's rows
+		// are DROPPED, and additionally refuses while a resync is outstanding.
 		// Between them they cover both ways a response can be overtaken: one
 		// that returns while the resync is still running (the counter has not
 		// moved yet — the in-flight check catches it) and one that returns after
@@ -1760,10 +1771,16 @@ export const localIndex = {
 	 * This one changes when a resync SETTLES, which is what makes a capture
 	 * taken before or during that resync detectably stale afterwards; the
 	 * mid-flight case is covered by the in-flight check in `clearAskIfSettled`
-	 * rather than by this counter. Returns 0 for an unhydrated workspace.
+	 * rather than by this counter.
+	 *
+	 * Returns 0 for a workspace nothing has happened to yet — but NOT as an
+	 * "unhydrated" sentinel, and no caller may read it as one: the counter
+	 * outlives the state, so a slug reset while unhydrated answers 1 with no
+	 * state in existence (IDEA-2913 review). The only meaningful use is
+	 * comparing a captured value against a later one.
 	 */
 	reconcileTokenFor(ws: string): number {
-		return workspaces.get(ws)?.resyncSeq ?? 0;
+		return reconcileTokens.get(ws) ?? 0;
 	},
 
 	scopeEpochFor(ws: string): number {

--- a/web/src/lib/stores/localIndexResyncSettled.svelte.test.ts
+++ b/web/src/lib/stores/localIndexResyncSettled.svelte.test.ts
@@ -453,3 +453,73 @@ describe('TASK-2909 — the ask outlives an unwritten resync', () => {
 		expect(localIndex.pendingResyncFor(ws)).toBe(false);
 	});
 });
+
+describe('IDEA-2913 — a verdict cannot cross a reset', () => {
+	/** Run one projection resync to completion, bumping the token once. */
+	async function oneResync(unparented: boolean, epoch: string): Promise<void> {
+		vi.spyOn(api.items, 'listIndex').mockResolvedValue({
+			items: [row('cached', 1)],
+			total: 1,
+			cursor: '1',
+			includes_unparented_metadata: unparented,
+			access_epoch: epoch,
+		} as unknown as Awaited<ReturnType<typeof api.items.listIndex>>);
+		await localIndex.ensureProjectionScope(ws, unparented);
+	}
+
+	it('a token captured against one state does not clear the ask of its replacement', async () => {
+		// Discriminates the MOVE (a per-state counter restarts at zero, so old
+		// and replacement both reach 1 after one resync each and the captured
+		// value matches). It does NOT discriminate the drop bump — with the
+		// counter outside the state the two resyncs alone already separate the
+		// numbers, so this passes with `markWorkspaceDropped`'s bump removed. A
+		// mutation run said so; the sibling test below is what covers that half,
+		// and this comment exists because the test's NAME would otherwise imply
+		// it covered both.
+		await boot();
+		await oneResync(true, 'e2');
+		const capturedInA = localIndex.reconcileTokenFor(ws);
+
+		// Sign-out / 403 purge / workspace deletion — the state object is gone.
+		localIndex.reset(ws);
+
+		await boot();
+		await oneResync(true, 'e2');
+		expect(localIndex.pendingResyncFor(ws)).toBe(true);
+
+		// Per-state, both would read 1 and this would clear an ask belonging to a
+		// workspace identity the response never saw. The token now outlives the
+		// state, so the reset itself moved it.
+		localIndex.markCaughtUp(ws, capturedInA);
+		expect(localIndex.pendingResyncFor(ws)).toBe(true);
+
+		// ...and the replacement's own loop is not wedged by that.
+		localIndex.markCaughtUp(ws, localIndex.reconcileTokenFor(ws));
+		expect(localIndex.pendingResyncFor(ws)).toBe(false);
+	});
+
+	it('a drop alone moves the token, with no resync involved', async () => {
+		// THE DROP BUMP'S ONLY DISCRIMINATOR, and the case it exists for: a
+		// capture taken in one state, no resync anywhere, and a reset. The
+		// counter surviving the state closes the ABA whenever a resync happens
+		// to separate the numbers; this closes it when nothing does. The bump
+		// lives in `markWorkspaceDropped` — the single funnel every drop path
+		// calls, enforced by localIndexResetGeneration.svelte.test.ts — rather
+		// than in `reset()`, so a drop that clears rows in place moves it too.
+		await boot();
+		const before = localIndex.reconcileTokenFor(ws);
+		localIndex.reset(ws);
+		expect(localIndex.reconcileTokenFor(ws)).not.toBe(before);
+	});
+
+	it('survives the state it counts — a fresh workspace does not restart it', async () => {
+		await boot();
+		await oneResync(true, 'e2');
+		const afterResync = localIndex.reconcileTokenFor(ws);
+		localIndex.reset(ws);
+		await boot();
+
+		// The replacement state is brand new; the token is not.
+		expect(localIndex.reconcileTokenFor(ws)).toBeGreaterThan(afterResync);
+	});
+});


### PR DESCRIPTION
Found by adversarial review during [[TASK-2909]] and filed rather than folded in, because it **predates** that unit — the scope epoch the reconcile token replaced had the same gap.

## The defect

A reconcile loop captures a token when it issues `/items-changes` and hands it back when it reports catch-up. That token lived on `WorkspaceState`, and `reset()` — sign-out, a 403 membership purge, a workspace deletion — deletes that object. The replacement starts counting from zero, so a response computed for the **previous identity** can find a matching value on the replacement and be treated as a clean catch-up for a workspace it never saw.

A classic **ABA**: the counter returns to a value the caller had seen, by way of a different object. No per-state value can close it, because *unchanged* and *reset back to zero* are the same number — which is exactly why `resetGenerations` already lives outside the `workspaces` map (TASK-2877).

## The fix

The token moves out of the state into a module-level map beside it, and bumps on the two events that can overtake a verdict: a resync **settling**, and the workspace's rows being **dropped**. The drop bump goes in `markWorkspaceDropped` rather than `reset()`, inheriting that helper's guarantee of being the single funnel every drop path calls — which `localIndexResetGeneration.svelte.test.ts` already enforces.

**One counter, not a second capture.** The obvious alternative was to have callers capture `resetGenerationFor` too and compare both. Two values to compare is two values to keep in step, and the door that forgets the second one is the next lapse — this plan has produced four of those. Both values answer one question, *is the state I measured still the state I am reporting to*, so it gets one value.

**Checked against the failure the predecessor unit produced** (widening a signal silently changes every answer it was already giving): the readers were enumerated by grep first, and they are exactly the reconcile path — `clearAskIfSettled` and the two loops. Nothing else reads it, which is what makes the move safe and was not true of `scopeEpoch`.

## Gates

| Gate | Result |
|---|---|
| `npx vite build` | ✅ built |
| `go build ./...` | ✅ (no Go files changed) |
| `npm run check` | ✅ 1101 files, **0 errors**, 6 pre-existing warnings |
| `npx vitest run` | ✅ **2189 passed** |
| `make lint` / `go test ./...` / `make test-pg` | N/A — no Go or store SQL in the diff |

**Mutation matrix — four mutants, three killed**: the drop bump removed, the comparison removed, the settle bump removed. Negative control scores BUILD-FAIL. The survivor is bootstrap's loop re-check reading a fresh value instead of its captured one — the same shape TASK-2909 recorded, for the same reason: the loop `continue`s whenever a resync fires, so the two readings cannot differ without an artificial yield.

**One test needed its claim corrected rather than its code.** The headline ABA test discriminates the *move* but not the *drop bump*, because with the counter outside the state two resyncs already separate the numbers — a mutation run said so. Its name would have implied it covered both, so the comment now says which half it carries and points at the sibling carrying the other.

IDEA-2913 · PLAN-2903

https://claude.ai/code/session_01Xk9M5UVPdc84xL5E1mZkm8
