### PR TITLE
fix(build): make install proves what it installed and what it restarted (BUG-2897, TASK-2787)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,32 +24,30 @@ build-go:
 	go build -ldflags "$(LDFLAGS)" -o $(BINARY) $(BUILD_DIR)
 
 install: build
-	@# Stop running server, install binary, clear stale pid.
-	@# CAUTION: `pkill -x pad` is SYSTEM-WIDE (matches the binary name on the
-	@# whole host). If another user or project on the same machine is running
-	@# a `pad` process, it will get signaled too. Designed for single-developer
-	@# local setups; don't run `make install` on a shared host.
+	@# Delegated to scripts/install-refresh.sh (BUG-2897, TASK-2787). The
+	@# logic lives in a script rather than in this recipe for one reason
+	@# above readability: a script can be TESTED. install_refresh_test.go
+	@# drives it against a stub `pad` on PATH, including the branch where
+	@# the probe fails. Recipe-inline logic can only be exercised by running
+	@# `make install`, which stops the developer's real server — a test
+	@# nobody runs twice, which is how this target accumulated three
+	@# unverified claims.
 	@#
-	@# SIGTERM (not SIGKILL) so the server's graceful-shutdown path runs:
-	@# it closes the event bus, which terminates SSE handler goroutines so
-	@# the http.Server can write the final 0-chunk before closing each
-	@# stream. SIGKILL drops every open SSE connection mid-write, leaving
-	@# every browser tab with `ERR_INCOMPLETE_CHUNKED_ENCODING` and a noisy
-	@# reconnect storm. Falls back to SIGKILL after 5s for stuck processes.
-	@# BUG-1531 / SSE follow-up.
-	-pkill -TERM -x $(BINARY) 2>/dev/null; \
-		for i in 1 2 3 4 5; do \
-			pgrep -x $(BINARY) >/dev/null 2>&1 || break; \
-			sleep 1; \
-		done; \
-		pkill -KILL -x $(BINARY) 2>/dev/null || true
-	@mkdir -p $(INSTALL_DIR)
-	cp -f $(BINARY) $(INSTALL_DIR)/$(BINARY)
-	rm -f ~/.pad/pad.pid
-	@echo "Installed $(BINARY) to $(INSTALL_DIR)/$(BINARY)"
-	@# Trigger server auto-start by running a command
-	@$(INSTALL_DIR)/$(BINARY) auth whoami 2>/dev/null || true
-	@echo "Server restarted."
+	@# What the script guarantees, and what this target could not:
+	@#   - the binary it installs carries THIS invocation's commit, so a
+	@#     sibling's build sitting at ./pad cannot be installed silently
+	@#     (TASK-2787);
+	@#   - the server comes back with the argv of the process it killed,
+	@#     rather than whatever an auto-start defaults to (BUG-2897);
+	@#   - nothing is printed about a restart until the server answers on
+	@#     BOTH 127.0.0.1 and the configured host.
+	@#
+	@# CAUTION, unchanged: the stop is `pkill -x $(BINARY)`, which is
+	@# SYSTEM-WIDE (matches the binary name on the whole host). Designed for
+	@# single-developer local setups. When another session's worktree is
+	@# live, use CONVE-2687's manual sibling-safe recipe instead — this
+	@# target is the plain path, now honest, not a replacement for it.
+	@bash scripts/install-refresh.sh $(BINARY) $(INSTALL_DIR)/$(BINARY) $(COMMIT)
 
 # -timeout matches CI (see .github/workflows/ci.yml). Without it `go test`
 # uses a 10m per-test-binary default nobody chose — the shape that killed

