### PR TITLE
fix(web): a tab may only write to the durable cache under the scope that cache advertises (TASK-2922)

### DIFF
--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -1879,7 +1879,19 @@ export const localIndex = {
 		localSearch.upsert(ws, next);
 		// Write-through to IDB. Fire-and-forget; storage failures
 		// degrade silently.
-		persistUpserts(state.userId, ws, [next]).catch(() => undefined);
+		//
+		// The epoch names the scope THIS TAB believes it holds (TASK-2922), and
+		// the durable cache refuses the batch when it disagrees. The three
+		// guards above are all session-local — `scopeEpoch` bumps only when THIS
+		// tab resyncs, `fencedIds` is recomputed only by THIS tab's resync, and
+		// `movedOutFloor` records only evictions THIS tab consumed — so none of
+		// them can see a scope change another tab learned about. That is the gap
+		// the argument closes, and it closes it at the shared resource rather
+		// than by trying to teach this tab something it has not been told.
+		//
+		// RAM is already written above, deliberately: a refusal defers the
+		// durable copy by one poll, it does not discard the row.
+		persistUpserts(state.userId, ws, [next], state.accessEpoch).catch(() => undefined);
 	},
 
 	/**

--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -1889,8 +1889,11 @@ export const localIndex = {
 		// the argument closes, and it closes it at the shared resource rather
 		// than by trying to teach this tab something it has not been told.
 		//
-		// RAM is already written above, deliberately: a refusal defers the
-		// durable copy by one poll, it does not discard the row.
+		// RAM is already written above, deliberately. A refusal defers the
+		// durable copy and never discards the row: everything reaching this
+		// call is server truth, so any later snapshot, delta or cold boot
+		// re-supplies it. See persistUpserts' own note for why provenance
+		// rather than the next poll is what makes that safe.
 		persistUpserts(state.userId, ws, [next], state.accessEpoch).catch(() => undefined);
 	},
 

--- a/web/src/lib/stores/localIndexAccessEpochWiring.svelte.test.ts
+++ b/web/src/lib/stores/localIndexAccessEpochWiring.svelte.test.ts
@@ -522,6 +522,64 @@ describe('TASK-2922 — what an optimistic upsert hands on', () => {
 		expect(second).toBe('e2');
 	});
 
+	/**
+	 * THE REPAIR PATHS, enumerated rather than sampled (CONVE-18).
+	 *
+	 * Rounds 2 and 3 both attacked the same claim — that a refused durable write
+	 * is always re-supplied — from different directions, which is a reviewer
+	 * sampling a population I had not written down. The population is small, so
+	 * here it is in full, with the leg that pins each:
+	 *
+	 *   1. A later delta CARRIES the row → pinned in
+	 *      localIndexScopeWriteFence.idb.test.ts.
+	 *   2. A later delta's change for that id is STALE or EQUAL, so RAM wins and
+	 *      the change itself is not written → `applyDelta` still pushes the
+	 *      EXISTING row into the persist set, precisely so the cursor it is
+	 *      about to advance cannot lap a row whose write may not have landed.
+	 *      Pinned below. (That guard predates this unit and was added for the
+	 *      same hazard in its fire-and-forget costume; the epoch refusal is a
+	 *      new way to reach it, not a new hole.)
+	 *   3. A later delta's change is at or below the cursor FLOOR, where
+	 *      `applyDelta` skips it entirely. Unreachable for the case at hand and
+	 *      no leg is owed: the row was refused because a MUTATION just produced
+	 *      it, so its seq is the newest in the workspace and is above this tab's
+	 *      cursor by construction, and deltas are contiguous in seq from that
+	 *      cursor, so no batch can advance past the row without containing it.
+	 *   4. A RESYNC → `persistReplace` writes the SERVER's snapshot, so the row
+	 *      returns if and only if it is still in scope, which is the correct
+	 *      answer either way. Deliberately NO leg: the RAM copy plays no part
+	 *      here, so any test I could write would assert that a snapshot I
+	 *      handed the mock came back out of it — true for every build, fixed or
+	 *      broken. The first draft of this file had exactly that leg. What the
+	 *      resync does with the snapshot is pinned by the `persistReplace`
+	 *      tests above.
+	 *   5. A cold boot → `/items-index` persists the post-merge snapshot. Covered
+	 *      by the bootstrap tests already in this file.
+	 */
+	it('a delta that does NOT carry the refused row still persists it, so the cursor cannot lap it', async () => {
+		await bootUnder('e1', [row('seed', 1, 'kept')]);
+		// The mutation response the durable cache refused. RAM holds it at seq 9.
+		localIndex.upsert(ws, row('mine', 9, 'kept'));
+		persistence.persistDelta.mockClear();
+
+		// A later delta whose change for that id is STALE — RAM wins, so nothing
+		// about the change is written — while the cursor advances well past it.
+		localIndex.applyDelta(
+			ws,
+			[
+				{ id: 'mine', seq: 8, collection_slug: 'kept' },
+				{ id: 'other', seq: 20, collection_slug: 'kept' },
+			] as never,
+			'20',
+			false,
+		);
+
+		const args = persistence.persistDelta.mock.calls.at(-1) as unknown[];
+		const persisted = (args[2] as ItemIndexRow[]).map((r) => r.id);
+		expect(persisted).toContain('mine');
+		expect(args[3]).toBe('20');
+	});
+
 	it('DEFERRED, NOT LOST — RAM keeps the row the durable cache refuses', async () => {
 		// The cost the fence takes deliberately. `upsert` writes RAM and the
 		// search index BEFORE it calls persistence, so a behind tab keeps

--- a/web/src/lib/stores/localIndexAccessEpochWiring.svelte.test.ts
+++ b/web/src/lib/stores/localIndexAccessEpochWiring.svelte.test.ts
@@ -463,3 +463,85 @@ describe('IDEA-2898 — what the resync hands on', () => {
 		expect(args[5]).toBe(localIndex.accessEpochFor(ws));
 	});
 });
