### PR TITLE
fix(cli): item show --format markdown emits the body verbatim (IDEA-2937)

### DIFF
--- a/cmd/pad/cmd_item.go
+++ b/cmd/pad/cmd_item.go
@@ -732,11 +732,12 @@ func showCmd() *cobra.Command {
 				// same bytes back with `item update --stdin`, and the write
 				// path stores them exactly as sent. A `Println` here made
 				// that round trip append one newline per cycle, without
-				// bound, and made `$(...)` capture LOSE one instead, since
-				// command substitution strips every trailing newline. Both
-				// directions were this one line. The human-facing surface is
-				// the default table format below, which still ends the body
-				// with a newline.
+				// bound. (The `$(...)` capture that LOSES a byte is a
+				// different thing and is not fixed by this: command
+				// substitution strips every trailing newline from whatever
+				// it captures, `cat` included, before and after this change.)
+				// The human-facing surface is the default table format
+				// below, which still ends the body with a newline.
 				fmt.Print(item.Content)
 				return nil
 			}

--- a/cmd/pad/cmd_item.go
+++ b/cmd/pad/cmd_item.go
@@ -726,7 +726,18 @@ func showCmd() *cobra.Command {
 			}
 
 			if formatFlag == "markdown" {
-				fmt.Println(item.Content)
+				// The body is written VERBATIM — no trailing newline of our
+				// own (IDEA-2937). `--format markdown` is the machine-facing
+				// surface: agents and tools read a body here and write the
+				// same bytes back with `item update --stdin`, and the write
+				// path stores them exactly as sent. A `Println` here made
+				// that round trip append one newline per cycle, without
+				// bound, and made `$(...)` capture LOSE one instead, since
+				// command substitution strips every trailing newline. Both
+				// directions were this one line. The human-facing surface is
+				// the default table format below, which still ends the body
+				// with a newline.
+				fmt.Print(item.Content)
 				return nil
 			}
 

