### PR TITLE
fix(web): workspace identity recovers after a failed cold load, on the condition rather than a signal (TASK-2200)

### DIFF
--- a/web/src/lib/services/syncPostOutageResultType.svelte.test.ts
+++ b/web/src/lib/services/syncPostOutageResultType.svelte.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * TASK-2200 — THE MEASUREMENT the recovery design rests on.
+ *
+ * The obvious place to hang "re-acquire what the outage cost us" is the
+ * `full_refresh` branch the workspace layout already has: it reads as the
+ * everything-is-stale signal, and the reconcile subscriber next to it is
+ * already shaped that way. This file is why the recovery is NOT gated there.
+ *
+ * When the server comes back, `/changes` SUCCEEDS. The cursor was seeded during
+ * the outage — `setWorkspace`'s own seeding call failed and fell back to client
+ * time — so an ordinary quiet workspace answers with nothing to report, and the
+ * result is `caught_up`. **The type that means "nothing was missed" is exactly
+ * the one delivered when everything was.** A `full_refresh` arrives only when
+ * `/changes` ITSELF fails or the absence exceeds the incremental window, which
+ * is the case where the server is still down and recovery cannot work anyway.
+ *
+ * So the recovery is gated on the CONDITION — identity actually missing — and
+ * runs on every result. These legs pin the reading that forced that choice; if
+ * a future change makes a returning server emit `full_refresh` after all, this
+ * file fails and the gating decision should be revisited rather than inherited.
+ */
+
+let changesImpl: (ws: string, since: number) => Promise<unknown> = async () => ({
+	updated: [],
+	deleted: [],
+	server_time: 0,
+	collections_changed: false,
+});
+
+vi.mock('$lib/api/client', () => ({
+	api: {
+		changes: {
+			since: (ws: string, since: number) => changesImpl(ws, since),
+		},
+	},
+}));
+
+vi.mock('$lib/services/sse.svelte', () => ({
+	sseService: {
+		onSyncRequired: () => {},
+		get connected() {
+			return true;
+		},
+	},
+}));
+
+const { syncService } = await import('./sync.svelte');
+
+type Result = { type: string };
+
+beforeEach(() => {
+	changesImpl = async () => ({
+		updated: [],
+		deleted: [],
+		server_time: 0,
+		collections_changed: false,
+	});
+});
+
+/** The outage: the cursor seed itself fails and falls back to client time. */
+async function seedDuringOutage() {
+	changesImpl = async () => {
+		throw new Error('server down');
+	};
+	await syncService.setWorkspace('ws');
+}
+
+describe('TASK-2200 — what a returning server actually reports', () => {
+	it('reports caught_up, NOT full_refresh, when the server returns to a quiet workspace', async () => {
+		await seedDuringOutage();
+
+		// Server back, nothing changed while it was gone.
+		changesImpl = async () => ({
+			updated: [],
+			deleted: [],
+			server_time: 1_000,
+			collections_changed: false,
+		});
+
+		const seen: string[] = [];
+		const off = syncService.onSync((r: Result) => {
+			seen.push(r.type);
+		});
+		await syncService.triggerSync();
+		off();
+
+		expect(seen).toEqual(['caught_up']);
+		// Stated as the negative too, because THIS is the assertion the design
+		// turns on: a recovery hung off `full_refresh` would never run here.
+		expect(seen).not.toContain('full_refresh');
+	});
+
+	it('reports incremental — still not full_refresh — when changes did land', async () => {
+		await seedDuringOutage();
+
+		changesImpl = async () => ({
+			updated: [{ id: 'i1' }],
+			deleted: [],
+			server_time: 2_000,
+			collections_changed: false,
+		});
+
+		const seen: string[] = [];
+		const off = syncService.onSync((r: Result) => {
+			seen.push(r.type);
+		});
+		await syncService.triggerSync();
+		off();
+
+		expect(seen).toEqual(['incremental']);
+	});
+
+	it('CONTROL — full_refresh IS what arrives when /changes itself fails', async () => {
+		await seedDuringOutage();
+
+		// Still down. Without this leg the two assertions above would also pass
+		// against a service that had simply stopped emitting `full_refresh` at
+		// all, which would make them evidence for nothing.
+		changesImpl = async () => {
+			throw new Error('still down');
+		};
+
+		const seen: string[] = [];
+		const off = syncService.onSync((r: Result) => {
+			seen.push(r.type);
+		});
+		await syncService.triggerSync();
+		off();
+
+		expect(seen).toEqual(['full_refresh']);
+	});
+});

--- a/web/src/lib/stores/collections.svelte.ts
+++ b/web/src/lib/stores/collections.svelte.ts
@@ -34,6 +34,17 @@ let loading = $state(false);
 // (Codex review). Plain counter — not reactive; it only fences async writes.
 let collectionsLoadSeq = 0;
 