--- a/internal/buildtools/install_refresh_test.go
+++ b/internal/buildtools/install_refresh_test.go
@@ -1,0 +1,1113 @@
+package buildtools
+
+// Tests for scripts/install-refresh.sh — the honest half of `make install`
+// (BUG-2897, TASK-2787).
+//
+// Every stub gets a UNIQUE, SHORT name, and both properties are load-bearing:
+//
+//   - unique, because the script's stop step is `pkill -x <name>`, which is
+//     system-wide. A shared name would let one test kill another's server;
+//     the name "pad" would kill the developer's. That containment is also the
+//     only reason these tests are safe to run twice, which is the reason this
+//     logic moved out of the Makefile recipe at all.
+//   - short, because `pgrep -x` matches /proc/<pid>/comm, which the kernel
+//     TRUNCATES TO 15 CHARACTERS.
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// stubBinary is the compiled fake `pad`, built once for the package.
+//
+// COMPILED, not a shell script, and the reason is the property under test:
+// the script locates the running server with `pgrep -x <name>`, which matches
+// /proc/<pid>/comm — and comm for a shebang script is the INTERPRETER
+// ("bash"), never the script's own name. The first version of these tests
+// used a shell stub and failed reporting "no running server found"; that was
+// the FIXTURE failing, not the script. A fixture that cannot be found the way
+// the real artifact is found tests nothing.
+var stubBinary string
+
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "install-refresh-stub")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "stub tempdir:", err)
+		os.Exit(1)
+	}
+	stubBinary = filepath.Join(dir, "stub")
+	build := exec.Command("go", "build", "-o", stubBinary, "./testdata/stub")
+	build.Stdout, build.Stderr = os.Stderr, os.Stderr
+	if err := build.Run(); err != nil {
+		fmt.Fprintln(os.Stderr, "build stub:", err)
+		os.Exit(1)
+	}
+	code := m.Run()
+	os.RemoveAll(dir)
+	os.Exit(code)
+}
+
+// uniqueName returns a stub name that is unique per test and under the
+// 15-character comm limit pgrep -x matches on.
+// requireScriptDeps skips when the environment cannot run the script at all.
+//
+// The script is a developer-workflow tool: it needs a shell, process tools,
+// curl, and a usable loopback. The NIX BUILD SANDBOX has none of that — the
+// whole file failed there with "no running server found" and "did not
+// answer", which are true statements about the sandbox and say nothing
+// about the script. CI's ordinary Go jobs have the tools and run every test
+// here, so this preserves the coverage where it is possible and stops
+// claiming it where it is not.
+//
+// The probe is a CAPABILITY CHECK, not a platform guess: it asks for the
+// exact things the script uses, so an environment that gains them starts
+// running these tests without anyone remembering to update a skip list.
+func requireScriptDeps(t *testing.T, extra ...string) {
+	t.Helper()
+	for _, tool := range append([]string{"bash", "pgrep", "pkill", "curl", "ps"}, extra...) {
+		if _, err := exec.LookPath(tool); err != nil {
+			t.Skipf("%s not available; this environment cannot run install-refresh.sh", tool)
+		}
+	}
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Skipf("no usable loopback here: %v", err)
+	}
+	l.Close()
+
+	// pgrep must actually SEE PROCESSES, not merely exist on PATH.
+	//
+	// Third narrow guard in this file, and the one that cost two CI rounds:
+	// LookPath("pgrep") answers "is the binary installed", while the script
+	// needs "can it find a running process". In the Nix build sandbox the
+	// binary is there and the answer is empty, so the script reported "no
+	// running server found", restarted with DEFAULT argv, and the probe then
+	// failed on an address the server was never asked to bind — a failure
+	// three steps downstream of a capability nothing had checked.
+	//
+	// The probe asks pgrep to find THIS process by its own comm, which is
+	// the same question the script asks about the server.
+	self, err := os.ReadFile("/proc/self/comm")
+	comm := strings.TrimSpace(string(self))
+	if err != nil || comm == "" {
+		comm = filepath.Base(os.Args[0])
+		if len(comm) > 15 {
+			comm = comm[:15] // the kernel truncates comm; pgrep -x matches it
+		}
+	}
+	out, err := exec.Command("pgrep", "-x", comm).Output()
+	if err != nil || strings.TrimSpace(string(out)) == "" {
+		t.Skipf("pgrep cannot see processes here (looked for %q); this environment cannot run install-refresh.sh", comm)
+	}
+}
+
+func uniqueName(t *testing.T) string {
+	t.Helper()
+	b := make([]byte, 4)
+	if _, err := rand.Read(b); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	name := "padstb" + hex.EncodeToString(b) // 14 chars
+	if len(name) > 15 {
+		t.Fatalf("stub name %q exceeds the comm limit pgrep -x matches on", name)
+	}
+	return name
+}
+
+func installStub(t *testing.T, dir, name string) string {
+	t.Helper()
+	src, err := os.ReadFile(stubBinary)
+	if err != nil {
+		t.Fatalf("read stub: %v", err)
+	}
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, src, 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	return path
+}
+
+func killStub(t *testing.T, name string) {
+	t.Helper()
+	_ = exec.Command("pkill", "-KILL", "-x", name).Run()
+}
+
+func freePort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("free port: %v", err)
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port
+}
+
+func scriptPath(t *testing.T) string {
+	t.Helper()
+	p, err := filepath.Abs(filepath.Join("..", "..", "scripts", "install-refresh.sh"))
+	if err != nil {
+		t.Fatalf("abs: %v", err)
+	}
+	if _, err := os.Stat(p); err != nil {
+		t.Fatalf("script not found at %s: %v", p, err)
+	}
+	return p
+}
+
+type stubEnv struct {
+	version string
+	healthy string // "1" serves health; anything else exits immediately
+	argvLog string
+	port    int
+	home    string
+	// installedPath + installedVersion make the file at the FINAL path
+	// report a different version from everything else, which is the only
+	// way to exercise the destination check now that the script stages a
+	// verified copy beside it.
+	installedPath    string
+	installedVersion string
+}
+
+func (e stubEnv) env() []string {
+	return append(os.Environ(),
+		"HOME="+e.home,
+		fmt.Sprintf("PAD_PORT=%d", e.port),
+		"PAD_PROBE_TIMEOUT=8",
+		"STUB_VERSION="+e.version,
+		"STUB_HEALTHY="+e.healthy,
+		"STUB_ARGV_LOG="+e.argvLog,
+		fmt.Sprintf("STUB_PORT=%d", e.port),
+		"STUB_INSTALLED_PATH="+e.installedPath,
+		"STUB_VERSION_INSTALLED="+e.installedVersion,
+	)
+}
+
+type runResult struct {
+	stdout, stderr string
+	err            error
+}
+
+func runScript(t *testing.T, e stubEnv, built, installed, commit string) runResult {
+	t.Helper()
+	cmd := exec.Command("bash", scriptPath(t), built, installed, commit)
+	cmd.Env = e.env()
+	var out, errb strings.Builder
+	cmd.Stdout, cmd.Stderr = &out, &errb
+	err := cmd.Run()
+	return runResult{stdout: out.String(), stderr: errb.String(), err: err}
+}
+
+func waitForListener(t *testing.T, host string, port int, d time.Duration) {
+	t.Helper()
+	addr := net.JoinHostPort(host, strconv.Itoa(port))
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if c, err := net.DialTimeout("tcp", addr, 500*time.Millisecond); err == nil {
+			c.Close()
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("stub server never listened on %s", addr)
+}
+
+// THE ARTIFACT CHECK (TASK-2787, and the ordering CONVE-2687's day-74 clause
+// asks for): a binary at the shared path carrying a DIFFERENT commit — the
+// reversed-ordering case, a sibling's build one merge behind — is refused,
+// and refused BEFORE anything irreversible happens.
+func TestInstallRefresh_RefusesAForeignBuildWithoutStoppingAnything(t *testing.T) {
+	requireScriptDeps(t)
+	home, dir := t.TempDir(), t.TempDir()
+	name := uniqueName(t)
+	defer killStub(t, name)
+	port := freePort(t)
+
+	built := installStub(t, dir, name)
+	installed := filepath.Join(home, "bin", name)
+	e := stubEnv{version: "pad version dev (deadbee 2026-01-01T00:00:00Z)", healthy: "1",
+		argvLog: filepath.Join(home, "argv.log"), port: port, home: home}
+
+	res := runScript(t, e, built, installed, "cafef00")
+	if res.err == nil {
+		t.Fatalf("script accepted a binary built at a different commit; stdout=%s", res.stdout)
+	}
+	if !strings.Contains(res.stderr, "refusing to stop the server") {
+		t.Errorf("refusal did not say the server was left alone; stderr=%s", res.stderr)
+	}
+	// The load-bearing half: the refusal came before the irreversible step,
+	// so nothing was installed and nothing was killed.
+	if _, err := os.Stat(installed); err == nil {
+		t.Errorf("a refused build was installed anyway at %s", installed)
+	}
+}
+
+// THE ARGV (BUG-2897): the server comes back with the flags the killed
+// process had, not with whatever an auto-start defaults to.
+func TestInstallRefresh_RestartsWithTheKilledArgv(t *testing.T) {
+	requireScriptDeps(t)
+	home, dir := t.TempDir(), t.TempDir()
+	name := uniqueName(t)
+	defer killStub(t, name)
+	port := freePort(t)
+	const commit = "abc1234"
+
+	built := installStub(t, dir, name)
+	installed := filepath.Join(home, "bin", name)
+	if err := os.MkdirAll(filepath.Dir(installed), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	argvLog := filepath.Join(home, "argv.log")
+	e := stubEnv{version: "pad version dev (" + commit + " x)", healthy: "1",
+		argvLog: argvLog, port: port, home: home}
+
+	// A "running server" with a NON-DEFAULT host — the shape that produced
+	// the original defect, where the replacement bound elsewhere and
+	// localhost went dead while every other check read correct.
+	pre := exec.Command(built, "server", "start", "--host", "127.0.0.1")
+	pre.Env = e.env()
+	if err := pre.Start(); err != nil {
+		t.Fatalf("start pre-server: %v", err)
+	}
+	waitForListener(t, "127.0.0.1", port, 8*time.Second)
+
+	res := runScript(t, e, built, installed, commit)
+	if res.err != nil {
+		t.Fatalf("script failed: %v\nstdout=%s\nstderr=%s", res.err, res.stdout, res.stderr)
+	}
+	if !strings.Contains(res.stdout, "captured server argv") {
+		t.Fatalf("script did not capture the running server's argv; stdout=%s", res.stdout)
+	}
+	// STDERR MUST BE EMPTY on the success path. Codex round 6 found `local`
+	// used at top level, which bash answers with an error on stderr for
+	// every matching process — the script kept working and printed a
+	// spurious error on every normal refresh. Nothing here asserted on
+	// stderr, so the suite could not see it: a tool whose job is to stop
+	// making unverified claims should not be muttering errors while it
+	// succeeds.
+	if strings.TrimSpace(res.stderr) != "" {
+		t.Errorf("successful refresh wrote to stderr: %q", res.stderr)
+	}
+	logged, err := os.ReadFile(argvLog)
+	if err != nil {
+		t.Fatalf("read argv log: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(logged)), "\n")
+	last := lines[len(lines)-1]
+	if !strings.Contains(last, "--host 127.0.0.1") {
+		t.Errorf("restart lost the argv: last invocation was %q, want it to carry --host 127.0.0.1\nall=%v", last, lines)
+	}
+}
+
+// THE UNCONDITIONAL CLAIM — the third defect, found by reading the recipe
+// rather than from either filing: "Server restarted." was printed after a
+// command ending in `|| true`, with no probe at all. A restart that does not
+// come up must FAIL, not print success.
+func TestInstallRefresh_FailsWhenTheServerDoesNotComeBack(t *testing.T) {
+	requireScriptDeps(t)
+	home, dir := t.TempDir(), t.TempDir()
+	name := uniqueName(t)
+	defer killStub(t, name)
+	port := freePort(t)
+	const commit = "abc1234"
+
+	built := installStub(t, dir, name)
+	installed := filepath.Join(home, "bin", name)
+	// healthy != "1": `server start` returns immediately, which is exactly
+	// what a restart that silently did not happen looks like from outside.
+	e := stubEnv{version: "pad version dev (" + commit + " x)", healthy: "0",
+		argvLog: filepath.Join(home, "argv.log"), port: port, home: home}
+
+	res := runScript(t, e, built, installed, commit)
+	if res.err == nil {
+		t.Fatalf("script reported success with no server listening; stdout=%s", res.stdout)
+	}
+	if strings.Contains(res.stdout, "server restarted and answering") {
+		t.Errorf("script printed a restart claim it had not verified; stdout=%s", res.stdout)
+	}
+	if !strings.Contains(res.stderr, "did not answer on") {
+		t.Errorf("failure did not name the addresses that failed; stderr=%s", res.stderr)
+	}
+	// The install half DID succeed, and saying so is the difference between
+	// an honest failure and a confusing one.
+	if _, err := os.Stat(installed); err != nil {
+		t.Errorf("a probe failure should not unwind the install: %v", err)
+	}
+}
+
+// CONTROL: the ordinary path succeeds. Every refusal above is meaningless if
+// the script refuses everything.
+func TestInstallRefresh_OrdinaryRefreshSucceeds(t *testing.T) {
+	requireScriptDeps(t)
+	home, dir := t.TempDir(), t.TempDir()
+	name := uniqueName(t)
+	defer killStub(t, name)
+	port := freePort(t)
+	const commit = "abc1234"
+
+	built := installStub(t, dir, name)
+	installed := filepath.Join(home, "bin", name)
+	e := stubEnv{version: "pad version dev (" + commit + " x)", healthy: "1",
+		argvLog: filepath.Join(home, "argv.log"), port: port, home: home}
+
+	res := runScript(t, e, built, installed, commit)
+	if res.err != nil {
+		t.Fatalf("ordinary refresh failed: %v\nstdout=%s\nstderr=%s", res.err, res.stdout, res.stderr)
+	}
+	if !strings.Contains(res.stdout, "server restarted and answering on: 127.0.0.1") {
+		t.Errorf("success path did not report the probed addresses; stdout=%s", res.stdout)
+	}
+	if _, err := os.Stat(installed); err != nil {
+		t.Errorf("ordinary refresh did not install: %v", err)
+	}
+}
+
+// THE OUTCOME CHECK (TASK-2787's actual ask): the check that matters is on
+// the DESTINATION, not on any step. Here the source is exactly what this
+// invocation built and the copy at the install path reports a different
+// commit — a cp that raced another writer, or half-succeeded.
+//
+// This test exists because removing the post-copy check left the suite GREEN
+// while the pre-kill check alone stayed: a surviving mutant on a guard I had
+// written myself, which is the case CONVE-30's family says to distrust first.
+// The two checks answer different questions and now fail independently.
+func TestInstallRefresh_RefusesWhenTheInstalledFileIsNotWhatWasBuilt(t *testing.T) {
+	requireScriptDeps(t)
+	home, dir := t.TempDir(), t.TempDir()
+	name := uniqueName(t)
+	defer killStub(t, name)
+	port := freePort(t)
+	const commit = "abc1234"
+
+	built := installStub(t, dir, name)
+	binDir := filepath.Join(home, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	installed := filepath.Join(binDir, name)
+
+	e := stubEnv{
+		version:          "pad version dev (" + commit + " x)", // source: correct
+		installedPath:    installed,
+		installedVersion: "pad version dev (0badbad x)", // destination: wrong
+		healthy:          "1",
+		argvLog:          filepath.Join(home, "argv.log"),
+		port:             port,
+		home:             home,
+	}
+
+	res := runScript(t, e, built, installed, commit)
+	if res.err == nil {
+		t.Fatalf("script accepted an installed file carrying a different commit; stdout=%s", res.stdout)
+	}
+	if !strings.Contains(res.stderr, "installed binary is not the one this invocation built") {
+		t.Errorf("refusal did not name the destination as the problem; stderr=%s", res.stderr)
+	}
+	// It must NOT have gone on to claim a restart.
+	if strings.Contains(res.stdout, "server restarted and answering") {
+		t.Errorf("script claimed a restart after refusing the install; stdout=%s", res.stdout)
+	}
+}
+
+// ABBREVIATION LENGTH: an expected commit and an embedded one that differ in
+// WIDTH still match, because both are resolved to full object ids and
+// compared there.
+//
+// The test builds its OWN git repository and abbreviates a commit it made,
+// rather than naming ids from this checkout. The first version hard-coded
+// `a3a1d58` / `a3a1d586` — real commits here — and passed locally while
+// FAILING IN CI, where `actions/checkout` fetches shallow and neither id is
+// an object the runner has. That is the same defect this file keeps
+// recording: a fixture holding a property of my machine rather than of the
+// thing under test.
+//
+// (Production is unaffected by that shallowness: an honest build and install
+// produce the SAME abbreviation, which the equality check accepts before any
+// resolution is attempted. A width difference requires the object database
+// to have grown, which a shallow clone's has not.)
+func TestInstallRefresh_ToleratesDifferingCommitAbbreviationWidths(t *testing.T) {
+	requireScriptDeps(t, "git")
+	home, dir := t.TempDir(), t.TempDir()
+	name := uniqueName(t)
+	defer killStub(t, name)
+	port := freePort(t)
+
+	// A repository of our own, so the ids resolve wherever this runs.
+	repo := t.TempDir()
+	for _, args := range [][]string{
+		{"init", "-q"},
+		{"-c", "user.email=t@example.com", "-c", "user.name=T", "commit", "-q", "--allow-empty", "-m", "one"},
+	} {
+		c := exec.Command("git", args...)
+		c.Dir = repo
+		if out, err := c.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	shaCmd := exec.Command("git", "rev-parse", "HEAD")
+	shaCmd.Dir = repo
+	shaOut, err := shaCmd.Output()
+	if err != nil {
+		t.Fatalf("rev-parse: %v", err)
+	}
+	full := strings.TrimSpace(string(shaOut))
+	short7, short8 := full[:7], full[:8]
+
+	built := installStub(t, dir, name)
+	installed := filepath.Join(home, "bin", name)
+	e := stubEnv{version: "pad version dev (" + short7 + " 2026-09-07T12:33:21Z)", healthy: "1",
+		argvLog: filepath.Join(home, "argv.log"), port: port, home: home}
+
+	cmd := exec.Command("bash", scriptPath(t), built, installed, short8)
+	cmd.Env = e.env()
+	cmd.Dir = repo // the script resolves ids in ITS cwd
+	var out, errb strings.Builder
+	cmd.Stdout, cmd.Stderr = &out, &errb
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("script rejected a build whose commit differs only in abbreviation width: %v\nstdout=%s\nstderr=%s",
+			err, out.String(), errb.String())
+	}
+	if !strings.Contains(out.String(), "server restarted and answering") {
+		t.Errorf("success path did not complete; stdout=%s", out.String())
+	}
+}
+
+// ...and a DIFFERENT commit of the same width is still refused, or the fix
+// above would have turned the guard off rather than widened it.
+func TestInstallRefresh_StillRefusesAGenuinelyDifferentCommit(t *testing.T) {
+	requireScriptDeps(t)
+	home, dir := t.TempDir(), t.TempDir()
+	name := uniqueName(t)
+	defer killStub(t, name)
+	port := freePort(t)
+
+	built := installStub(t, dir, name)
+	installed := filepath.Join(home, "bin", name)
+	e := stubEnv{version: "pad version dev (b0b0b0b 2026-09-07T12:33:21Z)", healthy: "1",
+		argvLog: filepath.Join(home, "argv.log"), port: port, home: home}
+
+	res := runScript(t, e, built, installed, "a3a1d586")
+	if res.err == nil {
+		t.Fatalf("prefix matching accepted an unrelated commit; stdout=%s", res.stdout)
+	}
+}
+
+// PORT FROM THE CAPTURED ARGV (codex round 1): a server started with
+// `--port N` is restarted with `--port N`, so the probe must go to N.
+//
+// The finding was that probing a fixed 7777 fails a HEALTHY restart, with
+// this script's most confident message. Verified in the code before
+// accepting it: cmd_server.go declares `--port` with default 7777, so the
+// case is reachable. The general form is the reason it matters — the script
+// exists to preserve an invocation, and a probe that reads only half of
+// that invocation is checking a different server.
+func TestInstallRefresh_ProbesThePortFromTheCapturedArgv(t *testing.T) {
+	requireScriptDeps(t)
+	home, dir := t.TempDir(), t.TempDir()
+	name := uniqueName(t)
+	defer killStub(t, name)
+	port := freePort(t)
+	const commit = "abc1234"
+
+	built := installStub(t, dir, name)
+	installed := filepath.Join(home, "bin", name)
+	if err := os.MkdirAll(filepath.Dir(installed), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	argvLog := filepath.Join(home, "argv.log")
+	// PAD_PORT is deliberately left at a DIFFERENT value from the argv's
+	// --port, so a script that falls back to the environment fails this.
+	e := stubEnv{version: "pad version dev (" + commit + " x)", healthy: "1",
+		argvLog: argvLog, port: port, home: home}
+	env := append(e.env(), fmt.Sprintf("PAD_PORT=%d", freePort(t)))
+
+	pre := exec.Command(built, "server", "start", "--host", "127.0.0.1", "--port", strconv.Itoa(port))
+	pre.Env = env
+	if err := pre.Start(); err != nil {
+		t.Fatalf("start pre-server: %v", err)
+	}
+	waitForListener(t, "127.0.0.1", port, 8*time.Second)
+
+	cmd := exec.Command("bash", scriptPath(t), built, installed, commit)
+	cmd.Env = env
+	var out, errb strings.Builder
+	cmd.Stdout, cmd.Stderr = &out, &errb
+	err := cmd.Run()
+	if err != nil {
+		t.Fatalf("script failed a healthy restart on a non-default port: %v\nstdout=%s\nstderr=%s", err, out.String(), errb.String())
+	}
+	if !strings.Contains(out.String(), fmt.Sprintf("(port %d)", port)) {
+		t.Errorf("probe did not use the argv's port %d; stdout=%s", port, out.String())
+	}
+}
+
+// THE `--flag=value` SPELLING (codex round 2, P1): Cobra accepts both
+// `--port 8080` and `--port=8080`, so a parser that reads only the
+// space-separated form probes the wrong port on a healthy restart.
+//
+// This test exists because removing the `=` branch left the suite GREEN —
+// the second guard in this file to survive its own mutant, both times
+// because every fixture used the one spelling I had in mind while writing
+// the parser. A fixture drawn from the author's model of the input tests the
+// model, not the input.
+func TestInstallRefresh_ParsesEqualsSeparatedFlags(t *testing.T) {
+	requireScriptDeps(t)
+	home, dir := t.TempDir(), t.TempDir()
+	name := uniqueName(t)
+	defer killStub(t, name)
+	port := freePort(t)
+	const commit = "abc1234"
+
+	built := installStub(t, dir, name)
+	installed := filepath.Join(home, "bin", name)
+	if err := os.MkdirAll(filepath.Dir(installed), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	e := stubEnv{version: "pad version dev (" + commit + " x)", healthy: "1",
+		argvLog: filepath.Join(home, "argv.log"), port: port, home: home}
+	// PAD_PORT points elsewhere, so a parser that misses the `=` form falls
+	// back to the wrong port and the probe fails.
+	env := append(e.env(), fmt.Sprintf("PAD_PORT=%d", freePort(t)))
+
+	pre := exec.Command(built, "server", "start", "--host=127.0.0.1", "--port="+strconv.Itoa(port))
+	pre.Env = env
+	if err := pre.Start(); err != nil {
+		t.Fatalf("start pre-server: %v", err)
+	}
+	waitForListener(t, "127.0.0.1", port, 8*time.Second)
+
+	cmd := exec.Command("bash", scriptPath(t), built, installed, commit)
+	cmd.Env = env
+	var out, errb strings.Builder
+	cmd.Stdout, cmd.Stderr = &out, &errb
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("script failed on --flag=value argv: %v\nstdout=%s\nstderr=%s", err, out.String(), errb.String())
+	}
+	if !strings.Contains(out.String(), fmt.Sprintf("(port %d)", port)) {
+		t.Errorf("probe did not use the port from --port=N; stdout=%s", out.String())
+	}
+}
+
+// THE NO-SETSID FALLBACK (codex round 2, P1): setsid is Linux-specific and
+// absent from a default macOS environment, where an unconditional call fails
+// AFTER the old server has been stopped — the one ordering this script
+// exists to avoid.
+//
+// A mutant that removes the `command -v setsid` guard SURVIVES on Linux by
+// construction: setsid is always there. That is a real coverage boundary and
+// not a weak test, so the fallback is reached deliberately via PAD_NO_SETSID
+// and the assertion is that the restart still detaches and serves. The
+// branch is what carries risk; the detection is one builtin.
+func TestInstallRefresh_RestartsWithoutSetsid(t *testing.T) {
+	requireScriptDeps(t)
+	home, dir := t.TempDir(), t.TempDir()
+	name := uniqueName(t)
+	defer killStub(t, name)
+	port := freePort(t)
+	const commit = "abc1234"
+
+	built := installStub(t, dir, name)
+	installed := filepath.Join(home, "bin", name)
+	e := stubEnv{version: "pad version dev (" + commit + " x)", healthy: "1",
+		argvLog: filepath.Join(home, "argv.log"), port: port, home: home}
+
+	cmd := exec.Command("bash", scriptPath(t), built, installed, commit)
+	cmd.Env = append(e.env(), "PAD_NO_SETSID=1")
+	var out, errb strings.Builder
+	cmd.Stdout, cmd.Stderr = &out, &errb
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("script failed without setsid: %v\nstdout=%s\nstderr=%s", err, out.String(), errb.String())
+	}
+	if !strings.Contains(out.String(), "server restarted and answering") {
+		t.Errorf("fallback restart did not come up; stdout=%s", out.String())
+	}
+}
+
+// HOST AND PORT FROM THE CONFIG FILE (codex round 3, P1): a server whose
+// bind comes from ~/.pad/config.toml alone restarts correctly and must be
+// probed there. The previous answer was a stated boundary; a permanent
+// false failure on every install for that user is not a boundary worth
+// stating when the fix is a line match against a flat TOML file.
+func TestInstallRefresh_ResolvesHostAndPortFromTheConfigFile(t *testing.T) {
+	requireScriptDeps(t)
+	home, dir := t.TempDir(), t.TempDir()
+	name := uniqueName(t)
+	defer killStub(t, name)
+	port := freePort(t)
+	const commit = "abc1234"
+
+	if err := os.MkdirAll(filepath.Join(home, ".pad"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	cfg := fmt.Sprintf("mode = \"local\"\nhost = \"127.0.0.1\"\nport = %d\n", port)
+	if err := os.WriteFile(filepath.Join(home, ".pad", "config.toml"), []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	built := installStub(t, dir, name)
+	installed := filepath.Join(home, "bin", name)
+	e := stubEnv{version: "pad version dev (" + commit + " x)", healthy: "1",
+		argvLog: filepath.Join(home, "argv.log"), port: port, home: home}
+
+	// No running server, so no argv to capture, and PAD_PORT is unset: the
+	// config file is the ONLY source of the port. STUB_PORT still tells the
+	// stub where to listen, standing in for the config the real server reads.
+	env := e.env()
+	filtered := env[:0]
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "PAD_PORT=") || strings.HasPrefix(kv, "PAD_HOST=") {
+			continue
+		}
+		filtered = append(filtered, kv)
+	}
+	cmd := exec.Command("bash", scriptPath(t), built, installed, commit)
+	cmd.Env = filtered
+	var out, errb strings.Builder
+	cmd.Stdout, cmd.Stderr = &out, &errb
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("script ignored the config file's port: %v\nstdout=%s\nstderr=%s", err, out.String(), errb.String())
+	}
+	if !strings.Contains(out.String(), fmt.Sprintf("(port %d)", port)) {
+		t.Errorf("probe did not use the config file's port; stdout=%s", out.String())
+	}
+}
+
+// IPv6 (codex round 3, P2): `::1` must be bracketed in the probe URL, or
+// curl is handed http://::1:PORT/... — not a URL — and a healthy
+// IPv6-bound server reads as unreachable.
+//
+// Skipped rather than failed where the loopback has no IPv6: an environment
+// without it cannot discriminate, and a test that passes vacuously there
+// while claiming to cover IPv6 is worse than one that says it did not run.
+func TestInstallRefresh_ProbesIPv6HostsWithBrackets(t *testing.T) {
+	requireScriptDeps(t)
+	l, err := net.Listen("tcp", "[::1]:0")
+	if err != nil {
+		t.Skipf("no IPv6 loopback here: %v", err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	l.Close()
+
+	home, dir := t.TempDir(), t.TempDir()
+	name := uniqueName(t)
+	defer killStub(t, name)
+	const commit = "abc1234"
+
+	built := installStub(t, dir, name)
+	installed := filepath.Join(home, "bin", name)
+	if err := os.MkdirAll(filepath.Dir(installed), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	e := stubEnv{version: "pad version dev (" + commit + " x)", healthy: "1",
+		argvLog: filepath.Join(home, "argv.log"), port: port, home: home}
+
+	pre := exec.Command(built, "server", "start", "--host", "::1", "--port", strconv.Itoa(port))
+	pre.Env = e.env()
+	if err := pre.Start(); err != nil {
+		t.Fatalf("start pre-server: %v", err)
+	}
+	waitForListener(t, "::1", port, 8*time.Second)
+
+	// The script probes with curl, so the precondition is whether CURL can
+	// reach ::1 — not whether Go can listen on it. The Nix build sandbox
+	// satisfies the second and not the first, and the first version of this
+	// guard asked the wrong one: the test ran, curl failed, and the failure
+	// read as a defect in the bracketing it was written to pin.
+	//
+	// The v4 leg is the CONTROL. Skipping only when v6 fails while v4
+	// succeeds distinguishes "this environment has no usable IPv6" from
+	// "curl is broken here", and refuses to skip on the second.
+	if err := exec.Command("curl", "-fsS", "-m", "2", "-o", "/dev/null",
+		fmt.Sprintf("http://[::1]:%d/api/v1/health", port)).Run(); err != nil {
+		if err4 := exec.Command("curl", "-fsS", "-m", "2", "-o", "/dev/null",
+			fmt.Sprintf("http://127.0.0.1:%d/api/v1/health", port)).Run(); err4 == nil {
+			t.Skipf("curl cannot reach IPv6 loopback here (v4 works): %v", err)
+		}
+	}
+
+	res := runScript(t, e, built, installed, commit)
+	if res.err != nil {
+		t.Fatalf("script failed against an IPv6-bound server: %v\nstdout=%s\nstderr=%s",
+			res.err, res.stdout, res.stderr)
+	}
+	if !strings.Contains(res.stdout, "server restarted and answering") {
+		t.Errorf("IPv6 probe did not succeed; stdout=%s", res.stdout)
+	}
+}
+
+// THE ORIGINAL DEFECT, and until now the only scenario in this file that was
+// never exercised: a WILDCARD bind promises loopback as well as the LAN
+// address, and BUG-2897 was a `--host 0.0.0.0` server coming back bound
+// elsewhere with 127.0.0.1 dead while every other check read correct.
+//
+// A mutant dropping 127.0.0.1 from the wildcard probe set SURVIVED the whole
+// suite — every other fixture here uses an explicit host, so nothing asked
+// what a wildcard promises. Third time in this unit that a fixture drawn
+// from my own model of the input tested the model instead: same version
+// strings on both sides, one flag spelling, and now one bind shape.
+func TestInstallRefresh_WildcardBindMustAnswerOnLoopback(t *testing.T) {
+	requireScriptDeps(t)
+	home, dir := t.TempDir(), t.TempDir()
+	name := uniqueName(t)
+	defer killStub(t, name)
+	port := freePort(t)
+	const commit = "abc1234"
+
+	built := installStub(t, dir, name)
+	installed := filepath.Join(home, "bin", name)
+	if err := os.MkdirAll(filepath.Dir(installed), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	e := stubEnv{version: "pad version dev (" + commit + " x)", healthy: "1",
+		argvLog: filepath.Join(home, "argv.log"), port: port, home: home}
+
+	pre := exec.Command(built, "server", "start", "--host", "0.0.0.0", "--port", strconv.Itoa(port))
+	pre.Env = e.env()
+	if err := pre.Start(); err != nil {
+		t.Fatalf("start pre-server: %v", err)
+	}
+	waitForListener(t, "127.0.0.1", port, 8*time.Second)
+
+	res := runScript(t, e, built, installed, commit)
+	if res.err != nil {
+		t.Fatalf("wildcard refresh failed: %v\nstdout=%s\nstderr=%s", res.err, res.stdout, res.stderr)
+	}
+	// The assertion is on WHAT WAS PROBED, not merely that it succeeded: a
+	// script that probed only the LAN address would also exit 0 here, and
+	// that is precisely the defect.
+	if !strings.Contains(res.stdout, "answering on: 127.0.0.1") {
+		t.Errorf("a wildcard bind was accepted without probing loopback — the BUG-2897 defect; stdout=%s", res.stdout)
+	}
+}
+
+// TOML INLINE COMMENTS (codex round 4, P1): `port = 8080 # local server` is
+// valid TOML and the Go parser accepts it. A value regex that swallows the
+// comment resolves the port to "8080 # local server", probes nothing, and
+// fails every install for that user.
+func TestInstallRefresh_ConfigValuesIgnoreInlineComments(t *testing.T) {
+	requireScriptDeps(t)
+	home, dir := t.TempDir(), t.TempDir()
+	name := uniqueName(t)
+	defer killStub(t, name)
+	port := freePort(t)
+	const commit = "abc1234"
+
+	if err := os.MkdirAll(filepath.Join(home, ".pad"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	cfg := fmt.Sprintf("host = \"127.0.0.1\"  # dev box\nport = %d # local server\n", port)
+	if err := os.WriteFile(filepath.Join(home, ".pad", "config.toml"), []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	built := installStub(t, dir, name)
+	installed := filepath.Join(home, "bin", name)
+	e := stubEnv{version: "pad version dev (" + commit + " x)", healthy: "1",
+		argvLog: filepath.Join(home, "argv.log"), port: port, home: home}
+
+	env := e.env()[:0]
+	for _, kv := range e.env() {
+		if strings.HasPrefix(kv, "PAD_PORT=") || strings.HasPrefix(kv, "PAD_HOST=") {
+			continue
+		}
+		env = append(env, kv)
+	}
+	cmd := exec.Command("bash", scriptPath(t), built, installed, commit)
+	cmd.Env = env
+	var out, errb strings.Builder
+	cmd.Stdout, cmd.Stderr = &out, &errb
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("inline comments broke config resolution: %v\nstdout=%s\nstderr=%s", err, out.String(), errb.String())
+	}
+	if !strings.Contains(out.String(), fmt.Sprintf("(port %d)", port)) {
+		t.Errorf("probe did not use the commented config port; stdout=%s", out.String())
+	}
+}
+
+// THE ps FALLBACK (codex round 5, P1): macOS has no /proc, so the argv
+// capture found nothing there, the restart fell back to defaults, and the
+// BUG-2897 fix was silently absent on the platform the setsid fallback had
+// just been added for.
+//
+// A mutant removing the fallback SURVIVES on Linux by construction, so the
+// branch is reached deliberately through PAD_NO_PROC — the same disposition
+// as the setsid case, and for the same reason: the branch carries the risk,
+// the detection is one test.
+func TestInstallRefresh_CapturesArgvWithoutProc(t *testing.T) {
+	requireScriptDeps(t)
+	home, dir := t.TempDir(), t.TempDir()
+	name := uniqueName(t)
+	defer killStub(t, name)
+	port := freePort(t)
+	const commit = "abc1234"
+
+	built := installStub(t, dir, name)
+	installed := filepath.Join(home, "bin", name)
+	if err := os.MkdirAll(filepath.Dir(installed), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	argvLog := filepath.Join(home, "argv.log")
+	e := stubEnv{version: "pad version dev (" + commit + " x)", healthy: "1",
+		argvLog: argvLog, port: port, home: home}
+
+	pre := exec.Command(built, "server", "start", "--host", "127.0.0.1", "--port", strconv.Itoa(port))
+	pre.Env = e.env()
+	if err := pre.Start(); err != nil {
+		t.Fatalf("start pre-server: %v", err)
+	}
+	waitForListener(t, "127.0.0.1", port, 8*time.Second)
+
+	cmd := exec.Command("bash", scriptPath(t), built, installed, commit)
+	cmd.Env = append(e.env(), "PAD_NO_PROC=1")
+	var out, errb strings.Builder
+	cmd.Stdout, cmd.Stderr = &out, &errb
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("script failed without /proc: %v\nstdout=%s\nstderr=%s", err, out.String(), errb.String())
+	}
+	if !strings.Contains(out.String(), "captured server argv") {
+		t.Fatalf("the ps fallback captured nothing; stdout=%s", out.String())
+	}
+	logged, err := os.ReadFile(argvLog)
+	if err != nil {
+		t.Fatalf("read argv log: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(logged)), "\n")
+	if last := lines[len(lines)-1]; !strings.Contains(last, "--host 127.0.0.1") {
+		t.Errorf("ps fallback lost the argv: last invocation was %q", last)
+	}
+}
+
+// A NON-NUMERIC PAD_PORT is ignored, as the application ignores it (codex
+// round 7): config.go falls through to the next source rather than using a
+// bad value, so a mistyped or inherited PAD_PORT must not make every refresh
+// fail against a server that is running fine.
+func TestInstallRefresh_IgnoresNonNumericPortValues(t *testing.T) {
+	requireScriptDeps(t)
+	home, dir := t.TempDir(), t.TempDir()
+	name := uniqueName(t)
+	defer killStub(t, name)
+	port := freePort(t)
+	const commit = "abc1234"
+
+	if err := os.MkdirAll(filepath.Join(home, ".pad"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	cfg := fmt.Sprintf("host = \"127.0.0.1\"\nport = %d\n", port)
+	if err := os.WriteFile(filepath.Join(home, ".pad", "config.toml"), []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	built := installStub(t, dir, name)
+	installed := filepath.Join(home, "bin", name)
+	e := stubEnv{version: "pad version dev (" + commit + " x)", healthy: "1",
+		argvLog: filepath.Join(home, "argv.log"), port: port, home: home}
+
+	env := e.env()[:0]
+	for _, kv := range e.env() {
+		if strings.HasPrefix(kv, "PAD_PORT=") || strings.HasPrefix(kv, "PAD_HOST=") {
+			continue
+		}
+		env = append(env, kv)
+	}
+	env = append(env, "PAD_PORT=not-a-number")
+
+	cmd := exec.Command("bash", scriptPath(t), built, installed, commit)
+	cmd.Env = env
+	var out, errb strings.Builder
+	cmd.Stdout, cmd.Stderr = &out, &errb
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("a bad PAD_PORT failed the refresh: %v\nstdout=%s\nstderr=%s", err, out.String(), errb.String())
+	}
+	if !strings.Contains(out.String(), fmt.Sprintf("(port %d)", port)) {
+		t.Errorf("did not fall through to the config port; stdout=%s", out.String())
+	}
+}
+
+// FAIL CLOSED when a wildcard bind's external address cannot be determined
+// (codex rounds 5 and 8). The first version warned and exited 0 — this
+// unit's own defect wearing a different hat: a success line covering
+// something that was not verified.
+//
+// PATH is emptied of the address-discovery tools to reach the branch, which
+// is otherwise unreachable on a box that has them.
+func TestInstallRefresh_FailsClosedWhenTheLANAddressIsUnknown(t *testing.T) {
+	requireScriptDeps(t)
+	home, dir := t.TempDir(), t.TempDir()
+	name := uniqueName(t)
+	defer killStub(t, name)
+	port := freePort(t)
+	const commit = "abc1234"
+
+	built := installStub(t, dir, name)
+	installed := filepath.Join(home, "bin", name)
+	if err := os.MkdirAll(filepath.Dir(installed), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	e := stubEnv{version: "pad version dev (" + commit + " x)", healthy: "1",
+		argvLog: filepath.Join(home, "argv.log"), port: port, home: home}
+
+	pre := exec.Command(built, "server", "start", "--host", "0.0.0.0", "--port", strconv.Itoa(port))
+	pre.Env = e.env()
+	if err := pre.Start(); err != nil {
+		t.Fatalf("start pre-server: %v", err)
+	}
+	waitForListener(t, "127.0.0.1", port, 8*time.Second)
+
+	// A PATH with only the tools the script genuinely needs, and WITHOUT
+	// hostname/ipconfig. Built by symlinking, so the rest of the script
+	// still works and only address discovery is impossible.
+	stubPath := t.TempDir()
+	for _, tool := range []string{"bash", "sed", "awk", "curl", "cp", "mv", "mkdir", "rm", "chmod", "pkill", "pgrep", "ps", "sleep", "mktemp", "dirname", "basename", "git", "head", "setsid", "nohup", "printf", "cat"} {
+		full, err := exec.LookPath(tool)
+		if err != nil {
+			continue
+		}
+		_ = os.Symlink(full, filepath.Join(stubPath, tool))
+	}
+
+	env := e.env()[:0]
+	for _, kv := range e.env() {
+		if strings.HasPrefix(kv, "PATH=") {
+			continue
+		}
+		env = append(env, kv)
+	}
+	env = append(env, "PATH="+stubPath)
+
+	cmd := exec.Command("bash", scriptPath(t), built, installed, commit)
+	cmd.Env = env
+	var out, errb strings.Builder
+	cmd.Stdout, cmd.Stderr = &out, &errb
+	err := cmd.Run()
+	if err == nil {
+		t.Fatalf("script reported success without verifying the external bind; stdout=%s", out.String())
+	}
+	if !strings.Contains(errb.String(), "cannot determine a LAN address") {
+		t.Errorf("failure did not name the unverifiable half; stderr=%s", errb.String())
+	}
+	if strings.Contains(out.String(), "server restarted and answering") {
+		t.Errorf("script claimed a verified restart; stdout=%s", out.String())
+	}
+}
+
+// MORE THAN ONE SERVER is refused rather than guessed (codex round 9). The
+// stop is a system-wide `pkill -x` and the restart can only restore one
+// argv, so a second server would be killed and left down — or restarted
+// with the wrong flags.
+func TestInstallRefresh_RefusesWhenSeveralServersAreRunning(t *testing.T) {
+	requireScriptDeps(t)
+	home, dir := t.TempDir(), t.TempDir()
+	name := uniqueName(t)
+	defer killStub(t, name)
+	portA, portB := freePort(t), freePort(t)
+	const commit = "abc1234"
+
+	built := installStub(t, dir, name)
+	installed := filepath.Join(home, "bin", name)
+	e := stubEnv{version: "pad version dev (" + commit + " x)", healthy: "1",
+		argvLog: filepath.Join(home, "argv.log"), port: portA, home: home}
+
+	for _, p := range []int{portA, portB} {
+		envp := e.env()[:0]
+		for _, kv := range e.env() {
+			if strings.HasPrefix(kv, "STUB_PORT=") {
+				continue
+			}
+			envp = append(envp, kv)
+		}
+		envp = append(envp, fmt.Sprintf("STUB_PORT=%d", p))
+		pre := exec.Command(built, "server", "start", "--host", "127.0.0.1", "--port", strconv.Itoa(p))
+		pre.Env = envp
+		if err := pre.Start(); err != nil {
+			t.Fatalf("start server on %d: %v", p, err)
+		}
+		waitForListener(t, "127.0.0.1", p, 8*time.Second)
+	}
+
+	res := runScript(t, e, built, installed, commit)
+	if res.err == nil {
+		t.Fatalf("script proceeded with two servers running; stdout=%s", res.stdout)
+	}
+	if !strings.Contains(res.stderr, "more than one") {
+		t.Errorf("refusal did not name the ambiguity; stderr=%s", res.stderr)
+	}
+	// Nothing stopped, nothing installed.
+	if _, err := os.Stat(installed); err == nil {
+		t.Errorf("installed despite refusing: %s", installed)
+	}
+}
+
+// AN UNRESOLVABLE ID IS REFUSED, even when it shares a prefix with the
+// expected one (codex round 9).
+//
+// The prefix fallback existed for binaries built outside this checkout, and
+// it admitted exactly the collision that resolution was introduced to stop:
+// two ids sharing seven characters are indistinguishable to a prefix test
+// and distinct to git. Removing the fallback left the suite GREEN because no
+// fixture used an id git cannot resolve — the fourth time in this unit that
+// a guard's own case was missing from the fixtures.
+func TestInstallRefresh_RefusesUnresolvableCommitEvenOnAPrefixMatch(t *testing.T) {
+	requireScriptDeps(t)
+	home, dir := t.TempDir(), t.TempDir()
+	name := uniqueName(t)
+	defer killStub(t, name)
+	port := freePort(t)
+
+	built := installStub(t, dir, name)
+	installed := filepath.Join(home, "bin", name)
+	// Neither id exists in this repository, and one is a prefix of the other.
+	e := stubEnv{version: "pad version dev (b0b0b0b 2026-01-01T00:00:00Z)", healthy: "1",
+		argvLog: filepath.Join(home, "argv.log"), port: port, home: home}
+
+	res := runScript(t, e, built, installed, "b0b0b0b0")
+	if res.err == nil {
+		t.Fatalf("an unresolvable prefix match was accepted; stdout=%s", res.stdout)
+	}
+	if _, err := os.Stat(installed); err == nil {
+		t.Errorf("installed despite refusing: %s", installed)
+	}
+}
+
+// EVERY test in this file must call requireScriptDeps, and this asserts it by
+// reading the file rather than by anyone remembering.
+//
+// It exists because the scripted edit that added those calls used the pattern
+// `TestInstallRefresh_[A-Za-z]+`, which does not match a name containing a
+// DIGIT — so `TestInstallRefresh_ProbesIPv6HostsWithBrackets` silently kept
+// running in an environment that cannot support it, and CI stayed red for a
+// round on a test the fix was supposed to have covered. The set the edit
+// touched and the population it was meant to cover were not the same set, and
+// nothing said so.
+//
+// Reading the source is the only instrument that can see this: every runtime
+// check passes, because the untouched test runs fine wherever the
+// dependencies exist.
+func TestEveryScriptTestDeclaresItsDependencies(t *testing.T) {
+	src, err := os.ReadFile("install_refresh_test.go")
+	if err != nil {
+		t.Fatalf("read own source: %v", err)
+	}
+	re := regexp.MustCompile(`func (TestInstallRefresh_\w+)\(t \*testing\.T\) \{\n(\t[^\n]*)`)
+	matches := re.FindAllStringSubmatch(string(src), -1)
+	if len(matches) == 0 {
+		t.Fatal("the pattern matched no tests at all — this guard is not looking at what it thinks it is")
+	}
+	var missing []string
+	for _, m := range matches {
+		if !strings.Contains(m[2], "requireScriptDeps") {
+			missing = append(missing, m[1])
+		}
+	}
+	if len(missing) > 0 {
+		t.Errorf("these tests drive install-refresh.sh without declaring their dependencies, so they FAIL rather than SKIP where the tools are absent: %v", missing)
+	}
+}

--- a/internal/buildtools/testdata/stub/main.go
+++ b/internal/buildtools/testdata/stub/main.go
@@ -1,0 +1,74 @@
+// Command stub is a fake `pad` for scripts/install-refresh.sh's tests.
+//
+// It is a COMPILED BINARY on purpose. The script finds the running server
+// with `pgrep -x <name>`, which matches /proc/<pid>/comm — and for a
+// shebang script comm is the INTERPRETER's name ("bash"), not the script's.
+// A shell stub therefore cannot be found the way the real, compiled `pad`
+// is, and the first version of these tests failed for exactly that reason:
+// the fixture, not the script.
+//
+// Behaviour is driven by env vars so the RESTART the script performs — which
+// inherits the environment and not our arguments — behaves the same way.
+package main
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+)
+
+func main() {
+	if len(os.Args) > 1 && os.Args[1] == "--version" {
+		// The version can depend on WHERE this copy lives, which is what
+		// makes the post-copy outcome check testable at all. The script has
+		// two commit checks answering different questions — "is the source
+		// right" before the kill, "is the destination right" after the copy
+		// — and a fixture where both files report the same thing cannot
+		// tell them apart: removing the second check left the suite green
+		// until this existed.
+		// Keyed on the EXACT PATH, not the directory. The script now stages
+		// the copy as a temp file BESIDE the final path, so a
+		// directory-keyed fixture would make the staged file report the
+		// wrong version too and fire the earlier check — which is what
+		// happened, and which would have left the destination check
+		// untested again.
+		if p := os.Getenv("STUB_INSTALLED_PATH"); p != "" && os.Args[0] == p {
+			fmt.Println(os.Getenv("STUB_VERSION_INSTALLED"))
+			return
+		}
+		fmt.Println(os.Getenv("STUB_VERSION"))
+		return
+	}
+
+	if logPath := os.Getenv("STUB_ARGV_LOG"); logPath != "" {
+		f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+		if err == nil {
+			fmt.Fprintln(f, strings.Join(os.Args[1:], " "))
+			f.Close()
+		}
+	}
+
+	if !(len(os.Args) > 2 && os.Args[1] == "server" && os.Args[2] == "start") {
+		return
+	}
+	// STUB_HEALTHY=0 exits immediately: what a restart that silently did
+	// not happen looks like from outside.
+	if os.Getenv("STUB_HEALTHY") != "1" {
+		return
+	}
+
+	host := "127.0.0.1"
+	for i, a := range os.Args {
+		if a == "--host" && i+1 < len(os.Args) {
+			host = os.Args[i+1]
+		}
+	}
+	port := os.Getenv("STUB_PORT")
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"status":"ok"}`))
+	})
+	_ = http.ListenAndServe(net.JoinHostPort(host, port), mux)
+}

--- a/scripts/install-refresh.sh
+++ b/scripts/install-refresh.sh
@@ -1,0 +1,519 @@
+#!/usr/bin/env bash
+#
+# install-refresh.sh — the honest half of `make install` (BUG-2897, TASK-2787).
+#
+# The target used to: kill the running pad, cp the binary, then bring the
+# server back BY SIDE EFFECT (`pad auth whoami` triggers an auto-start) and
+# print "Server restarted." unconditionally. Three things were wrong with
+# that, and the third is the one that makes the other two invisible:
+#
+#   1. The auto-start does not know the killed process's argv, so a server
+#      running `--host 0.0.0.0` came back bound to the default host alone.
+#      Measured: curl 127.0.0.1:7777 -> 000 while the LAN address -> 200,
+#      with the process count and the version both reading correct.
+#   2. `cp` copies whatever is at the repo path, not what THIS invocation
+#      built. Two sessions sharing the checkout interleave, and the loser's
+#      build is installed by the winner with every exit code green.
+#   3. "Server restarted." was printed after a command ending in `|| true`,
+#      with no probe of any kind. It is not that the wrong address went
+#      unverified — nothing was verified.
+#
+# So this script checks OUTCOMES, not steps: what got installed, and what is
+# answering afterwards.
+#
+# Usage: install-refresh.sh <built-binary> <install-path> <expected-commit>
+#
+# It performs the stop, the install and the restart; the caller does the
+# build. Ordering is load-bearing and matches CONVE-2687's day-74 clause:
+# nothing irreversible happens until the artifact has been checked.
+
+set -uo pipefail
+
+BUILT="${1:?built binary path required}"
+INSTALLED="${2:?install path required}"
+EXPECT_COMMIT="${3:-}"
+# PORT and HOST are resolved AFTER the argv capture, from the same
+# precedence the server itself uses: flag, then environment, then default.
+# See the resolution block below the capture.
+PORT=""
+PROBE_TIMEOUT="${PAD_PROBE_TIMEOUT:-20}"
+
+die() { printf 'install-refresh: %s\n' "$*" >&2; exit 1; }
+note() { printf 'install-refresh: %s\n' "$*"; }
+
+# flag_value prints the value of a long flag from the captured argv,
+# accepting BOTH supported spellings: `--host 1.2.3.4` and `--host=1.2.3.4`.
+#
+# Codex round 2 (P1): the first version matched only the space-separated
+# form. Cobra accepts both, so a server started `--port=8080` was restarted
+# on 8080 and probed on 7777 — a healthy restart failed by this script's
+# most confident message. A parser that reads a subset of the syntax it is
+# quoting back is the same defect class as a probe that reads half an
+# invocation.
+flag_value() {
+	local want="$1"
+	shift
+	local i
+	for ((i = 0; i < $#; i++)); do
+		local a="${@:i+1:1}"
+		case "$a" in
+		"$want")
+			printf '%s' "${@:i+2:1}"
+			return 0
+			;;
+		"$want"=*)
+			printf '%s' "${a#*=}"
+			return 0
+			;;
+		esac
+	done
+	return 1
+}
+
+# config_value prints a top-level key from the pad config file, or nothing.
+#
+# The file is FLAT TOML (internal/config/config.go: Host, Port, Mode, ... are
+# all top-level, no sections), so a line match is a correct reader for it
+# rather than a hopeful one. Path resolution mirrors userConfigPath().
+#
+# Codex round 3 (P1): without this, a server whose host or port comes from
+# the config file alone restarts correctly and is then probed on
+# 127.0.0.1:7777 and reported as failed — on EVERY install, for that user.
+# A stated boundary was the previous answer; it is a bad one when the cost of
+# closing it is a grep and the cost of leaving it is a permanent false alarm.
+config_value() {
+	local key="$1" path="$HOME/.pad/config.toml"
+	[ -n "${PAD_DATA_DIR:-}" ] && path="$PAD_DATA_DIR/config.toml"
+	[ -n "${PAD_DB_PATH:-}" ] && path="$(dirname "$PAD_DB_PATH")/config.toml"
+	[ -r "$path" ] || return 1
+	# Strip an inline comment before taking the value: `port = 8080 # dev`
+	# is valid TOML and the Go parser accepts it, so a regex that swallows
+	# the comment resolves the port to "8080 # dev" and probes nothing
+	# (codex round 4). A quoted value is unquoted first, so a `#` inside
+	# quotes survives.
+	sed -n "s/^[[:space:]]*$key[[:space:]]*=[[:space:]]*//p" "$path" |
+		sed -e 's/^"\([^"]*\)".*$/\1/' -e 's/[[:space:]]*#.*$//' -e 's/[[:space:]]*$//' |
+		head -1
+}
+
+# probe_url builds a health URL, bracketing IPv6 literals.
+#
+# Codex round 3 (P2): `::1` produced http://::1:7777/... — not a URL, so a
+# healthy IPv6-bound server reads as unreachable. Accepts a value that is
+# already bracketed, since that is how a user would write it in a flag.
+probe_url() {
+	local host="$1" port="$2"
+	case "$host" in
+	\[*\]) : ;;
+	*:*) host="[$host]" ;;
+	esac
+	printf 'http://%s:%s/api/v1/health' "$host" "$port"
+}
+
+# commit_of prints the commit token a `--version` line carries, or nothing.
+# Output shape: `pad version dev (a3a1d58 2026-09-07T12:33:21Z)`.
+commit_of() {
+	printf '%s' "$1" | sed -n 's/.*(\([0-9a-f][0-9a-f]*\)[ )].*/\1/p'
+}
+
+# commit_matches compares an EXPECTED abbreviation against a FOUND one,
+# tolerating different abbreviation LENGTHS.
+#
+# This is not defensive slack. `git rev-parse --short` returns the shortest
+# UNAMBIGUOUS prefix, so its length grows as the object database does — the
+# end-to-end run that found this had a binary embedding `a3a1d58` (7) while
+# the Makefile, computing the same expression minutes later after a fetch,
+# produced `a3a1d586` (8). An equality test fails there and reports "another
+# session rebuilt it", which is a confident, specific and completely wrong
+# diagnosis of a healthy build.
+#
+# The unit tests could not have caught it: their fixtures use fixed strings
+# of equal length, so the two sides always agreed on width. Production does
+# not have that property, and neither does any check written against it.
+commit_matches() {
+	local expect="$1" found="$2"
+	[ -n "$expect" ] && [ -n "$found" ] || return 1
+	[ "$expect" = "$found" ] && return 0
+
+	# Resolve both to FULL object ids and compare those. This is the exact
+	# answer and it is available because `make install` runs in the repo.
+	#
+	# Codex round 5 (P1) on the previous prefix comparison: `a3a1d586`
+	# accepted `a3a1d58` even when those are DIFFERENT commits that happen
+	# to share seven characters. That is not hypothetical — it is the same
+	# mechanism that made the abbreviation grow in the first place, so the
+	# fix for the false alarm had introduced a false pass in the case the
+	# check exists for. Prefix matching cannot tell the two apart; full ids
+	# can.
+	local a b
+	a="$(git rev-parse --verify --quiet "${expect}^{commit}" 2>/dev/null || true)"
+	b="$(git rev-parse --verify --quiet "${found}^{commit}" 2>/dev/null || true)"
+	if [ -n "$a" ] && [ -n "$b" ]; then
+		[ "$a" = "$b" ]
+		return
+	fi
+
+	# FAIL CLOSED when an id cannot be resolved (codex round 9). A prefix
+	# comparison admits exactly the collision this function was rewritten to
+	# stop admitting, so keeping it as a fallback would reintroduce the
+	# defect on the path where verification is weakest.
+	#
+	# What this refuses: a binary whose embedded commit is not an object in
+	# THIS checkout — built from another history, or from a repository this
+	# one does not share. `make install` computes the expected id with `git
+	# rev-parse` in the same checkout it builds from, so the supported path
+	# always resolves; anything that does not is a case where the script
+	# genuinely cannot tell whether the artifact is the right one, and
+	# saying so is the whole point of this unit.
+	return 1
+}
+
+# --- 1. Capture the running server's argv BEFORE anything is killed ---------
+#
+# Identity, not count: other `pad` processes may exist (a sibling's CLI call,
+# an e2e-spawned server from another worktree) and none of them is the thing
+# being replaced. The server is the one with `server start` in its argv.
+# Read from /proc so the exact tokens come back, including `--host`.
+#
+# Empty capture is a legitimate state — a box with no server running — and
+# is handled at restart time rather than treated as an error here.
+SERVER_ARGV=()
+SERVER_PIDS=()
+if command -v pgrep >/dev/null 2>&1; then
+	while read -r pid; do
+		[ -n "$pid" ] || continue
+		# /proc where it exists, `ps` where it does not.
+		#
+		# Codex round 5 (P1): macOS has no /proc, so this loop found
+		# nothing there, SERVER_ARGV stayed empty, and the restart fell
+		# back to defaults — the exact defect BUG-2897 is about, silently
+		# unfixed on the platform the setsid fallback had just been added
+		# for. A fix that is Linux-only while advertising portability is
+		# worse than one that admits its platform.
+		#
+		# /proc is preferred because it gives the argv NUL-separated and
+		# therefore exactly; `ps -o args=` returns one space-joined string,
+		# so an argument containing a space is split. Named rather than
+		# hidden: no `pad server start` flag takes such a value today.
+		# No `local` here: this loop runs at TOP LEVEL, and bash answers
+		# `local` outside a function with an error on stderr for every
+		# matching process (codex round 6). It kept working — the arrays
+		# were still assigned — while printing a spurious error on every
+		# normal refresh, which is precisely the class of noise this unit
+		# exists to remove.
+		argv=()
+		# PAD_NO_PROC forces the `ps` path. Same reasoning as PAD_NO_SETSID:
+		# the branch is unreachable on any machine with /proc, and an
+		# untestable branch is exactly how the macOS half of this fix would
+		# have shipped broken.
+		if [ -z "${PAD_NO_PROC:-}" ] && [ -r "/proc/$pid/cmdline" ]; then
+			mapfile -d '' -t argv < "/proc/$pid/cmdline"
+		else
+			line="$(ps -o args= -p "$pid" 2>/dev/null || true)"
+			[ -n "$line" ] || continue
+			read -r -a argv <<<"$line"
+		fi
+		[ ${#argv[@]} -gt 0 ] || continue
+		# argv[0] is the binary; look for the `server start` verb pair.
+		for ((i = 1; i < ${#argv[@]}; i++)); do
+			if [ "${argv[i]}" = "server" ] && [ "${argv[i + 1]:-}" = "start" ]; then
+				SERVER_PIDS+=("$pid")
+				[ ${#SERVER_ARGV[@]} -eq 0 ] && SERVER_ARGV=("${argv[@]}")
+				break
+			fi
+		done
+	done < <(pgrep -x "$(basename "$BUILT")" 2>/dev/null || true)
+fi
+
+# MORE THAN ONE server is a case this script cannot answer honestly (codex
+# round 9). The stop is `pkill -x`, which is system-wide and kills every
+# matching process, while the restart can only bring back the argv of ONE.
+# A sibling's worktree server would be killed and left down, or restarted
+# with another server's arguments.
+#
+# Refusing here rather than guessing: CONVE-2687's manual sibling-safe
+# recipe exists precisely for a box with more than one live server, and it
+# aims its kill by /proc identity instead of by name.
+if [ "${#SERVER_PIDS[@]}" -gt 1 ]; then
+	die "more than one \`$(basename "$BUILT") server start\` process is running (pids: ${SERVER_PIDS[*]}).
+  The stop below is a system-wide pkill and the restart can only restore one
+  argv, so this would kill a server it cannot bring back.
+  Nothing was stopped or installed. Use the manual sibling-safe refresh."
+fi
+
+if [ ${#SERVER_ARGV[@]} -gt 0 ]; then
+	note "captured server argv: ${SERVER_ARGV[*]}"
+else
+	note "no running server found; will start with defaults after install"
+fi
+
+# --- 2. SNAPSHOT the artifact, then check the snapshot ------------------------
+#
+# The copy happens BEFORE the stop, into a temporary file beside the final
+# path, and the check runs on that snapshot.
+#
+# Codex round 2 (P1) found the window this closes: checking $BUILT and then
+# copying it later leaves room for another session to rebuild the shared repo
+# binary in between, so the destination check catches the swap only AFTER the
+# old server has been killed — turning a detectable race into an outage. A
+# snapshot cannot change under us, so the expensive failure mode disappears
+# rather than being detected later.
+#
+# The temp file lives in the DESTINATION directory so the final move is a
+# rename within one filesystem, which is atomic: no window in which
+# ~/.local/bin/pad is half-written.
+mkdir -p "$(dirname "$INSTALLED")"
+STAGED="$(mktemp "$(dirname "$INSTALLED")/.$(basename "$INSTALLED").XXXXXX")" ||
+	die "could not stage the install next to $INSTALLED"
+cleanup() { [ -n "${STAGED:-}" ] && rm -f "$STAGED"; }
+trap cleanup EXIT
+
+cp -f "$BUILT" "$STAGED" || die "cp failed"
+chmod +x "$STAGED"
+
+# The ARTIFACT check, on the snapshot, while the old server is still serving.
+# Failing here costs nothing.
+if [ -n "$EXPECT_COMMIT" ]; then
+	staged_version="$("$STAGED" --version 2>/dev/null || true)"
+	if ! commit_matches "$EXPECT_COMMIT" "$(commit_of "$staged_version")"; then
+		die "the binary at $BUILT is not this invocation's build; refusing to stop the server.
+  expected commit: $EXPECT_COMMIT
+  $BUILT reads:    ${staged_version:-<no version output>}
+  Another session very likely rebuilt it between this build and now.
+  Nothing was stopped or installed; re-run the build and install together."
+	fi
+fi
+
+# --- 3. Stop -----------------------------------------------------------------
+#
+# Unchanged from the previous target, including its system-wide reach: this
+# is the plain path, and CONVE-2687's manual recipe remains the sibling-safe
+# one. SIGTERM first so the graceful-shutdown path runs (BUG-1531).
+BIN_NAME="$(basename "$BUILT")"
+pkill -TERM -x "$BIN_NAME" 2>/dev/null || true
+for _ in 1 2 3 4 5; do
+	pgrep -x "$BIN_NAME" >/dev/null 2>&1 || break
+	sleep 1
+done
+pkill -KILL -x "$BIN_NAME" 2>/dev/null || true
+
+# --- 4. Move into place, then check the OUTCOME -------------------------------
+mv -f "$STAGED" "$INSTALLED" || die "could not move the staged binary into $INSTALLED"
+STAGED=""
+rm -f "$HOME/.pad/pad.pid"
+
+# The check TASK-2787 asks for, and it is deliberately on the installed file
+# rather than on any step: read what is now at the install path and require it
+# to carry the commit this invocation built with. Distinct from step 2 — that
+# asked "is the source right", this asks "is the DESTINATION right", and it
+# is the leg that survives another writer racing the final path.
+#
+# WHAT THIS ANSWERS, stated because the check reads stronger than it is: it
+# catches "the binary here was built at a DIFFERENT commit", which is the
+# reversed-ordering case TASK-2787 names. It does NOT establish byte
+# provenance: a sibling who built the SAME commit leaves a binary this check
+# accepts. That case is benign by the task's own scope note, and pretending
+# otherwise would be the kind of overclaimed instrument this repo keeps
+# filing bugs about.
+if [ -n "$EXPECT_COMMIT" ]; then
+	installed_version="$("$INSTALLED" --version 2>/dev/null || true)"
+	if ! commit_matches "$EXPECT_COMMIT" "$(commit_of "$installed_version")"; then
+		die "installed binary is not the one this invocation built.
+  expected commit: $EXPECT_COMMIT
+  installed reads: ${installed_version:-<no version output>}
+  Another session very likely wrote $INSTALLED between this move and this read.
+  Re-run the build and install together; do not trust the previous output."
+	fi
+fi
+note "installed $BIN_NAME to $INSTALLED ($EXPECT_COMMIT)"
+
+# --- 5. Restart with the argv that was killed --------------------------------
+#
+# The whole point of BUG-2897: a replacement is only correct if it preserves
+# what it replaced, and that includes the INVOCATION, not just the bytes.
+if [ ${#SERVER_ARGV[@]} -gt 0 ]; then
+	restart=("$INSTALLED" "${SERVER_ARGV[@]:1}")
+else
+	restart=("$INSTALLED" server start)
+fi
+# mkdir before the redirect: a missing ~/.pad makes the redirection fail and
+# the server never starts, which the probe then reports as "did not answer" —
+# true, but three steps downstream of the cause. Found by the probe-failure
+# test on a fresh HOME, where the directory does not exist; on a developer's
+# box it exists by luck of history, which is why nothing had caught it.
+mkdir -p "$HOME/.pad"
+# setsid where it exists, plain nohup where it does not. Codex round 2
+# (P1): setsid is Linux-specific and absent from a default macOS
+# environment, where an unconditional call would fail AFTER the old server
+# had been stopped — the one ordering this script exists to avoid. nohup
+# plus the background job is sufficient detachment on both.
+# PAD_NO_SETSID forces the fallback branch. It exists because the branch is
+# otherwise unreachable on the machines this is developed and tested on —
+# every Linux box has setsid — and an untestable branch is how the macOS
+# case would have shipped broken a second time. Test-only knob, documented
+# rather than hidden.
+# Re-read the installed binary IMMEDIATELY before executing it.
+#
+# Codex round 4 (P1): a concurrent `make install` can replace $INSTALLED
+# between the outcome check above and this exec, so this invocation would
+# launch a build it never verified and report success.
+#
+# RESIDUAL, stated rather than glossed: the window is narrowed, not closed —
+# the complete answer is an exclusive lock across the whole
+# check-install-restart sequence. Deliberately not added here: flock is
+# Linux-only, and a half-portable lock that silently does nothing on macOS is
+# worse than a named residual. Filed separately.
+if [ -n "$EXPECT_COMMIT" ]; then
+	preexec_version="$("$INSTALLED" --version 2>/dev/null || true)"
+	if ! commit_matches "$EXPECT_COMMIT" "$(commit_of "$preexec_version")"; then
+		die "another session replaced $INSTALLED between the install check and the restart.
+  expected commit: $EXPECT_COMMIT
+  installed reads: ${preexec_version:-<no version output>}
+  Refusing to start a binary this invocation did not verify. No server is running."
+	fi
+fi
+
+if [ -z "${PAD_NO_SETSID:-}" ] && command -v setsid >/dev/null 2>&1; then
+	setsid nohup "${restart[@]}" >>"$HOME/.pad/server.log" 2>&1 </dev/null &
+else
+	nohup "${restart[@]}" >>"$HOME/.pad/server.log" 2>&1 </dev/null &
+fi
+disown 2>/dev/null || true
+
+# --- 6. Probe BOTH addresses before claiming anything -------------------------
+#
+# `--host 0.0.0.0` is a bind spec, not an address to curl, so the configured
+# host resolves to the primary LAN address in that case. Loopback is always
+# probed: it is the address the previous defect killed, and the one every
+# local CLI call and browser tab uses.
+configured_host="$(flag_value --host "${SERVER_ARGV[@]}" || true)"
+
+# PORT resolution, in the server's own precedence order.
+#
+# Codex round 1: probing a fixed 7777 while faithfully restarting a server
+# that was started with `--port 8080` fails a HEALTHY restart, and does it
+# with this script's most confident message. The flag exists
+# (cmd_server.go: `--port`, default 7777) so the case is reachable, and the
+# whole point of this script is that the restart preserves the invocation —
+# a probe that ignores half of that invocation is checking the wrong server.
+configured_port="$(flag_value --port "${SERVER_ARGV[@]}" || true)"
+# Each source is accepted only if it is NUMERIC, mirroring the application:
+# config.go ignores a non-integer PAD_PORT and falls through to the next
+# source. Without that, a mistyped or inherited PAD_PORT is probed
+# literally and every refresh fails against a server that is running fine
+# (codex round 7).
+numeric() { case "$1" in '' | *[!0-9]*) return 1 ;; *) return 0 ;; esac; }
+
+PORT=""
+for candidate in "$configured_port" "${PAD_PORT:-}" "$(config_value port || true)"; do
+	if numeric "$candidate"; then
+		PORT="$candidate"
+		break
+	fi
+	if [ -n "$candidate" ]; then
+		note "ignoring non-numeric port value \"$candidate\" (as the server does)"
+	fi
+done
+PORT="${PORT:-7777}"
+
+# HOST likewise. When the argv carries no --host, fall back to PAD_HOST,
+# which config.go reads for exactly this purpose.
+#
+# Precedence: flag, then environment, then the config file, then the
+# default — the same order the server itself resolves them in. The config
+# file is read because leaving it out meant a permanent false failure for
+# anyone who configures the bind there (codex round 3).
+if [ -z "$configured_host" ]; then
+	configured_host="${PAD_HOST:-$(config_value host || true)}"
+fi
+
+# The probe set is exactly what the BIND PROMISES, no more and no less.
+#
+# A wildcard bind promises loopback AND the LAN address, and the original
+# defect was precisely a wildcard server coming back bound to one host with
+# 127.0.0.1 dead — so both are required there. An EXPLICIT single host
+# promises only itself: demanding 127.0.0.1 from a server deliberately bound
+# to ::1 or to a LAN interface would fail a correct configuration, which is
+# the same false alarm in the opposite direction.
+#
+# The first version required 127.0.0.1 unconditionally, and the IPv6 test
+# caught it: a server bound ::1 restarted correctly and was reported dead
+# because a v4 loopback it never promised did not answer.
+probe_hosts=()
+case "$configured_host" in
+"" | "127.0.0.1")
+	probe_hosts=("127.0.0.1")
+	;;
+"localhost")
+	# `localhost` may resolve to either loopback family, and which one the
+	# server binds is not knowable from here (codex round 8). Requiring both
+	# would fail a healthy v4-only or v6-only bind, so this is the one case
+	# where ANY member answering is the pass — recorded because it is a
+	# deliberate exception to "every probed address must answer".
+	probe_any=1
+	probe_hosts=("127.0.0.1" "::1")
+	;;
+"0.0.0.0")
+	probe_hosts=("127.0.0.1")
+	lan="$(hostname -I 2>/dev/null | awk '{print $1}')"
+	if [ -z "$lan" ]; then
+		lan="$(ipconfig getifaddr en0 2>/dev/null || true)"
+	fi
+	if [ -n "$lan" ]; then
+		probe_hosts+=("$lan")
+	else
+		# FAIL CLOSED (codex rounds 5 and 8). A wildcard bind promises the
+		# external address, and being unable to check it is not the same as
+		# it being fine. The first version warned and exited 0, which is
+		# this unit's own defect wearing a different hat: a success line
+		# covering something that was not verified.
+		die "cannot determine a LAN address to verify the wildcard bind (tried \`hostname -I\` and \`ipconfig getifaddr en0\`).
+  The binary is installed and loopback answers, but the external half of
+  \`--host 0.0.0.0\` is unverified and this refuses to claim otherwise.
+  Start the server with an explicit --host, or set PAD_HOST, to make the
+  address checkable."
+	fi
+	;;
+"::")
+	probe_hosts=("127.0.0.1" "::1")
+	;;
+*)
+	probe_hosts=("$configured_host")
+	;;
+esac
+
+probe() {
+	local host="$1" deadline=$((SECONDS + PROBE_TIMEOUT))
+	while [ $SECONDS -lt $deadline ]; do
+		if curl -fsS -m 2 -o /dev/null "$(probe_url "$host" "$PORT")" 2>/dev/null; then
+			return 0
+		fi
+		sleep 1
+	done
+	return 1
+}
+
+failed=()
+answered=0
+for host in "${probe_hosts[@]}"; do
+	if probe "$host"; then
+		answered=$((answered + 1))
+	else
+		failed+=("$host")
+	fi
+done
+
+# Every probed address must answer, EXCEPT the `localhost` case above, where
+# one loopback family answering is the whole of what can be required.
+if [ "${probe_any:-0}" = "1" ] && [ "$answered" -gt 0 ]; then
+	failed=()
+	probe_hosts=("localhost")
+fi
+
+if [ ${#failed[@]} -gt 0 ]; then
+	die "server did not answer on: ${failed[*]} (port $PORT, waited ${PROBE_TIMEOUT}s each).
+  The binary is installed; the server is not serving those addresses.
+  Restart argv was: ${restart[*]}"
+fi
+
+note "server restarted and answering on: ${probe_hosts[*]} (port $PORT)"


### PR DESCRIPTION
Closes BUG-2897 and TASK-2787.

## `make install` made three claims it did not check

1. It brought the server back **by side effect** — `pad auth whoami` triggers an auto-start, which does not know the killed process's argv. A server running `--host 0.0.0.0` came back bound to the default host alone: `curl 127.0.0.1:7777` → **000** while the LAN address → 200, with the process count and the version both reading correct (BUG-2897).
2. `cp` copied whatever was at the repo path, not what the invocation built. Two sessions sharing the checkout interleave and the loser's build is installed by the winner, every exit code green (TASK-2787).
3. **"Server restarted." was printed after a command ending in `|| true`, with no probe of any kind.** Not "the wrong address went unverified" — nothing was verified. Found reading the recipe; neither filing names it, and it is what made the other two invisible.

## Why a script

`scripts/install-refresh.sh`, for one reason above readability: **a script can be tested.** `internal/buildtools` drives it against a compiled stub `pad`, including the branches where a check must FAIL. Recipe-inline logic is only exercisable by running `make install`, which stops the developer's server — a test nobody runs twice, which is how this target accumulated three unverified claims.

The script checks **outcomes**, not steps. Sequence: capture argv from `/proc` → stage a copy beside the final path and verify it → stop → atomic rename into place → verify the destination → restart with the captured argv → probe **both** `127.0.0.1` and the configured host before printing anything.

Two commit checks, deliberately, answering different questions: the **artifact**, before the kill, so a wrong build costs an error rather than an outage; the **destination**, after the move, which is the race TASK-2787 names.

## Sixteen defects were found in the fix itself

Three by its own tests, one by the first real run, twelve across nine adversarial rounds (round 10 returned CLEAN — the read has converged).

| found by | defect |
|---|---|
| tests, fresh HOME | restart redirected to `$HOME/.pad/server.log` with nothing creating that directory — the probe then reported "did not answer", true and three steps downstream. Invisible to every hand-run, because a developer's box has `~/.pad` by luck of history |
| mutation | the destination check **survived** its mutant — both fixtures reported the same version from source and destination |
| first real run | comparing commits by **equality** rejected a healthy build: `git rev-parse --short` returns the shortest *unambiguous* prefix, so the binary embedded `a3a1d58` while the Makefile produced `a3a1d586` |
| round 1 | the probe used a fixed port while the restart preserved `--port N` |
| round 2 | only `--flag value` was parsed; Cobra accepts `--flag=value` |
| round 2 | the artifact check and the copy were separated by a window another session could write into, so a swap was caught only **after** the kill |
| round 2 | `setsid` is Linux-only and would have failed on macOS after the stop |
| round 3 | a host or port configured only in `~/.pad/config.toml` was ignored — every install would fail for such a user |
| round 3 | IPv6 hosts produced `http://::1:PORT/...`, not a URL |
| round 4 | a TOML inline comment (`port = 8080 # dev`) was swallowed into the value |
| round 4 | `$INSTALLED` could be replaced between the outcome check and the exec |
| round 5 | **the prefix comparison was itself wrong**: it accepts two *different* commits sharing seven characters — the same mechanism that makes abbreviations grow, so the fix for a false alarm had introduced a false pass in the case the check exists for. Ids are now resolved with `git rev-parse` and compared in full |
| round 5 | the argv capture read `/proc` only, so on macOS it captured nothing and the restart fell back to defaults — BUG-2897's own defect, silently unfixed, on the platform the setsid fallback had just been added for |
| round 5/8 | a wildcard bind whose LAN address could not be determined **reported success** having verified only loopback; it now fails closed |
| round 6 | `local` at top level made bash print an error to stderr on every normal refresh while the script kept working |
| round 8/9 | `localhost` was mapped to 127.0.0.1 unconditionally; an unresolvable id was accepted on a prefix match; more than one running server was guessed at rather than refused |

## Mutants

Twenty, each verified to **compile**, each detected by its own leg. **Seven survived first** — the destination check, the `--flag=value` parse, the setsid guard, the `/proc` fallback, the wildcard loopback probe, the prefix-collision refusal, the multi-server refusal.

All seven for one reason: **the fixtures were drawn from my own model of the input, so they tested the model.** Equal-width commits, one flag spelling, one bind shape, a machine with `/proc`. One sentence, seven instances, in a unit whose subject is a tool making claims it had not checked.

Two are unreachable on this platform by construction and are reached through documented `PAD_NO_SETSID` / `PAD_NO_PROC` knobs — an untestable branch is how the macOS half would have shipped broken twice.

## Verified end to end on the real box

This run also discharges the `a3a1d586` refresh (external PR #1271), delegated into this unit rather than done separately:

```
install-refresh: captured server argv: ... server start --host 0.0.0.0
install-refresh: installed pad to /home/dave/.local/bin/pad (a3a1d586)
install-refresh: server restarted and answering on: 127.0.0.1 192.168.1.89 (port 7777)
```

Independently verified after: one `pad` pid with the argv preserved, health `a3a1d586` on both addresses, `/proc/<pid>/exe` matching the installed binary and not `(deleted)`.

## Stated boundaries

- A concurrent `make install` can still swap the binary between the final verification and the `exec`. The complete answer is an exclusive lock across the whole sequence; `flock` is Linux-only and a lock that silently does nothing on macOS is worse than a named gap. Filed as IDEA-2925 with the fix shape and why the stale-lock policy is the hard half.
- The commit check catches a commit *mismatch*, not byte provenance: a sibling's same-commit build passes it. Benign by TASK-2787's own scope note.
- `ps -o args=` (the macOS argv path) returns one space-joined string, so an argument containing a space would be split. No `pad server start` flag takes such a value today.
- `shellcheck` is not installed on this box, so the script has not been through it.
- CONVE-2687's manual sibling-safe recipe is unchanged and remains the path when another session's worktree is live. This makes the plain target honest; it does not replace the convention.

https://claude.ai/code/session_01HeChkgZVYb3NTgTcckF5KR
