### PR TITLE
fix(store): preserve valid item references across workspace import

### DIFF
--- a/docs/backup.md
+++ b/docs/backup.md
@@ -162,6 +162,13 @@ pad workspace import my-workspace.json
 pad workspace import --name "imported-workspace" my-workspace.json
 ```
 
+Item reference numbers are preserved when the imported items have positive,
+workspace-unique numbers, including gaps left by deleted items. This keeps
+references such as `[[TASK-2]]` pointing to the same task after restoration or
+SQLite→PostgreSQL migration. Legacy archives with duplicate, missing, or invalid
+numbers retain the sequential-renumbering fallback; references in those archives
+may need manual repair.
+
 ### One case where an export is not importable
 
 A workspace whose stored data contains a **NUL character** exports fine and is

--- a/internal/store/export.go
+++ b/internal/store/export.go
@@ -597,11 +597,25 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 		}
 	}
 
-	// Import items (first pass: create items, remap collection_id)
-	// Item numbers are assigned sequentially in created_at order to produce
-	// workspace-global numbering. Exported item_number values are ignored
-	// because old exports used per-collection numbering which can have
-	// duplicates within a workspace.
+	// Preserve modern archives' reference numbers, including deletion gaps and
+	// out-of-order items: content and comments still refer to those numbers.
+	// Legacy archives used per-collection numbering (or had no numbers), so
+	// retain sequential allocation when the imported set is not workspace-unique.
+	// Orphans are skipped below and must not force valid items to be renumbered.
+	preserveItemNumbers := true
+	seenItemNumbers := make(map[int]bool, len(data.Items))
+	for _, it := range data.Items {
+		if collMap[it.CollectionID] == "" {
+			continue
+		}
+		if it.ItemNumber <= 0 || seenItemNumbers[it.ItemNumber] {
+			preserveItemNumbers = false
+			break
+		}
+		seenItemNumbers[it.ItemNumber] = true
+	}
+
+	// Import items (first pass: create items, remap collection_id).
 	//
 	// IDEA-1486 + IDEA-1488: precompute each item's coerced fields/tags so
 	// the second-pass UPDATE (which re-applies fields after the ID remap)
@@ -649,6 +663,10 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 		parentID := resolveImportParent(it.ParentID, itemMap, insertedItems)
 
 		nextItemNumber++
+		itemNumber := nextItemNumber
+		if preserveItemNumbers {
+			itemNumber = it.ItemNumber
+		}
 		// IDEA-1486 + IDEA-1488: coerce empty-string / malformed
 		// fields/tags at the import boundary. After migration 056 /
 		// pgmigrations 035 hardened items.fields and items.tags to
@@ -736,7 +754,7 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 			INSERT INTO items (id, workspace_id, collection_id, title, slug, content, fields, tags, pinned, sort_order, parent_id, created_by, last_modified_by, source, item_number, created_at, updated_at, seq)
 			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULLIF(?, ''), ?, ?, ?, ?, ?, ?, `+nextWorkspaceSeqSubquery+`)`),
 			newItemID, ws.ID, newCollID, itemTitle, itemSlug, it.Content, fieldsJSON, tagsJSON, s.dialect.BoolToInt(it.Pinned), it.SortOrder,