--- a/cmd/pad/format_markdown_routing_test.go
+++ b/cmd/pad/format_markdown_routing_test.go
@@ -59,6 +59,7 @@ func captureStdout(t *testing.T, fn func()) string {
 	fn()
 
 	_ = w.Close()
+	defer func() { _ = r.Close() }()
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(r); err != nil {
 		t.Fatalf("read captured stdout: %v", err)

--- a/cmd/pad/item_show_markdown_roundtrip_test.go
+++ b/cmd/pad/item_show_markdown_roundtrip_test.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// IDEA-2937: `pad item show <ref> --format markdown` is the machine-facing read
+// of an item body, and `pad item update <ref> --stdin` is the write. Together
+// they are the read-modify-write shape every agent and tool reaches for, so the
+// pair has to be a FIXED POINT: reading a body and writing those same bytes back
+// must leave the stored body byte-identical.
+//
+// It was not. `show` printed the body with fmt.Println, adding a newline the
+// stored body did not have, and the write path stores what it is sent verbatim
+// (measured against a live server: a body with no trailing newline, and one with
+// three, both stored exactly as sent). So each round trip grew the body by one
+// byte, without bound — 518, 519, 520, 521, 522 on the reporter's fixture — and
+// a `$(...)` capture LOST a byte instead, because command substitution strips
+// every trailing newline from what it captures.
+//
+// Both directions were the same missing byte-fidelity on the read side, which is
+// why these tests assert EQUALITY with the body rather than `strings.Contains`.
+
+func markdownShowBodies() map[string]string {
+	return map[string]string{
+		// The common case: a body that already ends with a newline. This is the
+		// one that grew unboundedly, because Println always added a second one.
+		"trailing newline": "line one\nline two\n",
+		// A body with NO trailing newline. This is what a `$(...)`-based tool
+		// writes back, so it is a real stored shape, not a synthetic one — and
+		// it is the case a "add a newline only when one is missing" fix would
+		// still get wrong.
+		"no trailing newline": "line one\nline two",
+		// Deliberate blank lines at the end of a body are content. Nothing on
+		// this path may normalize them away.
+		"several trailing newlines": "line one\n\n\n",
+		// A body that is only whitespace still round-trips as itself.
+		"newline only": "\n",
+		// An empty body emits nothing at all — not a bare newline.
+		"empty": "",
+	}
+}
+
+// The bytes `show --format markdown` writes to stdout must BE the stored body:
+// no prefix, no suffix, nothing added or removed.
+func TestItemShowMarkdown_EmitsBodyVerbatim(t *testing.T) {
+	for name, body := range markdownShowBodies() {
+		t.Run(name, func(t *testing.T) {
+			setupFormatRoutingTest(t, jsonHandler(t, map[string]any{
+				"/items/DOC-1": models.Item{Slug: "doc-1", Title: "a doc", Content: body},
+			}))
+			formatFlag = "markdown"
+
+			cmd := showCmd()
+			cmd.SetArgs([]string{"DOC-1"})
+
+			var execErr error
+			out := captureStdout(t, func() { execErr = cmd.Execute() })
+			if execErr != nil {
+				t.Fatalf("execute item show --format markdown: %v\noutput:\n%q", execErr, out)
+			}
+
+			if out != body {
+				t.Errorf("markdown output is not the stored body verbatim\n stored: %q\n emitted: %q\n delta: %+d bytes",
+					body, out, len(out)-len(body))
+			}
+		})
+	}
+}
+
+// The write half: `--stdin` must send exactly the bytes it was given. Paired
+// with the test above, this is the fixed point — what `show` emits is what
+// `update` sends, so a body survives any number of round trips unchanged.
+func TestItemUpdateStdin_SendsBodyVerbatim(t *testing.T) {
+	for name, body := range markdownShowBodies() {
+		t.Run(name, func(t *testing.T) {
+			var sent string
+			var seenPatch bool
+
+			setupFormatRoutingTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodPatch {
+					seenPatch = true
+					var payload struct {
+						Content *string `json:"content"`
+					}
+					if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+						t.Errorf("decode PATCH body: %v", err)
+					} else if payload.Content == nil {
+						t.Errorf("PATCH carried no content key")
+					} else {
+						sent = *payload.Content
+					}
+				}
+				_ = json.NewEncoder(w).Encode(models.Item{Slug: "doc-1", Title: "a doc", Content: body})
+			}))
+			formatFlag = "table"
+
+			restoreStdin := feedStdin(t, body)
+			defer restoreStdin()
+
+			cmd := updateCmd()
+			cmd.SetArgs([]string{"DOC-1", "--stdin"})
+
+			var execErr error
+			out := captureStdout(t, func() { execErr = cmd.Execute() })
+			if execErr != nil {
+				t.Fatalf("execute item update --stdin: %v\noutput:\n%s", execErr, out)
+			}
+			if !seenPatch {
+				t.Fatalf("no PATCH reached the server; output:\n%s", out)
+			}
+			if sent != body {
+				t.Errorf("--stdin did not send the body verbatim\n given: %q\n sent: %q\n delta: %+d bytes",
+					body, sent, len(sent)-len(body))
+			}
+		})
+	}
+}
+
+// feedStdin points os.Stdin at a pipe carrying s, and returns a restore func.
+// The update command reads os.Stdin directly (io.ReadAll), not cmd.InOrStdin,
+// so cobra's SetIn is not enough here — the same reason captureStdout swaps
+// os.Stdout rather than using SetOut.
+func feedStdin(t *testing.T, s string) func() {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	orig := os.Stdin
+	os.Stdin = r
+
+	go func() {
+		_, _ = io.Copy(w, strings.NewReader(s))
+		_ = w.Close()
+	}()
+
+	return func() { os.Stdin = orig }
+}

--- a/cmd/pad/item_show_markdown_roundtrip_test.go
+++ b/cmd/pad/item_show_markdown_roundtrip_test.go
@@ -143,5 +143,10 @@ func feedStdin(t *testing.T, s string) func() {
 		_ = w.Close()
 	}()
 
-	return func() { os.Stdin = orig }
+	return func() {
+		os.Stdin = orig
+		// Close the read end too, not just restore the swap: without this
+		// each subtest leaks a file descriptor (codex round 1).
+		_ = r.Close()
+	}
 }


### PR DESCRIPTION
`pad item show <ref> --format markdown` printed the body with `fmt.Println`, adding a trailing newline the stored body does not have. The write half sends what it is given and the server stores it verbatim, so read-modify-write — the shape every agent and tool reaches for — was not a fixed point: each cycle grew the body by one byte, without bound.

Reported on IDEA-2937 from the pad-mobile release lane; the lead hit the same shape editing a playbook body.

## Measured

Live, against the local server, writing back exactly what the previous read returned:

