### PR TITLE
fix(cli,mcp): item update --parent "" is refused, not silently ignored (BUG-2941)

### DIFF
--- a/cmd/pad/cmd_item.go
+++ b/cmd/pad/cmd_item.go
@@ -1024,6 +1024,36 @@ Examples:
   pad item update DOC-3 --stdin < updated-doc.md`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// AN EMPTY --parent IS REFUSED, not ignored (BUG-2941) — and it is
+			// refused HERE, before the client is built or a single request is
+			// sent (codex round 1 [P1]). The first draft put this beside the
+			// parent handling further down, which is after the GetItem below,
+			// so a refused call still made a request; a test that only watched
+			// for WRITES would have passed a version that refuses after
+			// fetching, and did.
+			//
+			// `--parent ""` reads as "detach this item", and for a long time
+			// it exited 0 and printed the updated item while doing nothing:
+			// `hasFieldChanges` tests `parentRef != ""`, so an empty value
+			// contributed no patch and the key the server's clear-path needs
+			// (`parent` present, empty) never went on the wire. BUG-2078
+			// shipped `--clear-parent` as the working route and left this one
+			// looking like it worked; getpad.dev's CLI reference still taught
+			// the empty form as the way to detach, which is where the
+			// expectation came from.
+			//
+			// Refusing rather than quietly aliasing it to --clear-parent: two
+			// spellings for one operation is what produced the confusion, and
+			// naming the flag that does the job is the actionable answer.
+			//
+			// UPDATE only, deliberately. On `item create` an empty --parent
+			// expresses nothing to ignore — there is no parent to detach —
+			// and `--parent "$MAYBE_EMPTY"` is a normal shell idiom there.
+			// Same asymmetry as v0.18/v0.19's update-only clear flags.
+			if cmd.Flags().Changed("parent") && parentFlag == "" {
+				return fmt.Errorf(`--parent "" does not detach an item and never did — it is silently ignored; use --clear-parent to remove the parent link`)
+			}
+
 			client, _ := getClient()
 			ws := getWorkspace()
 			slug := args[0]
@@ -1083,31 +1113,6 @@ Examples:
 			// no longer clobber each other — the old read-modify-write here
 			// (fetch item, merge locally, send the whole blob) lost the later
 			// writer's change on the last write.
-			// AN EMPTY --parent IS REFUSED HERE, not ignored (BUG-2941).
-			//
-			// `--parent ""` reads as "detach this item", and for a long time
-			// it exited 0 and printed the updated item while doing nothing:
-			// `hasFieldChanges` tests `parentRef != ""`, so an empty value
-			// contributes no patch and the key the server's clear-path needs
-			// (`parent` present, empty) never goes on the wire. BUG-2078
-			// shipped `--clear-parent` as the working route but left this one
-			// looking like it worked, and the public CLI docs still taught it
-			// — which is where the expectation came from.
-			//
-			// Refusing rather than quietly aliasing it to --clear-parent: two
-			// spellings for one operation is what produced the confusion, and
-			// a caller who typed the empty form wanted a detach that this
-			// command did not perform. Naming the flag that does it is the
-			// actionable answer.
-			//
-			// UPDATE only, deliberately. On `item create` an empty --parent
-			// expresses nothing to ignore — there is no parent to detach —
-			// and `--parent "$MAYBE_EMPTY"` is a normal shell idiom there.
-			// Same asymmetry as v0.18/v0.19's update-only clear flags.
-			if cmd.Flags().Changed("parent") && parentFlag == "" {
-				return fmt.Errorf(`--parent "" does not detach an item and never did — it is silently ignored; use --clear-parent to remove the parent link`)
-			}
-
 			parentRef := parentFlag
 
 			hasFieldChanges := status != "" || priority != "" || assignee != "" || parentRef != "" || category != "" || len(fieldFlags) > 0 || clearParent

--- a/cmd/pad/cmd_item.go
+++ b/cmd/pad/cmd_item.go
@@ -1083,6 +1083,31 @@ Examples:
 			// no longer clobber each other — the old read-modify-write here
 			// (fetch item, merge locally, send the whole blob) lost the later
 			// writer's change on the last write.
+			// AN EMPTY --parent IS REFUSED HERE, not ignored (BUG-2941).
+			//
+			// `--parent ""` reads as "detach this item", and for a long time
+			// it exited 0 and printed the updated item while doing nothing:
+			// `hasFieldChanges` tests `parentRef != ""`, so an empty value
+			// contributes no patch and the key the server's clear-path needs
+			// (`parent` present, empty) never goes on the wire. BUG-2078
+			// shipped `--clear-parent` as the working route but left this one
+			// looking like it worked, and the public CLI docs still taught it
+			// — which is where the expectation came from.
+			//
+			// Refusing rather than quietly aliasing it to --clear-parent: two
+			// spellings for one operation is what produced the confusion, and
+			// a caller who typed the empty form wanted a detach that this
+			// command did not perform. Naming the flag that does it is the
+			// actionable answer.
+			//
+			// UPDATE only, deliberately. On `item create` an empty --parent
+			// expresses nothing to ignore — there is no parent to detach —
+			// and `--parent "$MAYBE_EMPTY"` is a normal shell idiom there.
+			// Same asymmetry as v0.18/v0.19's update-only clear flags.
+			if cmd.Flags().Changed("parent") && parentFlag == "" {
+				return fmt.Errorf(`--parent "" does not detach an item and never did — it is silently ignored; use --clear-parent to remove the parent link`)
+			}
+
 			parentRef := parentFlag
 
 			hasFieldChanges := status != "" || priority != "" || assignee != "" || parentRef != "" || category != "" || len(fieldFlags) > 0 || clearParent
@@ -1323,7 +1348,7 @@ Examples:
 	cmd.Flags().StringVar(&priority, "priority", "", "update priority field")
 	cmd.Flags().StringVar(&assignee, "assign", "", "assign to user (name or email)")
 	cmd.Flags().StringVar(&roleFlag, "role", "", "assign agent role (slug)")
-	cmd.Flags().StringVar(&parentFlag, "parent", "", "update parent item (ref, slug, or ID); an empty --parent \"\" is silently ignored, it does NOT clear — use --clear-parent")
+	cmd.Flags().StringVar(&parentFlag, "parent", "", "update parent item (ref, slug, or ID); an empty --parent \"\" is REFUSED, it does not clear — use --clear-parent")
 	cmd.Flags().StringVar(&category, "category", "", "update category field")
 	cmd.Flags().StringVar(&tags, "tags", "", "update tags (JSON array)")
 	cmd.Flags().StringArrayVarP(&fieldFlags, "field", "f", nil, "set a field (repeatable): --field key=value; refused for implementation_notes (use `pad item note`), decision_log (`pad item decide`) and convention (`pad library activate`)")

--- a/cmd/pad/cmd_item.go
+++ b/cmd/pad/cmd_item.go
@@ -1032,8 +1032,9 @@ Examples:
 			// for WRITES would have passed a version that refuses after
 			// fetching, and did.
 			//
-			// `--parent ""` reads as "detach this item", and for a long time
-			// it exited 0 and printed the updated item while doing nothing:
+			// `--parent ""` is naturally READ as "detach this item" — that is
+			// the caller's intent, never what the code did — and for a long
+			// time it exited 0 and printed the updated item while doing nothing:
 			// `hasFieldChanges` tests `parentRef != ""`, so an empty value
 			// contributed no patch and the key the server's clear-path needs
 			// (`parent` present, empty) never went on the wire. BUG-2078

--- a/cmd/pad/item_parent_clear_test.go
+++ b/cmd/pad/item_parent_clear_test.go
@@ -22,12 +22,15 @@ import (
 // the expectation came from.
 
 func TestItemUpdateParent_EmptyValueRefused(t *testing.T) {
-	var sawRequest bool
+	// ZERO requests, not "no writes" (codex round 1 [P1]). The first version
+	// of this test ignored GETs, and the first version of the fix refused
+	// AFTER the item fetch — so a refused call still hit the server and this
+	// test passed anyway. Counting every method is what makes it an
+	// instrument for "refused before anything happened".
+	var requests []string
 
 	setupFormatRoutingTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			sawRequest = true
-		}
+		requests = append(requests, r.Method+" "+r.URL.Path)
 		_ = json.NewEncoder(w).Encode(models.Item{Slug: "task-5", CollectionSlug: "tasks"})
 	}))
 	formatFlag = "table"
@@ -46,8 +49,9 @@ func TestItemUpdateParent_EmptyValueRefused(t *testing.T) {
 	if !strings.Contains(execErr.Error(), "--clear-parent") {
 		t.Errorf("refusal must point at --clear-parent; got %q", execErr)
 	}
-	if sawRequest {
-		t.Errorf("a refused --parent must not send a write")
+	if len(requests) != 0 {
+		t.Errorf("a refused --parent must not reach the server at all; it made %d request(s): %v",
+			len(requests), requests)
 	}
 }
 

--- a/cmd/pad/item_parent_clear_test.go
+++ b/cmd/pad/item_parent_clear_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// BUG-2941: `pad item update <ref> --parent ""` exited 0 and printed the
+// updated item while doing nothing. `hasFieldChanges` tests `parentRef != ""`,
+// so the empty value built no patch and the key the server's clear-path needs
+// (`parent` present, empty) never reached the wire. The two representations of
+// the link then disagreed — `parent_id` read null while `parent_ref` and the
+// child listing still named the parent, and the terminal-status guard still
+// refused to close the parent for `open_children`.
+//
+// BUG-2078 shipped `--clear-parent` as the working route and left this one
+// looking like it worked. The public CLI docs still taught it, which is where
+// the expectation came from.
+
+func TestItemUpdateParent_EmptyValueRefused(t *testing.T) {
+	var sawRequest bool
+
+	setupFormatRoutingTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			sawRequest = true
+		}
+		_ = json.NewEncoder(w).Encode(models.Item{Slug: "task-5", CollectionSlug: "tasks"})
+	}))
+	formatFlag = "table"
+
+	cmd := updateCmd()
+	cmd.SetArgs([]string{"TASK-5", "--parent", ""})
+
+	var execErr error
+	out := captureStdout(t, func() { execErr = cmd.Execute() })
+
+	if execErr == nil {
+		t.Fatalf(`--parent "" must be refused, got success:\n%s`, out)
+	}
+	// The refusal has to name the flag that works, or it just moves the dead
+	// end one step later.
+	if !strings.Contains(execErr.Error(), "--clear-parent") {
+		t.Errorf("refusal must point at --clear-parent; got %q", execErr)
+	}
+	if sawRequest {
+		t.Errorf("a refused --parent must not send a write")
+	}
+}
+
+// The control legs. Refusing the empty form must not disturb either
+// neighbouring behaviour, or the fix trades one silent surprise for another.
+func TestItemUpdateParent_NonEmptyAndAbsentStillWork(t *testing.T) {
+	t.Run("a real parent still sets the link", func(t *testing.T) {
+		var patched bool
+		setupFormatRoutingTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodPatch {
+				patched = true
+			}
+			_ = json.NewEncoder(w).Encode(models.Item{ID: "parent-id", Slug: "plan-9", CollectionSlug: "plans"})
+		}))
+		formatFlag = "table"
+
+		cmd := updateCmd()
+		cmd.SetArgs([]string{"TASK-5", "--parent", "PLAN-9"})
+
+		var execErr error
+		out := captureStdout(t, func() { execErr = cmd.Execute() })
+		if execErr != nil {
+			t.Fatalf("a non-empty --parent must still work: %v\n%s", execErr, out)
+		}
+		if !patched {
+			t.Error("expected the update to dispatch")
+		}
+	})
+
+	t.Run("no --parent at all is untouched", func(t *testing.T) {
+		setupFormatRoutingTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_ = json.NewEncoder(w).Encode(models.Item{Slug: "task-5", CollectionSlug: "tasks"})
+		}))
+		formatFlag = "table"
+
+		cmd := updateCmd()
+		cmd.SetArgs([]string{"TASK-5", "--status", "done"})
+
+		var execErr error
+		out := captureStdout(t, func() { execErr = cmd.Execute() })
+		if execErr != nil {
+			t.Fatalf("an update that never mentions --parent must be unaffected: %v\n%s", execErr, out)
+		}
+	})
+}
+
+// CREATE is deliberately NOT refused: an empty --parent there expresses nothing
+// to ignore, since there is no parent to detach, and `--parent "$MAYBE_EMPTY"`
+// is a normal shell idiom. This test exists so that asymmetry is a decision
+// somebody made rather than a gap — if a later change refuses it there too,
+// this test says what was traded away.
+func TestItemCreateParent_EmptyValueStillAccepted(t *testing.T) {
+	setupFormatRoutingTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(models.Item{Slug: "new-task", CollectionSlug: "tasks"})
+	}))
+	formatFlag = "table"
+
+	cmd := createCmd()
+	cmd.SetArgs([]string{"tasks", "a title", "--parent", ""})
+
+	var execErr error
+	out := captureStdout(t, func() { execErr = cmd.Execute() })
+	if execErr != nil {
+		t.Fatalf(`create with an empty --parent must still be accepted: %v\n%s`, execErr, out)
+	}
+}

--- a/internal/mcp/catalog_item_fields.go
+++ b/internal/mcp/catalog_item_fields.go
@@ -604,8 +604,9 @@ func actionItemUpdate(ctx context.Context, input map[string]any, env ActionEnv) 
 // the way to detach.
 //
 // It exists because BUG-2941 made the CLI REFUSE `--parent ""`, and stdio MCP
-// shells out to the CLI: BuildCLIArgs emits a flag for any key that is
-// PRESENT, so `parent: ""` became `--parent ""` and an agent following the
+// shells out to the CLI: BuildCLIArgs emits this string flag whenever the key
+// is PRESENT, empty or not, so `parent: ""` became `--parent ""` and an agent
+// following the
 // documented convention would have been refused on stdio while the remote
 // door went on ignoring it (codex round 1 [P1]). That is a transport
 // divergence created by a fix for a transport-independent bug — the same

--- a/internal/mcp/catalog_item_fields.go
+++ b/internal/mcp/catalog_item_fields.go
@@ -594,7 +594,33 @@ func actionItemUpdate(ctx context.Context, input map[string]any, env ActionEnv) 
 	if errRes != nil {
 		return errRes, nil
 	}
+	dropInertEmptyParent(out)
 	return env.Dispatch(ctx, []string{"item", "update"}, out)
+}
+
+// dropInertEmptyParent removes a present-but-empty `parent` before dispatch,
+// so the catalog keeps the meaning it has documented since v0.19 — an empty
+// DECLARED string means "not provided" on this tool, and `clear_parent` is
+// the way to detach.
+//
+// It exists because BUG-2941 made the CLI REFUSE `--parent ""`, and stdio MCP
+// shells out to the CLI: BuildCLIArgs emits a flag for any key that is
+// PRESENT, so `parent: ""` became `--parent ""` and an agent following the
+// documented convention would have been refused on stdio while the remote
+// door went on ignoring it (codex round 1 [P1]). That is a transport
+// divergence created by a fix for a transport-independent bug — the same
+// class BUG-2870 exists to close, so it is not acceptable as a side effect of
+// this one.
+//
+// Dropped rather than refused: the empty value is inert BY DOCUMENTED DESIGN
+// here, so nobody typed it meaning "detach" — unlike at the CLI, where a
+// human typing `--parent ""` is expressing exactly that. Same input, opposite
+// dispositions, because the two surfaces have opposite conventions about what
+// an empty declared string means.
+func dropInertEmptyParent(input map[string]any) {
+	if v, ok := input["parent"].(string); ok && v == "" {
+		delete(input, "parent")
+	}
 }
 
 // rejectFieldsParam wraps a non-writer pad_item action so a `fields`

--- a/internal/mcp/catalog_item_fields_test.go
+++ b/internal/mcp/catalog_item_fields_test.go
@@ -2276,3 +2276,49 @@ func TestPadItemUpdate_EmptyCompatIDIsStillAClearAfterTheNilFix(t *testing.T) {
 		t.Fatalf("an empty compat ID is a CLEAR and still conflicts with a set: %s", msg)
 	}
 }
+
+// BUG-2941 made the CLI refuse `--parent ""`, and stdio MCP shells out to the
+// CLI — so without dropInertEmptyParent, BuildCLIArgs would turn the catalog's
+// documented-inert `parent: ""` into a refusal on stdio while the remote door
+// kept ignoring it. A transport divergence introduced by a fix, which is the
+// class BUG-2870 exists to close.
+func TestPadItemUpdate_EmptyParentIsDroppedNotDispatched(t *testing.T) {
+	disp, msg, isErr := dispatchPadItem(t, map[string]any{
+		"action": "update",
+		"ref":    "TASK-5",
+		"parent": "",
+		"status": "done",
+	})
+	if isErr {
+		t.Fatalf("an empty parent is inert on this tool, not an error: %s", msg)
+	}
+	if argsContainPair(disp.gotArgs, "--parent", "") {
+		t.Errorf("--parent \"\" must not reach the CLI — it is refused there now: %v", disp.gotArgs)
+	}
+	for _, a := range disp.gotArgs {
+		if a == "--parent" {
+			t.Errorf("no --parent flag should be emitted at all: %v", disp.gotArgs)
+		}
+	}
+	// The control: the rest of the call still dispatches, so dropping the key
+	// did not turn an ordinary update into a no-op.
+	if !argsContainPair(disp.gotArgs, "--status", "done") {
+		t.Errorf("the rest of the update must still be dispatched: %v", disp.gotArgs)
+	}
+}
+
+// ...and a REAL parent still reaches the CLI, so the drop is about emptiness
+// and not about the key.
+func TestPadItemUpdate_NonEmptyParentStillDispatched(t *testing.T) {
+	disp, msg, isErr := dispatchPadItem(t, map[string]any{
+		"action": "update",
+		"ref":    "TASK-5",
+		"parent": "PLAN-9",
+	})
+	if isErr {
+		t.Fatalf("a real parent must dispatch: %s", msg)
+	}
+	if !argsContainPair(disp.gotArgs, "--parent", "PLAN-9") {
+		t.Errorf("--parent PLAN-9 must reach the CLI: %v", disp.gotArgs)
+	}
+}

--- a/internal/mcp/catalog_item_fields_test.go
+++ b/internal/mcp/catalog_item_fields_test.go
@@ -2283,14 +2283,23 @@ func TestPadItemUpdate_EmptyCompatIDIsStillAClearAfterTheNilFix(t *testing.T) {
 // kept ignoring it. A transport divergence introduced by a fix, which is the
 // class BUG-2870 exists to close.
 func TestPadItemUpdate_EmptyParentIsDroppedNotDispatched(t *testing.T) {
+	// `comment` is carried empty ALONGSIDE the empty parent, deliberately
+	// (codex round 2 [P2]): without it this test passes an implementation
+	// that drops EVERY empty-valued key, which would be a much larger and
+	// undiscussed change to the tool's input handling. The assertion below
+	// is that `parent` is the only key this touches.
 	disp, msg, isErr := dispatchPadItem(t, map[string]any{
-		"action": "update",
-		"ref":    "TASK-5",
-		"parent": "",
-		"status": "done",
+		"action":  "update",
+		"ref":     "TASK-5",
+		"parent":  "",
+		"comment": "",
+		"status":  "done",
 	})
 	if isErr {
 		t.Fatalf("an empty parent is inert on this tool, not an error: %s", msg)
+	}
+	if !argsContainPair(disp.gotArgs, "--comment", "") {
+		t.Errorf("only `parent` is dropped — an empty `comment` must reach the CLI exactly as before: %v", disp.gotArgs)
 	}
 	if argsContainPair(disp.gotArgs, "--parent", "") {
 		t.Errorf("--parent \"\" must not reach the CLI — it is refused there now: %v", disp.gotArgs)


### PR DESCRIPTION
```
pad item update IDEA-2937 --parent ""
```

exited 0 and printed the updated item, and did nothing. `hasFieldChanges` tests `parentRef != ""`, so an empty value builds no field patch and the key the server's clear-path needs (`parent` present, empty) never reaches the wire. Afterwards the two representations of the link disagree — `parent_id` reads null while `parent_ref` and `pad item list --parent <ref>` still name the parent, and the parent still refuses to close with `open_children`.

BUG-2078 shipped `--clear-parent` as the route that works and left this one looking like it worked. getpad.dev's CLI reference still taught the empty form as the way to detach, which is where the expectation came from — that half is [pad-web #137](https://github.com/PerpetualSoftware/pad-web/pull/137), to merge after this.

Reported by a user who followed that documentation to correct a mis-parented item, got a success message, and found the item still parented.

## The change

`--parent ""` on **update** is refused, with a message naming `--clear-parent`. Refusing rather than quietly aliasing it: two spellings for one operation is what produced the confusion, and naming the flag that does the job is the actionable answer.

**Compat, stated plainly:** a script passing `--parent "$P"` with `P` empty now gets a loud failure where it used to get a silent no-op — **and a script in that position was already getting a wrong answer**, since the silent no-op reads as a detach that never happened.

`item create` is deliberately **not** refused: an empty `--parent` expresses nothing to ignore there (no parent exists to detach), and `--parent "$MAYBE_EMPTY"` is a normal shell idiom. A test pins that asymmetry so it stays a decision rather than becoming a gap.

## What review caught, and it is the more interesting half

**The refusal was in the wrong place.** It sat beside the parent handling, which is *after* `client.GetItem` — so a refused call still made a request. My test asserted "no write reached the server" and ignored GETs, so it passed a version that refuses after fetching. The guard now runs first in `RunE`, before the client is built, and the test counts **every** request.

**It would have split the transports.** Stdio MCP shells out to the CLI, and `BuildCLIArgs` emits this string flag whenever its key is present — so the catalog's `parent: ""`, documented **inert** since v0.19, would have become `--parent ""` and been refused on stdio while the remote door went on ignoring it. A fix for a transport-independent bug introducing a transport divergence, which is precisely the class the previous unit (BUG-2870, #1283) exists to close. `dropInertEmptyParent` removes the key in `actionItemUpdate` before dispatch.

The same input therefore gets opposite treatment at the two doors, and that is deliberate: at the CLI a human typing `--parent ""` is expressing a detach, so it is **refused** with the flag that performs one; in the catalog an empty declared string means "not provided" by documented design, so nobody typed it meaning detach, and it is **dropped**. Opposite conventions, not an unsettled rule.

## Tests

- CLI: the empty form is refused, the refusal names `--clear-parent`, and **zero** requests reach the server; a real parent still sets the link; an update that never mentions `--parent` is untouched; create still accepts the empty form.
- MCP: `parent: ""` is dropped and never dispatched, an empty `comment` alongside it **still reaches the CLI** (so the test discriminates "drops an empty parent" from "drops every empty-valued key"), and a real parent still dispatches.

Every one was run against the unfixed code: removing the guard fails the CLI test, removing `dropInertEmptyParent` fails the MCP test, and dropping *every* empty key fails the discriminating leg. Each mutant was confirmed to build first.

## Gates

`go test ./...` exit 0 · `make lint` 0 issues · `gofmt -l` clean, on `5e6b1f73` (rebased onto `ee0d9458`). Codex CLEAN at round 3; rounds 1 and 2 are the two findings above plus the test-discrimination gap.

https://claude.ai/code/session_01HeChkgZVYb3NTgTcckF5KR
