### PR TITLE
fix(web): a snapshot cannot reinstate a row whose eviction the cache already consumed (TASK-2920)

### DIFF
--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -180,6 +180,36 @@ class WorkspaceState {
 	// the race it guards is within a single session.
 	fencedIds = new Set<string>();
 
+	// `movedOutFloor` maps an item id to the `seq` at which THIS session consumed
+	// a `moved_out` eviction for it (TASK-2920 / PLAN-2903 item 6). It is a
+	// per-id SEQ FLOOR, not a blocklist, and the distinction is the whole design:
+	// a row is refused only while the evidence offered for it is NOT NEWER than
+	// the eviction, so a genuine re-add — which the server stamps with a fresh,
+	// higher seq — is admitted without anything having to expire or be cleaned
+	// up. Correctness therefore does not depend on the pruning below; that is
+	// only about the map's size.
+	//
+	// It exists because `applyDelta`'s `moved_out` branch is a HARD evict
+	// (`state.items.delete`), which leaves no row for the ordinary
+	// `existing.seq` guards to compare against. Every door that merges rows
+	// FETCHED OR READ BEFORE the eviction was consumed therefore saw an absent
+	// id and reinstated the row: the cold `/items-index` snapshot and the warm
+	// IDB hydrate (both via `mergeRow`), the resync snapshot, and a stale
+	// optimistic `upsert`.
+	//
+	// The values compared are `seq` against `seq`, which IS orderable —
+	// strictly monotonic per workspace — unlike `access_epoch`, whose
+	// unorderability is what defeated the fences on IDEA-2898's abandoned
+	// branch. PLAN-2903's working rule asks that this be stated rather than
+	// assumed, so: this fence is entitled to say "older".
+	//
+	// Not persisted, for the same reason `fencedIds` is not: the eviction it
+	// records reaches IDB atomically with the cursor advance in the same
+	// `persistDelta` call, so a reload finds the row already gone from disk and
+	// the cursor already past it — there is no window on the other side to
+	// guard. The map guards a within-session race only.
+	movedOutFloor = new Map<string, number>();
+
 	// `pendingRetags` records collection renames (collection id → latest new
 	// slug) seen via `retagCollection` (BUG-2601). A rename event can land
 	// BEFORE this workspace's rows exist (SSE connects fast; bootstrap's warm
@@ -345,6 +375,34 @@ function cursorAsNum(c: string): number {
 }
 
 /**
+ * Is this row older evidence than an eviction this session already consumed?
+ * (TASK-2920.)
+ *
+ * ONE function rather than the comparison written at each of the four write
+ * doors, because a rule landing at one door and not its sibling is the failure
+ * PLAN-2903 has now hit five times — including once inside this very file, where
+ * `bootstrap`'s reconcile loop cleared `pendingResync` directly instead of going
+ * through `clearAskIfSettled`.
+ *
+ * `<=`, not `<`: the eviction IS the row's change at that seq, so a row offered
+ * AT the floor is the same news, not newer news. Only a strictly higher seq is
+ * evidence the row came back.
+ *
+ * A row with NO `seq` is admitted. There is genuinely no basis to order it, and
+ * this file already resolves that case the same way in `upsert` ("Rows or peers
+ * missing `seq` overwrite unconditionally"). The cost is bounded to a legacy /
+ * mixed-deployment server that stamps no seq; refusing instead would drop rows
+ * permanently in that deployment, which is the worse of the two failures.
+ */
+function refusedByMovedOut(state: WorkspaceState, row: ItemIndexRow | Item): boolean {
+	const floor = state.movedOutFloor.get(row.id);
+	if (floor === undefined) return false;
+	const seq = (row as ItemIndexRow).seq;
+	if (seq === undefined) return false;
+	return seq <= floor;
+}
+
+/**
  * Apply a single row to a workspace's items map with the per-row
  * seq guard. Used by `bootstrap` (both warm and cold paths) and
  * `upsert`/`applyDelta` indirectly via the existing inline logic.
@@ -352,6 +410,7 @@ function cursorAsNum(c: string): number {
  * stale.
  */
 function mergeRow(state: WorkspaceState, row: ItemIndexRow | Item): boolean {
+	if (refusedByMovedOut(state, row)) return false;
 	let next = toSkinny(row);
 	const existing = state.items.get(next.id);
 	next = preserveProjectionMetadata(existing, next);
@@ -563,6 +622,14 @@ async function resyncProjectionScope(
 			state.accessEpoch = fallbackEpoch;
 		}
 		for (const row of resp.items) {
+			// The snapshot can predate an eviction this session already consumed
+			// (TASK-2920). A resync SELF-HEALS that case — it pins the cursor to
+			// the snapshot's below, so the caller's next `/items-changes`
+			// re-delivers the eviction — so the guard here closes a visible
+			// flicker rather than a durable defect. It is applied anyway because
+			// this is the same door under a different roof, and the alternative
+			// is a rule that holds in `mergeRow` and not here.
+			if (refusedByMovedOut(state, row)) continue;
 			const next = toSkinny(row);
 			const existing = state.items.get(next.id);
 			if (
@@ -1244,6 +1311,11 @@ export const localIndex = {
 						// Authoritative re-add — the row is visible again, so
 						// lift any fence so its optimistic edits aren't dropped.
 						state.fencedIds.delete(change.id);
+						// Same for the eviction floor (TASK-2920). Dropping it is
+						// housekeeping, not correctness: this row's seq is now at
+						// or above the floor, so the floor could no longer refuse
+						// anything the ordinary `existing.seq` guards admit.
+						state.movedOutFloor.delete(change.id);
 					} else {
 						toPersist.push(existing);
 					}
@@ -1259,6 +1331,17 @@ export const localIndex = {
 				state.items.delete(change.id);
 				localSearch.remove(ws, change.id);
 				toRemove.push(change.id);
+				// Record the seq at which this eviction was consumed, so a row
+				// set fetched or read BEFORE it cannot reinstate the row after
+				// it (TASK-2920). Highest wins: two evictions for one id can
+				// arrive out of order across concurrent reconcile loops, and the
+				// floor must not regress.
+				if (change.seq !== undefined) {
+					const floor = state.movedOutFloor.get(change.id);
+					if (floor === undefined || change.seq > floor) {
+						state.movedOutFloor.set(change.id, change.seq);
+					}
+				}
 				continue;
 			}
 			// `deleted: true` is the server's derived view of
@@ -1275,6 +1358,10 @@ export const localIndex = {
 			toPersist.push(skinny);
 			// Authoritative re-add under the current scope — lift any fence.
 			state.fencedIds.delete(change.id);
+			// ...and the eviction floor (TASK-2920), for the same reason: the
+			// server has just said this row is visible again, at a seq at or
+			// above the floor.
+			state.movedOutFloor.delete(change.id);
 			// Keep the search index in lockstep with the canonical
 			// store — TASK-1363. Soft-deleted rows still index (the
 			// `_deleted` flag gates them out at search time) so a
@@ -1498,6 +1585,12 @@ export const localIndex = {
 		// fence lifts only via an authoritative applyDelta re-add or the next
 		// resync recomputing the set.
 		if (state.fencedIds.has(next.id)) return;
+		// Eviction floor (TASK-2920). `fencedIds` does not cover this: it holds
+		// ids a RESYNC dropped, and is REPLACED wholesale by the next resync,
+		// whereas a `moved_out` eviction is recorded by a delta and must outlive
+		// resyncs. The `sinceEpoch` guard above does not cover it either — that
+		// bumps on a resync, and an eviction is not one.
+		if (refusedByMovedOut(state, next)) return;
 		const existing = state.items.get(row.id);
 		next = preserveProjectionMetadata(existing, next);
 		if (

--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -412,9 +412,23 @@ function cursorAsNum(c: string): number {
  *
  * Oldest-first eviction, which is the direction that matters: an entry's whole
  * job is to outlive row sets FETCHED BEFORE IT, so the oldest entry is the one
- * whose racing fetches are likeliest to have long since landed. Evicting one
- * re-opens the original window for that single id — strictly better than an
- * unbounded map, and no worse than the behaviour before this fence existed.
+ * whose racing fetches are likeliest to have long since landed.
+ *
+ * WHAT THE CAP DOES NOT CLOSE, stated plainly because a bound that reads as a
+ * guarantee is worse than one that reads as a bound (codex round 2 P2). The
+ * reconcile loop PAGES, so more than one page of evictions can be consumed
+ * inside a single in-flight snapshot; past 5000 of them the oldest floors are
+ * gone before that snapshot merges, and those ids can be reinstated exactly as
+ * they were before this fence existed. Every id under the cap is still
+ * protected, so the cap strictly reduces the exposure and never widens it — but
+ * it does not eliminate it.
+ *
+ * Closing it needs a different mechanism, not a bigger number: the cold path
+ * would have to PIN its cursor to the snapshot's the way `resyncProjectionScope`
+ * already does, so the replay re-delivers every eviction in the gap and no
+ * per-id record is load-bearing at all. That is a change to the cold path's
+ * cursor contract and it interacts with TASK-2906's durable monotonicity gate,
+ * so it is filed rather than smuggled in here — see TASK-2920's trail.
  */
 const MOVED_OUT_FLOOR_CAP = 5000;
 

--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -186,8 +186,7 @@ class WorkspaceState {
 	// a row is refused only while the evidence offered for it is NOT NEWER than
 	// the eviction, so a genuine re-add — which the server stamps with a fresh,
 	// higher seq — is admitted without anything having to expire or be cleaned
-	// up. Correctness therefore does not depend on the pruning below; that is
-	// only about the map's size.
+	// up. Correctness therefore does not depend on any pruning.
 	//
 	// It exists because `applyDelta`'s `moved_out` branch is a HARD evict
 	// (`state.items.delete`), which leaves no row for the ordinary
@@ -208,6 +207,12 @@ class WorkspaceState {
 	// `persistDelta` call, so a reload finds the row already gone from disk and
 	// the cursor already past it — there is no window on the other side to
 	// guard. The map guards a within-session race only.
+	// BOUNDED, and NOT by the `delete` on the authoritative re-add paths: that
+	// lift fires only when an item comes BACK, which by definition never happens
+	// for one that moved out permanently — so it prunes exactly the entries that
+	// were already harmless and none of the ones that accumulate (codex round 1
+	// P2, against the first draft of the comment above, which implied otherwise).
+	// `noteMovedOut` caps the map; see `MOVED_OUT_FLOOR_CAP`.
 	movedOutFloor = new Map<string, number>();
 
 	// `pendingRetags` records collection renames (collection id → latest new
@@ -394,6 +399,48 @@ function cursorAsNum(c: string): number {
  * mixed-deployment server that stamps no seq; refusing instead would drop rows
  * permanently in that deployment, which is the worse of the two failures.
  */
+/**
+ * How many eviction floors one workspace keeps (TASK-2920, codex round 1 P2).
+ *
+ * 5000 is `DefaultItemChangesLimit` in `internal/store/items.go` — the server's
+ * per-page cap on `/items-changes`, and the one that applies here: the client
+ * method takes an optional `limit` and both live callers (`deltaSync` and
+ * `bootstrap`'s reconcile loop) pass none. Sizing the map to a full page means a
+ * bulk move — the only way to add entries quickly — can never evict the floors
+ * it is itself in the middle of recording. At a 36-byte uuid key plus a number
+ * that is well under 1 MB per workspace, and it is session-local.
+ *
+ * Oldest-first eviction, which is the direction that matters: an entry's whole
+ * job is to outlive row sets FETCHED BEFORE IT, so the oldest entry is the one
+ * whose racing fetches are likeliest to have long since landed. Evicting one
+ * re-opens the original window for that single id — strictly better than an
+ * unbounded map, and no worse than the behaviour before this fence existed.
+ */
+const MOVED_OUT_FLOOR_CAP = 5000;
+
+/**
+ * Record that an eviction for `id` was consumed at `seq`, keeping the map
+ * bounded (TASK-2920).
+ *
+ * Highest wins, because the floor must never regress. A floor RAISED in place
+ * deliberately keeps its original insertion position rather than moving to the
+ * end: `Map` iteration order is what the cap evicts by, and a re-raise is the
+ * same eviction learned about twice, not a newer one to give a fresh lease.
+ */
+function noteMovedOut(state: WorkspaceState, id: string, seq: number): void {
+	const floor = state.movedOutFloor.get(id);
+	if (floor !== undefined) {
+		if (seq > floor) state.movedOutFloor.set(id, seq);
+		return;
+	}
+	state.movedOutFloor.set(id, seq);
+	while (state.movedOutFloor.size > MOVED_OUT_FLOOR_CAP) {
+		const oldest = state.movedOutFloor.keys().next();
+		if (oldest.done) break;
+		state.movedOutFloor.delete(oldest.value);
+	}
+}
+
 function refusedByMovedOut(state: WorkspaceState, row: ItemIndexRow | Item): boolean {
 	const floor = state.movedOutFloor.get(row.id);
 	if (floor === undefined) return false;
@@ -1337,10 +1384,7 @@ export const localIndex = {
 				// arrive out of order across concurrent reconcile loops, and the
 				// floor must not regress.
 				if (change.seq !== undefined) {
-					const floor = state.movedOutFloor.get(change.id);
-					if (floor === undefined || change.seq > floor) {
-						state.movedOutFloor.set(change.id, change.seq);
-					}
+					noteMovedOut(state, change.id, change.seq);
 				}
 				continue;
 			}

--- a/web/src/lib/stores/localIndexInverseColdCheck.svelte.test.ts
+++ b/web/src/lib/stores/localIndexInverseColdCheck.svelte.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { api } from '$lib/api/client';
+import type { ItemIndexRow } from '$lib/types';
+import { localIndex } from './localIndex.svelte';
+import { localSearch } from './localSearch.svelte';
+
+/**
+ * PLAN-2903 item 6 / TASK-2920 — the INVERSE cold check.
+ *
+ * The covered direction is "RAM holds a row the snapshot omits", which
+ * `resyncProjectionScope` closes by dropping every absent id. This file is the
+ * other direction: the snapshot holds a row whose eviction RAM has ALREADY
+ * CONSUMED, because a `moved_out` delta was applied while `/items-index` was in
+ * flight.
+ *
+ * Why the cold path and not the resync path: a resync PINS the cursor to the
+ * snapshot's (`state.cursor = resp.cursor`), so the eviction it reinstates is
+ * re-delivered by the caller's very next `/items-changes` and the row goes away
+ * again. `bootstrap`'s cold branch keeps the HIGHER cursor and then sets
+ * `pendingResync = false`, so the eviction is never replayed — the reinstated
+ * row is durable, and the same branch persists it to IDB, so it survives a
+ * reload.
+ */
+
+const ws = 'inverse-cold-test';
+
+function row(id: string, seq: number, collection = 'kept'): ItemIndexRow {
+	return {
+		id,
+		seq,
+		title: `Title ${id}`,
+		collection_slug: collection,
+		created_at: '2026-01-01T00:00:00Z',
+		updated_at: '2026-01-01T00:00:00Z',
+	} as ItemIndexRow;
+}
+
+/** Both of ItemPicker's read paths, asked about one id — as the sibling suites do. */
+function canSee(id: string, collection: string): boolean {
+	const listed = localIndex.getByCollection(ws, collection).some((r) => r.id === id);
+	const searched = localSearch
+		.search(ws, `Title ${id}`, { limit: 20 })
+		.some((hit) => hit.id === id);
+	return listed || searched;
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void } {
+	let resolve!: (v: T) => void;
+	const promise = new Promise<T>((r) => {
+		resolve = r;
+	});
+	return { promise, resolve };
+}
+
+/** Let the bootstrap body run up to (and into) its `/items-index` await. */
+async function settle(): Promise<void> {
+	for (let i = 0; i < 20; i++) await Promise.resolve();
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	localIndex.reset(ws);
+});
+
+describe('cold bootstrap vs. an eviction that raced the snapshot', () => {
+	it('does not reinstate a row whose moved_out was applied while /items-index was in flight', async () => {
+		const gate = deferred<Awaited<ReturnType<typeof api.items.listIndex>>>();
+		vi.spyOn(api.items, 'listIndex').mockReturnValueOnce(gate.promise);
+
+		// Cold boot begins: empty IDB, so this takes the /items-index branch.
+		const boot = localIndex.bootstrap(ws, { userId: null });
+		await settle();
+
+		// While that request is outstanding, the route's own reconcile applies a
+		// delta carrying the eviction. This is the exact call `deltaSync` makes
+		// (`web/src/routes/[username]/[workspace]/[collection]/+page.svelte`),
+		// with the same argument shape; the SSE handler that drives it is
+		// registered in `onMount` and is NOT gated on bootstrapState, so it can
+		// and does run inside this window.
+		localIndex.applyDelta(ws, [{ id: 'secret', seq: 100, moved_out: true }], '100', false);
+		expect(canSee('secret', 'revoked')).toBe(false);
+
+		// The snapshot was taken BEFORE the move, so it still lists the row, and
+		// its cursor is behind the eviction's seq.
+		gate.resolve({
+			items: [row('keeper', 1, 'kept'), row('secret', 40, 'revoked')],
+			total: 2,
+			cursor: '95',
+			includes_unparented_metadata: false,
+			access_epoch: 'epoch-1',
+		});
+		await boot;
+
+		// The property under test.
+		expect(canSee('secret', 'revoked')).toBe(false);
+	});
+
+	it('leaves no replay that could heal it: the cursor stays past the eviction and nothing is pending', async () => {
+		const gate = deferred<Awaited<ReturnType<typeof api.items.listIndex>>>();
+		vi.spyOn(api.items, 'listIndex').mockReturnValueOnce(gate.promise);
+
+		const boot = localIndex.bootstrap(ws, { userId: null });
+		await settle();
+		localIndex.applyDelta(ws, [{ id: 'secret', seq: 100, moved_out: true }], '100', false);
+		gate.resolve({
+			items: [row('keeper', 1, 'kept'), row('secret', 40, 'revoked')],
+			total: 2,
+			cursor: '95',
+			includes_unparented_metadata: false,
+			access_epoch: 'epoch-1',
+		});
+		await boot;
+
+		// This is the half that makes the first assertion's failure PERMANENT
+		// rather than transient, and it is asserted separately so a fix that
+		// merely re-fires a sync is not mistaken for a fix that holds the
+		// property. A later `/items-changes?since=100` cannot re-deliver a
+		// change at seq 100.
+		expect(localIndex.cursorFor(ws)).toBe('100');
+		expect(localIndex.pendingResyncFor(ws)).toBe(false);
+	});
+});

--- a/web/src/lib/stores/localIndexMovedOutFloor.svelte.test.ts
+++ b/web/src/lib/stores/localIndexMovedOutFloor.svelte.test.ts
@@ -1,0 +1,259 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { api } from '$lib/api/client';
+import type { ItemIndexRow } from '$lib/types';
+
+/**
+ * TASK-2920 / PLAN-2903 item 6 — the eviction floor at the doors OTHER than the
+ * cold `/items-index` merge.
+ *
+ * The cold door and its permanence are pinned by
+ * `localIndexInverseColdCheck.svelte.test.ts`. This file covers the rest of the
+ * population, because the failure this plan keeps repeating is a rule landing at
+ * one door and not its sibling:
+ *
+ *   - the WARM IDB hydrate (the other `mergeRow` caller),
+ *   - `upsert` (the optimistic write path),
+ *   - `resyncProjectionScope`'s snapshot merge.
+ *
+ * Mocked persistence, like its sibling wiring files: jsdom has no IndexedDB, so
+ * the hydrate has to be driven at the boundary.
+ */
+
+const persistence = vi.hoisted(() => {
+	let gate: Promise<unknown> | null = null;
+	let payload = {
+		items: [] as ItemIndexRow[],
+		cursor: '0',
+		includesUnparentedMetadata: null as boolean | null,
+		accessEpoch: null as string | null,
+		durableRead: true,
+		retags: {} as Record<string, string>,
+	};
+	return {
+		__setHydrate(next: typeof payload, gatedOn: Promise<unknown> | null) {
+			payload = next;
+			gate = gatedOn;
+		},
+		hydrate: vi.fn(async () => {
+			if (gate) await gate;
+			return payload;
+		}),
+		persistDelta: vi.fn(async () => undefined),
+		persistRemovals: vi.fn(async () => undefined),
+		persistReplace: vi.fn(async () => true),
+		persistAccessEpoch: vi.fn(async () => undefined),
+		persistRetag: vi.fn(async () => undefined),
+		persistUpserts: vi.fn(async () => undefined),
+		wipe: vi.fn(async () => undefined),
+	};
+});
+vi.mock('./localIndexPersistence', () => persistence);
+
+const { localIndex } = await import('./localIndex.svelte');
+const { localSearch } = await import('./localSearch.svelte');
+
+const ws = 'moved-out-floor';
+
+function row(id: string, seq: number, collection = 'kept'): ItemIndexRow {
+	return {
+		id,
+		seq,
+		title: `Title ${id}`,
+		collection_slug: collection,
+		created_at: '2026-01-01T00:00:00Z',
+		updated_at: '2026-01-01T00:00:00Z',
+	} as ItemIndexRow;
+}
+
+function canSee(id: string, collection: string): boolean {
+	const listed = localIndex.getByCollection(ws, collection).some((r) => r.id === id);
+	const searched = localSearch
+		.search(ws, `Title ${id}`, { limit: 20 })
+		.some((hit) => hit.id === id);
+	return listed || searched;
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void } {
+	let resolve!: (v: T) => void;
+	const promise = new Promise<T>((r) => {
+		resolve = r;
+	});
+	return { promise, resolve };
+}
+
+async function settle(): Promise<void> {
+	for (let i = 0; i < 20; i++) await Promise.resolve();
+}
+
+/** A populated warm cache whose read is held open until the returned gate resolves. */
+function gatedWarmCache(items: ItemIndexRow[], cursor: string) {
+	const gate = deferred<void>();
+	persistence.__setHydrate(
+		{
+			items,
+			cursor,
+			includesUnparentedMetadata: false,
+			accessEpoch: 'epoch-1',
+			durableRead: true,
+			retags: {},
+		},
+		gate.promise,
+	);
+	return gate;
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	localIndex.reset(ws);
+	persistence.__setHydrate(
+		{
+			items: [],
+			cursor: '0',
+			includesUnparentedMetadata: null,
+			accessEpoch: null,
+			durableRead: true,
+			retags: {},
+		},
+		null,
+	);
+});
+
+describe('the warm IDB hydrate — mergeRow’s other caller', () => {
+	it('does not reinstate a row whose moved_out was applied while the durable cache was being read', async () => {
+		const gate = gatedWarmCache([row('keeper', 1, 'kept'), row('secret', 40, 'revoked')], '95');
+		// The reconcile that follows the hydrate must not itself resurrect
+		// anything; it is not what this test is about.
+		vi.spyOn(api.items, 'changes').mockResolvedValue({
+			changes: [],
+			cursor: '100',
+			includes_unparented_metadata: false,
+			access_epoch: 'epoch-1',
+		});
+
+		const boot = localIndex.bootstrap(ws, { userId: null });
+		await settle();
+
+		// The eviction lands while `hydrate` is still awaiting.
+		localIndex.applyDelta(ws, [{ id: 'secret', seq: 100, moved_out: true }], '100', false);
+		gate.resolve();
+		await boot;
+
+		expect(canSee('secret', 'revoked')).toBe(false);
+		// The cached row that was NOT evicted still hydrates — without this the
+		// assertion above would also pass on a hydrate that dropped everything.
+		expect(canSee('keeper', 'kept')).toBe(true);
+	});
+
+	it('control: with no eviction in the window, the same cached row hydrates normally', async () => {
+		const gate = gatedWarmCache([row('keeper', 1, 'kept'), row('secret', 40, 'revoked')], '95');
+		vi.spyOn(api.items, 'changes').mockResolvedValue({
+			changes: [],
+			cursor: '100',
+			includes_unparented_metadata: false,
+			access_epoch: 'epoch-1',
+		});
+
+		const boot = localIndex.bootstrap(ws, { userId: null });
+		await settle();
+		// Same shape, same timing — an unrelated cursor advance rather than an
+		// eviction, so any failure above is attributable to the eviction and not
+		// to the gating.
+		localIndex.applyDelta(ws, [], '100', false);
+		gate.resolve();
+		await boot;
+
+		expect(canSee('secret', 'revoked')).toBe(true);
+	});
+});
+
+describe('upsert — the optimistic write path', () => {
+	async function bootWithEviction(): Promise<void> {
+		vi.spyOn(api.items, 'listIndex').mockResolvedValueOnce({
+			items: [row('secret', 40, 'revoked')],
+			total: 1,
+			cursor: '40',
+			includes_unparented_metadata: false,
+			access_epoch: 'epoch-1',
+		});
+		await localIndex.bootstrap(ws, { userId: null });
+		expect(canSee('secret', 'revoked')).toBe(true);
+		localIndex.applyDelta(ws, [{ id: 'secret', seq: 100, moved_out: true }], '100', false);
+		expect(canSee('secret', 'revoked')).toBe(false);
+	}
+
+	it('refuses a stale optimistic response that predates the eviction', async () => {
+		await bootWithEviction();
+		// A create/update issued before the move, resolving after it. Neither
+		// existing guard covers this: `fencedIds` holds only ids a RESYNC
+		// dropped, and `sinceEpoch` bumps only on a resync.
+		localIndex.upsert(ws, row('secret', 40, 'revoked'));
+		expect(canSee('secret', 'revoked')).toBe(false);
+	});
+
+	it('admits a genuine re-add above the floor — this is a seq floor, not a blocklist', async () => {
+		await bootWithEviction();
+		// The discriminator for the whole design. If the fence were a blocklist,
+		// this row would be refused too and the item could never come back.
+		localIndex.upsert(ws, row('secret', 150, 'revoked'));
+		expect(canSee('secret', 'revoked')).toBe(true);
+	});
+
+	it('admits a row carrying NO seq — there is no basis to order it against the floor', async () => {
+		await bootWithEviction();
+		// The deliberate choice in `refusedByMovedOut`, pinned so it stays a
+		// choice rather than drifting. A server that stamps no `seq` (legacy /
+		// mixed deployment) offers nothing the floor can compare against;
+		// refusing on that evidence would drop the row permanently, which is the
+		// worse of the two failures. `upsert` already resolves the same
+		// ambiguity the same way for its own guard.
+		const noSeq = {
+			id: 'secret',
+			title: 'Title secret',
+			collection_slug: 'revoked',
+			created_at: '2026-01-01T00:00:00Z',
+			updated_at: '2026-01-01T00:00:00Z',
+		} as ItemIndexRow;
+		localIndex.upsert(ws, noSeq);
+		expect(canSee('secret', 'revoked')).toBe(true);
+	});
+
+	it('refuses a row AT the floor: the eviction is the row’s change at that seq, not older news', async () => {
+		await bootWithEviction();
+		localIndex.upsert(ws, row('secret', 100, 'revoked'));
+		expect(canSee('secret', 'revoked')).toBe(false);
+	});
+});
+
+describe('resyncProjectionScope — the same door under a different roof', () => {
+	it('does not reinstate a row whose moved_out was applied while its snapshot was in flight', async () => {
+		vi.spyOn(api.items, 'listIndex').mockResolvedValueOnce({
+			items: [row('keeper', 1, 'kept'), row('secret', 40, 'revoked')],
+			total: 2,
+			cursor: '40',
+			includes_unparented_metadata: false,
+			access_epoch: 'epoch-1',
+		});
+		await localIndex.bootstrap(ws, { userId: null });
+
+		const gate = deferred<Awaited<ReturnType<typeof api.items.listIndex>>>();
+		vi.spyOn(api.items, 'listIndex').mockReturnValueOnce(gate.promise);
+		const resync = localIndex.ensureAccessScope(ws, 'epoch-2');
+		await settle();
+
+		localIndex.applyDelta(ws, [{ id: 'secret', seq: 100, moved_out: true }], '100', false);
+		gate.resolve({
+			items: [row('keeper', 1, 'kept'), row('secret', 40, 'revoked')],
+			total: 2,
+			cursor: '95',
+			includes_unparented_metadata: false,
+			access_epoch: 'epoch-2',
+		});
+		await resync;
+
+		// A resync self-heals this case via its cursor pin, so what this pins is
+		// the absence of the FLICKER — the row is never reinstated in the first
+		// place, rather than reinstated and re-evicted a round-trip later.
+		expect(canSee('secret', 'revoked')).toBe(false);
+		expect(canSee('keeper', 'kept')).toBe(true);
+	});
+});

--- a/web/src/lib/stores/localIndexMovedOutFloor.svelte.test.ts
+++ b/web/src/lib/stores/localIndexMovedOutFloor.svelte.test.ts
@@ -224,6 +224,98 @@ describe('upsert — the optimistic write path', () => {
 	});
 });
 
+describe('the floor map is bounded (codex round 1 P2)', () => {
+	/**
+	 * The lift on the authoritative re-add paths prunes only ids that came BACK,
+	 * which is never the case for an item moved out permanently — so the cap in
+	 * `noteMovedOut` is the only thing standing between a long-lived tab and one
+	 * entry per eviction forever. These two tests pin the cap and the direction
+	 * it evicts in; without them the constant is a comment.
+	 */
+	const CAP = 5000;
+
+	function evictions(from: number, count: number, idOf: (i: number) => string) {
+		return Array.from({ length: count }, (_, i) => ({
+			id: idOf(from + i),
+			seq: from + i,
+			moved_out: true as const,
+		}));
+	}
+
+	async function bootEmpty(): Promise<void> {
+		vi.spyOn(api.items, 'listIndex').mockResolvedValueOnce({
+			items: [],
+			total: 0,
+			cursor: '0',
+			includes_unparented_metadata: false,
+			access_epoch: 'epoch-1',
+		});
+		await localIndex.bootstrap(ws, { userId: null });
+	}
+
+	it('evicts the OLDEST floor once the cap is exceeded, and keeps the rest', async () => {
+		await bootEmpty();
+		localIndex.applyDelta(ws, [{ id: 'oldest', seq: 1, moved_out: true }], '1', false);
+		localIndex.applyDelta(ws, [{ id: 'second', seq: 2, moved_out: true }], '2', false);
+		// Fill to exactly the cap, then push one past it.
+		localIndex.applyDelta(ws, evictions(3, CAP - 2, (i) => `bulk-${i}`), String(CAP), false);
+		localIndex.applyDelta(ws, [{ id: 'newest', seq: CAP + 1, moved_out: true }], String(CAP + 1), false);
+
+		// The oldest floor is gone, so its id is admitted again — this is the
+		// bound, observable from outside.
+		localIndex.upsert(ws, row('oldest', 1, 'revoked'));
+		expect(canSee('oldest', 'revoked')).toBe(true);
+		// ...and nothing else went with it. Without this leg the assertion above
+		// would also pass on a map that dropped everything.
+		localIndex.upsert(ws, row('second', 2, 'revoked'));
+		expect(canSee('second', 'revoked')).toBe(false);
+		localIndex.upsert(ws, row('newest', CAP + 1, 'revoked'));
+		expect(canSee('newest', 'revoked')).toBe(false);
+	});
+
+	it('an authoritative re-add frees its slot, so the cap evicts one fewer old floor', async () => {
+		await bootEmpty();
+		localIndex.applyDelta(ws, [{ id: 'oldest', seq: 1, moved_out: true }], '1', false);
+		// Fill to EXACTLY the cap.
+		localIndex.applyDelta(ws, evictions(2, CAP - 1, (i) => `bulk-${i}`), String(CAP), false);
+
+		// The server says one of them is visible again. That lift is what this
+		// test is about: it is otherwise unobservable — after a re-add the row's
+		// own `existing.seq` guard subsumes everything the floor could refuse —
+		// and it is precisely what makes room here.
+		localIndex.applyDelta(
+			ws,
+			[row('bulk-5', CAP + 1, 'kept')],
+			String(CAP + 1),
+			false,
+		);
+		// One more eviction. With the lift the map is back at the cap and nothing
+		// is dropped; without it the map would be one over and `oldest` would go.
+		localIndex.applyDelta(ws, [{ id: 'newest', seq: CAP + 2, moved_out: true }], String(CAP + 2), false);
+
+		localIndex.upsert(ws, row('oldest', 1, 'revoked'));
+		expect(canSee('oldest', 'revoked')).toBe(false);
+	});
+
+	it('a floor RAISED in place keeps its position — a re-raise is not a fresh lease', async () => {
+		await bootEmpty();
+		localIndex.applyDelta(ws, [{ id: 'oldest', seq: 1, moved_out: true }], '1', false);
+		localIndex.applyDelta(ws, [{ id: 'second', seq: 2, moved_out: true }], '2', false);
+		// The same id evicted again at a higher seq. If this moved it to the end
+		// of the map, `second` would become the oldest and be evicted below.
+		localIndex.applyDelta(ws, [{ id: 'oldest', seq: 3, moved_out: true }], '3', false);
+		localIndex.applyDelta(ws, evictions(4, CAP - 2, (i) => `bulk-${i}`), String(CAP + 1), false);
+		localIndex.applyDelta(ws, [{ id: 'newest', seq: CAP + 2, moved_out: true }], String(CAP + 2), false);
+
+		// `oldest` was still the oldest entry despite the re-raise, so it went.
+		localIndex.upsert(ws, row('oldest', 3, 'revoked'));
+		expect(canSee('oldest', 'revoked')).toBe(true);
+		// `second` did not.
+		localIndex.upsert(ws, row('second', 2, 'revoked'));
+		expect(canSee('second', 'revoked')).toBe(false);
+	});
+});
+
 describe('resyncProjectionScope — the same door under a different roof', () => {
 	it('does not reinstate a row whose moved_out was applied while its snapshot was in flight', async () => {
 		vi.spyOn(api.items, 'listIndex').mockResolvedValueOnce({


### PR DESCRIPTION
Closes TASK-2920 — PLAN-2903 item 6, filed as a confirmation unit: *does the inverse cold check already exist in IDEA-2898's minimal shape, or not?* It does not, it is reachable, and the fix is here.

## The defect

`applyDelta`'s `moved_out` branch is a HARD evict — `state.items.delete(id)` — deliberately leaving no RAM tombstone. So every door that merges rows **fetched or read before** that eviction was consumed saw an absent id and put the row back, because the ordinary `existing.seq` guards had nothing to compare against.

The cold `/items-index` merge is the one that cannot heal:

| | reinstates? | permanent? |
|---|---|---|
| `resyncProjectionScope` | yes | **no** — it PINS the cursor to the snapshot's, so the next `/items-changes` re-delivers the eviction |
| `bootstrap` cold branch | yes | **yes** — keeps the HIGHER cursor, sets `pendingResync = false`, no loop |
| `bootstrap` warm IDB hydrate | yes | **yes** — cursor already past the eviction, reconcile resumes from it |
| `upsert` | yes | **yes** — touches no cursor, nothing replays |

The cold branch then persists the merged rows, so a reinstated row is durable and survives a reload.

The window is real. The collection route's SSE handler is registered in `onMount` with **no gate on `bootstrapState`**, so it drives a full `deltaSync` while the cold request is outstanding. Two comments already in the file say the same thing from other directions ("an SSE/applyDelta that landed during the in-flight /items-index request…", "SSE connects fast; bootstrap's warm IDB hydrate hasn't run").

The warm-hydrate door is worth calling out: it is equally permanent and it is **not** what item 6 describes — item 6 says "while `/items-index` was in flight", and an IDB read is not that. It was found by enumerating the class rather than fixing the named instance.

## The fix

A per-id eviction floor (`movedOutFloor`: id → seq of the consumed `moved_out`) and one predicate, `refusedByMovedOut`, at all four doors — `mergeRow` covers two of them, so it is three call sites.

**It is a seq FLOOR, not a blocklist.** A row is refused only while the evidence offered for it is not newer than the eviction, so a genuine re-add carries a higher server-stamped seq and is admitted with nothing having to expire.

Per PLAN-2903's working rule, stated rather than assumed: the compared values are **seq against seq, which is orderable** (strictly monotonic per workspace). This fence is entitled to say "older" — unlike the IDEA-2898 fences that failed, which rested that word on `access_epoch`, a hash.

Not persisted: the eviction reaches IDB atomically with the cursor advance in the same `persistDelta` call, so a reload finds the row already gone and the cursor already past it.

The map is capped at 5000 (`DefaultItemChangesLimit`, the server's per-page cap — both live callers pass no limit), evicting oldest-first. **The cap is a bound, not a guarantee**, and the comment says so: the reconcile loop pages, so past 5000 evictions inside one in-flight snapshot the oldest floors go and those ids are exposed as before. Closing that needs the cold path to pin its cursor the way the resync does, which changes that path's cursor contract and interacts with TASK-2906's durable monotonicity gate — filed as IDEA-2924 rather than smuggled in here.

## Evidence

- **12 tests** across two new files; **6 fail on the unfixed tree** (verified by restoring `a3a1d586`'s source and re-running). The 3 that pass unfixed are controls and the permanence assertion, by design.
- **Mutation matrix: 13 mutants, 11 killed.** The 2 survivors were predicted before the run and are explained on the trail: a defensive `max()` unreachable through `applyDelta`'s own cursor guards, and a floor lift on a branch whose effect is subsumed by the row's own seq guard.
- One survivor was **not** predicted — the missing-`seq` branch, a deliberate choice with nothing enforcing it. A test now pins it.
- **Gates:** web 136 files / 2201 tests green; svelte-check 1101 files, 0 errors (6 pre-existing warnings, none in touched files); Go 29 packages ok; `golangci-lint` 0 issues.
- **Codex:** 3 rounds. Round 1 found unbounded map growth (real — the lift never fires for a permanently moved-out id, so my comment's pruning claim was false). Round 2 found the cap's residual window (real, documented, deferred to IDEA-2924). Round 3 CLEAN.

https://claude.ai/code/session_01Xk9M5UVPdc84xL5E1mZkm8