+
+describe('TASK-2922 — what an optimistic upsert hands on', () => {
+	/**
+	 * Acquire a baseline the way a real session does — through a cold bootstrap
+	 * whose snapshot carries the epoch that describes it. Calling
+	 * `ensureAccessScope` on a never-bootstrapped workspace does NOT adopt: the
+	 * silent adopt is gated on the durable cache having answered (`cacheRead`),
+	 * so it returns with the baseline still null and every argument assertion
+	 * below would read `null` and pass for the wrong reason.
+	 */
+	async function bootUnder(epoch: string, rows: ItemIndexRow[]): Promise<void> {
+		vi.spyOn(api.items, 'listIndex').mockResolvedValueOnce({
+			items: rows,
+			total: rows.length,
+			cursor: String(rows.length),
+			includes_unparented_metadata: false,
+			access_epoch: epoch,
+		});
+		await localIndex.bootstrap(ws, { userId: null });
+	}
+
+	it('names the scope THIS TAB believes it holds, so the cache can contradict it', async () => {
+		// The fence itself is at the callee, pinned against a real database in
+		// localIndexScopeWriteFence.idb.test.ts. What cannot be seen there is
+		// whether the caller supplies the value — and a wrong or absent argument
+		// is silent in jsdom, where persistence is a no-op. So: assert the
+		// argument, per CONVE-19.
+		await bootUnder('e1', [row('seed', 1, 'kept')]);
+		persistence.persistUpserts.mockClear();
+
+		localIndex.upsert(ws, row('a', 2, 'kept'));
+
+		const args = persistence.persistUpserts.mock.calls.at(-1) as unknown[];
+		expect(args[3]).toBe('e1');
+		expect(args[3]).toBe(localIndex.accessEpochFor(ws));
+	});
+
+	it('CONTROL — the argument TRACKS the belief rather than being a fixed value', async () => {
+		// Without this leg the assertion above passes against a caller that
+		// hard-codes any single epoch, or that reads a copy captured once.
+		await bootUnder('e1', [row('seed', 1, 'kept')]);
+		localIndex.upsert(ws, row('a', 2, 'kept'));
+		const first = (persistence.persistUpserts.mock.calls.at(-1) as unknown[])[3];
+
+		vi.spyOn(api.items, 'listIndex').mockResolvedValueOnce({
+			items: [row('seed', 1, 'kept')],
+			total: 1,
+			cursor: '1',
+			includes_unparented_metadata: false,
+			access_epoch: 'e2',
+		});
+		await localIndex.ensureAccessScope(ws, 'e2');
+		localIndex.upsert(ws, row('b', 3, 'kept'));
+		const second = (persistence.persistUpserts.mock.calls.at(-1) as unknown[])[3];
+
+		expect(first).toBe('e1');
+		expect(second).toBe('e2');
+	});
+
+	it('DEFERRED, NOT LOST — RAM keeps the row the durable cache refuses', async () => {
+		// The cost the fence takes deliberately. `upsert` writes RAM and the
+		// search index BEFORE it calls persistence, so a behind tab keeps
+		// serving its own row for the whole window; only the shared durable copy
+		// waits. Asserting the ORDER rather than just the end state, because a
+		// refactor that moved the persist ahead of the RAM write would turn a
+		// deferral into a loss and nothing else here would notice.
+		await bootUnder('e1', [row('seed', 1, 'kept')]);
+		persistence.persistUpserts.mockClear();
+
+		let ramHadRowAtPersistTime = false;
+		persistence.persistUpserts.mockImplementationOnce(async () => {
+			ramHadRowAtPersistTime = localIndex
+				.getByCollection(ws, 'kept')
+				.some((r) => r.id === 'local');
+			return undefined;
+		});
+		localIndex.upsert(ws, row('local', 5, 'kept'));
+
+		expect(ramHadRowAtPersistTime).toBe(true);
+		expect(localIndex.getByCollection(ws, 'kept').map((r) => r.id)).toContain('local');
+	});
+});

