### PR TITLE
feat(web): a cold offline load renders the board from cache, fenced by scope (TASK-2946)

### DIFF
--- a/web/src/lib/stores/collectionBoardCacheWiring.test.ts
+++ b/web/src/lib/stores/collectionBoardCacheWiring.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * TASK-2946 — a SOURCE PIN for the board's cache fallback, with the same limits
+ * the workspace layout's pin already records: it cannot see reachability, a
+ * short-circuit survives it, and it should be DELETED the day that route grows
+ * a component harness.
+ *
+ * What it is worth: the fallback cannot be silently removed, and — the part a
+ * behavioural store test cannot reach — it cannot silently MOVE. Its position is
+ * the correctness property here: inside the transient-failure branch and not the
+ * `not_found` one. "Deleted" and "unreachable" are different answers and only
+ * the second may render from cache (BUG-2025 drew that line; this keeps it).
+ */
+const boardSource = readFileSync(
+	fileURLToPath(
+		new URL('../../routes/[username]/[workspace]/[collection]/+page.svelte', import.meta.url),
+	),
+	'utf8',
+);
+
+describe('TASK-2946 — the board falls back to the durable cache, in the right branch', () => {
+	it('asks the store for a cached collection', () => {
+		expect(boardSource).toContain('await collectionStore.cachedCollection(ws, coll)');
+	});
+
+	it('does so AFTER the not_found branch, so a 404 can never render from cache', () => {
+		const notFound = boardSource.indexOf("err.code === 'not_found'");
+		const fallback = boardSource.indexOf('await collectionStore.cachedCollection(ws, coll)');
+		expect(notFound).toBeGreaterThan(-1);
+		expect(fallback).toBeGreaterThan(-1);
+		// The 404 test comes first and returns its own state; the fallback lives
+		// in the `else`. A fallback that drifted above this test would serve a
+		// cached copy of a collection the server says is GONE.
+		expect(notFound).toBeLessThan(fallback);
+	});
+
+	it('says so in the UI rather than rendering stale data silently', () => {
+		// Rendering a saved copy without saying so would be worse than the error
+		// card it replaces, which at least told the truth.
+		expect(boardSource).toContain('metaFromCache = true');
+		expect(boardSource).toContain('{#if metaFromCache}');
+	});
+
+	it('clears the degraded flag per load, so a later success cannot leave the banner up', () => {
+		expect(boardSource).toContain('metaFromCache = false');
+	});
+});

--- a/web/src/lib/stores/collections.svelte.ts
+++ b/web/src/lib/stores/collections.svelte.ts
@@ -1,7 +1,7 @@
 import { api } from '$lib/api/client';
 import type { Collection, Item } from '$lib/types';
 import { localIndex } from './localIndex.svelte';
-import { hydrateCollections, persistCollections } from './localIndexPersistence';
+import { hydrateCollections, persistCollections, readDurableEpoch } from './localIndexPersistence';
 
 let collections = $state<Collection[]>([]);
 let items = $state<Item[]>([]);