+// The workspace and promise of the `loadCollections` request currently in
+// flight, or nulls when none is (TASK-2200). `loading` cannot answer this: it
+// is a single global flag with no workspace on it, so it cannot tell a caller
+// asking about workspace A that the in-flight request is for B.
+//
+// Consumed only by `ensureCollections`, and deliberately not by
+// `loadCollections` itself — see that method's note on why coalescing every
+// caller would be wrong.
+let inFlightWs: string | null = null;
+let inFlightLoad: Promise<void> | null = null;
+
 export const collectionStore = {
 	get collections() { return collections; },
 	get items() { return items; },
@@ -72,9 +83,45 @@ export const collectionStore = {
 		return collections.filter(c => !c.is_default).sort((a, b) => a.sort_order - b.sort_order);
 	},
 
+	/**
+	 * ENSURE this workspace's collection list exists — as distinct from
+	 * `loadCollections`, which fetches a fresh one (TASK-2200).
+	 *
+	 * Two intents, and only one of them can be satisfied by a request that is
+	 * already in flight:
+	 *
+	 *   - "I need A list" (this method). A request issued a moment ago answers
+	 *     it perfectly, so joining it is right and a second fetch is waste.
+	 *   - "I need a FRESH list" (`loadCollections`). The caller knows the list
+	 *     MOVED — an SSE rename, a settings save, a server `collections_changed`
+	 *     — and a request issued BEFORE that move cannot answer it. Coalescing
+	 *     there would quietly serve pre-change data.
+	 *
+	 * That is why the coalescing lives here rather than inside `loadCollections`
+	 * where it would cover every caller. Every other call site in the app is the
+	 * second intent and is correctly left alone; this is the only one that is
+	 * the first (codex round 2 asked for the population, and that is it).
+	 *
+	 * No-ops when the list is already this workspace's. Never rejects for the
+	 * fresh-already case; a genuine fetch failure rejects like `loadCollections`.
+	 */
+	async ensureCollections(ws: string): Promise<void> {
+		if (collectionsWorkspace === ws) return;
+		// Join, rather than issue a second request for the same answer. The
+		// joined promise settles when THAT request does, which is the semantics
+		// the caller wants: "tell me when a list exists".
+		if (inFlightWs === ws && inFlightLoad) return inFlightLoad;
+		return collectionStore.loadCollections(ws);
+	},
+
 	async loadCollections(ws: string) {
 		const seq = ++collectionsLoadSeq;
 		loading = true;
+		// Published for `ensureCollections` to join. Recorded per WORKSPACE: a
+		// switch can leave A's request in flight while B's starts, and a joiner
+		// asking about A must not be handed B's promise.
+		inFlightWs = ws;
+		const load = (async () => {
 		try {
 			const result = await api.collections.list(ws);
 			// Drop a stale response: a newer loadCollections (e.g. a workspace
@@ -93,7 +140,16 @@ export const collectionStore = {
 			// Only the latest in-flight load owns the `loading` flag — an older
 			// load resolving late must not flip it off while the newer one runs.
 			if (seq === collectionsLoadSeq) loading = false;
+			// Same ownership rule for the join slot: an older load settling late
+			// must not clear a newer one's promise out from under a joiner.
+			if (seq === collectionsLoadSeq) {
+				inFlightWs = null;
+				inFlightLoad = null;
+			}
 		}
+		})();
+		inFlightLoad = load;
+		return load;
 	},
 
 	async loadItems(ws: string, collectionSlug?: string, params?: Record<string, string | number | boolean | undefined>) {

--- a/web/src/lib/stores/collections.svelte.ts
+++ b/web/src/lib/stores/collections.svelte.ts
@@ -34,10 +34,25 @@ let loading = $state(false);
 // (Codex review). Plain counter — not reactive; it only fences async writes.
 let collectionsLoadSeq = 0;
 
-// The workspace and promise of the `loadCollections` request currently in
-// flight, or nulls when none is (TASK-2200). `loading` cannot answer this: it
-// is a single global flag with no workspace on it, so it cannot tell a caller
-// asking about workspace A that the in-flight request is for B.
+// The workspace and promise of the load that will actually COMMIT — a single
+// slot TAGGED with its workspace, not a per-workspace map (TASK-2200, codex
+// round 3, which read the first draft of this comment as claiming the latter;
+// the comment was wrong, the slot was not).
+//
+// A map would be the worse structure here, and the reason is the generation
+// guard directly below: `loadCollections` commits only the LATEST call, so once
+// a load for B starts, A's in-flight request is already dead — its response
+// will be dropped by `seq !== collectionsLoadSeq`. Handing an
+// `ensureCollections('A')` caller that request's promise would resolve them
+// against a result that never lands, which is a quieter version of the bug this
+// unit exists to fix. Issuing a fresh A request is the correct answer, and it
+// is what the single slot produces.
+//
+// What the workspace TAG is for is the opposite mistake: without it, a joiner
+// asking about A would be handed B's promise and resolve against B's list.
+//
+// `loading` cannot serve either purpose — it is a single global flag with no
+// workspace on it and no promise behind it.
 //
 // Consumed only by `ensureCollections`, and deliberately not by
 // `loadCollections` itself — see that method's note on why coalescing every
@@ -117,9 +132,11 @@ export const collectionStore = {
 	async loadCollections(ws: string) {
 		const seq = ++collectionsLoadSeq;
 		loading = true;
-		// Published for `ensureCollections` to join. Recorded per WORKSPACE: a
-		// switch can leave A's request in flight while B's starts, and a joiner
-		// asking about A must not be handed B's promise.
+		// Published for `ensureCollections` to join, tagged with the workspace
+		// so a joiner asking about A is never handed B's promise. Overwriting a
+		// previous tenant is correct rather than lossy: this assignment happens
+		// after `++collectionsLoadSeq`, so the load being displaced has already
+		// lost the right to commit.
 		inFlightWs = ws;
 		const load = (async () => {
 		try {

--- a/web/src/lib/stores/collectionsEnsure.svelte.test.ts
+++ b/web/src/lib/stores/collectionsEnsure.svelte.test.ts
@@ -112,6 +112,37 @@ describe('TASK-2200 — ensureCollections', () => {
 		await Promise.all([other, mine]);
 	});
 
+	it('issues a FRESH request rather than joining a load a later workspace superseded', async () => {
+		const { api, collectionStore } = await load();
+
+		const releases: ((v: Collection[]) => void)[] = [];
+		const list = vi
+			.spyOn(api.collections, 'list')
+			.mockImplementation(() => new Promise<Collection[]>((r) => releases.push(r)));
+
+		// alpha, then beta, then someone needs alpha again — all three in
+		// flight at once (codex round 3 asked for this ordering).
+		const alpha = collectionStore.loadCollections('alpha');
+		const beta = collectionStore.loadCollections('beta');
+		const ensured = collectionStore.ensureCollections('alpha');
+
+		// THREE requests, and the third is the point. Round 3 read this as a
+		// missing join and proposed a per-workspace map; the map would be the
+		// defect. `loadCollections` commits only the LATEST call, so beta's
+		// start already killed alpha's first request — its response is dropped
+		// by the generation guard. Joining it would resolve this caller against
+		// a result that never lands, which is a quieter version of the bug this
+		// unit exists to fix.
+		expect(list).toHaveBeenCalledTimes(3);
+
+		releases.forEach((r) => r([coll('tasks')]));
+		await Promise.all([alpha, beta, ensured]);
+
+		// And the fresh alpha request is the one that commits, because it is
+		// the latest.
+		expect(collectionStore.collectionsAreFreshFor('alpha')).toBe(true);
+	});
+
 	it('releases the join slot once the load settles, so a later ensure issues a real request', async () => {
 		const { api, collectionStore } = await load();
 

--- a/web/src/lib/stores/collectionsEnsure.svelte.test.ts
+++ b/web/src/lib/stores/collectionsEnsure.svelte.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Collection } from '$lib/types';
+
+/**
+ * TASK-2200 — `ensureCollections`, and the distinction it exists to keep.
+ *
+ * The shell-brick recovery needs "make sure this workspace has a collection
+ * list". Every other caller in the app needs "fetch a fresh one, because I know
+ * it moved". Those are different requests: a fetch already in flight answers
+ * the first perfectly and cannot answer the second, since it was issued before
+ * the change the caller is reacting to.
+ *
+ * So the coalescing lives in `ensureCollections` and NOT in `loadCollections`.
+ * The control leg below is the one that keeps that true — without it, moving
+ * the join into `loadCollections` (which would look like a tidy simplification)
+ * would pass every other assertion here while quietly serving pre-change data
+ * to an SSE rename.
+ */
+
+function coll(slug: string): Collection {
+	return { id: `id-${slug}`, slug, name: slug, is_default: true, sort_order: 0 } as Collection;
+}
+
+async function load() {
+	vi.resetModules();
+	const { api } = await import('$lib/api/client');
+	const { collectionStore } = await import('./collections.svelte');
+	return { api, collectionStore };
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe('TASK-2200 — ensureCollections', () => {
+	it('JOINS a load already in flight for the same workspace instead of issuing a second', async () => {
+		const { api, collectionStore } = await load();
+
+		let release: (v: Collection[]) => void = () => {};
+		const list = vi
+			.spyOn(api.collections, 'list')
+			.mockImplementation(() => new Promise<Collection[]>((r) => (release = r)));
+
+		const first = collectionStore.loadCollections('alpha');
+		const joined = collectionStore.ensureCollections('alpha');
+
+		expect(list).toHaveBeenCalledTimes(1);
+
+		release([coll('tasks')]);
+		await Promise.all([first, joined]);
+
+		// The joiner settles on the SAME request, and that request's result is
+		// what landed — asserting both, because a join that resolved early
+		// would leave the caller acting on an empty list.
+		expect(collectionStore.collections.map((c) => c.slug)).toEqual(['tasks']);
+		expect(list).toHaveBeenCalledTimes(1);
+	});
+
+	it('does nothing, and issues no request, when the list is already this workspace’s', async () => {
+		const { api, collectionStore } = await load();
+
+		const list = vi.spyOn(api.collections, 'list').mockResolvedValue([coll('tasks')]);
+		await collectionStore.loadCollections('alpha');
+		list.mockClear();
+
+		await collectionStore.ensureCollections('alpha');
+
+		expect(list).not.toHaveBeenCalled();
+	});
+
+	it('CONTROL — loadCollections is NOT coalesced, because a change-driven fetch cannot join a pre-change one', async () => {
+		const { api, collectionStore } = await load();
+
+		// EVERY resolver, not the last one: two calls to the same
+		// `mockImplementation` produce two promises, and holding a single
+		// `release` would leave the first pending forever. The first draft of
+		// this leg did exactly that and timed out — a fixture bug that looks
+		// identical to the product hanging.
+		const releases: ((v: Collection[]) => void)[] = [];
+		const list = vi
+			.spyOn(api.collections, 'list')
+			.mockImplementation(() => new Promise<Collection[]>((r) => releases.push(r)));
+
+		const first = collectionStore.loadCollections('alpha');
+		const second = collectionStore.loadCollections('alpha');
+
+		// Two requests, deliberately. This is the leg that fails if someone
+		// moves the join into `loadCollections`; every other assertion in this
+		// file would still pass.
+		expect(list).toHaveBeenCalledTimes(2);
+
+		releases.forEach((r) => r([coll('tasks')]));
+		await Promise.all([first, second]);
+	});
+
+	it('does not join a load in flight for a DIFFERENT workspace', async () => {
+		const { api, collectionStore } = await load();
+
+		const releases: ((v: Collection[]) => void)[] = [];
+		const list = vi
+			.spyOn(api.collections, 'list')
+			.mockImplementation(() => new Promise<Collection[]>((r) => releases.push(r)));
+
+		const other = collectionStore.loadCollections('beta');
+		const mine = collectionStore.ensureCollections('alpha');
+
+		// Handing back beta's promise would resolve alpha's caller against
+		// beta's list — the exact confusion `collectionsAreFreshFor` exists for.
+		expect(list).toHaveBeenCalledTimes(2);
+
+		releases.forEach((r) => r([coll('tasks')]));
+		await Promise.all([other, mine]);
+	});
+
+	it('releases the join slot once the load settles, so a later ensure issues a real request', async () => {
+		const { api, collectionStore } = await load();
+
+		const list = vi.spyOn(api.collections, 'list').mockRejectedValueOnce(new Error('down'));
+		await collectionStore.ensureCollections('alpha').catch(() => undefined);
+		expect(list).toHaveBeenCalledTimes(1);
+
+		// A stale join slot would make every later ensure resolve against the
+		// dead request and never retry — which is the failure mode this whole
+		// unit is about, reintroduced one level down.
+		list.mockResolvedValue([coll('tasks')]);
+		await collectionStore.ensureCollections('alpha');
+
+		expect(list).toHaveBeenCalledTimes(2);
+		expect(collectionStore.collectionsAreFreshFor('alpha')).toBe(true);
+	});
+});

--- a/web/src/lib/stores/localIndexLayoutDriverWiring.test.ts
+++ b/web/src/lib/stores/localIndexLayoutDriverWiring.test.ts
@@ -80,10 +80,8 @@ describe('TASK-2200 — the same layout drives shell recovery', () => {
 		// changed-signal term left standing — which is precisely the state this
 		// unit found the file in, and the state a returning server does not
 		// reach (see below).
-		expect(layoutSource).toContain(
-			'const collectionsMissing = !collectionStore.collectionsAreFreshFor(ws)',
-		);
-		expect(layoutSource).toContain('if (collectionsMissing || collectionsChanged)');
+		expect(layoutSource).toContain('collectionStore.ensureCollections(ws)');
+		expect(layoutSource).toContain('collectionsChanged\n\t\t\t\t? collectionStore.loadCollections(ws)');
 	});
 
 	it('does not gate recovery on the full_refresh signal', () => {

--- a/web/src/lib/stores/localIndexLayoutDriverWiring.test.ts
+++ b/web/src/lib/stores/localIndexLayoutDriverWiring.test.ts
@@ -60,3 +60,39 @@ describe('TASK-2921 — the workspace layout drives the reconcile for every rout
 		expect(layoutSource).toContain('syncService.markSynced()');
 	});
 });
+
+describe('TASK-2200 — the same layout drives shell recovery', () => {
+	/**
+	 * Same instrument, same limits, same delete-condition as the block above —
+	 * this is a SOURCE PIN and it cannot see reachability. What it is worth: the
+	 * two recovery calls cannot be silently deleted, which would restore a shell
+	 * that stays navigation-less after the server returns while every
+	 * behavioural test stays green, because they call `recoverIfMissing` and
+	 * `loadCollections` directly.
+	 */
+	it('re-acquires workspace identity from the sync subscriber', () => {
+		expect(layoutSource).toContain('await workspaceStore.recoverIfMissing(ws)');
+	});
+
+	it('re-acquires the collection list on the freshness CONDITION, not on a signal type', () => {
+		// The condition is the anchor, not the call: `loadCollections(ws)` also
+		// appears in the `full_refresh` / `collections_changed` branch, which
+		// serves a different purpose (refresh a list we HAVE because the server
+		// says it changed). Anchoring on the call alone would pass with the
+		// recovery gate deleted and that branch left standing — which is
+		// precisely the state this unit found the file in.
+		expect(layoutSource).toContain('if (!collectionStore.collectionsAreFreshFor(ws))');
+	});
+
+	it('runs the recovery OUTSIDE the full_refresh branch', () => {
+		// Measured, not assumed (syncPostOutageResultType.svelte.test.ts): a
+		// returning server reports `caught_up`, so recovery hung inside the
+		// full_refresh branch would not run in the case this unit exists for.
+		// The pin: the recovery calls appear BEFORE the branch opens.
+		const recovery = layoutSource.indexOf('await workspaceStore.recoverIfMissing(ws)');
+		const branch = layoutSource.indexOf("if (result.type === 'full_refresh'");
+		expect(recovery).toBeGreaterThan(-1);
+		expect(branch).toBeGreaterThan(-1);
+		expect(recovery).toBeLessThan(branch);
+	});
+});

--- a/web/src/lib/stores/localIndexLayoutDriverWiring.test.ts
+++ b/web/src/lib/stores/localIndexLayoutDriverWiring.test.ts
@@ -74,23 +74,26 @@ describe('TASK-2200 — the same layout drives shell recovery', () => {
 		expect(layoutSource).toContain('await workspaceStore.recoverIfMissing(ws)');
 	});
 
-	it('re-acquires the collection list on the freshness CONDITION, not on a signal type', () => {
-		// The condition is the anchor, not the call: `loadCollections(ws)` also
-		// appears in the `full_refresh` / `collections_changed` branch, which
-		// serves a different purpose (refresh a list we HAVE because the server
-		// says it changed). Anchoring on the call alone would pass with the
-		// recovery gate deleted and that branch left standing — which is
-		// precisely the state this unit found the file in.
-		expect(layoutSource).toContain('if (!collectionStore.collectionsAreFreshFor(ws))');
+	it('re-acquires the collection list on the freshness CONDITION, not on a signal type alone', () => {
+		// The MISSING term is the anchor, not the call. `loadCollections(ws)`
+		// would still appear with the recovery term deleted and the
+		// changed-signal term left standing — which is precisely the state this
+		// unit found the file in, and the state a returning server does not
+		// reach (see below).
+		expect(layoutSource).toContain(
+			'const collectionsMissing = !collectionStore.collectionsAreFreshFor(ws)',
+		);
+		expect(layoutSource).toContain('if (collectionsMissing || collectionsChanged)');
 	});
 
-	it('runs the recovery OUTSIDE the full_refresh branch', () => {
+	it('does not gate recovery on the full_refresh signal', () => {
 		// Measured, not assumed (syncPostOutageResultType.svelte.test.ts): a
-		// returning server reports `caught_up`, so recovery hung inside the
-		// full_refresh branch would not run in the case this unit exists for.
-		// The pin: the recovery calls appear BEFORE the branch opens.
+		// returning server reports `caught_up`, so recovery reachable only via
+		// `full_refresh` would not run in the case this unit exists for. The
+		// pin: identity recovery is not inside a result-type test, and the
+		// collection load is reachable on the missing term alone.
 		const recovery = layoutSource.indexOf('await workspaceStore.recoverIfMissing(ws)');
-		const branch = layoutSource.indexOf("if (result.type === 'full_refresh'");
+		const branch = layoutSource.indexOf("result.type === 'full_refresh'");
 		expect(recovery).toBeGreaterThan(-1);
 		expect(branch).toBeGreaterThan(-1);
 		expect(recovery).toBeLessThan(branch);

--- a/web/src/lib/stores/workspace.svelte.ts
+++ b/web/src/lib/stores/workspace.svelte.ts
@@ -14,6 +14,14 @@ let loading = $state(false);
 // membership for workspace B.
 let membershipSeq = 0;
 
+// The `loadAll` request currently in flight, or null. Consumed by
+// `recoverIfMissing`, which must JOIN it rather than skip past it: acting on a
+// still-empty `workspaces` sends `setCurrent` down its single-workspace
+// fallback for no reason (TASK-2200, codex round 4). Cleared in `loadAll`'s
+// own `finally`, so a failed request does not leave a dead promise behind for
+// the next caller to await.
+let inFlightLoadAll: Promise<void> | null = null;
+
 /**
  * Resource-scoped permission helpers (PLAN-1100 / TASK-1101).
  *
@@ -68,11 +76,18 @@ export const workspaceStore = {
 
 	async loadAll() {
 		loading = true;
-		try {
-			workspaces = await api.workspaces.list();
-		} finally {
-			loading = false;
-		}
+		// Published so `recoverIfMissing` can JOIN this request rather than
+		// skip past it — see the note there (codex round 4).
+		const load = (async () => {
+			try {
+				workspaces = await api.workspaces.list();
+			} finally {
+				loading = false;
+				inFlightLoadAll = null;
+			}
+		})();
+		inFlightLoadAll = load;
+		return load;
 	},
 
 	/**
@@ -105,9 +120,19 @@ export const workspaceStore = {
 	 * on an in-flight one.
 	 */
 	async recoverIfMissing(ws: string): Promise<void> {
-		if (workspaces.length === 0 && !loading) {
+		if (workspaces.length === 0) {
 			try {
-				await workspaceStore.loadAll();
+				// JOIN an in-flight list request rather than skipping past it
+				// (codex round 4). The first draft skipped on `!loading` and
+				// went straight to `setCurrent`, which — with `workspaces` still
+				// empty — falls back to a single-workspace fetch; if THAT failed
+				// while the in-flight list succeeded moments later, `current`
+				// stayed null and the shell stayed broken until the next sync
+				// result. Recoverable, but a wasted round, and the skip was the
+				// same "in flight" question `ensureCollections` answers by
+				// joining. Got it right in one place and wrong in the other, in
+				// one unit; they now answer it the same way.
+				await (inFlightLoadAll ?? workspaceStore.loadAll());
 			} catch {
 				// Still unreachable. Leave both pieces of state as they are —
 				// the next sync result asks again, and asking again is the whole

--- a/web/src/lib/stores/workspace.svelte.ts
+++ b/web/src/lib/stores/workspace.svelte.ts
@@ -75,6 +75,61 @@ export const workspaceStore = {
 		}
 	},
 
+	/**
+	 * Re-acquire workspace identity when a previous attempt left it missing
+	 * (TASK-2200).
+	 *
+	 * THE DEFECT THIS EXISTS FOR. A cold load while the server is unreachable
+	 * leaves `workspaces` empty and `current` null, and NOTHING retried either:
+	 * the root layout attempts `loadAll` once per auth resolution, and
+	 * `setCurrent` runs once from an effect keyed on a workspace slug that does
+	 * not change. Every other caller of both is a user action — a topbar
+	 * reorder, the workspace switcher, the create-workspace modal. So when the
+	 * server came back the board could recover (its own Retry, and the items
+	 * cache) inside a shell with no navigation at all: the sidebar builds its
+	 * links from `current`, so with `current` null there are no links to build,
+	 * and only F5 fixed it.
+	 *
+	 * GATED ON THE CONDITION, NOT ON A SIGNAL TYPE. The caller is the workspace
+	 * layout's sync subscriber, and it calls this on EVERY sync result rather
+	 * than on `full_refresh` alone. That is deliberate and measured: after a
+	 * server returns, `/changes` usually SUCCEEDS with nothing to report, so the
+	 * result is `caught_up` — the type that means "nothing was missed" is
+	 * exactly the one that arrives when everything was missed, because the
+	 * cursor was seeded during the outage. Gating recovery on `full_refresh`
+	 * would therefore miss the common case. The condition below is the real
+	 * gate, and it is cheap: two reads, both false on a healthy session.
+	 *
+	 * IDEMPOTENT AND SELF-LIMITING. When identity is intact this does nothing
+	 * and issues no request. `loading` keeps it from stacking a second list call
+	 * on an in-flight one.
+	 */
+	async recoverIfMissing(ws: string): Promise<void> {
+		if (workspaces.length === 0 && !loading) {
+			try {
+				await workspaceStore.loadAll();
+			} catch {
+				// Still unreachable. Leave both pieces of state as they are —
+				// the next sync result asks again, and asking again is the whole
+				// mechanism. Swallowing here rather than rethrowing keeps a
+				// failure from taking the caller's other subscribers down.
+				return;
+			}
+		}
+		// Checked AFTER the list attempt, and against the slug rather than for
+		// mere presence: `setCurrent` resolves out of `workspaces` when it can
+		// and falls back to a single-workspace fetch when it cannot, so running
+		// it second gives it the array to work with. A `current` pointing at a
+		// DIFFERENT workspace is also wrong here — this is the recovery path for
+		// the workspace the layout is showing.
+		if (!current || current.slug !== ws) {
+			// `setCurrent` catches its own failures into `current = null`, so
+			// there is nothing to catch here and nothing to report: a still-down
+			// server simply leaves the condition true for the next attempt.
+			await workspaceStore.setCurrent(ws);
+		}
+	},
+
 	async setCurrent(ws: Workspace | string) {
 		// Capture a sequence token for this call. Any /me response received
 		// after a later setCurrent / create has run will be discarded — see

--- a/web/src/lib/stores/workspace.svelte.ts
+++ b/web/src/lib/stores/workspace.svelte.ts
@@ -20,7 +20,20 @@ let membershipSeq = 0;
 // fallback for no reason (TASK-2200, codex round 4). Cleared in `loadAll`'s
 // own `finally`, so a failed request does not leave a dead promise behind for
 // the next caller to await.
+//
+// NOT ADDRESSED HERE, and named rather than left implicit: `loadAll` has no
+// guard on which RESPONSE commits, so two overlapping calls can leave the
+// OLDER list in `workspaces` if it resolves last. `collections.svelte.ts` has
+// exactly that guard (`seq !== collectionsLoadSeq`) and this store does not.
+// Pre-existing, unrelated to the recovery path — the recovery only ever joins,
+// never issues a competing call — and a separate fix with its own test.
 let inFlightLoadAll: Promise<void> | null = null;
+// Monotonic generation for `loadAll`, so its cleanup can tell "I still own the
+// slot" from "a newer call took it" — the same instrument, and the same name
+// shape, as `collectionsLoadSeq` next door. A promise-identity check would read
+// more directly but forces a self-reference the type checker cannot prove is
+// assigned before use.
+let loadAllSeq = 0;
 
 /**
  * Resource-scoped permission helpers (PLAN-1100 / TASK-1101).
@@ -75,6 +88,7 @@ export const workspaceStore = {
 	},
 
 	async loadAll() {
+		const seq = ++loadAllSeq;
 		loading = true;
 		// Published so `recoverIfMissing` can JOIN this request rather than
 		// skip past it — see the note there (codex round 4).
@@ -82,8 +96,25 @@ export const workspaceStore = {
 			try {
 				workspaces = await api.workspaces.list();
 			} finally {
-				loading = false;
-				inFlightLoadAll = null;
+				// OWNERSHIP, by promise identity (codex round 5). Clearing
+				// unconditionally lets an older overlapping request finish first
+				// and clear a NEWER one's slot, after which a concurrent
+				// `recoverIfMissing` starts a third request instead of joining
+				// the load still running — the race round 4 just closed,
+				// reintroduced by its own cleanup.
+				//
+				// This is the same rule `collections.svelte.ts` already applies
+				// to its `loading` flag and join slot, expressed there with a
+				// sequence counter. Third time in this unit that a rule was
+				// applied at one door and not its sibling.
+				//
+				// `loading` moves under the same guard for the same reason: an
+				// older load flipping it off while a newer one runs is the
+				// spinner half of the same mistake.
+				if (seq === loadAllSeq) {
+					loading = false;
+					inFlightLoadAll = null;
+				}
 			}
 		})();
 		inFlightLoadAll = load;

--- a/web/src/lib/stores/workspaceRecovery.svelte.test.ts
+++ b/web/src/lib/stores/workspaceRecovery.svelte.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Workspace } from '$lib/types';
+
+/**
+ * TASK-2200 — the shell brick, and specifically the half nothing retried.
+ *
+ * A cold load while the server is unreachable leaves `workspaces` empty and
+ * `current` null. Both are acquired exactly once — `loadAll` from the root
+ * layout's per-auth-resolution attempt, `setCurrent` from an effect keyed on a
+ * workspace slug that does not change — and every other caller of either is a
+ * user action. So when the server came back, the board could recover while the
+ * sidebar stayed empty: its links are built from `current`, and only F5 fixed
+ * it.
+ *
+ * `recoverIfMissing` is the retry, and these legs pin the two things that make
+ * it one: that it ACTS when identity is missing, and that it does NOTHING when
+ * identity is intact. The second matters as much as the first — a recovery that
+ * fired unconditionally would re-list the workspaces on every sync result of
+ * every healthy session, which is a worse defect than the one being fixed and
+ * would pass any test that only checked the first.
+ *
+ * Fresh module per test: the store holds module-level rune state with no reset.
+ */
+
+function ws(slug: string, name = slug): Workspace {
+	return { id: `id-${slug}`, slug, name, owner_username: 'dave' } as unknown as Workspace;
+}
+
+async function load() {
+	vi.resetModules();
+	const { api } = await import('$lib/api/client');
+	const { workspaceStore } = await import('./workspace.svelte');
+	return { api, workspaceStore };
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe('TASK-2200 — workspace identity recovers after a failed cold load', () => {
+	it('re-acquires the list AND the current workspace when both are missing', async () => {
+		const { api, workspaceStore } = await load();
+
+		// The outage: the cold load's list attempt rejected, so the store is
+		// empty and `current` was never resolved.
+		const list = vi.spyOn(api.workspaces, 'list').mockRejectedValueOnce(new Error('down'));
+		await workspaceStore.loadAll().catch(() => undefined);
+		expect(workspaceStore.workspaces).toEqual([]);
+		expect(workspaceStore.current).toBeNull();
+
+		// The server returns.
+		list.mockResolvedValue([ws('alpha')]);
+		vi.spyOn(api.workspaces, 'me').mockResolvedValue({} as never);
+
+		await workspaceStore.recoverIfMissing('alpha');
+
+		expect(workspaceStore.workspaces.map((w) => w.slug)).toEqual(['alpha']);
+		expect(workspaceStore.current?.slug).toBe('alpha');
+	});
+
+	it('CONTROL — does nothing, and issues no request, when identity is intact', async () => {
+		const { api, workspaceStore } = await load();
+
+		vi.spyOn(api.workspaces, 'list').mockResolvedValue([ws('alpha')]);
+		vi.spyOn(api.workspaces, 'me').mockResolvedValue({} as never);
+		await workspaceStore.loadAll();
+		await workspaceStore.setCurrent('alpha');
+
+		const list = vi.spyOn(api.workspaces, 'list');
+		const get = vi.spyOn(api.workspaces, 'get');
+		list.mockClear();
+		get.mockClear();
+
+		await workspaceStore.recoverIfMissing('alpha');
+
+		expect(list).not.toHaveBeenCalled();
+		expect(get).not.toHaveBeenCalled();
+	});
+
+	it('leaves the condition TRUE when the server is still down, so the next result retries', async () => {
+		const { api, workspaceStore } = await load();
+
+		const list = vi.spyOn(api.workspaces, 'list').mockRejectedValue(new Error('still down'));
+		vi.spyOn(api.workspaces, 'get').mockRejectedValue(new Error('still down'));
+
+		// Must not throw — a rejection here would take the sync subscriber's
+		// other consumers down with it.
+		await expect(workspaceStore.recoverIfMissing('alpha')).resolves.toBeUndefined();
+		expect(workspaceStore.workspaces).toEqual([]);
+		expect(workspaceStore.current).toBeNull();
+
+		// The retry is the whole mechanism: a second call must try again rather
+		// than latch on the first failure the way the code it replaces did.
+		list.mockResolvedValue([ws('alpha')]);
+		vi.spyOn(api.workspaces, 'me').mockResolvedValue({} as never);
+		await workspaceStore.recoverIfMissing('alpha');
+
+		expect(workspaceStore.current?.slug).toBe('alpha');
+	});
+
+	it('re-points `current` when it names a DIFFERENT workspace than the one asked for', async () => {
+		const { api, workspaceStore } = await load();
+
+		vi.spyOn(api.workspaces, 'list').mockResolvedValue([ws('alpha'), ws('beta')]);
+		vi.spyOn(api.workspaces, 'me').mockResolvedValue({} as never);
+		await workspaceStore.loadAll();
+		await workspaceStore.setCurrent('alpha');
+		expect(workspaceStore.current?.slug).toBe('alpha');
+
+		// Presence is not the property — being the RIGHT workspace is. A
+		// `current`-is-null check alone would pass this and leave the layout
+		// showing beta's route against alpha's identity.
+		await workspaceStore.recoverIfMissing('beta');
+
+		expect(workspaceStore.current?.slug).toBe('beta');
+	});
+
+	it('does not stack a second list request on one already in flight', async () => {
+		const { api, workspaceStore } = await load();
+
+		let release: (v: Workspace[]) => void = () => {};
+		const list = vi
+			.spyOn(api.workspaces, 'list')
+			.mockImplementation(() => new Promise<Workspace[]>((r) => (release = r)));
+		vi.spyOn(api.workspaces, 'me').mockResolvedValue({} as never);
+
+		const inFlight = workspaceStore.loadAll();
+		await workspaceStore.recoverIfMissing('alpha');
+		expect(list).toHaveBeenCalledTimes(1);
+
+		release([ws('alpha')]);
+		await inFlight;
+	});
+});

--- a/web/src/lib/stores/workspaceRecovery.svelte.test.ts
+++ b/web/src/lib/stores/workspaceRecovery.svelte.test.ts
@@ -115,6 +115,43 @@ describe('TASK-2200 — workspace identity recovers after a failed cold load', (
 		expect(workspaceStore.current?.slug).toBe('beta');
 	});
 
+	it('an OLDER overlapping load settling first does not clear the newer one’s join slot', async () => {
+		const { api, workspaceStore } = await load();
+
+		const settle: { resolve: (v: Workspace[]) => void; reject: (e: Error) => void }[] = [];
+		const list = vi
+			.spyOn(api.workspaces, 'list')
+			.mockImplementation(
+				() => new Promise<Workspace[]>((resolve, reject) => settle.push({ resolve, reject })),
+			);
+		vi.spyOn(api.workspaces, 'me').mockResolvedValue({} as never);
+
+		const older = workspaceStore.loadAll();
+		const newer = workspaceStore.loadAll();
+		expect(list).toHaveBeenCalledTimes(2);
+
+		// The OLDER request settles first, and it FAILS — which is what keeps
+		// `workspaces` empty so the recovery below has something to recover.
+		// The first draft of this leg resolved it successfully, which populated
+		// the array, sent the recovery straight past its list branch, and made
+		// the assertion pass against unconditional cleanup too: a fixture that
+		// could not fail, caught by running it against the mutant.
+		settle[0].reject(new Error('older attempt failed'));
+		await older.catch(() => undefined);
+
+		const recovering = workspaceStore.recoverIfMissing('alpha');
+
+		// Still two. Unconditional cleanup would have let the older failure
+		// clear the slot the NEWER load still owns (codex round 5), and this
+		// would be a third request instead of a join — the race round 4 closed,
+		// reintroduced by its own cleanup.
+		expect(list).toHaveBeenCalledTimes(2);
+
+		settle[1].resolve([ws('alpha')]);
+		await Promise.all([newer, recovering]);
+		expect(workspaceStore.current?.slug).toBe('alpha');
+	});
+
 	it('JOINS a list request already in flight, and still resolves `current` from it', async () => {
 		const { api, workspaceStore } = await load();
 

--- a/web/src/lib/stores/workspaceRecovery.svelte.test.ts
+++ b/web/src/lib/stores/workspaceRecovery.svelte.test.ts
@@ -115,20 +115,34 @@ describe('TASK-2200 — workspace identity recovers after a failed cold load', (
 		expect(workspaceStore.current?.slug).toBe('beta');
 	});
 
-	it('does not stack a second list request on one already in flight', async () => {
+	it('JOINS a list request already in flight, and still resolves `current` from it', async () => {
 		const { api, workspaceStore } = await load();
 
 		let release: (v: Workspace[]) => void = () => {};
 		const list = vi
 			.spyOn(api.workspaces, 'list')
 			.mockImplementation(() => new Promise<Workspace[]>((r) => (release = r)));
+		// The single-workspace fallback is DOWN. That is the discriminating
+		// part: the first draft of `recoverIfMissing` skipped an in-flight list
+		// and went straight to `setCurrent`, which — with `workspaces` still
+		// empty — takes this fallback, and when it failed `current` stayed null
+		// even though the list request succeeded moments later (codex round 4).
+		const get = vi.spyOn(api.workspaces, 'get').mockRejectedValue(new Error('down'));
 		vi.spyOn(api.workspaces, 'me').mockResolvedValue({} as never);
 
 		const inFlight = workspaceStore.loadAll();
-		await workspaceStore.recoverIfMissing('alpha');
+		const recovering = workspaceStore.recoverIfMissing('alpha');
+
+		// One request, not two.
 		expect(list).toHaveBeenCalledTimes(1);
 
 		release([ws('alpha')]);
-		await inFlight;
+		await Promise.all([inFlight, recovering]);
+
+		// And the outcome, which the call-count assertion alone cannot see:
+		// `current` is resolved OUT OF THE JOINED LIST, so the dead fallback is
+		// never needed.
+		expect(workspaceStore.current?.slug).toBe('alpha');
+		expect(get).not.toHaveBeenCalled();
 	});
 });

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -24,7 +24,20 @@
 
 	let showShortcuts = $state(false);
 	let authReady = $state(false);
-	let workspacesLoaded = $state(false);
+	// An ATTEMPT has been made, not a load has SUCCEEDED (TASK-2200). The old
+	// name said the latter and the code did the former — it is set before the
+	// call and never reset, so a `loadAll` that REJECTED read afterwards as a
+	// completed load. That was half of the cold-load-during-outage shell brick:
+	// the flag it left behind disabled the only automatic retry this effect has.
+	//
+	// Deliberately still set BEFORE the call, and deliberately not reset on
+	// failure. Setting it only on success would re-arm an effect whose guard
+	// READS `workspaceStore.loading`, so every failed attempt would flip that
+	// dependency and re-run the effect — a hot retry loop against a server that
+	// is down. Recovery belongs where it can be gated on a CONDITION rather than
+	// on a flag: `workspaceStore.recoverIfMissing`, driven by the workspace
+	// layout's sync subscriber.
+	let workspacesRequested = $state(false);
 	let authLoadFailed = $state(false);
 	let isAuthPage = $derived(
 		page.url.pathname === '/login'
@@ -134,7 +147,7 @@
 		// alone: authReady flips true inside the unauthenticated branches of
 		// onMount BEFORE the /login redirect completes, so during that window a
 		// logged-out user on a protected route would otherwise fire loadAll()
-		// and latch workspacesLoaded=true, blocking the retry after login.
+		// and latch workspacesRequested=true, blocking the retry after login.
 		// authLoadFailed covers the deployment case where the auth endpoint is
 		// unavailable and authStore.authenticated stays false by design.
 		if (
@@ -142,10 +155,10 @@
 			(authStore.authenticated || authLoadFailed) &&
 			!isAuthPage &&
 			!isSharePage &&
-			!workspacesLoaded &&
+			!workspacesRequested &&
 			!workspaceStore.loading
 		) {
-			workspacesLoaded = true;
+			workspacesRequested = true;
 			workspaceStore.loadAll();
 		}
 	});

--- a/web/src/routes/[username]/[workspace]/+layout.svelte
+++ b/web/src/routes/[username]/[workspace]/+layout.svelte
@@ -80,20 +80,30 @@
 				// Still unreachable. The next sync result asks again; throwing
 				// out of a subscriber would take the other subscribers with it.
 			}
-			if (!collectionStore.collectionsAreFreshFor(ws)) {
-				// The collections analogue, and `collectionsAreFreshFor` is the
-				// right predicate rather than `collections.length === 0`: it
-				// already distinguishes "this workspace's list" from a stale
-				// previous workspace's, and a genuinely empty workspace stamps
-				// its slug on success so this does not re-fire for it.
+			// ONE collection load, two reasons to want it (codex round 1). The
+			// recovery reason and the refresh reason are different — we are
+			// MISSING the list, versus the server says the list CHANGED — but
+			// they are not exclusive, and asking them as separate `if`s fired
+			// two requests whenever both were true. The store's load-generation
+			// guard drops the older response rather than corrupting anything,
+			// so this was waste and a superseded request rather than a wrong
+			// list; it is still a request nobody needed.
+			//
+			// `collectionsAreFreshFor` is the right recovery predicate rather
+			// than `collections.length === 0`: it already distinguishes "this
+			// workspace's list" from a stale previous workspace's, and a
+			// genuinely empty workspace stamps its slug on success, so it does
+			// not re-fire for one.
+			const collectionsMissing = !collectionStore.collectionsAreFreshFor(ws);
+			const collectionsChanged =
+				result.type === 'full_refresh' ||
+				(result.type === 'incremental' && result.changes.collections_changed);
+			if (collectionsMissing || collectionsChanged) {
 				collectionStore.loadCollections(ws).catch(() => {
-					// Same posture as above — the next result retries.
+					// Same posture as the identity recovery above: the next sync
+					// result asks again, and throwing out of a subscriber would
+					// take the other subscribers with it.
 				});
-			}
-			if (result.type === 'full_refresh' || (result.type === 'incremental' && result.changes.collections_changed)) {
-				// Distinct from the recovery above and still needed: this one
-				// refreshes a list we HAVE because the server says it CHANGED.
-				collectionStore.loadCollections(ws);
 			}
 			// Always reconcile, even for `caught_up` — SSE delivers events, not
 			// delta data, and a previous failure won't recover without a fresh

--- a/web/src/routes/[username]/[workspace]/+layout.svelte
+++ b/web/src/routes/[username]/[workspace]/+layout.svelte
@@ -58,7 +58,41 @@
 			// reconcile is still safe to skip: whichever layout instance IS
 			// showing that workspace has its own subscription.
 			if (ws !== wsSlug) return;
+			// RECOVERY, on EVERY result type and gated on the CONDITION rather
+			// than on the signal (TASK-2200). A cold load during a server
+			// outage leaves workspace identity and the collection list missing
+			// with nothing to retry either: the root layout attempts `loadAll`
+			// once per auth resolution, and `setCurrent` / `loadCollections`
+			// run once from an effect keyed on a slug that does not change. The
+			// board could then recover — its own Retry, and the items cache —
+			// inside a shell with no navigation, because the sidebar builds its
+			// links from `workspaceStore.current` and the collection list.
+			//
+			// Not gated on `full_refresh`, and that is the measured part: when
+			// the server comes back, `/changes` usually SUCCEEDS with nothing to
+			// report, so the result is `caught_up`. The type meaning "nothing
+			// was missed" is exactly the one that arrives when everything was,
+			// because the cursor was seeded during the outage. Both calls below
+			// are no-ops when nothing is missing.
+			try {
+				await workspaceStore.recoverIfMissing(ws);
+			} catch {
+				// Still unreachable. The next sync result asks again; throwing
+				// out of a subscriber would take the other subscribers with it.
+			}
+			if (!collectionStore.collectionsAreFreshFor(ws)) {
+				// The collections analogue, and `collectionsAreFreshFor` is the
+				// right predicate rather than `collections.length === 0`: it
+				// already distinguishes "this workspace's list" from a stale
+				// previous workspace's, and a genuinely empty workspace stamps
+				// its slug on success so this does not re-fire for it.
+				collectionStore.loadCollections(ws).catch(() => {
+					// Same posture as above — the next result retries.
+				});
+			}
 			if (result.type === 'full_refresh' || (result.type === 'incremental' && result.changes.collections_changed)) {
+				// Distinct from the recovery above and still needed: this one
+				// refreshes a list we HAVE because the server says it CHANGED.
 				collectionStore.loadCollections(ws);
 			}
 			// Always reconcile, even for `caught_up` — SSE delivers events, not

--- a/web/src/routes/[username]/[workspace]/+layout.svelte
+++ b/web/src/routes/[username]/[workspace]/+layout.svelte
@@ -80,31 +80,32 @@
 				// Still unreachable. The next sync result asks again; throwing
 				// out of a subscriber would take the other subscribers with it.
 			}
-			// ONE collection load, two reasons to want it (codex round 1). The
-			// recovery reason and the refresh reason are different — we are
-			// MISSING the list, versus the server says the list CHANGED — but
-			// they are not exclusive, and asking them as separate `if`s fired
-			// two requests whenever both were true. The store's load-generation
-			// guard drops the older response rather than corrupting anything,
-			// so this was waste and a superseded request rather than a wrong
-			// list; it is still a request nobody needed.
+			// ONE collection call, and WHICH one is the caller's intent (codex
+			// rounds 1 and 2). Two reasons to want the list, and they are not
+			// the same request:
 			//
-			// `collectionsAreFreshFor` is the right recovery predicate rather
-			// than `collections.length === 0`: it already distinguishes "this
-			// workspace's list" from a stale previous workspace's, and a
-			// genuinely empty workspace stamps its slug on success, so it does
-			// not re-fire for one.
-			const collectionsMissing = !collectionStore.collectionsAreFreshFor(ws);
+			//   - the server says the list CHANGED, so a fetch issued before
+			//     that change cannot answer it — `loadCollections`, always a
+			//     real request;
+			//   - we simply do not HAVE this workspace's list, which a request
+			//     already in flight answers perfectly — `ensureCollections`,
+			//     which joins it instead of issuing a second one.
+			//
+			// Asking them as two separate `if`s fired two requests whenever both
+			// were true (round 1), and the recovery arm alone still raced the
+			// workspace effect's own in-flight load (round 2). The store owns
+			// the join because only the store can see what is in flight.
 			const collectionsChanged =
 				result.type === 'full_refresh' ||
 				(result.type === 'incremental' && result.changes.collections_changed);
-			if (collectionsMissing || collectionsChanged) {
-				collectionStore.loadCollections(ws).catch(() => {
-					// Same posture as the identity recovery above: the next sync
-					// result asks again, and throwing out of a subscriber would
-					// take the other subscribers with it.
-				});
-			}
+			const collectionWork = collectionsChanged
+				? collectionStore.loadCollections(ws)
+				: collectionStore.ensureCollections(ws);
+			collectionWork.catch(() => {
+				// Same posture as the identity recovery above: the next sync
+				// result asks again, and throwing out of a subscriber would take
+				// the other subscribers with it.
+			});
 			// Always reconcile, even for `caught_up` — SSE delivers events, not
 			// delta data, and a previous failure won't recover without a fresh
 			// attempt. The localIndex cursor is independent of


### PR DESCRIPTION
Unit A of TASK-2200 — the shell brick. Unit B (persist collection metadata so a cold offline load renders from cache) is filed separately as TASK-2946.

## The defect

A cold load while the server is unreachable left the shell permanently navigation-less. When the server came back the board recovered — its own Retry, plus the items cache — inside a shell with **no links at all**. Only F5 fixed it, and nothing said so.

**What nothing retried.** `workspaces` and `current` are each acquired exactly once: `loadAll` from the root layout's per-auth-resolution attempt, `setCurrent` from an effect keyed on a workspace slug that does not change. Every other caller of either is a user action — a topbar reorder, the workspace switcher, the create-workspace modal. `setCurrent` cannot self-heal either: with an empty array it falls back to a single-workspace fetch and CATCHES the failure into `current = null`. The sidebar builds its links from `current`, so there were none to build.

**The item that filed this blamed `loadCollections`**, which is the half that has a recovery path. The permanent half is identity, in a file the item never cites. Full premise-by-premise recon is on TASK-2200's trail.

## Gated on the condition, not on `full_refresh` — and that is the measured part

The obvious home for recovery is the workspace layout's existing `full_refresh` branch. It is the wrong one. When the server comes back, `/changes` **succeeds**, and because the cursor was seeded during the outage a quiet workspace answers with nothing to report — so the result is **`caught_up`**. The type meaning "nothing was missed" is exactly the one delivered when everything was. `full_refresh` arrives only when `/changes` itself fails, which is the case where the server is still down and recovery cannot work anyway.

`syncPostOutageResultType.svelte.test.ts` pins that reading, with a CONTROL leg proving `full_refresh` is still emitted when it should be — so if a future change makes a returning server emit it after all, the gating decision gets revisited rather than inherited.

**That correction also lands on this unit's own recon**, which claimed collections "now recover on their own" via TASK-2921's `full_refresh` subscriber. True only when `/changes` also fails. I traced the subscriber and the SSE reconnect and stopped one link short of the one that decides it.

## What ships

- **`workspaceStore.recoverIfMissing(ws)`** — re-acquires the list when `workspaces` is empty, re-points `current` when it is null or names a different workspace. Issues nothing when identity is intact.
- **`collectionStore.ensureCollections(ws)`** — "make sure a list exists", as distinct from `loadCollections`'s "fetch a fresh one". Joins an in-flight load rather than duplicating it.
- **The workspace layout calls them on every sync result**, picking by intent: `loadCollections` when the server says the list changed, `ensureCollections` otherwise.
- **`workspacesLoaded` → `workspacesRequested`** in the root layout — a rename, not new semantics. It said a load had SUCCEEDED while the code set it before the call and never reset it, so a rejected `loadAll` read afterwards as a completed one.

**Divergence from the ruling, flagged rather than buried.** The ruling was "the latch means a load succeeded, so a rejected `loadAll` leaves it unset". Setting it only on success re-arms an effect whose guard READS `workspaceStore.loading` — every failed attempt flips that dependency, the effect re-runs, and the result is a hot retry loop against a down server. The honest name plus a condition-gated recovery elsewhere gets the intent without it. The logged-out-mid-redirect guard is untouched, as ruled.

## Review rounds — and what their distribution said

| Round | Finding |
|---|---|
| 1 | Duplicate collection load when `full_refresh` and stale coincided |
| 2 | The recovery arm still raced the workspace effect's own in-flight load |
| 3 | The in-flight slot's comment claimed a per-workspace map; **the proposed map would have been the defect** |
| 4 | `recoverIfMissing` SKIPPED an in-flight `loadAll` where its sibling JOINS |
| 5 | `loadAll`'s cleanup was unguarded, so an older request could clear a newer one's slot |
| 6 | CLEAN |

**One finding per round, five rounds, all in one layer: the in-flight coordination around the new recovery path.** Read as a set that is not five unrelated bugs — it is one mechanism (generation counter + keyed in-flight slot + ownership-guarded cleanup) that now exists **twice**, hand-rolled, in two stores. Rounds 4 and 5 are both literally "you applied the rule in one store and not the other", and three times in this unit a rule went in at one door and not its sibling.

The branch-removing answer is to extract that mechanism once and have both stores use it. **Not done here** — it touches `loadCollections`'s 19 call sites and belongs in its own unit with its own tests, not folded into a recovery fix. Filed as a follow-up.

Round 3 is worth its own line: the finding was right about the prose and wrong about the remedy. `loadCollections` commits only the LATEST call, so a superseded request's response is dropped — joining it would resolve the caller against a result that never lands. The comment was corrected and the ordering it named is pinned as a test asserting the behaviour, not the proposal.

## Tests

`workspaceRecovery.svelte.test.ts` pins the audit's own sequence plus a **CONTROL** leg proving an intact session issues NO request — a recovery that fired unconditionally would re-list workspaces on every sync result of every healthy session, which is worse than the defect and would pass any test that only checked the first leg. Also: a still-down server leaves the condition true so the next result retries; a `current` naming a different workspace is re-pointed; an in-flight load is JOINED with the single-workspace fallback held down (the leg that discriminates round 4); an older overlapping load settling first does not clear the newer one's slot.

`collectionsEnsure.svelte.test.ts`'s load-bearing leg is the **CONTROL** — `loadCollections` is NOT coalesced — because moving the join down into it would look like a tidy simplification and would pass every other assertion in the file while quietly serving pre-change data to an SSE rename.

**Two fixtures were caught not discriminating and rewritten**, both by running them against the mutant rather than by reading them: one held a single `release` across two mocked promises and hung, and one resolved an older request successfully, which populated the array and made the assertion pass against unconditional cleanup too.

## Named, not fixed

`loadAll` has no guard on which RESPONSE commits, so two overlapping calls can leave the older list in `workspaces`. `collections.svelte.ts` has that guard; this store does not. Pre-existing, unreachable through the recovery path (which only ever joins), and written into the store's own comment so the next reader finds it at the code.

## Gates

| Gate | Result |
|---|---|
| `golangci-lint` | 0 issues |
| `go test ./...` | 30 packages ok, 0 FAIL |
| `svelte-check` | 0 errors |
| `vitest` | 2261 passed / 143 files |

On `20a34b36`, `origin/main` at `ee0d9458` — rebased and re-gated after #1283 (BUG-2870, CLI/MCP)
landed first. No overlap with this diff, and the full Go suite confirms it: that unit's GO was
older than mine and its checks finished minutes apart, so under the standing rule mine was void
on the new tip rather than inherited by it. Every gate above was re-run on the rebased tree.

https://claude.ai/code/session_01Xk9M5UVPdc84xL5E1mZkm8