--- a/web/src/lib/stores/localIndexPersistence.idb.test.ts
+++ b/web/src/lib/stores/localIndexPersistence.idb.test.ts
@@ -34,7 +34,7 @@ describe('BUG-2609 end-to-end: stale snapshot does not clobber a newer persisted
 		await persistDelta(U, WS, [row('x', 7)], 'cursor-7', false, null);
 		// 2) The stale RAM snapshot (older seq) lands LAST — the fire-and-forget
 		//    upsert that BUG-2609's evidence run captured mid-flight.
-		await persistUpserts(U, WS, [row('x', 5)]);
+		await persistUpserts(U, WS, [row('x', 5)], null);
 
 		// The seq guard refused the stale write: IDB still holds seq 7...
 		expect((await rawItem(U, WS, 'x'))?.seq).toBe(7);
@@ -53,7 +53,7 @@ describe('BUG-2609 end-to-end: stale snapshot does not clobber a newer persisted
 		const WS = 'ws-2609-asym';
 
 		await persistDelta(U, WS, [row('x', 7)], 'cursor-7', false, null);
-		await persistUpserts(U, WS, [row('x', undefined)]); // seq-less snapshot lands last
+		await persistUpserts(U, WS, [row('x', undefined)], null); // seq-less snapshot lands last
 
 		expect((await rawItem(U, WS, 'x'))?.seq).toBe(7);
 		expect((await hydrate(U, WS)).items.find((i) => i.id === 'x')?.seq).toBe(7);
@@ -64,8 +64,8 @@ describe('BUG-2609 end-to-end: stale snapshot does not clobber a newer persisted
 		const U = null;
 		const WS = 'ws-2609-fwd';
 
-		await persistUpserts(U, WS, [row('x', 5)]);
-		await persistUpserts(U, WS, [row('x', 8)]); // newer — must land
+		await persistUpserts(U, WS, [row('x', 5)], null);
+		await persistUpserts(U, WS, [row('x', 8)], null); // newer — must land
 
 		expect((await rawItem(U, WS, 'x'))?.seq).toBe(8);
 		expect((await hydrate(U, WS)).items.find((i) => i.id === 'x')?.seq).toBe(8);
@@ -132,7 +132,7 @@ describe('database naming', () => {
 		// assertion above would pass for the wrong reason. Persist through the
 		// module, then read the raw store under the harness name directly.
 		const { persistUpserts } = await loadPersistence();
-		await persistUpserts('user-42', 'My WS', [row('y', 1)]);
+		await persistUpserts('user-42', 'My WS', [row('y', 1)], null);
 
 		const dbNameShouldBe = harnessDbName('user-42', 'My WS');
 		expect(dbNameShouldBe).toBe(

--- a/web/src/lib/stores/localIndexPersistence.ts
+++ b/web/src/lib/stores/localIndexPersistence.ts
@@ -479,19 +479,81 @@ export async function hydrate(
  * `applyDelta`/`bootstrap` write-through. Batching matters when an
  * SSE flurry arrives — a single tx is much cheaper than N
  * one-shot puts.
+ *
+ * THE WRITER NAMES THE SCOPE IT BELIEVES IT HOLDS (TASK-2922, PLAN-2903 item
+ * 1), and a batch whose belief the cache contradicts writes NOTHING. This was
+ * the one durable door with no check of any kind, and it is the door a tab that
+ * has NOT learned about a scope change reaches the shared cache through — the
+ * other two writers already refuse or repair such a batch, in different ways
+ * and for different reasons:
+ *
+ *   - `persistReplace` is the resync itself, so it defines the scope rather
+ *     than claiming one.
+ *   - `persistDelta` carries or states an epoch alongside its rows, so a batch
+ *     from a behind tab drags the durable epoch BACK to that tab's older value.
+ *     The cache then DISAGREES with the server's next response, and that
+ *     disagreement is what triggers the repair. It self-heals.
+ *
+ * `persistUpserts` writes no meta row, and that is exactly why it needed this.
+ * Without the check, a stale row from a behind tab lands under the epoch the
+ * RESYNC stamped: the cache advertises the new scope over a row fetched under
+ * the old one, `ensureAccessScope` compares equal on every future poll AND
+ * every future cold boot, and nothing re-fires until the next access change. A
+ * permission-revoked row is then durable indefinitely.
+ *
+ * WHY THIS IS AN EQUALITY TEST AND NOT AN ORDERING ONE. An `access_epoch` is a
+ * hash of the live grant set; it can answer "same or different" and nothing
+ * else. PLAN-2903's working rule asks each unit to name whether the values its
+ * fence compares are orderable, and these are NOT — so this fence never says
+ * "older", "stale" or "behind", and cannot become an ordering claim wearing an
+ * equality costume, which is what defeated the fences on IDEA-2898's abandoned
+ * branch. Both sides are epochs; the only operator is `!==`.
+ *
+ * DEFERRED, NEVER LOST. A behind tab's optimistic upsert is dropped from the
+ * DURABLE cache until that tab resyncs — `localIndex.upsert` has already
+ * written RAM and the search index before it calls this, so the writing session
+ * sees its own row throughout, and its next `/items-changes` response carries
+ * the epoch it does not hold, which routes through `ensureAccessScope` into a
+ * resync whose snapshot re-includes the row. The write is delayed by one poll,
+ * not discarded. That is the trade this takes deliberately: a tab that cannot
+ * say what scope it holds has no business writing into a cache another tab
+ * reads.
+ *
+ * A cache with NO meta row is written normally. There is no scope claim on disk
+ * for the batch to contradict, and minting one here would invent a cursor — the
+ * same reason `persistAccessEpoch` declines to create the row.
  */
 export async function persistUpserts(
 	userId: string | null,
 	ws: string,
 	rows: ItemIndexRow[],
+	/**
+	 * The access epoch the WRITER believes describes the rows it is handing
+	 * over — `localIndex.upsert` passes `state.accessEpoch`. Required rather
+	 * than optional, so the type checker is what keeps a future call site from
+	 * skipping the guard by saying nothing; an optional parameter would make
+	 * the quiet call the unguarded one. `null` is a real value here, not an
+	 * absence: it is what a server that predates `access_epoch` produces, and
+	 * it matches the `null` such a server's deltas persist.
+	 */
+	expectedEpoch: string | null,
 ): Promise<void> {
 	if (!isSupported() || rows.length === 0) return;
 	const db = await open(userId, ws);
 	if (!db) return;
 	try {
-		const tx = db.transaction(['items', 'tombstones'], 'readwrite');
+		const tx = db.transaction(['items', 'meta', 'tombstones'], 'readwrite');
 		const itemsStore = tx.objectStore('items');
 		const tombstones = tx.objectStore('tombstones');
+		// Read BEFORE any write is issued in this transaction, so a contradicted
+		// batch lands nothing at all — the same shape as the cursor gate in
+		// `persistDelta`, and for the same reason: a partial refusal would leave
+		// the cache in a state neither writer describes.
+		const storedMeta = await readSyncRow(tx.objectStore('meta'));
+		if (storedMeta && (storedMeta.accessEpoch ?? null) !== expectedEpoch) {
+			await tx.done.catch(() => undefined);
+			return;
+		}
 		for (const row of rows) {
 			const stored = (await itemsStore.get(row.id)) as ItemIndexRow | undefined;
 			const tombstone = (await tombstones.get(row.id)) as TombstoneRow | undefined;
@@ -713,17 +775,23 @@ export async function persistDelta(
  * connection sidesteps that — the clear and the puts commit together (or not
  * at all), and no connection is ever torn down.
  *
- * RESIDUAL (codex F2, lead-accepted). Clearing `tombstones` for ids the
- * snapshot omits reopens, for those ids, the cross-tab resurrection window a
- * tombstone otherwise closes: a stale `persistUpserts` from ANOTHER tab — one
- * that did not run this resync, so its RAM `fencedIds` does not cover the id —
- * can land after the clear and reinsert an omitted row behind the replacement
- * cursor. This is PRE-EXISTING to the item-clear below: before unit 2 the same
- * tab could resurrect the same row with no tombstone in the picture at all, so
- * tombstones only ever ADDED protection and this clear does not widen the
- * hazard. Within one tab the `fencedIds` guard refuses the stale upsert before
- * it reaches persistence. Self-healing: the next resync recomputes the fence
- * and re-drops the row. Not worth a key-diff in this tx to close.
+ * THE F2 RESIDUAL THIS NOTE USED TO RECORD IS CLOSED, and closed somewhere
+ * else (TASK-2922). Clearing `tombstones` for ids the snapshot omits does
+ * reopen, for those ids, the cross-tab resurrection window a tombstone
+ * otherwise closes: a stale `persistUpserts` from ANOTHER tab — one that did
+ * not run this resync, so its RAM `fencedIds` does not cover the id — could
+ * land after the clear and reinsert an omitted row behind the replacement
+ * cursor. The acceptance rested on that being self-healing, "the next resync
+ * recomputes the fence and re-drops the row", and the premise is false in the
+ * case that matters: the repair belongs to the tab that made the stale write,
+ * so a tab that goes away after its write commits — closed, frozen, discarded —
+ * takes the repair with it, and the row stays durable under an epoch the server
+ * agrees with. What closes it is the epoch check in `persistUpserts`, which
+ * refuses the write at its own door rather than teaching this transaction to
+ * diff keys. A tombstone is SEQ evidence and the thing being refused is a SCOPE
+ * fact; the key-diff fits the reachable case by coincidence of ordering, and
+ * cannot refuse a genuinely newer row the writing tab could still see under the
+ * old scope. So the clear below stays exactly as it was.
  */
 export async function persistReplace(
 	userId: string | null,

--- a/web/src/lib/stores/localIndexPersistence.ts
+++ b/web/src/lib/stores/localIndexPersistence.ts
@@ -509,15 +509,29 @@ export async function hydrate(
  * equality costume, which is what defeated the fences on IDEA-2898's abandoned
  * branch. Both sides are epochs; the only operator is `!==`.
  *
- * DEFERRED, NEVER LOST. A behind tab's optimistic upsert is dropped from the
- * DURABLE cache until that tab resyncs — `localIndex.upsert` has already
- * written RAM and the search index before it calls this, so the writing session
- * sees its own row throughout, and its next `/items-changes` response carries
- * the epoch it does not hold, which routes through `ensureAccessScope` into a
- * resync whose snapshot re-includes the row. The write is delayed by one poll,
- * not discarded. That is the trade this takes deliberately: a tab that cannot
- * say what scope it holds has no business writing into a cache another tab
- * reads.
+ * DEFERRED, NEVER LOST — and the reason is PROVENANCE, not scheduling. A
+ * behind tab's optimistic upsert is dropped from the DURABLE cache until that
+ * tab resyncs, and `localIndex.upsert` has already written RAM and the search
+ * index before it calls this, so the writing session keeps serving its own row
+ * throughout. What makes the drop safe is that every row reaching this door is
+ * SERVER TRUTH — a mutation response, an SSE-derived row, or on the
+ * drag-reorder path a seq-less optimistic guess the authoritative response
+ * supersedes moments later — so the durable copy is a CACHE of something the
+ * server still holds. Any later snapshot, any later delta from this tab's
+ * cursor (which this door never advances, so a refused mutation stays inside
+ * the next window), and every cold boot re-supply it.
+ *
+ * The first draft of this paragraph gave the repair as "the tab's next
+ * `/items-changes`". That is true whenever one happens and it is NOT
+ * guaranteed: reconciles are SSE-driven rather than timed, so a quiet
+ * workspace whose SSE connection has dropped may not poll again in that
+ * session (codex round 2 P1). The correction matters because the two
+ * statements bound different things — the poll bounds how long the durable
+ * cache LAGS, and provenance is what says no row is ever at RISK. Only the
+ * second is load-bearing, and it was the one I had not written down.
+ *
+ * That is the trade this takes deliberately: a tab that cannot say what scope
+ * it holds has no business writing into a cache another tab reads.
  *
  * A cache with NO meta row is written normally. There is no scope claim on disk
  * for the batch to contradict, and minting one here would invent a cursor — the

--- a/web/src/lib/stores/localIndexPersistence.unit2.idb.test.ts
+++ b/web/src/lib/stores/localIndexPersistence.unit2.idb.test.ts
@@ -43,11 +43,11 @@ describe('BUG-2633 — tombstones stop a stale snapshot resurrecting an evicted 
 		const U = null;
 		const WS = 'ws-2633-evict';
 
-		await persistUpserts(U, WS, [row('x', 5)]);
+		await persistUpserts(U, WS, [row('x', 5)], null);
 		// A delta evicts x (moved-out) and advances the cursor to 10 — atomic.
 		await persistDelta(U, WS, [], '10', false, null, ['x']);
 		// The stale RAM snapshot for x (seq 5, behind the cursor) lands last.
-		await persistUpserts(U, WS, [row('x', 5)]);
+		await persistUpserts(U, WS, [row('x', 5)], null);
 
 		expect(await rawItem(U, WS, 'x')).toBeUndefined();
 		expect((await hydrate(U, WS)).items.find((i) => i.id === 'x')).toBeUndefined();
@@ -60,9 +60,9 @@ describe('BUG-2633 — tombstones stop a stale snapshot resurrecting an evicted 
 		const U = null;
 		const WS = 'ws-2633-seqless';
 
-		await persistUpserts(U, WS, [row('x', 5)]);
+		await persistUpserts(U, WS, [row('x', 5)], null);
 		await persistDelta(U, WS, [], '10', false, null, ['x']);
-		await persistUpserts(U, WS, [row('x', undefined)]); // optimistic seq-less snapshot
+		await persistUpserts(U, WS, [row('x', undefined)], null); // optimistic seq-less snapshot
 
 		expect(await rawItem(U, WS, 'x')).toBeUndefined();
 	});
@@ -72,9 +72,9 @@ describe('BUG-2633 — tombstones stop a stale snapshot resurrecting an evicted 
 		const U = null;
 		const WS = 'ws-2633-supersede';
 
-		await persistUpserts(U, WS, [row('x', 5)]);
+		await persistUpserts(U, WS, [row('x', 5)], null);
 		await persistDelta(U, WS, [], '10', false, null, ['x']); // tombstone x @ 10
-		await persistUpserts(U, WS, [row('x', 11)]); // newer than the tombstone
+		await persistUpserts(U, WS, [row('x', 11)], null); // newer than the tombstone
 
 		expect((await rawItem(U, WS, 'x'))?.seq).toBe(11);
 		expect(await rawTombstone(U, WS, 'x')).toBeUndefined(); // supersession cleared it
@@ -91,7 +91,7 @@ describe('BUG-2633 — tombstones stop a stale snapshot resurrecting an evicted 
 
 		expect((await rawTombstone(U, WS, 'y'))?.deletedAtSeq).toBe(20);
 		// An in-flight stale upsert behind that cursor cannot bring y back.
-		await persistUpserts(U, WS, [row('y', 15)]);
+		await persistUpserts(U, WS, [row('y', 15)], null);
 		expect(await rawItem(U, WS, 'y')).toBeUndefined();
 	});
 
@@ -102,17 +102,17 @@ describe('BUG-2633 — tombstones stop a stale snapshot resurrecting an evicted 
 
 		// A row is optimistically upserted before any sync writes meta.sync, then
 		// removed. With no persisted cursor the tombstone stamps the row's own seq.
-		await persistUpserts(U, WS, [row('z', 5)]);
+		await persistUpserts(U, WS, [row('z', 5)], null);
 		await persistRemovals(U, WS, ['z']);
 		expect((await rawTombstone(U, WS, 'z'))?.deletedAtSeq).toBe(5);
 
 		// A delayed stale snapshot of the same row cannot bring it back...
-		await persistUpserts(U, WS, [row('z', 5)]);
+		await persistUpserts(U, WS, [row('z', 5)], null);
 		expect(await rawItem(U, WS, 'z')).toBeUndefined();
 		expect((await hydrate(U, WS)).items.find((i) => i.id === 'z')).toBeUndefined();
 
 		// ...but a genuinely newer create still supersedes the tombstone.
-		await persistUpserts(U, WS, [row('z', 9)]);
+		await persistUpserts(U, WS, [row('z', 9)], null);
 		expect((await rawItem(U, WS, 'z'))?.seq).toBe(9);
 	});
 
@@ -121,14 +121,14 @@ describe('BUG-2633 — tombstones stop a stale snapshot resurrecting an evicted 
 		const U = null;
 		const WS = 'ws-2633-f4';
 
-		await persistUpserts(U, WS, [row('x', 5)]);
+		await persistUpserts(U, WS, [row('x', 5)], null);
 		await persistDelta(U, WS, [], '20', false, null, ['x']); // tombstone x @ 20
 		// An out-of-order lower-cursor eviction for the same id must not lower it.
 		await persistDelta(U, WS, [], '10', false, null, ['x']);
 		expect((await rawTombstone(U, WS, 'x'))?.deletedAtSeq).toBe(20);
 
 		// A snapshot at a seq between the two stamps is still refused.
-		await persistUpserts(U, WS, [row('x', 15)]);
+		await persistUpserts(U, WS, [row('x', 15)], null);
 		expect(await rawItem(U, WS, 'x')).toBeUndefined();
 	});
 });
@@ -143,7 +143,7 @@ describe('BUG-2634 — durable retag overlay survives a racing delta and a reloa
 		const U = null;
 		const WS = 'ws-2634-race';
 
-		await persistUpserts(U, WS, [collRow('a1', 1, 'coll-a', 'old-a')]);
+		await persistUpserts(U, WS, [collRow('a1', 1, 'coll-a', 'old-a')], null);
 		// Collection renamed old-a → new-a: rows rewritten in place + overlay persisted.
 		await persistRetag(U, WS, 'coll-a', ['a1'], 'new-a');
 		expect((await rawItem(U, WS, 'a1'))?.collection_slug).toBe('new-a');
@@ -165,7 +165,7 @@ describe('BUG-2634 — durable retag overlay survives a racing delta and a reloa
 		const U = null;
 		const WS = 'ws-2634-moved';
 
-		await persistUpserts(U, WS, [collRow('a1', 1, 'coll-a', 'old-a')]);
+		await persistUpserts(U, WS, [collRow('a1', 1, 'coll-a', 'old-a')], null);
 		// Rename coll-a → new-a: a1 rewritten in place + overlay persisted.
 		await persistRetag(U, WS, 'coll-a', ['a1'], 'new-a');
 		// a1 then genuinely MOVES to coll-b via an authoritative delta at a newer seq.
@@ -186,7 +186,7 @@ describe('BUG-2634 — durable retag overlay survives a racing delta and a reloa
 		const U = null;
 		const WS = 'ws-2634-latest';
 
-		await persistUpserts(U, WS, [collRow('a1', 1, 'coll-a', 'v0')]);
+		await persistUpserts(U, WS, [collRow('a1', 1, 'coll-a', 'v0')], null);
 		await persistRetag(U, WS, 'coll-a', ['a1'], 'v1');
 		await persistRetag(U, WS, 'coll-a', ['a1'], 'v2');
 		expect(await rawRetags(U, WS)).toEqual({ 'coll-a': 'v2' });
@@ -197,7 +197,7 @@ describe('BUG-2634 — durable retag overlay survives a racing delta and a reloa
 		const U = null;
 		const WS = 'ws-2634-replace';
 
-		await persistUpserts(U, WS, [collRow('a1', 1, 'coll-a', 'old-a')]);
+		await persistUpserts(U, WS, [collRow('a1', 1, 'coll-a', 'old-a')], null);
 		await persistRetag(U, WS, 'coll-a', ['a1'], 'new-a');
 		expect(await rawRetags(U, WS)).toEqual({ 'coll-a': 'new-a' });
 
@@ -218,11 +218,11 @@ describe('BUG-2635 — equal-seq merge keeps a merged projection cross-tab', () 
 		const WS = 'ws-2635-merge';
 
 		// Tab B has the merged row: is_unparented projected in at seq 7.
-		await persistUpserts(U, WS, [row('x', 7, { is_unparented: true })]);
+		await persistUpserts(U, WS, [row('x', 7, { is_unparented: true })], null);
 		// Tab A holds a stale RAM snapshot at the SAME seq that never merged the
 		// projection, and persists it. Under the old blind-accept-at-equal-seq it
 		// would drop is_unparented; the merge refuses it.
-		await persistUpserts(U, WS, [row('x', 7)]);
+		await persistUpserts(U, WS, [row('x', 7)], null);
 
 		expect((await rawItem(U, WS, 'x'))?.is_unparented).toBe(true);
 	});
@@ -232,8 +232,8 @@ describe('BUG-2635 — equal-seq merge keeps a merged projection cross-tab', () 
 		const U = null;
 		const WS = 'ws-2635-preserve';
 
-		await persistUpserts(U, WS, [row('x', 5, { is_unparented: true })]);
-		await persistUpserts(U, WS, [row('x', 8)]); // mutation snapshot omits the projection
+		await persistUpserts(U, WS, [row('x', 5, { is_unparented: true })], null);
+		await persistUpserts(U, WS, [row('x', 8)], null); // mutation snapshot omits the projection
 
 		const stored = await rawItem(U, WS, 'x');
 		expect(stored?.seq).toBe(8);
@@ -247,7 +247,7 @@ describe('persistReplace clears the tombstone store too', () => {
 		const U = null;
 		const WS = 'ws-replace-tombstones';
 
-		await persistUpserts(U, WS, [row('x', 5)]);
+		await persistUpserts(U, WS, [row('x', 5)], null);
 		await persistDelta(U, WS, [], '10', false, null, ['x']); // tombstone x
 		expect(await rawTombstones(U, WS)).toHaveLength(1);
 
@@ -275,7 +275,7 @@ describe('v1 → v2 migration through the real module', () => {
 		// The module opens at IDB_FORMAT_VERSION (2) → upgrade runs, tombstones
 		// store is created, existing data retained.
 		const { persistUpserts, hydrate } = await loadPersistence();
-		await persistUpserts(U, WS, [row('fresh', 4)]);
+		await persistUpserts(U, WS, [row('fresh', 4)], null);
 
 		expect((await rawItem(U, WS, 'keep'))?.seq).toBe(3); // survived the format bump
 		expect(await rawTombstones(U, WS)).toHaveLength(0); // new store, empty
@@ -293,9 +293,12 @@ describe('raw readers address the module database', () => {
 		const U = 'user-9';
 		const WS = 'Name With Spaces';
 
-		await persistUpserts(U, WS, [
-			{ id: 'r', seq: 1, collection_id: 'c', collection_slug: 's' } as unknown as ItemIndexRow,
-		]);
+		await persistUpserts(
+			U,
+			WS,
+			[{ id: 'r', seq: 1, collection_id: 'c', collection_slug: 's' } as unknown as ItemIndexRow],
+			null,
+		);
 		await persistRetag(U, WS, 'c', ['r'], 's2');
 		await persistDelta(U, WS, [], '9', false, null, ['r']);
 

--- a/web/src/lib/stores/localIndexPersistenceAccessEpoch.idb.test.ts
+++ b/web/src/lib/stores/localIndexPersistenceAccessEpoch.idb.test.ts
@@ -19,7 +19,9 @@ import { loadPersistence, openSecondConnection, harnessDbName } from '../../test
  * SCOPE. This file covers only what the minimal shape ships. The cross-tab
  * hazard — a write from a tab that has not yet learned the new scope
  * reinserting a row while the cache still advertises the current epoch — is
- * NOT closed here and is not meant to be; it is F2, and PLAN-2903 owns it.
+ * NOT closed here and is not meant to be; it is F2, and PLAN-2903 owned it.
+ * It is closed now, by the epoch check `persistUpserts` applies to its own
+ * batch, and pinned in localIndexScopeWriteFence.idb.test.ts (TASK-2922).
  */
 
 function row(id: string, seq: number): ItemIndexRow {

--- a/web/src/lib/stores/localIndexScopeWriteFence.idb.test.ts
+++ b/web/src/lib/stores/localIndexScopeWriteFence.idb.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from "vitest";
+import type { ItemIndexRow } from "$lib/types";
+import { loadPersistence, rawItems } from "../../test/idbHarness";
+
+/**
+ * TASK-2922 / PLAN-2903 item 1 — F2: a cache that holds old-scope rows while
+ * advertising the new epoch.
+ *
+ * THE ROUTE, and the ordering is the whole thing. A write that commits BEFORE
+ * the resync is superseded by `persistReplace`'s clear and needs no fence (the
+ * last leg here pins that). The hazard is the write that lands AFTER: a tab
+ * that has not learned about the scope change has none of the RAM-local guards
+ * that would stop it — `scopeEpoch` never bumped there, `fencedIds` is
+ * recomputed only by a resync, `movedOutFloor` saw no eviction — so the row
+ * reaches `persistUpserts`, and both the stored row and its tombstone were just
+ * cleared by the replace, so `resolveRowWrite` sees an unopposed insert.
+ *
+ * WHY IT DOES NOT SELF-HEAL, which is what the earlier acceptance rested on.
+ * The repair belongs to the tab that made the stale write — its own next
+ * `/items-changes` carries the epoch it does not hold, and it resyncs. A tab
+ * that goes away after its write commits takes the repair with it, and
+ * `persistUpserts` writes no meta row, so the epoch on disk stays at the value
+ * the RESYNC stamped. Every later reader — every poll, every cold boot — then
+ * compares equal and re-checks nothing.
+ *
+ * These are sequential calls through the real module. IDB serializes the
+ * transactions, so ordering the calls IS the interleaving (see idbHarness).
+ */
+
+function row(id: string, seq: number): ItemIndexRow {
+	return { id, seq, collection_slug: "c" } as unknown as ItemIndexRow;
+}
+
+describe("TASK-2922 — a tab may only write under the scope the cache advertises", () => {
+	it("refuses a behind tab reinserting a row the resync dropped", async () => {
+		const U = null;
+		const WS = "ws-2922-behind";
+		const { persistDelta, persistReplace, persistUpserts, hydrate } =
+			await loadPersistence();
+
+		// Both tabs share a cache holding `secret` under epoch e1.
+		await persistDelta(
+			U,
+			WS,
+			[row("secret", 10), row("ok", 11)],
+			"11",
+			false,
+			"e1",
+		);
+
+		// Tab A learns the scope narrowed and resyncs. Its snapshot omits
+		// `secret`, and it stamps e2 on the meta row.
+		expect(
+			await persistReplace(U, WS, [row("ok", 11)], "12", false, "e2"),
+		).toBe(true);
+
+		// Tab B never learned about e2 and still believes e1.
+		await persistUpserts(U, WS, [row("secret", 10)], "e1");
+
+		// Asserted on the RAW store as well as through `hydrate`: a hydrate-only
+		// assertion would also pass if the row were stored and merely filtered
+		// on read, which is a different (and non-existent) mechanism.
+		expect((await rawItems(U, WS)).map((r) => r.id).sort()).toEqual(["ok"]);
+		const after = await hydrate(U, WS);
+		expect(after.items.map((r) => r.id)).toEqual(["ok"]);
+		// And the epoch is untouched — the refusal must not also cost the cache
+		// the scope statement the resync correctly recorded.
+		expect(after.accessEpoch).toBe("e2");
+		expect(after.cursor).toBe("12");
+	});
+
+	it("CONTROL — the CURRENT tab writes normally through the same door", async () => {
+		const U = null;
+		const WS = "ws-2922-current";
+		const { persistDelta, persistReplace, persistUpserts, hydrate } =
+			await loadPersistence();
+
+		await persistDelta(U, WS, [row("ok", 11)], "11", false, "e1");
+		await persistReplace(U, WS, [row("ok", 11)], "12", false, "e2");
+
+		// Same call, same sequence, same door — only the writer's belief differs.
+		// Without this leg the assertion above would also pass against a
+		// `persistUpserts` that had simply stopped writing anything.
+		await persistUpserts(U, WS, [row("fresh", 13)], "e2");
+
+		expect((await hydrate(U, WS)).items.map((r) => r.id).sort()).toEqual([
+			"fresh",
+			"ok",
+		]);
+	});
+
+	it("refuses the WHOLE batch, not the contradicting row", async () => {
+		const U = null;
+		const WS = "ws-2922-whole";
+		const { persistDelta, persistReplace, persistUpserts, hydrate } =
+			await loadPersistence();
+
+		await persistDelta(
+			U,
+			WS,
+			[row("secret", 10), row("ok", 11)],
+			"11",
+			false,
+			"e1",
+		);
+		await persistReplace(U, WS, [row("ok", 11)], "12", false, "e2");
+
+		// The batch is one claim, made under one scope. Splitting it — writing
+		// the rows that happen to be innocuous and dropping the rest — would
+		// require deciding per row which scope authorised it, which is exactly
+		// what the writer cannot tell us and why it names its scope once.
+		await persistUpserts(
+			U,
+			WS,
+			[row("secret", 10), row("unrelated", 13)],
+			"e1",
+		);
+
+		expect((await hydrate(U, WS)).items.map((r) => r.id)).toEqual(["ok"]);
+	});
+
+	it("writes normally when the cache carries no scope claim at all", async () => {
+		const U = null;
+		const WS = "ws-2922-nometa";
+		const { persistUpserts, hydrate } = await loadPersistence();
+
+		// No meta row: nothing on disk for the batch to contradict. Minting one
+		// here would invent a cursor, which is the claim that everything up to it
+		// has been seen — the same reason `persistAccessEpoch` declines.
+		await persistUpserts(U, WS, [row("a", 1)], "e1");
+
+		expect((await hydrate(U, WS)).items.map((r) => r.id)).toEqual(["a"]);
+	});
+
+	it("treats null on both sides as a match — a server without access_epoch still writes", async () => {
+		const U = null;
+		const WS = "ws-2922-null";
+		const { persistDelta, persistUpserts, hydrate } =
+			await loadPersistence();
+
+		// A server that predates `access_epoch` persists a null baseline. `null`
+		// is a real value on both sides here, not an absence, so the two agree
+		// and this deployment is unaffected by the fence.
+		await persistDelta(U, WS, [row("a", 1)], "1", false, null);
+		await persistUpserts(U, WS, [row("b", 2)], null);
+
+		expect((await hydrate(U, WS)).items.map((r) => r.id).sort()).toEqual([
+			"a",
+			"b",
+		]);
+	});
+
+	it("a stale write that lands BEFORE the resync is dropped by the replace, not by this fence", async () => {
+		const U = null;
+		const WS = "ws-2922-ordering";
+		const { persistDelta, persistReplace, persistUpserts, hydrate } =
+			await loadPersistence();
+
+		await persistDelta(U, WS, [row("ok", 11)], "11", false, "e1");
+		// Tab B's stale write commits while the cache still advertises e1, so
+		// the fence has nothing to object to and lets it through...
+		await persistUpserts(U, WS, [row("secret", 10)], "e1");
+		expect((await hydrate(U, WS)).items.map((r) => r.id).sort()).toEqual([
+			"ok",
+			"secret",
+		]);
+
+		// ...and the resync's clear is what removes it. This leg exists so the
+		// fence's scope is explicit: it closes the window AFTER a replace, and
+		// the window before one was never open.
+		await persistReplace(U, WS, [row("ok", 11)], "12", false, "e2");
+		expect((await hydrate(U, WS)).items.map((r) => r.id)).toEqual(["ok"]);
+	});
+});

--- a/web/src/lib/stores/localIndexScopeWriteFence.idb.test.ts
+++ b/web/src/lib/stores/localIndexScopeWriteFence.idb.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from "vitest";
-import type { ItemIndexRow } from "$lib/types";
-import { loadPersistence, rawItems } from "../../test/idbHarness";
+import { describe, it, expect } from 'vitest';
+import type { ItemIndexRow } from '$lib/types';
+import { loadPersistence, rawItems } from '../../test/idbHarness';
 
 /**
  * TASK-2922 / PLAN-2903 item 1 — F2: a cache that holds old-scope rows while
@@ -28,147 +28,136 @@ import { loadPersistence, rawItems } from "../../test/idbHarness";
  */
 
 function row(id: string, seq: number): ItemIndexRow {
-	return { id, seq, collection_slug: "c" } as unknown as ItemIndexRow;
+	return { id, seq, collection_slug: 'c' } as unknown as ItemIndexRow;
 }
 
-describe("TASK-2922 — a tab may only write under the scope the cache advertises", () => {
-	it("refuses a behind tab reinserting a row the resync dropped", async () => {
+describe('TASK-2922 — a tab may only write under the scope the cache advertises', () => {
+	it('refuses a behind tab reinserting a row the resync dropped', async () => {
 		const U = null;
-		const WS = "ws-2922-behind";
-		const { persistDelta, persistReplace, persistUpserts, hydrate } =
-			await loadPersistence();
+		const WS = 'ws-2922-behind';
+		const { persistDelta, persistReplace, persistUpserts, hydrate } = await loadPersistence();
 
 		// Both tabs share a cache holding `secret` under epoch e1.
-		await persistDelta(
-			U,
-			WS,
-			[row("secret", 10), row("ok", 11)],
-			"11",
-			false,
-			"e1",
-		);
+		await persistDelta(U, WS, [row('secret', 10), row('ok', 11)], '11', false, 'e1');
 
 		// Tab A learns the scope narrowed and resyncs. Its snapshot omits
 		// `secret`, and it stamps e2 on the meta row.
-		expect(
-			await persistReplace(U, WS, [row("ok", 11)], "12", false, "e2"),
-		).toBe(true);
+		expect(await persistReplace(U, WS, [row('ok', 11)], '12', false, 'e2')).toBe(true);
 
 		// Tab B never learned about e2 and still believes e1.
-		await persistUpserts(U, WS, [row("secret", 10)], "e1");
+		await persistUpserts(U, WS, [row('secret', 10)], 'e1');
 
 		// Asserted on the RAW store as well as through `hydrate`: a hydrate-only
 		// assertion would also pass if the row were stored and merely filtered
 		// on read, which is a different (and non-existent) mechanism.
-		expect((await rawItems(U, WS)).map((r) => r.id).sort()).toEqual(["ok"]);
+		expect((await rawItems(U, WS)).map((r) => r.id).sort()).toEqual(['ok']);
 		const after = await hydrate(U, WS);
-		expect(after.items.map((r) => r.id)).toEqual(["ok"]);
+		expect(after.items.map((r) => r.id)).toEqual(['ok']);
 		// And the epoch is untouched — the refusal must not also cost the cache
 		// the scope statement the resync correctly recorded.
-		expect(after.accessEpoch).toBe("e2");
-		expect(after.cursor).toBe("12");
+		expect(after.accessEpoch).toBe('e2');
+		expect(after.cursor).toBe('12');
 	});
 
-	it("CONTROL — the CURRENT tab writes normally through the same door", async () => {
+	it('CONTROL — the CURRENT tab writes normally through the same door', async () => {
 		const U = null;
-		const WS = "ws-2922-current";
-		const { persistDelta, persistReplace, persistUpserts, hydrate } =
-			await loadPersistence();
+		const WS = 'ws-2922-current';
+		const { persistDelta, persistReplace, persistUpserts, hydrate } = await loadPersistence();
 
-		await persistDelta(U, WS, [row("ok", 11)], "11", false, "e1");
-		await persistReplace(U, WS, [row("ok", 11)], "12", false, "e2");
+		await persistDelta(U, WS, [row('ok', 11)], '11', false, 'e1');
+		await persistReplace(U, WS, [row('ok', 11)], '12', false, 'e2');
 
 		// Same call, same sequence, same door — only the writer's belief differs.
 		// Without this leg the assertion above would also pass against a
 		// `persistUpserts` that had simply stopped writing anything.
-		await persistUpserts(U, WS, [row("fresh", 13)], "e2");
+		await persistUpserts(U, WS, [row('fresh', 13)], 'e2');
 
-		expect((await hydrate(U, WS)).items.map((r) => r.id).sort()).toEqual([
-			"fresh",
-			"ok",
-		]);
+		expect((await hydrate(U, WS)).items.map((r) => r.id).sort()).toEqual(['fresh', 'ok']);
 	});
 
-	it("refuses the WHOLE batch, not the contradicting row", async () => {
+	it('refuses the WHOLE batch, not the contradicting row', async () => {
 		const U = null;
-		const WS = "ws-2922-whole";
-		const { persistDelta, persistReplace, persistUpserts, hydrate } =
-			await loadPersistence();
+		const WS = 'ws-2922-whole';
+		const { persistDelta, persistReplace, persistUpserts, hydrate } = await loadPersistence();
 
-		await persistDelta(
-			U,
-			WS,
-			[row("secret", 10), row("ok", 11)],
-			"11",
-			false,
-			"e1",
-		);
-		await persistReplace(U, WS, [row("ok", 11)], "12", false, "e2");
+		await persistDelta(U, WS, [row('secret', 10), row('ok', 11)], '11', false, 'e1');
+		await persistReplace(U, WS, [row('ok', 11)], '12', false, 'e2');
 
 		// The batch is one claim, made under one scope. Splitting it — writing
 		// the rows that happen to be innocuous and dropping the rest — would
 		// require deciding per row which scope authorised it, which is exactly
 		// what the writer cannot tell us and why it names its scope once.
-		await persistUpserts(
-			U,
-			WS,
-			[row("secret", 10), row("unrelated", 13)],
-			"e1",
-		);
+		await persistUpserts(U, WS, [row('secret', 10), row('unrelated', 13)], 'e1');
 
-		expect((await hydrate(U, WS)).items.map((r) => r.id)).toEqual(["ok"]);
+		expect((await hydrate(U, WS)).items.map((r) => r.id)).toEqual(['ok']);
 	});
 
-	it("writes normally when the cache carries no scope claim at all", async () => {
+	it('an ordinary delta restores the durable copy a refusal deferred', async () => {
 		const U = null;
-		const WS = "ws-2922-nometa";
+		const WS = 'ws-2922-restore';
+		const { persistDelta, persistReplace, persistUpserts, hydrate } = await loadPersistence();
+
+		await persistDelta(U, WS, [row('ok', 11)], '11', false, 'e1');
+		await persistReplace(U, WS, [row('ok', 11)], '12', false, 'e2');
+
+		// A legitimate mutation in the behind tab — still in scope, so the
+		// snapshot would carry it — but the tab's belief is stale, so the write
+		// is refused.
+		await persistUpserts(U, WS, [row('mine', 13)], 'e1');
+		expect((await hydrate(U, WS)).items.map((r) => r.id)).toEqual(['ok']);
+
+		// The row was SERVER TRUTH, and this door never advances the cursor, so
+		// the mutation is still inside the next delta's window. This leg is what
+		// makes "deferred, not lost" a measured claim rather than an assumption
+		// about scheduling: it does not depend on WHEN the tab reconciles, only
+		// on the row being re-supplied when it does (codex round 2 P1).
+		await persistDelta(U, WS, [row('mine', 13)], '13', false, 'e2');
+
+		expect((await hydrate(U, WS)).items.map((r) => r.id).sort()).toEqual(['mine', 'ok']);
+	});
+
+	it('writes normally when the cache carries no scope claim at all', async () => {
+		const U = null;
+		const WS = 'ws-2922-nometa';
 		const { persistUpserts, hydrate } = await loadPersistence();
 
 		// No meta row: nothing on disk for the batch to contradict. Minting one
 		// here would invent a cursor, which is the claim that everything up to it
 		// has been seen — the same reason `persistAccessEpoch` declines.
-		await persistUpserts(U, WS, [row("a", 1)], "e1");
+		await persistUpserts(U, WS, [row('a', 1)], 'e1');
 
-		expect((await hydrate(U, WS)).items.map((r) => r.id)).toEqual(["a"]);
+		expect((await hydrate(U, WS)).items.map((r) => r.id)).toEqual(['a']);
 	});
 
-	it("treats null on both sides as a match — a server without access_epoch still writes", async () => {
+	it('treats null on both sides as a match — a server without access_epoch still writes', async () => {
 		const U = null;
-		const WS = "ws-2922-null";
-		const { persistDelta, persistUpserts, hydrate } =
-			await loadPersistence();
+		const WS = 'ws-2922-null';
+		const { persistDelta, persistUpserts, hydrate } = await loadPersistence();
 
 		// A server that predates `access_epoch` persists a null baseline. `null`
 		// is a real value on both sides here, not an absence, so the two agree
 		// and this deployment is unaffected by the fence.
-		await persistDelta(U, WS, [row("a", 1)], "1", false, null);
-		await persistUpserts(U, WS, [row("b", 2)], null);
+		await persistDelta(U, WS, [row('a', 1)], '1', false, null);
+		await persistUpserts(U, WS, [row('b', 2)], null);
 
-		expect((await hydrate(U, WS)).items.map((r) => r.id).sort()).toEqual([
-			"a",
-			"b",
-		]);
+		expect((await hydrate(U, WS)).items.map((r) => r.id).sort()).toEqual(['a', 'b']);
 	});
 
-	it("a stale write that lands BEFORE the resync is dropped by the replace, not by this fence", async () => {
+	it('a stale write that lands BEFORE the resync is dropped by the replace, not by this fence', async () => {
 		const U = null;
-		const WS = "ws-2922-ordering";
-		const { persistDelta, persistReplace, persistUpserts, hydrate } =
-			await loadPersistence();
+		const WS = 'ws-2922-ordering';
+		const { persistDelta, persistReplace, persistUpserts, hydrate } = await loadPersistence();
 
-		await persistDelta(U, WS, [row("ok", 11)], "11", false, "e1");
+		await persistDelta(U, WS, [row('ok', 11)], '11', false, 'e1');
 		// Tab B's stale write commits while the cache still advertises e1, so
 		// the fence has nothing to object to and lets it through...
-		await persistUpserts(U, WS, [row("secret", 10)], "e1");
-		expect((await hydrate(U, WS)).items.map((r) => r.id).sort()).toEqual([
-			"ok",
-			"secret",
-		]);
+		await persistUpserts(U, WS, [row('secret', 10)], 'e1');
+		expect((await hydrate(U, WS)).items.map((r) => r.id).sort()).toEqual(['ok', 'secret']);
 
 		// ...and the resync's clear is what removes it. This leg exists so the
 		// fence's scope is explicit: it closes the window AFTER a replace, and
 		// the window before one was never open.
-		await persistReplace(U, WS, [row("ok", 11)], "12", false, "e2");
-		expect((await hydrate(U, WS)).items.map((r) => r.id)).toEqual(["ok"]);
+		await persistReplace(U, WS, [row('ok', 11)], '12', false, 'e2');
+		expect((await hydrate(U, WS)).items.map((r) => r.id)).toEqual(['ok']);
 	});
 });


### PR DESCRIPTION
Closes PLAN-2903 item 1 — **F2**, the last of that plan's six units. TASK-2922.

## The defect

The durable local index could hold rows fetched under a **revoked** scope while its meta row advertised the **current** one. Once in that state nothing re-fired: `ensureAccessScope` compares the two epochs, finds them equal, and re-checks nothing — on every later poll and on every later cold boot. A permission-revoked row stayed readable indefinitely.

**The route is one door, not two.** `persistReplace` clears the tombstone store wholesale, so ids its snapshot DROPPED lose the only cross-tab record that they were dropped. A tab that did not run that resync has none of the guards that would stop it writing them back — `scopeEpoch`, `fencedIds` and `movedOutFloor` are all session-local and none of them bumped in that tab — so the row reaches `persistUpserts`, where both the stored row and its tombstone were just cleared and `resolveRowWrite` sees an unopposed insert. `persistUpserts` writes no meta row, so the epoch stays at the value the resync stamped.

`persistDelta` was checked for the same hole and does **not** have it: a batch from a behind tab carries that tab's own older epoch, which drags the durable epoch BACK, and the resulting disagreement with the server's next response is what triggers the repair. It self-heals; only the upsert door did not. The first version of that check was written against `undefined` and reproduced by construction — the real caller passes the tab's own belief, because a tab that never resynced still has `durableSnapshotCommitted === true`.

## The fix

`persistUpserts` takes the epoch its caller believes it holds, reads `meta.sync` inside its own transaction, and writes **nothing** when the two differ.

Both sides are `access_epoch`s and the only operator is `!==`. An access epoch is a hash of the live grant set and can answer "same or different" and nothing else — PLAN-2903's working rule asks each unit to state whether the values its fence compares are orderable before it writes one, and these are not. Nothing here says "older", so nothing here can be an ordering claim in an equality costume, which is what defeated the fences on IDEA-2898's abandoned branch.

The parameter is **required**, so the type checker is the enforcement; an optional one would make the quiet call site the unguarded one. That is the whole of the 28-call-site churn in the two persistence test files.

**Cost, taken deliberately: deferred, never lost** — and by *provenance*, not scheduling. Every row reaching that door is server truth, and the door never advances the cursor, so a refused mutation stays inside the next delta's window. RAM and the search index are written before the persist, so the writing session keeps serving its own row throughout.

## Withdrawn: the lead-accepted residual

`persistReplace` carried a `RESIDUAL (codex F2, lead-accepted)` note whose acceptance rested on the hazard being self-healing — *"the next resync recomputes the fence and re-drops the row"*. That premise is false in the case that matters: the repair belongs to the tab that made the stale write, so a tab that goes away after its write commits — closed, frozen, discarded — takes the repair with it. The note now records what closed it and why.

The key-diff that note declines stays declined, for a better reason than cost: a tombstone is SEQ evidence and the thing being refused is a SCOPE fact, so it fits the reachable case by coincidence of ordering and cannot refuse a genuinely newer row the writing tab could still see under the old scope. Measured, not argued — that variant closes the defect too, at **2 failed / 2237** (it breaks a pinned tombstone property), against **1 failed / 2237** for this one, where the 1 was the recon leg itself.

## Premise corrections to the plan

TASK-2922's brief said to start from four clauses. Two were **ruled against** by units that landed after it was written — TASK-2909 review round 1 P2 explicitly rejected "an unconfirmed delta writes nothing" in favour of carry-the-stored-epoch, and `persistDelta` writes the meta row today by design. The two that hold are `ensureAccessScope` and `movedOutFloor`'s seq floor. PLAN-2903's ruled shape for this item is rewritten to those two on the plan.

That is the third premise correction on this plan's items; the two worked on day 77 were the first two.

## Tests

`localIndexScopeWriteFence.idb.test.ts` pins the route against a real IndexedDB: the refusal (asserted on the raw store as well as through `hydrate`), a CONTROL leg proving the current tab still writes through the same door, whole-batch refusal, restore-through-an-ordinary-delta, the no-meta-row and null-epoch boundaries, and a leg making the ORDERING explicit — a stale write landing BEFORE the resync is dropped by the replace, not by this fence.

Wiring legs in `localIndexAccessEpochWiring.svelte.test.ts` (CONVE-19) assert the caller passes its own belief, that the argument TRACKS that belief rather than being fixed, that RAM is written before the persist, and that a delta which does not carry the refused row still persists it so the cursor cannot lap it.

**Counterfactuals, each run against the unfixed tree:** removing the fence fails the three defect legs; passing a fixed `null` fails the two wiring legs; moving the persist ahead of the RAM write fails the deferral leg; removing `toPersist.push(existing)` fails the no-lap leg. The four boundary legs pass either way, which is what they are for.

## Review rounds

| Round | Result |
|---|---|
| 1 | CLEAN (lean default) |
| 2 | P1 — the deferral claim rested on a poll that is SSE-driven, not timed. Correct: the mechanism I wrote only usually holds. Rewritten to provenance, plus a restore leg. |
| 3 | P1 — false positive on mechanism (the no-lap guard predates this unit), true on coverage. Answered by enumerating the repair paths in full rather than the third instance. |
| 4 | CLEAN |

Read as a set: 0 → 1 → 1 → 0, and both findings lived in ONE layer — the justification of the deferral claim. The fence itself was clean from round 1. One leg was **deleted** during round 3 rather than strengthened: it asserted that a resync carries the refused row, and passed because the snapshot handed to the mock contained it — true for every build, fixed or broken.

## Gates

| Gate | Result |
|---|---|
| `golangci-lint` | 0 issues |
| `go test ./...` | 30 packages ok, 0 FAIL |
| `svelte-check` | 0 errors |
| `vitest` | 2243 passed / 140 files |

Run on the rebased tree at `f15f4f4d`, on `origin/main` at `5d29b771`.

https://claude.ai/code/session_01Xk9M5UVPdc84xL5E1mZkm8