@@ -156,11 +156,18 @@ export const collectionStore = {
 	async loadCollections(ws: string) {
 		const seq = ++collectionsLoadSeq;
 		loading = true;
-		// Captured BEFORE the request so `persistCollections` can tell whether a
-		// resync landed underneath it — the list carries no scope of its own and
-		// the stamp is borrowed from the row cache, so it is only honest if that
-		// cache held still (TASK-2946).
-		const epochBefore = localIndex.accessEpochFor(ws);
+		// The DURABLE scope claim before the request, so `persistCollections` can
+		// tell whether a resync landed underneath it — the list carries no scope
+		// of its own and the stamp is borrowed from the row cache, so it is only
+		// honest if that cache held still (TASK-2946).
+		//
+		// Durable rather than `localIndex.accessEpochFor(ws)`, for two reasons
+		// that both cost the feature its common path while it was RAM-based
+		// (codex round 2): a cold tab has no RAM epoch yet, because this fetch
+		// starts before `bootstrap` runs, so every fresh visit refused to cache;
+		// and RAM is not the value `hydrateCollections` compares against, so a
+		// RAM-based bracket could agree while the fence's own value moved.
+		const userId = localIndex.userIdFor(ws);
 		// Published for `ensureCollections` to join, tagged with the workspace
 		// so a joiner asking about A is never handed B's promise. Overwriting a
 		// previous tenant is correct rather than lossy: this assignment happens
@@ -169,7 +176,17 @@ export const collectionStore = {
 		inFlightWs = ws;
 		const load = (async () => {
 		try {
-			const result = await api.collections.list(ws);
+			// Issued TOGETHER, not sequentially. Awaiting the durable read first
+			// would delay the request by a round trip to IndexedDB and — worse —
+			// stop `loadCollections` issuing its fetch synchronously, which is
+			// what lets `ensureCollections` see an in-flight load and join it.
+			// Started in the same tick, the epoch read is "before the fetch" in
+			// the only sense that matters: a resync landing after this point is
+			// exactly what the comparison at write time is looking for.
+			const [result, epochBefore] = await Promise.all([
+				api.collections.list(ws),
+				readDurableEpoch(userId, ws),
+			]);
 			// Drop a stale response: a newer loadCollections (e.g. a workspace
 			// switch that resolved first) has superseded this one, so writing
 			// `collections`/`collectionsWorkspace` here would clobber the newer
@@ -186,13 +203,7 @@ export const collectionStore = {
 			// (TASK-2946). Fire-and-forget and best-effort, like every other
 			// durable write here; `persistCollections` itself decides whether the
 			// stamp it would write is honest.
-			void persistCollections(
-				localIndex.userIdFor(ws),
-				ws,
-				result,
-				epochBefore,
-				localIndex.accessEpochFor(ws),
-			);
+			void persistCollections(userId, ws, result, epochBefore);
 		} finally {
 			// Only the latest in-flight load owns the `loading` flag — an older
 			// load resolving late must not flip it off while the newer one runs.

--- a/web/src/lib/stores/collections.svelte.ts
+++ b/web/src/lib/stores/collections.svelte.ts
@@ -1,6 +1,6 @@
 import { api } from '$lib/api/client';
 import type { Collection, Item } from '$lib/types';
-import { localIndex } from './localIndex.svelte';
+import { authStore } from './auth.svelte';
 import { hydrateCollections, persistCollections, readDurableEpoch } from './localIndexPersistence';
 
 let collections = $state<Collection[]>([]);
@@ -149,7 +149,7 @@ export const collectionStore = {
 	 * is the correct trade rather than an oversight.
 	 */
 	async cachedCollection(ws: string, slug: string): Promise<Collection | null> {
-		const list = await hydrateCollections(localIndex.userIdFor(ws), ws);
+		const list = await hydrateCollections(authStore.userId || null, ws);
 		return list?.find((c) => c.slug === slug) ?? null;
 	},
 
@@ -167,7 +167,15 @@ export const collectionStore = {
 		// starts before `bootstrap` runs, so every fresh visit refused to cache;
 		// and RAM is not the value `hydrateCollections` compares against, so a
 		// RAM-based bracket could agree while the fence's own value moved.
-		const userId = localIndex.userIdFor(ws);
+		// THE NAMESPACE COMES FROM `authStore`, not from localIndex (codex round
+		// 3). The cache is one IDB database per (user, workspace), and
+		// localIndex's own `userId` is a copy captured when `bootstrap` ran —
+		// which is AFTER the layout starts this fetch. Reading it here returned
+		// null on exactly the first visit this feature exists for, writing the
+		// list into the `anon` database while every later read used the
+		// authenticated one. Same source as every `bootstrap` caller passes, so
+		// the two cannot disagree.
+		const userId = authStore.userId || null;
 		// Published for `ensureCollections` to join, tagged with the workspace
 		// so a joiner asking about A is never handed B's promise. Overwriting a
 		// previous tenant is correct rather than lossy: this assignment happens
@@ -176,17 +184,19 @@ export const collectionStore = {
 		inFlightWs = ws;
 		const load = (async () => {
 		try {
-			// Issued TOGETHER, not sequentially. Awaiting the durable read first
-			// would delay the request by a round trip to IndexedDB and — worse —
-			// stop `loadCollections` issuing its fetch synchronously, which is
-			// what lets `ensureCollections` see an in-flight load and join it.
-			// Started in the same tick, the epoch read is "before the fetch" in
-			// the only sense that matters: a resync landing after this point is
-			// exactly what the comparison at write time is looking for.
-			const [result, epochBefore] = await Promise.all([
-				api.collections.list(ws),
-				readDurableEpoch(userId, ws),
-			]);
+			// STRICTLY BEFORE the request, not concurrently with it (codex round
+			// 3). Running them together looked free and was not: `Promise.all`
+			// starts both, but the durable read RESOLVES later and can observe a
+			// resync that landed AFTER the request was issued. The write would
+			// then compare that later epoch against itself, agree, and stamp an
+			// old-scope list with the new scope — the same defeat-by-construction
+			// round 1 found, reintroduced by the fix for round 2.
+			//
+			// The join `ensureCollections` performs does not depend on the fetch
+			// being issued synchronously; it depends on the in-flight slot, which
+			// is published synchronously above.
+			const epochBefore = await readDurableEpoch(userId, ws);
+			const result = await api.collections.list(ws);
 			// Drop a stale response: a newer loadCollections (e.g. a workspace
 			// switch that resolved first) has superseded this one, so writing
 			// `collections`/`collectionsWorkspace` here would clobber the newer

--- a/web/src/lib/stores/collections.svelte.ts
+++ b/web/src/lib/stores/collections.svelte.ts
@@ -1,5 +1,7 @@
 import { api } from '$lib/api/client';
 import type { Collection, Item } from '$lib/types';
+import { localIndex } from './localIndex.svelte';
+import { hydrateCollections, persistCollections } from './localIndexPersistence';
 
 let collections = $state<Collection[]>([]);
 let items = $state<Item[]>([]);
@@ -129,9 +131,36 @@ export const collectionStore = {
 		return collectionStore.loadCollections(ws);
 	},
 
+	/**
+	 * The cached collection list for this workspace, or null (TASK-2946).
+	 *
+	 * For the caller that has just FAILED to reach the server and needs to
+	 * render something honest. The scope fence lives in `hydrateCollections`,
+	 * so this cannot hand back a list whose scope the durable cache disagrees
+	 * with.
+	 *
+	 * DELIBERATELY NOT ADOPTED INTO `collections`. Seeding the reactive array
+	 * from cache would also have to stamp `collectionsWorkspace`, and that
+	 * stamp is what `collectionsAreFreshFor` answers — which TASK-2200's
+	 * recovery reads to decide whether to keep re-fetching. A cached list
+	 * marked fresh would stop the retry that is the only route back to a real
+	 * one. So the cache is a read for a caller that wants it, not a substitute
+	 * for the array; the sidebar stays empty until a fetch succeeds, and that
+	 * is the correct trade rather than an oversight.
+	 */
+	async cachedCollection(ws: string, slug: string): Promise<Collection | null> {
+		const list = await hydrateCollections(localIndex.userIdFor(ws), ws);
+		return list?.find((c) => c.slug === slug) ?? null;
+	},
+
 	async loadCollections(ws: string) {
 		const seq = ++collectionsLoadSeq;
 		loading = true;
+		// Captured BEFORE the request so `persistCollections` can tell whether a
+		// resync landed underneath it — the list carries no scope of its own and
+		// the stamp is borrowed from the row cache, so it is only honest if that
+		// cache held still (TASK-2946).
+		const epochBefore = localIndex.accessEpochFor(ws);
 		// Published for `ensureCollections` to join, tagged with the workspace
 		// so a joiner asking about A is never handed B's promise. Overwriting a
 		// previous tenant is correct rather than lossy: this assignment happens
@@ -153,6 +182,17 @@ export const collectionStore = {
 			// leaves the prior (possibly stale) array in place, and its stamp
 			// with it, which is the correct conservative signal.
 			collectionsWorkspace = ws;
+			// Cache the list for a future cold load that cannot reach the server
+			// (TASK-2946). Fire-and-forget and best-effort, like every other
+			// durable write here; `persistCollections` itself decides whether the
+			// stamp it would write is honest.
+			void persistCollections(
+				localIndex.userIdFor(ws),
+				ws,
+				result,
+				epochBefore,
+				localIndex.accessEpochFor(ws),
+			);
 		} finally {
 			// Only the latest in-flight load owns the `loading` flag — an older
 			// load resolving late must not flip it off while the newer one runs.

--- a/web/src/lib/stores/collectionsCachedRead.svelte.test.ts
+++ b/web/src/lib/stores/collectionsCachedRead.svelte.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Collection } from '$lib/types';
+
+/**
+ * TASK-2946 — `collectionStore.cachedCollection`, the read the board falls back
+ * to when the server is unreachable.
+ *
+ * The fence itself lives in `hydrateCollections` and is pinned against a real
+ * IndexedDB in localIndexPersistenceCollections.idb.test.ts. What is pinned
+ * HERE is the store's half: that it asks for the list under the SAME user
+ * namespace the rows live in, and that it selects by slug rather than handing
+ * back whatever the cache holds.
+ */
+
+const persistence = vi.hoisted(() => ({
+	hydrateCollections: vi.fn(async () => null as Collection[] | null),
+	persistCollections: vi.fn(async () => undefined),
+	hydrate: vi.fn(async () => ({
+		items: [],
+		cursor: '0',
+		includesUnparentedMetadata: null,
+		accessEpoch: null,
+		durableRead: true,
+		retags: {},
+	})),
+	persistDelta: vi.fn(async () => undefined),
+	persistRemovals: vi.fn(async () => undefined),
+	persistReplace: vi.fn(async () => true),
+	persistAccessEpoch: vi.fn(async () => undefined),
+	persistRetag: vi.fn(async () => undefined),
+	persistUpserts: vi.fn(async () => undefined),
+	wipe: vi.fn(async () => undefined),
+	LOCAL_INDEX_SCHEMA_VERSION: 4,
+	IDB_FORMAT_VERSION: 2,
+}));
+vi.mock('./localIndexPersistence', () => persistence);
+
+const { collectionStore } = await import('./collections.svelte');
+
+function coll(slug: string): Collection {
+	return { id: `id-${slug}`, slug, name: slug } as unknown as Collection;
+}
+
+afterEach(() => {
+	for (const fn of Object.values(persistence)) {
+		if (typeof fn === 'function' && 'mockClear' in fn) fn.mockClear();
+	}
+});
+
+describe('TASK-2946 — cachedCollection', () => {
+	it('selects the requested slug out of the cached list', async () => {
+		persistence.hydrateCollections.mockResolvedValueOnce([coll('tasks'), coll('ideas')]);
+
+		const found = await collectionStore.cachedCollection('alpha', 'ideas');
+
+		expect(found?.slug).toBe('ideas');
+	});
+
+	it('returns null for a slug the cached list does not contain', async () => {
+		// Not the same as an empty cache, and the caller must not tell them
+		// apart by accident: a list that simply lacks this collection means the
+		// scope did not include it, and rendering anything would be inventing.
+		persistence.hydrateCollections.mockResolvedValueOnce([coll('tasks')]);
+
+		expect(await collectionStore.cachedCollection('alpha', 'ideas')).toBeNull();
+	});
+
+	it('returns null when the fence refused the list', async () => {
+		persistence.hydrateCollections.mockResolvedValueOnce(null);
+
+		expect(await collectionStore.cachedCollection('alpha', 'tasks')).toBeNull();
+	});
+});

--- a/web/src/lib/stores/collectionsCachedRead.svelte.test.ts
+++ b/web/src/lib/stores/collectionsCachedRead.svelte.test.ts
@@ -44,6 +44,13 @@ function coll(slug: string): Collection {
 }
 
 afterEach(() => {
+	// BOTH, and the second was missing: `mockClear` on the hoisted persistence
+	// mocks does nothing for the `vi.spyOn(api.collections, 'list')` spies the
+	// legs install, so their CALLS leaked into the next test. That made an
+	// ordering leg read a previous test's request as this one's and fail
+	// identically against fixed and broken code — the fixture failing for a
+	// reason that has nothing to do with what it asserts.
+	vi.restoreAllMocks();
 	for (const fn of Object.values(persistence)) {
 		if (typeof fn === 'function' && 'mockClear' in fn) fn.mockClear();
 	}
@@ -63,6 +70,37 @@ describe('TASK-2946 — what loadCollections hands the cache', () => {
 		await collectionStore.loadCollections('alpha');
 
 		expect(persistence.persistCollections).toHaveBeenCalledTimes(1);
+		const args = persistence.persistCollections.mock.calls.at(-1) as unknown[];
+		expect(args[3]).toBe('e1');
+	});
+
+	it('completes the durable read BEFORE issuing the request, not alongside it', async () => {
+		// The property, and it is not cosmetic (codex round 3). Run concurrently,
+		// the durable read RESOLVES after the request was issued and can observe
+		// a resync that landed in between — the write then compares that later
+		// epoch against itself, agrees, and stamps an old-scope list with the new
+		// scope. Defeat by construction, which is what round 1 found and what the
+		// round 2 fix reintroduced.
+		//
+		// Asserted by holding the epoch read PENDING and checking the request has
+		// not been issued: an ordering assertion on invocation alone would also
+		// pass for an implementation that merely happened to evaluate the read
+		// first.
+		let releaseEpoch: (v: string) => void = () => {};
+		persistence.readDurableEpoch.mockImplementationOnce(
+			() => new Promise<string>((r) => (releaseEpoch = r)),
+		);
+		const list = vi.spyOn(api.collections, 'list').mockResolvedValueOnce([coll('tasks')]);
+
+		const loading = collectionStore.loadCollections('alpha');
+		await new Promise((r) => setTimeout(r, 0));
+
+		expect(list).not.toHaveBeenCalled();
+
+		releaseEpoch('e1');
+		await loading;
+
+		expect(list).toHaveBeenCalledTimes(1);
 		const args = persistence.persistCollections.mock.calls.at(-1) as unknown[];
 		expect(args[3]).toBe('e1');
 	});

--- a/web/src/lib/stores/collectionsCachedRead.svelte.test.ts
+++ b/web/src/lib/stores/collectionsCachedRead.svelte.test.ts
@@ -15,6 +15,7 @@ import type { Collection } from '$lib/types';
 const persistence = vi.hoisted(() => ({
 	hydrateCollections: vi.fn(async () => null as Collection[] | null),
 	persistCollections: vi.fn(async () => undefined),
+	readDurableEpoch: vi.fn(async () => undefined as string | null | undefined),
 	hydrate: vi.fn(async () => ({
 		items: [],
 		cursor: '0',
@@ -35,6 +36,7 @@ const persistence = vi.hoisted(() => ({
 }));
 vi.mock('./localIndexPersistence', () => persistence);
 
+const { api } = await import('$lib/api/client');
 const { collectionStore } = await import('./collections.svelte');
 
 function coll(slug: string): Collection {
@@ -45,6 +47,39 @@ afterEach(() => {
 	for (const fn of Object.values(persistence)) {
 		if (typeof fn === 'function' && 'mockClear' in fn) fn.mockClear();
 	}
+});
+
+describe('TASK-2946 — what loadCollections hands the cache', () => {
+	it('stamps with the DURABLE epoch, so a cold tab with no RAM epoch still caches', async () => {
+		// The path the feature actually runs on, and the one every IDB test
+		// missed by seeding epochs directly (codex round 2). The workspace
+		// layout starts this fetch BEFORE `localIndex.bootstrap`, so RAM's epoch
+		// is null here; an earlier draft bracketed the fetch with RAM and
+		// therefore refused to cache on every fresh online visit — inert in its
+		// most common path, with all nine IDB legs green.
+		persistence.readDurableEpoch.mockResolvedValueOnce('e1');
+		vi.spyOn(api.collections, 'list').mockResolvedValueOnce([coll('tasks')]);
+
+		await collectionStore.loadCollections('alpha');
+
+		expect(persistence.persistCollections).toHaveBeenCalledTimes(1);
+		const args = persistence.persistCollections.mock.calls.at(-1) as unknown[];
+		expect(args[3]).toBe('e1');
+	});
+
+	it('does not cache a list it could not read a durable scope for', async () => {
+		// `undefined` is "no sync row / unreadable cache", not "the scope is
+		// null" — nothing to vouch for the stamp, so the write is refused
+		// downstream. Pinned here so the caller keeps passing the value through
+		// rather than substituting a default.
+		persistence.readDurableEpoch.mockResolvedValueOnce(undefined);
+		vi.spyOn(api.collections, 'list').mockResolvedValueOnce([coll('tasks')]);
+
+		await collectionStore.loadCollections('beta');
+
+		const args = persistence.persistCollections.mock.calls.at(-1) as unknown[];
+		expect(args[3]).toBeUndefined();
+	});
 });
 
 describe('TASK-2946 — cachedCollection', () => {

--- a/web/src/lib/stores/collectionsEnsure.svelte.test.ts
+++ b/web/src/lib/stores/collectionsEnsure.svelte.test.ts
@@ -10,14 +10,14 @@ import type { Collection } from '$lib/types';
  * the first perfectly and cannot answer the second, since it was issued before
  * the change the caller is reacting to.
  *
- * These legs also pin an ordering property nobody wrote down until it broke:
- * `loadCollections` must ISSUE its request synchronously. The assertions below
- * count calls in the same tick, so any `await` added before the fetch fails
- * them — which is how TASK-2946 caught itself adding a durable read in front of
- * the request. That await would also have delayed the in-flight slot, so
- * `ensureCollections` would have seen nothing to join and duplicated the
- * request: the very thing this file exists to prevent, reintroduced from the
- * other end.
+ * WHAT THESE LEGS PIN, stated because an earlier version of them accidentally
+ * pinned something else: the number of REQUESTS, not the tick they are issued
+ * in. They originally counted calls synchronously, which passed only because
+ * `loadCollections` happened to reach `api.collections.list` with no await in
+ * front of it — so TASK-2946 adding a durable read before the fetch failed all
+ * four for a reason that had nothing to do with coalescing. The join depends on
+ * the in-flight slot, which is published synchronously; when the request is
+ * issued is not part of the contract. They now flush before counting.
  *
  * So the coalescing lives in `ensureCollections` and NOT in `loadCollections`.
  * The control leg below is the one that keeps that true — without it, moving
@@ -25,6 +25,11 @@ import type { Collection } from '$lib/types';
  * would pass every other assertion here while quietly serving pre-change data
  * to an SSE rename.
  */
+
+/** Let any awaits inside `loadCollections` settle before counting requests. */
+async function flush(): Promise<void> {
+	await new Promise((r) => setTimeout(r, 0));
+}
 
 function coll(slug: string): Collection {
 	return { id: `id-${slug}`, slug, name: slug, is_default: true, sort_order: 0 } as Collection;
@@ -52,6 +57,7 @@ describe('TASK-2200 — ensureCollections', () => {
 
 		const first = collectionStore.loadCollections('alpha');
 		const joined = collectionStore.ensureCollections('alpha');
+		await flush();
 
 		expect(list).toHaveBeenCalledTimes(1);
 
@@ -92,6 +98,7 @@ describe('TASK-2200 — ensureCollections', () => {
 
 		const first = collectionStore.loadCollections('alpha');
 		const second = collectionStore.loadCollections('alpha');
+		await flush();
 
 		// Two requests, deliberately. This is the leg that fails if someone
 		// moves the join into `loadCollections`; every other assertion in this
@@ -112,6 +119,7 @@ describe('TASK-2200 — ensureCollections', () => {
 
 		const other = collectionStore.loadCollections('beta');
 		const mine = collectionStore.ensureCollections('alpha');
+		await flush();
 
 		// Handing back beta's promise would resolve alpha's caller against
 		// beta's list — the exact confusion `collectionsAreFreshFor` exists for.
@@ -134,6 +142,7 @@ describe('TASK-2200 — ensureCollections', () => {
 		const alpha = collectionStore.loadCollections('alpha');
 		const beta = collectionStore.loadCollections('beta');
 		const ensured = collectionStore.ensureCollections('alpha');
+		await flush();
 
 		// THREE requests, and the third is the point. Round 3 read this as a
 		// missing join and proposed a per-workspace map; the map would be the

--- a/web/src/lib/stores/collectionsEnsure.svelte.test.ts
+++ b/web/src/lib/stores/collectionsEnsure.svelte.test.ts
@@ -10,6 +10,15 @@ import type { Collection } from '$lib/types';
  * the first perfectly and cannot answer the second, since it was issued before
  * the change the caller is reacting to.
  *
+ * These legs also pin an ordering property nobody wrote down until it broke:
+ * `loadCollections` must ISSUE its request synchronously. The assertions below
+ * count calls in the same tick, so any `await` added before the fetch fails
+ * them — which is how TASK-2946 caught itself adding a durable read in front of
+ * the request. That await would also have delayed the in-flight slot, so
+ * `ensureCollections` would have seen nothing to join and duplicated the
+ * request: the very thing this file exists to prevent, reintroduced from the
+ * other end.
+ *
  * So the coalescing lives in `ensureCollections` and NOT in `loadCollections`.
  * The control leg below is the one that keeps that true — without it, moving
  * the join into `loadCollections` (which would look like a tidy simplification)

--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -1688,21 +1688,6 @@ export const localIndex = {
 		return workspaces.get(ws)?.accessEpoch ?? null;
 	},
 
-	/**
-	 * The user namespace this workspace's durable cache lives under (TASK-2946).
-	 *
-	 * Exposed rather than letting a second store read `authStore` for itself.
-	 * The cache is one IDB database per (user, workspace) pair, and a caller
-	 * that resolved the user independently could write into a DIFFERENT database
-	 * than the rows — at which point a collection list stamped against "the row
-	 * cache's epoch" would be stamped against a row cache it does not share,
-	 * and the fence that checks it would be comparing two unrelated caches.
-	 * One owner for the namespace, and it is the store that captured it.
-	 */
-	userIdFor(ws: string): string | null {
-		return workspaces.get(ws)?.userId ?? null;
-	},
-
 	/** Force a full snapshot when the server's projection capability changes. */
 	async ensureProjectionScope(ws: string, includesUnparentedMetadata: boolean): Promise<boolean> {
 		const state = ensureState(ws);

--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -1688,6 +1688,21 @@ export const localIndex = {
 		return workspaces.get(ws)?.accessEpoch ?? null;
 	},
 
+	/**
+	 * The user namespace this workspace's durable cache lives under (TASK-2946).
+	 *
+	 * Exposed rather than letting a second store read `authStore` for itself.
+	 * The cache is one IDB database per (user, workspace) pair, and a caller
+	 * that resolved the user independently could write into a DIFFERENT database
+	 * than the rows — at which point a collection list stamped against "the row
+	 * cache's epoch" would be stamped against a row cache it does not share,
+	 * and the fence that checks it would be comparing two unrelated caches.
+	 * One owner for the namespace, and it is the store that captured it.
+	 */
+	userIdFor(ws: string): string | null {
+		return workspaces.get(ws)?.userId ?? null;
+	},
+
 	/** Force a full snapshot when the server's projection capability changes. */
 	async ensureProjectionScope(ws: string, includesUnparentedMetadata: boolean): Promise<boolean> {
 		const state = ensureState(ws);

--- a/web/src/lib/stores/localIndexPersistence.ts
+++ b/web/src/lib/stores/localIndexPersistence.ts
@@ -936,7 +936,7 @@ export async function persistCollections(
 	after: string | null,
 ): Promise<void> {
 	if (!isSupported()) return;
-	// The scope moved under the fetch — see the note above.
+	// The scope moved under the fetch, as this tab saw it — see the note above.
 	if (before !== after) return;
 	const db = await open(userId, ws);
 	if (!db) return;
@@ -948,13 +948,26 @@ export async function persistCollections(
 			await tx.done.catch(() => undefined);
 			return;
 		}
-		// Stamped with the DURABLE epoch rather than the caller's `after`. They
-		// agree in the ordinary case, and where they do not it is because a
-		// write the caller could not see landed first — in which case the
-		// durable value is the one `hydrateCollections` will compare against,
-		// so it is the one worth recording.
+		// THE THIRD VANTAGE POINT, and the fence is worthless without it (codex
+		// round 1). `before !== after` catches a resync THIS tab observed. It
+		// cannot see one that ANOTHER tab landed durably while the fetch was in
+		// flight — and the first draft of this function stamped the row with
+		// `sync.accessEpoch` in that case, which makes the stamp agree with the
+		// disk BY CONSTRUCTION and lets `hydrateCollections` accept a list
+		// fetched under a scope the cache has already left. That is the exact
+		// disclosure this unit exists to prevent, written into it by a comment
+		// arguing that recording the durable value was the careful choice.
+		//
+		// So the stamp is the epoch the fetch actually happened under, and it is
+		// written only when all three agree: RAM before, RAM after, and disk
+		// now. One property — nothing moved — asked at every vantage point that
+		// can see a move.
+		if ((sync.accessEpoch ?? null) !== after) {
+			await tx.done.catch(() => undefined);
+			return;
+		}
 		store
-			.put({ key: 'collections', list, accessEpoch: sync.accessEpoch ?? null } satisfies CollectionsRow)
+			.put({ key: 'collections', list, accessEpoch: after } satisfies CollectionsRow)
 			.catch(() => undefined);
 		await tx.done;
 	} catch {

--- a/web/src/lib/stores/localIndexPersistence.ts
+++ b/web/src/lib/stores/localIndexPersistence.ts
@@ -908,15 +908,51 @@ export async function persistReplace(
 }
 
 /**
+ * The durable scope claim, as three distinguishable answers (TASK-2946):
+ * a string epoch, `null` for a cache written by a server that predates
+ * `access_epoch`, and `undefined` for NO SYNC ROW AT ALL.
+ *
+ * The third is why this is not just `string | null`. "The cache says its scope
+ * is null" and "the cache has never synced and says nothing" are different
+ * facts, and collapsing them would let a list fetched before the cache had any
+ * scope claim be stamped as though it matched one.
+ */
+export type DurableEpoch = string | null | undefined;
+
+/**
+ * Read the durable scope claim without opening a write transaction
+ * (TASK-2946). Called before a collection-list fetch so `persistCollections`
+ * has something to compare its commit-time read against.
+ *
+ * Returns `undefined` for an unreadable or absent cache as well as for a
+ * missing sync row — deliberately, since both mean "no claim I can vouch for",
+ * and `persistCollections` refuses on either.
+ */
+export async function readDurableEpoch(userId: string | null, ws: string): Promise<DurableEpoch> {
+	if (!isSupported()) return undefined;
+	const db = await open(userId, ws);
+	if (!db) return undefined;
+	try {
+		const tx = db.transaction('meta', 'readonly');
+		const sync = await readSyncRow(tx.objectStore('meta'));
+		await tx.done.catch(() => undefined);
+		return sync ? (sync.accessEpoch ?? null) : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+/**
  * Persist this workspace's collection list, stamped with the scope the durable
  * ROW cache described at the moment of the fetch (TASK-2946).
  *
- * WHY THE CALLER PASSES TWO EPOCHS. The list itself carries no scope
- * information — the collections endpoint returns a naked array — so the stamp
- * is borrowed from the row cache, and a borrowed stamp is only honest if the
- * thing it was borrowed from did not move underneath the fetch. `before` is the
- * epoch RAM held when the request was issued and `after` is the epoch it holds
- * now; when they differ, a resync landed mid-fetch and this list may describe
+ * WHY THE CALLER PASSES AN EPOCH. The list itself carries no scope information
+ * — the collections endpoint returns a naked array — so the stamp is borrowed
+ * from the row cache, and a borrowed stamp is only honest if the thing it was
+ * borrowed from did not move underneath the fetch. `before` is
+ * `readDurableEpoch` taken before the request was issued; this function reads
+ * the same value again inside its write transaction. When they differ, a resync
+ * landed mid-fetch — from this tab or any other — and this list may describe
  * either scope. It is not written at all.
  *
  * That refusal is the whole design in one line, and it costs nothing worth
@@ -932,12 +968,9 @@ export async function persistCollections(
 	userId: string | null,
 	ws: string,
 	list: Collection[],
-	before: string | null,
-	after: string | null,
+	before: DurableEpoch,
 ): Promise<void> {
 	if (!isSupported()) return;
-	// The scope moved under the fetch, as this tab saw it — see the note above.
-	if (before !== after) return;
 	const db = await open(userId, ws);
 	if (!db) return;
 	try {
@@ -948,26 +981,37 @@ export async function persistCollections(
 			await tx.done.catch(() => undefined);
 			return;
 		}
-		// THE THIRD VANTAGE POINT, and the fence is worthless without it (codex
-		// round 1). `before !== after` catches a resync THIS tab observed. It
-		// cannot see one that ANOTHER tab landed durably while the fetch was in
-		// flight — and the first draft of this function stamped the row with
-		// `sync.accessEpoch` in that case, which makes the stamp agree with the
-		// disk BY CONSTRUCTION and lets `hydrateCollections` accept a list
-		// fetched under a scope the cache has already left. That is the exact
-		// disclosure this unit exists to prevent, written into it by a comment
-		// arguing that recording the durable value was the careful choice.
+		// ONE VANTAGE POINT, BRACKETING THE FETCH (codex round 2). Earlier drafts
+		// asked RAM: the epoch the store believed before the request against the
+		// one it believed after. Two things were wrong with that, and both were
+		// found by review rather than by these tests, because every test seeded
+		// the epochs by hand and so never stood where a real caller stands.
 		//
-		// So the stamp is the epoch the fetch actually happened under, and it is
-		// written only when all three agree: RAM before, RAM after, and disk
-		// now. One property — nothing moved — asked at every vantage point that
-		// can see a move.
-		if ((sync.accessEpoch ?? null) !== after) {
+		//   - A COLD TAB HAS NO RAM EPOCH YET. The layout starts this fetch
+		//     before `localIndex.bootstrap` has run, so `before` was null and
+		//     `after` was whatever bootstrap had since learned — different, and
+		//     refused. A fresh online visit therefore cached NOTHING, and the
+		//     feature was inert in its most common path while every test passed.
+		//     RAM going null → e1 is the tab LEARNING, not the scope MOVING, and
+		//     a check that cannot tell those apart answers the wrong question.
+		//   - RAM IS NOT WHAT THE FENCE READS. `hydrateCollections` compares
+		//     against the DURABLE epoch, so a RAM-based guard could pass while
+		//     the value the fence will actually use had moved underneath it.
+		//
+		// So both reads are durable and both are of the value the fence uses:
+		// `before` is `readDurableEpoch` from before the request, and this one is
+		// read INSIDE the write transaction, which is the commit-time value by
+		// construction. Equal means nothing moved across the fetch and the list
+		// describes this scope. A `before` of `undefined` — no sync row yet —
+		// can never equal a present row's epoch, so a list fetched before the
+		// cache had any scope claim is refused rather than stamped with one it
+		// did not have.
+		if ((sync.accessEpoch ?? null) !== before) {
 			await tx.done.catch(() => undefined);
 			return;
 		}
 		store
-			.put({ key: 'collections', list, accessEpoch: after } satisfies CollectionsRow)
+			.put({ key: 'collections', list, accessEpoch: before } satisfies CollectionsRow)
 			.catch(() => undefined);
 		await tx.done;
 	} catch {

--- a/web/src/lib/stores/localIndexPersistence.ts
+++ b/web/src/lib/stores/localIndexPersistence.ts
@@ -34,7 +34,7 @@
 // so SvelteKit's prerender / SSR phase doesn't blow up.
 
 import { openDB, type IDBPDatabase } from 'idb';
-import type { ItemIndexRow } from '$lib/types';
+import type { Collection, ItemIndexRow } from '$lib/types';
 import { resolveRowWrite, type Tombstone } from './itemRowMerge';
 
 /**
@@ -132,6 +132,39 @@ interface MetaRow {
 interface RetagsRow {
 	key: 'retags';
 	map: Record<string, string>;
+}
+
+/**
+ * The cached collection list for this workspace, in the `meta` store under
+ * `key: 'collections'` (TASK-2946).
+ *
+ * ONE ROW, not an object store of collections, and the reason is the claim
+ * being stored. This is a SNAPSHOT of the visible set under a single scope —
+ * "these are the collections this caller could see, fetched while the durable
+ * cache described scope E" — and that claim is only true of the list as a
+ * whole. A store keyed by collection id would invite per-row writes, and a
+ * single collection written into a list stamped under a different scope makes
+ * the stamp a lie. One row can only be replaced.
+ *
+ * It also keeps the change off `IDB_FORMAT_VERSION`: the `meta` store already
+ * exists, so there is no upgrade branch and no migration to get wrong. (The
+ * item filing this predicted a new object store and a format bump; the snapshot
+ * argument is what changed it.)
+ *
+ * `accessEpoch` is BORROWED from the row cache, not reported by the server —
+ * `/workspaces/{ws}/collections` carries no `access_epoch`, unlike
+ * `/items-index` and `/items-changes`. `persistCollections` only writes when
+ * the row cache's epoch did not move across the fetch, which is what makes the
+ * borrowed stamp honest. A genuine server-side stamp would need that endpoint
+ * to return an ENVELOPE — it currently writes a naked array — and that is a
+ * wire-shape break for the web, CLI and MCP clients at once. Priced and
+ * declined (lead ruling, day 78); this note is here so the next person who
+ * wants it knows what it costs.
+ */
+interface CollectionsRow {
+	key: 'collections';
+	list: Collection[];
+	accessEpoch: string | null;
 }
 
 /**
@@ -871,6 +904,105 @@ export async function persistReplace(
 	} catch {
 		/* swallow — best-effort cache */
 		return false;
+	}
+}
+
+/**
+ * Persist this workspace's collection list, stamped with the scope the durable
+ * ROW cache described at the moment of the fetch (TASK-2946).
+ *
+ * WHY THE CALLER PASSES TWO EPOCHS. The list itself carries no scope
+ * information — the collections endpoint returns a naked array — so the stamp
+ * is borrowed from the row cache, and a borrowed stamp is only honest if the
+ * thing it was borrowed from did not move underneath the fetch. `before` is the
+ * epoch RAM held when the request was issued and `after` is the epoch it holds
+ * now; when they differ, a resync landed mid-fetch and this list may describe
+ * either scope. It is not written at all.
+ *
+ * That refusal is the whole design in one line, and it costs nothing worth
+ * having: a scope change in flight is the moment you would least want to
+ * commit a snapshot, and the next successful fetch caches it.
+ *
+ * NOT written when there is no `sync` meta row. A cache that has never synced
+ * has no scope claim for this list to agree with, so nothing later could check
+ * the stamp — and an unverifiable stamp is worse than an absent list, which at
+ * least renders the honest error card.
+ */
+export async function persistCollections(
+	userId: string | null,
+	ws: string,
+	list: Collection[],
+	before: string | null,
+	after: string | null,
+): Promise<void> {
+	if (!isSupported()) return;
+	// The scope moved under the fetch — see the note above.
+	if (before !== after) return;
+	const db = await open(userId, ws);
+	if (!db) return;
+	try {
+		const tx = db.transaction('meta', 'readwrite');
+		const store = tx.objectStore('meta');
+		const sync = await readSyncRow(store);
+		if (!sync) {
+			await tx.done.catch(() => undefined);
+			return;
+		}
+		// Stamped with the DURABLE epoch rather than the caller's `after`. They
+		// agree in the ordinary case, and where they do not it is because a
+		// write the caller could not see landed first — in which case the
+		// durable value is the one `hydrateCollections` will compare against,
+		// so it is the one worth recording.
+		store
+			.put({ key: 'collections', list, accessEpoch: sync.accessEpoch ?? null } satisfies CollectionsRow)
+			.catch(() => undefined);
+		await tx.done;
+	} catch {
+		/* swallow — best-effort cache */
+	}
+}
+
+/**
+ * Read back the cached collection list, or null (TASK-2946).
+ *
+ * THE FENCE LIVES HERE, at the door, so no caller can render a list without it:
+ * the stored stamp must EQUAL the epoch the durable cache currently advertises
+ * (`meta.sync.accessEpoch`). Same equality test as `persistUpserts`, for the
+ * same reason — an `access_epoch` is a hash of the live grant set and can
+ * answer "same or different" and nothing else, so nothing here says "older".
+ *
+ * BOTH SIDES ARE DURABLE, which is what makes this work with no network. The
+ * caller reaching for this has just failed to reach the server, so a live epoch
+ * is exactly what it cannot obtain; the question being asked is whether the
+ * cached list and the cached ROWS describe the same scope, and both answers are
+ * on disk.
+ *
+ * Null on: no cached list, no `sync` row to check against, or a stamp that
+ * disagrees. The caller renders its error card, which is the honest outcome —
+ * a list whose scope cannot be confirmed is not better than no list.
+ *
+ * Two nulls MATCH, deliberately: a server predating `access_epoch` writes null
+ * on both sides, and that deployment keeps its cache. Same disposition as
+ * `persistUpserts`.
+ */
+export async function hydrateCollections(
+	userId: string | null,
+	ws: string,
+): Promise<Collection[] | null> {
+	if (!isSupported()) return null;
+	const db = await open(userId, ws);
+	if (!db) return null;
+	try {
+		const tx = db.transaction('meta', 'readonly');
+		const store = tx.objectStore('meta');
+		const cached = (await store.get('collections')) as CollectionsRow | undefined;
+		const sync = await readSyncRow(store);
+		await tx.done.catch(() => undefined);
+		if (!cached || !sync) return null;
+		if ((cached.accessEpoch ?? null) !== (sync.accessEpoch ?? null)) return null;
+		return cached.list;
+	} catch {
+		return null;
 	}
 }
 

--- a/web/src/lib/stores/localIndexPersistenceCollections.idb.test.ts
+++ b/web/src/lib/stores/localIndexPersistenceCollections.idb.test.ts
@@ -37,7 +37,7 @@ describe('TASK-2946 — a cached collection list is stamped and fenced', () => {
 		const { persistDelta, persistCollections, hydrateCollections } = await loadPersistence();
 
 		await persistDelta(U, WS, [row('a', 1)], '1', false, 'e1');
-		await persistCollections(U, WS, [coll('tasks'), coll('ideas')], 'e1', 'e1');
+		await persistCollections(U, WS, [coll('tasks'), coll('ideas')], 'e1');
 
 		const list = await hydrateCollections(U, WS);
 		expect(list?.map((c) => c.slug)).toEqual(['tasks', 'ideas']);
@@ -50,7 +50,7 @@ describe('TASK-2946 — a cached collection list is stamped and fenced', () => {
 			await loadPersistence();
 
 		await persistDelta(U, WS, [row('a', 1)], '1', false, 'e1');
-		await persistCollections(U, WS, [coll('secret')], 'e1', 'e1');
+		await persistCollections(U, WS, [coll('secret')], 'e1');
 		expect((await hydrateCollections(U, WS))?.length).toBe(1);
 
 		// A resync under a NARROWED scope. The rows are replaced and the durable
@@ -70,7 +70,7 @@ describe('TASK-2946 — a cached collection list is stamped and fenced', () => {
 		// The list was requested while RAM said e1 and arrived after a resync had
 		// moved it to e2 — so it may describe either scope, and a stamp would be
 		// a guess. The whole point of taking two epochs.
-		await persistCollections(U, WS, [coll('tasks')], 'e1', 'e2');
+		await persistCollections(U, WS, [coll('tasks')], 'e1');
 
 		expect(await hydrateCollections(U, WS)).toBeNull();
 	});
@@ -86,7 +86,7 @@ describe('TASK-2946 — a cached collection list is stamped and fenced', () => {
 		// construction and hand the fence a list fetched under a scope the cache
 		// has already left (codex round 1).
 		await persistDelta(U, WS, [row('a', 1)], '1', false, 'e2');
-		await persistCollections(U, WS, [coll('secret')], 'e1', 'e1');
+		await persistCollections(U, WS, [coll('secret')], 'e1');
 
 		expect(await hydrateCollections(U, WS)).toBeNull();
 	});
@@ -98,7 +98,7 @@ describe('TASK-2946 — a cached collection list is stamped and fenced', () => {
 
 		// No `sync` row: there is no epoch to BORROW, so any stamp would be
 		// invented rather than observed.
-		await persistCollections(U, WS, [coll('tasks')], 'e1', 'e1');
+		await persistCollections(U, WS, [coll('tasks')], 'e1');
 		expect(await hydrateCollections(U, WS)).toBeNull();
 
 		// The discriminating half, and the reason this leg is not just restating
@@ -122,7 +122,7 @@ describe('TASK-2946 — a cached collection list is stamped and fenced', () => {
 		const { persistDelta, persistCollections, hydrateCollections } = await loadPersistence();
 
 		await persistDelta(U, WS, [row('a', 1)], '1', false, null);
-		await persistCollections(U, WS, [coll('tasks')], null, null);
+		await persistCollections(U, WS, [coll('tasks')], null);
 
 		expect((await hydrateCollections(U, WS))?.map((c) => c.slug)).toEqual(['tasks']);
 	});
@@ -133,7 +133,7 @@ describe('TASK-2946 — a cached collection list is stamped and fenced', () => {
 		const { persistDelta, persistCollections, hydrateCollections } = await loadPersistence();
 
 		await persistDelta(U, WS, [row('a', 1)], '1', false, 'e1');
-		await persistCollections(U, WS, [coll('tasks')], 'e1', 'e1');
+		await persistCollections(U, WS, [coll('tasks')], 'e1');
 
 		// Without this leg the refusal above would also pass against a fence
 		// that refused everything — including every ordinary session, which
@@ -159,8 +159,8 @@ describe('TASK-2946 — a cached collection list is stamped and fenced', () => {
 		const { persistDelta, persistCollections, hydrateCollections } = await loadPersistence();
 
 		await persistDelta(U, WS, [row('a', 1)], '1', false, 'e1');
-		await persistCollections(U, WS, [coll('tasks'), coll('gone')], 'e1', 'e1');
-		await persistCollections(U, WS, [coll('tasks')], 'e1', 'e1');
+		await persistCollections(U, WS, [coll('tasks'), coll('gone')], 'e1');
+		await persistCollections(U, WS, [coll('tasks')], 'e1');
 
 		// A list is a snapshot of the visible set under one scope, true only as
 		// a whole — a collection dropped by a narrowed scope must not survive as

--- a/web/src/lib/stores/localIndexPersistenceCollections.idb.test.ts
+++ b/web/src/lib/stores/localIndexPersistenceCollections.idb.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from 'vitest';
+import type { Collection, ItemIndexRow } from '$lib/types';
+import { loadPersistence } from '../../test/idbHarness';
+
+/**
+ * TASK-2946 — the cached collection list, and the fence that decides whether it
+ * may be rendered.
+ *
+ * The board's rows already survive an offline cold load: they hydrate from IDB
+ * before anything fetches. The collection METADATA did not, so the page failed
+ * closed — "Couldn't load this collection" over a cache holding the rows the
+ * user was looking at a minute ago.
+ *
+ * Caching it is not enough on its own, because a collection list is a SCOPE
+ * CLAIM: served without the scope it was fetched under it becomes a second way
+ * to show a collection the caller can no longer see, which is exactly the
+ * disclosure TASK-2922 closed for rows. Hence the stamp, and hence the fence.
+ *
+ * BOTH SIDES OF THE FENCE ARE DURABLE. The caller reaching for this has just
+ * failed to reach the server, so a live epoch is what it cannot have; the
+ * question is whether the cached list and the cached ROWS describe the same
+ * scope, and both answers are on disk.
+ */
+
+function coll(slug: string): Collection {
+	return { id: `id-${slug}`, slug, name: slug } as unknown as Collection;
+}
+
+function row(id: string, seq: number): ItemIndexRow {
+	return { id, seq, collection_slug: 'c' } as unknown as ItemIndexRow;
+}
+
+describe('TASK-2946 — a cached collection list is stamped and fenced', () => {
+	it('round-trips the list when the stamp still matches the durable rows', async () => {
+		const U = null;
+		const WS = 'ws-2946-ok';
+		const { persistDelta, persistCollections, hydrateCollections } = await loadPersistence();
+
+		await persistDelta(U, WS, [row('a', 1)], '1', false, 'e1');
+		await persistCollections(U, WS, [coll('tasks'), coll('ideas')], 'e1', 'e1');
+
+		const list = await hydrateCollections(U, WS);
+		expect(list?.map((c) => c.slug)).toEqual(['tasks', 'ideas']);
+	});
+
+	it('REFUSES a list whose stamp the durable rows have moved past', async () => {
+		const U = null;
+		const WS = 'ws-2946-moved';
+		const { persistDelta, persistCollections, hydrateCollections, persistReplace } =
+			await loadPersistence();
+
+		await persistDelta(U, WS, [row('a', 1)], '1', false, 'e1');
+		await persistCollections(U, WS, [coll('secret')], 'e1', 'e1');
+		expect((await hydrateCollections(U, WS))?.length).toBe(1);
+
+		// A resync under a NARROWED scope. The rows are replaced and the durable
+		// epoch moves; the cached list still describes the old scope and may name
+		// a collection this caller can no longer see.
+		await persistReplace(U, WS, [row('a', 1)], '2', false, 'e2');
+
+		expect(await hydrateCollections(U, WS)).toBeNull();
+	});
+
+	it('does NOT persist when the scope moved across the fetch', async () => {
+		const U = null;
+		const WS = 'ws-2946-inflight';
+		const { persistDelta, persistCollections, hydrateCollections } = await loadPersistence();
+
+		await persistDelta(U, WS, [row('a', 1)], '1', false, 'e2');
+		// The list was requested while RAM said e1 and arrived after a resync had
+		// moved it to e2 — so it may describe either scope, and a stamp would be
+		// a guess. The whole point of taking two epochs.
+		await persistCollections(U, WS, [coll('tasks')], 'e1', 'e2');
+
+		expect(await hydrateCollections(U, WS)).toBeNull();
+	});
+
+	it('does NOT persist into a cache that has never synced, and the row cannot appear later', async () => {
+		const U = null;
+		const WS = 'ws-2946-nosync';
+		const { persistDelta, persistCollections, hydrateCollections } = await loadPersistence();
+
+		// No `sync` row: there is no epoch to BORROW, so any stamp would be
+		// invented rather than observed.
+		await persistCollections(U, WS, [coll('tasks')], 'e1', 'e1');
+		expect(await hydrateCollections(U, WS)).toBeNull();
+
+		// The discriminating half, and the reason this leg is not just restating
+		// the hydrate fence: a list written with an invented `null` stamp would
+		// become READABLE the moment a sync row landed carrying null — which is
+		// every server predating `access_epoch`. The refusal at write time is
+		// what stops a list nobody could vouch for from being served later by a
+		// fence that has nothing to compare it against.
+		//
+		// (Found by mutating: removing the write-time guard left every other leg
+		// in this file green, because the hydrate fence covers the same ground
+		// up to exactly this case.)
+		await persistDelta(U, WS, [row('a', 1)], '1', false, null);
+
+		expect(await hydrateCollections(U, WS)).toBeNull();
+	});
+
+	it('treats null on both sides as a match — a server without access_epoch still caches', async () => {
+		const U = null;
+		const WS = 'ws-2946-null';
+		const { persistDelta, persistCollections, hydrateCollections } = await loadPersistence();
+
+		await persistDelta(U, WS, [row('a', 1)], '1', false, null);
+		await persistCollections(U, WS, [coll('tasks')], null, null);
+
+		expect((await hydrateCollections(U, WS))?.map((c) => c.slug)).toEqual(['tasks']);
+	});
+
+	it('CONTROL — an ordinary delta that does not move the epoch leaves the list readable', async () => {
+		const U = null;
+		const WS = 'ws-2946-control';
+		const { persistDelta, persistCollections, hydrateCollections } = await loadPersistence();
+
+		await persistDelta(U, WS, [row('a', 1)], '1', false, 'e1');
+		await persistCollections(U, WS, [coll('tasks')], 'e1', 'e1');
+
+		// Without this leg the refusal above would also pass against a fence
+		// that refused everything — including every ordinary session, which
+		// would make the whole feature inert while looking correct.
+		await persistDelta(U, WS, [row('b', 2)], '2', false, undefined);
+
+		expect((await hydrateCollections(U, WS))?.map((c) => c.slug)).toEqual(['tasks']);
+	});
+
+	it('returns null when nothing was ever cached, without inventing a list', async () => {
+		const U = null;
+		const WS = 'ws-2946-empty';
+		const { persistDelta, hydrateCollections } = await loadPersistence();
+
+		await persistDelta(U, WS, [row('a', 1)], '1', false, 'e1');
+
+		expect(await hydrateCollections(U, WS)).toBeNull();
+	});
+
+	it('replaces the whole list rather than merging into it', async () => {
+		const U = null;
+		const WS = 'ws-2946-replace';
+		const { persistDelta, persistCollections, hydrateCollections } = await loadPersistence();
+
+		await persistDelta(U, WS, [row('a', 1)], '1', false, 'e1');
+		await persistCollections(U, WS, [coll('tasks'), coll('gone')], 'e1', 'e1');
+		await persistCollections(U, WS, [coll('tasks')], 'e1', 'e1');
+
+		// A list is a snapshot of the visible set under one scope, true only as
+		// a whole — a collection dropped by a narrowed scope must not survive as
+		// a leftover. This is why it is ONE meta row and not a store of rows.
+		expect((await hydrateCollections(U, WS))?.map((c) => c.slug)).toEqual(['tasks']);
+	});
+});

--- a/web/src/lib/stores/localIndexPersistenceCollections.idb.test.ts
+++ b/web/src/lib/stores/localIndexPersistenceCollections.idb.test.ts
@@ -75,6 +75,22 @@ describe('TASK-2946 — a cached collection list is stamped and fenced', () => {
 		expect(await hydrateCollections(U, WS)).toBeNull();
 	});
 
+	it('does NOT persist when ANOTHER tab moved the durable scope under the fetch', async () => {
+		const U = null;
+		const WS = 'ws-2946-crosstab';
+		const { persistDelta, persistCollections, hydrateCollections } = await loadPersistence();
+
+		// This tab's RAM saw no change — `before` and `after` both e1 — but a
+		// sibling tab resynced to e2 and its write landed first. Stamping the
+		// list with the DURABLE epoch would make it agree with the disk by
+		// construction and hand the fence a list fetched under a scope the cache
+		// has already left (codex round 1).
+		await persistDelta(U, WS, [row('a', 1)], '1', false, 'e2');
+		await persistCollections(U, WS, [coll('secret')], 'e1', 'e1');
+
+		expect(await hydrateCollections(U, WS)).toBeNull();
+	});
+
 	it('does NOT persist into a cache that has never synced, and the row cannot appear later', async () => {
 		const U = null;
 		const WS = 'ws-2946-nosync';

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -76,6 +76,10 @@
 	// `indexError` retry box — instead of masking a
 	// live collection as deleted. Cleared at the top of every load.
 	let metaError = $state<Error | null>(null);
+	// TASK-2946 — this render came off the durable cache because the server was
+	// unreachable. Drives the degraded banner; cleared at the start of every
+	// load so a later success cannot leave it standing.
+	let metaFromCache = $state(false);
 	let viewMode = $state<ViewMode>('board');
 	// Page-wide within-group sort (TASK-1670 / IDEA-1648). 'manual' is the
 	// stored sort_order (drag order). Persisted per collection.
@@ -1164,6 +1168,9 @@
 		// URL-sync effect from firing with stale filter state while this
 		// route is erroring.
 		urlFiltersLoaded = false;
+		// Cleared per load: a successful fetch must not leave the previous
+		// load's degraded banner up (TASK-2946).
+		metaFromCache = false;
 		try {
 			// Items now flow through localIndex (the `items` $derived
 			// above reads `getByCollection`). We still fetch the
@@ -1260,7 +1267,35 @@
 				// A missing collection shows the empty / not-found state via
 				// the `collection` null branch in the template.
 			} else {
-				metaError = err instanceof Error ? err : new Error('Failed to load collection');
+				// TRANSIENT failure — and the one case where the durable cache
+				// can answer instead of an error card (TASK-2946). The rows are
+				// already here: `items` is derived from localIndex, which
+				// hydrates from IDB before it fetches, so a cold offline load
+				// had the user's rows in hand while this page said it could not
+				// load the collection.
+				//
+				// Only reached on a NON-404. A genuine `not_found` above must
+				// never render from cache: "deleted" and "unreachable" are
+				// different answers and the cache can only speak to the second
+				// (BUG-2025 drew that line; this keeps it).
+				//
+				// The scope fence is inside `cachedCollection` — a cached list
+				// whose stamp disagrees with the durable rows' epoch is refused
+				// there, so this cannot render a collection the caller may no
+				// longer be able to see. That is the disclosure TASK-2922 closed
+				// for rows, and it would arrive here through a second door.
+				const cached = await collectionStore.cachedCollection(ws, coll);
+				if (seq !== loadSeq) return;
+				if (cached && collGen === collectionGen) {
+					collection = cached;
+					metaError = null;
+					// The page is honest about what it is showing: the rows and
+					// the collection are both from disk and neither has been
+					// confirmed against the server this load.
+					metaFromCache = true;
+				} else {
+					metaError = err instanceof Error ? err : new Error('Failed to load collection');
+				}
 			}
 		} finally {
 			// Only the latest load owns the loading flag — a superseded
@@ -3036,6 +3071,27 @@
 	{:else if !collection}
 		<div class="empty-state">Collection not found</div>
 	{:else}
+		{#if metaFromCache}
+			<!-- TASK-2946. The collection metadata and the rows below both came
+			     off the durable cache because the server was unreachable, and
+			     neither has been confirmed this load. Saying so is the point:
+			     rendering stale data silently would be worse than the error card
+			     this replaces, which at least told the truth. -->
+			<div class="offline-banner" role="status">
+				<span aria-hidden="true">⚠️</span>
+				<span>
+					Showing a saved copy — couldn't reach the server, so this may be out of date.
+				</span>
+				<button
+					class="offline-banner-retry"
+					onclick={() => {
+						if (wsSlug && collSlug) loadCollection(wsSlug, collSlug, showArchived);
+					}}
+				>
+					Retry
+				</button>
+			</div>
+		{/if}
 		<!-- Header -->
 		<div class="page-header">
 			<div class="title-row">
@@ -3697,6 +3753,36 @@
 		text-align: center;
 		padding-top: 20vh;
 		color: var(--text-muted);
+	}
+
+	/* TASK-2946 — the degraded-render banner. Deliberately quiet rather than
+	   alarming: nothing is broken, the page is simply showing what it has. */
+	.offline-banner {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.5rem 0.75rem;
+		margin-bottom: 0.75rem;
+		border: 1px solid var(--border);
+		border-radius: 6px;
+		background: var(--bg-secondary);
+		color: var(--text-secondary);
+		font-size: 0.85rem;
+	}
+
+	.offline-banner-retry {
+		margin-left: auto;
+		padding: 0.2rem 0.6rem;
+		border: 1px solid var(--border);
+		border-radius: 4px;
+		background: var(--bg);
+		color: var(--text);
+		font-size: 0.8rem;
+		cursor: pointer;
+	}
+
+	.offline-banner-retry:hover {
+		background: var(--bg-hover);
 	}
 
 	.empty-state-box {


### PR DESCRIPTION
Unit B of TASK-2200 (unit A merged as `22fce211`, #1284).

## The defect

The rows already survived an offline cold load — localIndex hydrates from IDB before anything fetches — but collection **metadata was fetch-only**, so the board failed closed: *"Couldn't load this collection"* over a cache holding the rows the user was looking at a minute ago.

Two recon corrections narrowed it before any code was written: of the board's three parallel metadata fetches **only `api.collections.get` is fatal** (`views.list` and `members.list` already carry `.catch` defaults), and `Collection` is flat and cheaply persistable — `schema`/`settings`/`traits` are JSON strings and `list`/`get` return the same type, so a cached list can answer a `get` by slug.

## Why it needed a fence, not just a cache

A collection list is a **scope claim**. Served without the scope it was fetched under it becomes a second way to show a collection the caller can no longer see — the disclosure TASK-2922 closed for rows, arriving through another door. `hydrateCollections` refuses a list whose stamp does not EQUAL the durable rows' `meta.sync.accessEpoch`: the same equality test as `persistUpserts`, because an `access_epoch` is a hash of the live grant set and answers *same or different* and nothing else. Nothing here says "older".

**Both sides of the fence are durable**, which is what makes it work with no network. The ruling that scoped this said "the epoch the durable cache currently advertises", which reads as a live value; on a cold offline load there is none. The question actually asked is whether the cached list and the cached ROWS describe the same scope, and both answers are on disk.

## The stamp is borrowed, and that is the whole design

`/workspaces/{ws}/collections` returns a **naked array** and carries no `access_epoch`, unlike the two items endpoints. So the stamp comes from the row cache, and a borrowed stamp is honest only if the thing it was borrowed from held still: `readDurableEpoch` before the request, the same row read again **inside** the write transaction, and the write refused unless they agree.

A genuine server stamp would need that endpoint to return an envelope — a wire-shape break for web, CLI and MCP at once. Priced and declined; the price is written into the code so the next person who wants it knows it.

## Design decisions worth reading

- **One `meta` row, not an object store.** The stored value is a snapshot of the visible set under a single scope, true only as a whole; a store keyed by collection id would invite per-row writes, and one collection written into a list stamped under a different scope makes the stamp a lie. One row can only be replaced. It also keeps the change off `IDB_FORMAT_VERSION` — no upgrade branch, no migration. (The filing predicted a new store and a format bump; the snapshot argument is what changed it.)
- **The cache is NOT adopted into `collectionStore.collections`.** Seeding the reactive array would have to stamp `collectionsWorkspace`, which is what `collectionsAreFreshFor` answers — and TASK-2200's recovery reads that to decide whether to keep re-fetching. A cached list marked fresh would stop the retry that is the only route back to a real one. The sidebar stays empty until a fetch succeeds: a trade, stated.
- **Only a NON-404 renders from cache.** "Deleted" and "unreachable" are different answers and the cache can only speak to the second (BUG-2025 drew that line).
- **The page says what it is showing** — a quiet banner with a Retry. Rendering stale data silently would be worse than the error card it replaces.

## Review rounds

| Round | Findings |
|---|---|
| 1 | P1 — the stamp was written from the DURABLE epoch, making it agree by construction and defeating the fence |
| 2 | P1 — the RAM bracket meant a fresh visit **cached nothing**; P1 — RAM is not the value the fence reads |
| 3 | P1 — `Promise.all` meant the "before" read resolved AFTER the request was issued; P1 — the cache was written to the `anon` database on first visit |
| 4 | CLEAN |

**Five P1s, all one shape: the mechanism did not do what my comment said it did.** Every one lived in the borrowed-stamp bracket, and three were introduced by the fix for the previous round. Two of them I had explicitly argued for in prose — round 1's "the durable value is the one worth recording" and round 3's "same tick is before the fetch in the only sense that matters" — which is the failure mode my own trail keeps naming: an explanation is the part a successor reuses without re-deriving, so a wrong one is worse than none.

Round 2's first finding is the one to keep: **the feature was inert in its most common path while all nine IDB legs were green.** Every test seeded epochs by hand and so never stood where a real caller stands.

Round 3's second is the mirror: I added `localIndex.userIdFor` in this unit with a comment arguing it prevented a second source of truth for the cache namespace, and the accessor was itself a lagging copy. Deleted rather than patched — the fix for a second source is not a third.

## Tests

Ten IDB legs: the round trip, refusal after a resync moves the epoch, refusal when the scope moved across the fetch, the cross-tab case, the never-synced case, null-on-both-sides, whole-list replacement, and a **CONTROL** leg proving an ordinary delta leaves the list readable — without it the refusals would also pass against a fence that refused everything. Every guard mutated; each fails exactly one leg.

Store legs pin the path the IDB legs missed: a cold tab with no RAM epoch still caches, an unreadable durable claim passes through as `undefined`, and the durable read **completes** before the request is issued (held pending, asserting the request has not fired — an invocation-order assertion would pass for an implementation that merely evaluated it first).

Source pin for the board, whose load-bearing assertion is POSITION: the fallback must sit after the `not_found` branch.

**Three fixture repairs, all found by mutating rather than reading:** a missing `vi.restoreAllMocks()` that leaked spy calls between legs; a never-synced leg that passed with its guard removed; and TASK-2200's `collectionsEnsure` legs, which counted requests synchronously and were therefore pinning the tick rather than the request count.

## Gates

| Gate | Result |
|---|---|
| `golangci-lint` | 0 issues |
| `go test ./...` | 30 packages ok, 0 FAIL |
| `svelte-check` | 0 errors |
| `vitest` | 2280 passed / 146 files |

On `5e12e6bb`, `origin/main` at `367aae8e` — rebased and re-gated after #1286 (BUG-2943, prefix/ref
grammar) landed under the earlier GO. No file overlap with this diff; the full Go and web suites on
the rebased tree are the evidence rather than the assertion, and the vitest count rises to 2281
because that unit's own tests are now present. Every gate above was re-run there.

https://claude.ai/code/session_01Xk9M5UVPdc84xL5E1mZkm8