-			parentID, it.CreatedBy, it.LastModifiedBy, it.Source, nextItemNumber,
+			parentID, it.CreatedBy, it.LastModifiedBy, it.Source, itemNumber,
 			it.CreatedAt, it.UpdatedAt, ws.ID)
 		if err != nil {
 			return nil, fmt.Errorf("import item %s: %w", it.Title, err)

--- a/internal/store/export_reference_test.go
+++ b/internal/store/export_reference_test.go
@@ -1,0 +1,142 @@
+package store
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+func TestImportWorkspacePreservesReferenceTarget(t *testing.T) {
+	t.Parallel()
+	for _, deleteFirst := range []bool{false, true} {
+		t.Run(fmt.Sprintf("deleted_first=%v", deleteFirst), func(t *testing.T) {
+			s := testStore(t)
+			owner := createTestUser(t, s, "audit@example.com", "Audit", "password123")
+			ws := createTestWorkspace(t, s, "Reference source")
+			coll, err := s.CreateCollection(ws.ID, models.CollectionCreate{Name: "Tasks", Prefix: "TASK"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			first := createTestItem(t, s, ws.ID, coll.ID, "Obsolete task", "")
+			target := createTestItem(t, s, ws.ID, coll.ID, "Deploy the release", "")
+			note := createTestItem(t, s, ws.ID, coll.ID, "Release instructions", "Follow [[TASK-2]] before continuing.")
+			comment, err := s.CreateComment(ws.ID, note.ID, "", models.CommentCreate{Body: "Review [[TASK-2]] first."})
+			if err != nil {
+				t.Fatal(err)
+			}
+			// Deterministic fixture for ordinary items created one second apart.
+			for i, item := range []*models.Item{first, target, note} {
+				_, err := s.db.Exec(s.q("UPDATE items SET created_at = ? WHERE id = ?"), fmt.Sprintf("2026-09-01T12:00:0%dZ", i), item.ID)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			before, err := s.ResolveItem(ws.ID, "TASK-2")
+			if err != nil || before == nil || before.ID != target.ID {
+				t.Fatalf("source control: item=%+v err=%v", before, err)
+			}
+			if deleteFirst {
+				if err := s.DeleteItem(first.ID); err != nil {
+					t.Fatal(err)
+				}
+			}
+			bundle, err := s.ExportWorkspace(ws.Slug)
+			if err != nil {
+				t.Fatal(err)
+			}
+			dst, err := s.ImportWorkspace(bundle, "Reference restored", owner.ID, "cli")
+			if err != nil {
+				t.Fatal(err)
+			}
+			after, err := s.ResolveItem(dst.ID, "TASK-2")
+			if err != nil || after == nil {
+				t.Fatalf("restored ref lookup: item=%+v err=%v", after, err)
+			}
+			importedNote, err := s.ResolveItem(dst.ID, note.Slug)
+			if err != nil || importedNote == nil {
+				t.Fatalf("restored note lookup: item=%+v err=%v", importedNote, err)
+			}
+			t.Logf("before TASK-2=%q; after TASK-2=%q; restored body=%q; export/import succeeded", before.Title, after.Title, importedNote.Content)
+			if after.Title != target.Title {
+				t.Errorf("reference changed target: want %q, got %q", target.Title, after.Title)
+			}
+			if importedNote.Content != note.Content {
+				t.Errorf("content changed: %q", importedNote.Content)
+			}
+			comments, err := s.ListComments(importedNote.ID)
+			if err != nil || len(comments) != 1 || comments[0].Body != comment.Body {
+				t.Errorf("comments did not round-trip: %+v, err=%v", comments, err)
+			}
+		})
+	}
+}
+
+func TestImportWorkspaceItemNumberCompatibility(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name    string
+		numbers []int
+		want    []int
+		orphan  bool
+	}{
+		{name: "out of order with gaps", numbers: []int{7, 2}, want: []int{7, 2}},
+		{name: "legacy duplicate", numbers: []int{1, 1}, want: []int{1, 2}},
+		{name: "missing number", numbers: []int{0, 2}, want: []int{1, 2}},
+		{name: "negative number", numbers: []int{-1, 2}, want: []int{1, 2}},
+		{name: "unnumbered archive", numbers: []int{0, 0}, want: []int{1, 2}},
+		{name: "orphan duplicate ignored", numbers: []int{7, 2}, want: []int{7, 2}, orphan: true},
+		{name: "empty archive"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			s := testStore(t)
+			owner := createTestUser(t, s, "import@example.com", "Importer", "password123")
+			const timestamp = "2026-09-01T12:00:00Z"
+			bundle := &models.WorkspaceExport{
+				Version:   1,
+				Workspace: models.WorkspaceExportMeta{Name: "Number archive", Slug: "number-archive"},
+				Collections: []models.CollectionExport{
+					{ID: "tasks", Name: "Tasks", Slug: "tasks", Prefix: "TASK", Schema: `{"fields":[]}`, CreatedAt: timestamp, UpdatedAt: timestamp},
+					{ID: "plans", Name: "Plans", Slug: "plans", Prefix: "PLAN", Schema: `{"fields":[]}`, CreatedAt: timestamp, UpdatedAt: timestamp},
+				},
+			}
+			for i, number := range tc.numbers {
+				slug := fmt.Sprintf("item-%d", i)
+				bundle.Items = append(bundle.Items, models.ItemExport{
+					ID: slug, CollectionID: bundle.Collections[i].ID, Title: slug, Slug: slug,
+					ItemNumber: number, CreatedAt: timestamp, UpdatedAt: timestamp,
+				})
+			}
+			if tc.orphan {
+				bundle.Items = append(bundle.Items, models.ItemExport{ID: "orphan", CollectionID: "missing", ItemNumber: 7})
+			}
+			dst, err := s.ImportWorkspace(bundle, "Imported numbers", owner.ID, "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			imported, err := s.ExportWorkspace(dst.Slug)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(imported.Items) != len(tc.want) {
+				t.Fatalf("imported %d items, want %d", len(imported.Items), len(tc.want))
+			}
+			maxNumber := 0
+			for i, number := range tc.want {
+				item, err := s.GetItemBySlug(dst.ID, bundle.Items[i].Slug)
+				if err != nil || item == nil || item.ItemNumber == nil {
+					t.Fatalf("read imported item: %+v, err=%v", item, err)
+				}
+				if *item.ItemNumber != number {
+					t.Errorf("%s number=%d, want %d", item.Slug, *item.ItemNumber, number)
+				}
+				maxNumber = max(maxNumber, number)
+			}
+			created := createTestItem(t, s, dst.ID, imported.Collections[0].ID, "After import", "")
+			if created.ItemNumber == nil || *created.ItemNumber != maxNumber+1 {
+				t.Errorf("next number=%v, want %d", created.ItemNumber, maxNumber+1)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Closes #1270.

After deleting TASK-1, importing a workspace containing TASK-2 and TASK-3 previously reassigned them to TASK-1 and TASK-2 while leaving `[[TASK-2]]` text unchanged. A successful restore could therefore redirect instructions to the wrong task; SQLite→PostgreSQL migration uses the same path.

Preserve exported item numbers when the items being imported have positive, workspace-unique numbers. Ignore skipped orphan rows when checking that condition. Retain the existing sequential fallback for legacy duplicate, missing, or invalid numbers, so old per-collection archives remain importable. No schema or archive-format changes, dependencies, or API-shape changes.

The regression covers the actual create/delete/export/import/resolve path, item and comment text, reordered same-timestamp archives, deletion gaps, allocation above the preserved maximum, legacy duplicate/missing/negative numbers, orphan rows, and empty archives. The backup guide documents preservation and the legacy fallback.

## How to test

```sh
go test ./internal/store -run '^TestImportWorkspace(PreservesReferenceTarget|ItemNumberCompatibility)$' -count=2 -v
PAD_TEST_POSTGRES_URL='postgres://.../pad?sslmode=disable' go test ./internal/store -run '^TestImportWorkspace(PreservesReferenceTarget|ItemNumberCompatibility)$' -count=2 -v
make build
make test
```

The deletion regression failed on upstream before the fix; the no-deletion control passed. Both pass after the fix. All validation below ran against commit `416dd404f43e81e4cd36c77ed928819ea08b5ad3`:

- Full Linux SQLite suite: 7,000 test/subtest passes, 63 repository-defined skips, 29 packages; repeated with `-race`, same result and no race reports.
- Full Linux PostgreSQL 17 suite: 7,008 test/subtest passes, 56 repository-defined skips, 29 packages; repeated with `-race`, same result and no race reports.
- Full Node 24 build, Tiptap pin check, svelte-check (0 errors; 6 existing warnings), and Vitest (2,189 tests across 134 files).
- Playwright: 204 passed, 192 repository-defined skips, no failures.
- `GOOS=linux make lint` (0 issues), `make vuln`, `npm run audit:ci`, and `git diff --check` passed.

The full backend commands were `go test -json -timeout=45m ./... -count=1` and `go test -race -json -timeout=45m ./... -count=1`, each with SQLite and `PAD_TEST_POSTGRES_URL` pointing at an isolated PostgreSQL 17 instance. These run the complete `make test` package set. Linux arm64 containers used Go 1.26.6 and RAM-backed test storage, matching the repository's test database setup. Full native SQLite and PostgreSQL store suites also passed.

Validation environment notes: the native macOS full suite encounters pre-existing session-owner/process-token failures, reproduced on unmodified upstream main, and a `/var` versus `/private/var` path assertion. The corresponding CLI packages pass on Linux. Playwright used an external launcher configuration to quote the checkout path's spaces and retain the original working directory; no test cases were changed or excluded.

Hosted workflows were approved while local validation was finishing. Web, Playwright, and macOS/Windows smoke checks have passed; Go, PostgreSQL, and Nix checks are still running as of the ready-for-review transition. The full local matrix above has completed successfully.

## Checklist

- [x] `make build` passes (Node 24, matching CI)
- [x] Complete `make test` suite passes on Linux, both databases, with and without `-race` (native macOS caveats above)
- [x] New features have tests (regression coverage for this fix)
- [x] TypeScript types updated (not applicable: no API-shape change)
- [x] CLI help text updated (not applicable: no new command)