| | before | after |
| --- | --- | --- |
| seed stored | 18 B | 18 B |
| round 1 read | 19 B | 18 B |
| round 2 read | 20 B | 18 B |
| round 3 read | 21 B | 18 B |
| round 4 read | 22 B | 18 B |

After the fix all four reads are the same sha (`e9024f1a07d2`). The reporter's fixture grew 518 → 522 over the same four cycles.

The write path was measured too, and it is faithful in both directions already — a body with **no** trailing newline stores as 3 bytes, one with **three** trailing newlines stores as 6. So the whole defect was one line on the read side, and that is the only line changed.

## Scope: the `$()` loss is NOT this bug

The trail also records a *loss* (8931 bytes in, 8930 stored). That is command substitution, not us — `$()` strips every trailing newline from whatever it captures, and `C=$(cat file)` on the same 18-byte file yields 17 too. It behaves identically before and after this change. A tool that needs a lossless read must redirect or pipe rather than capture. Whether the server should normalize a stored body to end in exactly one newline — which would make even the `$()` path a fixed point, at the cost of destroying deliberate blank lines at the end of a body — is a separate question left on the trail for a ruling.

## Why verbatim rather than "add a newline only if one is missing"

The conditional form is a fixed point only for bodies that already end in a newline. Bodies that do not are a real stored shape — they are exactly what a `$()`-based tool writes back — so the conditional form would still corrupt the population that hit this. `--format markdown` is the machine-facing surface; the human-facing one is the default table format, which still ends the body with a newline and is unchanged.

## Class sweep

Five sites print an item/convention/playbook body with `fmt.Println`. Only one emits the body **as the entire output** and is therefore a round-trippable read: `item show --format markdown`. The other four decorate — `cmd_playbook.go:121` prepends `# REF: Title`, the two `cmd_library.go` sites print a header block and separators, and `cmd_item.go:754` is the human table format. Decorated output is not a write-back surface, so none of them carries this property. `internal/mcp/resources.go` composes item markdown from `--format json` and its comment ("prints only the body content") stays true — more exactly true than before.

## Tests

Both halves assert **equality** with the body, not `Contains`, over five bodies (trailing newline, none, several, newline-only, empty):

- `TestItemShowMarkdown_EmitsBodyVerbatim` — what `show` writes to stdout IS the stored body.
- `TestItemUpdateStdin_SendsBodyVerbatim` — what `--stdin` puts on the wire IS the bytes it was given.

Together they are the fixed point at the CLI boundary, given the server faithfulness measured above.

Both were run against the defect. Restoring the `Println` fails all five `show` subtests; a `TrimRight` on the stdin read fails three `update` subtests. Each mutant was confirmed to BUILD first, so neither green came from a non-compiling tree.

## Gates

- `go test ./...` — exit 0
- `make lint` — 0 issues
- `gofmt -l` — clean
- Web legs not run and not applicable: no web file is touched, and this worktree has no `node_modules` (the `npm ci` targets are the ones CLAUDE.md forbids here). `web/build` was copied in per CONVE-2729.

https://claude.ai/code/session_01HeChkgZVYb3NTgTcckF5KR

---

## Review and final gates (added after the first push)

Three commits: `8d8ac554` the fix and its tests, `01ad6493` and `8538e9b4` the two codex remarks.

Codex CLI, three rounds, all CLEAN:

- **Round 1** — CLEAN with two remarks, both real and both fixed in `01ad6493`: `feedStdin` restored `os.Stdin` without closing the pipe read end (one leaked descriptor per subtest), and the code comment still claimed the `$()` byte loss as this defect. The commit message had already been corrected on that point; the comment had not, and the comment is what the next reader has.
- **Round 2** — CLEAN with one nit on a pre-existing helper (`captureStdout` never closed its read end either), fixed in `8538e9b4` because these tests call it ten times.
- **Round 3** — CLEAN on the final tree, asked only whether that close is safely ordered and whether it changes any existing test.

Gates re-run on `8538e9b4`, the tree as it now stands, not on the first commit:

- `go test ./...` — exit 0
- `make lint` — 0 issues
- `go test ./cmd/pad/ -race` — exit 0
- `gofmt -l` — clean

## Filed, not fixed here

`pad item update <ref> --parent ""` reports success and does not detach — the other finding on IDEA-2937's trail. Different mechanism (`hasFieldChanges` tests `parentRef != ""`, so the key never reaches the server), and the public CLI docs still teach that route. BUG-2941.
