### PR TITLE
fix(cli): use PostgreSQL connection strings for backup and restore

### DIFF
--- a/cmd/pad/cmd_db.go
+++ b/cmd/pad/cmd_db.go
@@ -8,7 +8,6 @@ import (
 	"log/slog"
 	"net/url"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -128,8 +127,10 @@ the server resolves it (PAD_DB_PATH > PAD_DATA_DIR/pad.db > ~/.pad/pad.db).`,
 					"--file", output,
 				}
 
-				pgCmd := exec.Command("pg_dump", pgArgs...)
-				pgCmd.Env = append(os.Environ(), "PGDATABASE="+dbURL)
+				pgCmd, err := postgresClient("pg_dump", dbURL, pgArgs...)
+				if err != nil {
+					return err
+				}
 				pgCmd.Stdout = os.Stdout
 				pgCmd.Stderr = os.Stderr
 
@@ -250,8 +251,10 @@ WARNING: This will overwrite the current database contents.`,
 					"--single-transaction",
 				}
 
-				psqlCmd := exec.Command("psql", psqlArgs...)
-				psqlCmd.Env = append(os.Environ(), "PGDATABASE="+dbURL)
+				psqlCmd, err := postgresClient("psql", dbURL, psqlArgs...)
+				if err != nil {
+					return err
+				}
 				psqlCmd.Stdout = os.Stdout
 				psqlCmd.Stderr = os.Stderr
 

--- a/cmd/pad/postgres_client.go
+++ b/cmd/pad/postgres_client.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"errors"
+	"net/url"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// postgresClient passes an explicit conninfo to libpq: PGDATABASE alone does
+// not expand a URI. Extract the database password so it stays off argv.
+func postgresClient(name, conninfo string, args ...string) (*exec.Cmd, error) {
+	dsn, password, err := postgresClientConninfo(conninfo)
+	if err != nil {
+		return nil, err
+	}
+	if password != nil && os.Getenv("PGSERVICE") != "" {
+		return nil, errors.New("configure the password in the PostgreSQL service instead of inline with PGSERVICE")
+	}
+	cmd := exec.Command(name, append(args, "--dbname", dsn)...)
+	cmd.Env = os.Environ()
+	if password != nil {
+		cmd.Env = append(cmd.Env, "PGPASSWORD="+*password)
+	}
+	return cmd, nil
+}
+
+func postgresClientConninfo(raw string) (string, *string, error) {
+	invalid := errors.New("invalid PostgreSQL connection string")
+	if strings.HasPrefix(raw, "postgres://") || strings.HasPrefix(raw, "postgresql://") {
+		u, err := url.Parse(raw)
+		if err != nil || u.Fragment != "" {
+			return "", nil, invalid // url.Error includes the supplied password.
+		}
+		var password *string
+		if u.User != nil {
+			if value, ok := u.User.Password(); ok && value != "" {
+				password = &value
+				u.User = url.User(u.User.Username())
+			}
+		}
+		// libpq uses percent decoding, NOT form decoding: '+' is literal.
+		var query []string
+		service := false
+		for _, token := range strings.Split(u.RawQuery, "&") {
+			if token == "" {
+				continue
+			}
+			key, value, ok := strings.Cut(token, "=")
+			key, keyErr := url.PathUnescape(key)
+			value, valueErr := url.PathUnescape(value)
+			if !ok || keyErr != nil || valueErr != nil {
+				return "", nil, invalid
+			}
+			switch key {
+			case "password":
+				password = &value
+			case "sslpassword":
+				return "", nil, errors.New("configure sslpassword in a PostgreSQL service file instead of the connection string")
+			default:
+				service = service || key == "service"
+				query = append(query, token)
+			}
+		}
+		if service && password != nil {
+			return "", nil, errors.New("configure the password in the PostgreSQL service instead of inline with service")
+		}
+		u.RawQuery = strings.Join(query, "&")
+		return u.String(), password, nil
+	}
+	if !strings.Contains(raw, "=") {
+		return raw, nil, nil // A plain database name uses normal libpq defaults.
+	}
+
+	// Only remove password assignments. Keep all other tokens byte-for-byte,
+	// leaving connection-option interpretation (including services) to libpq.
+	var tokens []string
+	var password *string
+	service := false
+	const space = " \t\n\r\v\f"
+	for rest := raw; strings.TrimLeft(rest, space) != ""; {
+		rest = strings.TrimLeft(rest, space)
+		start := rest
+		i := strings.IndexAny(rest, "="+space)
+		if i <= 0 {
+			return "", nil, invalid
+		}
+		key := rest[:i]
+		rest = strings.TrimLeft(rest[i:], space)
+		if !strings.HasPrefix(rest, "=") {
+			return "", nil, invalid
+		}
+		rest = strings.TrimLeft(rest[1:], space)
+		quoted := strings.HasPrefix(rest, "'")
+		if quoted {
+			rest = rest[1:]
+		}
+		var value strings.Builder
+		closed := !quoted
+		for len(rest) > 0 {
+			c := rest[0]
+			if quoted && c == '\'' {
+				rest = rest[1:]
+				closed = true
+				break
+			}
+			if !quoted && strings.ContainsRune(space, rune(c)) {
+				break
+			}
+			rest = rest[1:]
+			if c == '\\' {
+				if rest == "" {
+					return "", nil, invalid
+				}
+				c, rest = rest[0], rest[1:]
+			}
+			value.WriteByte(c)
+		}
+		if !closed {
+			return "", nil, invalid
+		}
+		switch key {
+		case "password":
+			p := value.String()
+			password = &p
+		case "sslpassword":
+			return "", nil, errors.New("configure sslpassword in a PostgreSQL service file instead of the connection string")
+		default:
+			service = service || key == "service"
+			tokens = append(tokens, start[:len(start)-len(rest)])
+		}
+	}
+	if service && password != nil {
+		return "", nil, errors.New("configure the password in the PostgreSQL service instead of inline with service")
+	}
+	return strings.Join(tokens, " "), password, nil
+}

--- a/cmd/pad/postgres_client_test.go
+++ b/cmd/pad/postgres_client_test.go
@@ -1,0 +1,200 @@
+package main
+
+import (
+	"database/sql"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestPostgresClientConninfo(t *testing.T) {
+	for _, tc := range []struct {
+		name, input, want, password string
+		hasPassword, invalid        bool
+	}{
+		{name: "uri", input: "postgres://u:secret@host:5544/db?sslmode=require", want: "postgres://u@host:5544/db?sslmode=require", password: "secret", hasPassword: true},
+		{name: "escaped password", input: "postgresql://u:p%40ss%3A%27%5C@host/db", want: "postgresql://u@host/db", password: "p@ss:'\\", hasPassword: true},
+		{name: "query wins", input: "postgres://u:old@host/db?password=first&password=last&sslmode=disable", want: "postgres://u@host/db?sslmode=disable", password: "last", hasPassword: true},
+		{name: "empty userinfo password uses defaults", input: "postgres://u:@host/db", want: "postgres://u:@host/db"},
+		{name: "literal plus", input: "postgres://u@host/db?password=p+ass&application_name=a+b", want: "postgres://u@host/db?application_name=a+b", password: "p+ass", hasPassword: true},
+		{name: "multiple hosts", input: "postgresql://u:p@host1:5544,host2:5545/db?target_session_attrs=read-write", want: "postgresql://u@host1:5544,host2:5545/db?target_session_attrs=read-write", password: "p", hasPassword: true},
+		{name: "no password", input: "postgresql://u@host/db?application_name=backup", want: "postgresql://u@host/db?application_name=backup"},
+		{name: "keyword", input: "host=localhost port=5544 user=u password='p\\'a\\\\ss' dbname='data base' sslmode=disable", want: "host=localhost port=5544 user=u dbname='data base' sslmode=disable", password: "p'a\\ss", hasPassword: true},
+		{name: "escaped space", input: `dbname=db password=p\ ass user=u`, want: "dbname=db user=u", password: "p ass", hasPassword: true},
+		{name: "duplicate", input: "password=first dbname=db password=last", want: "dbname=db", password: "last", hasPassword: true},
+		{name: "embedded equals", input: "dbname=db password=a=b", want: "dbname=db", password: "a=b", hasPassword: true},
+		{name: "service", input: "service=myservice application_name=backup", want: "service=myservice application_name=backup"},
+		{name: "bare", input: "my_database", want: "my_database"},
+		{name: "unterminated", input: "password='secret", invalid: true},
+		{name: "trailing escape", input: "password=secret\\", invalid: true},
+		{name: "missing equals", input: "host localhost password=secret", invalid: true},
+		{name: "bad uri", input: "postgres://u:secret%zz@host/db", invalid: true},
+		{name: "bad query", input: "postgres://u:secret@host/db?password=%zz", invalid: true},
+		{name: "inline ssl passphrase", input: "postgres://u@host/db?sslpassword=secret", invalid: true},
+		{name: "service password precedence", input: "service=myservice password=secret", invalid: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dsn, password, err := postgresClientConninfo(tc.input)
+			if tc.invalid {
+				if err == nil || strings.Contains(err.Error(), "secret") {
+					t.Fatalf("expected a redacted error, got %v", err)
+				}
+				return
+			}
+			if err != nil || dsn != tc.want || (password != nil) != tc.hasPassword {
+				t.Fatalf("dsn=%q, password present=%v, err=%v", dsn, password != nil, err)
+			}
+			if password != nil && *password != tc.password {
+				t.Fatal("password decoded incorrectly")
+			}
+		})
+	}
+}
+
+func TestPostgresClientPasswordHandoff(t *testing.T) {
+	t.Setenv("PGPASSWORD", "inherited")
+	t.Setenv("PGSERVICE", "")
+	if err := os.Unsetenv("PGSERVICE"); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"pg_dump", "psql"} {
+		cmd, err := postgresClient(name, "postgres://u:explicit@host/db", "--file", "backup.sql")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(strings.Join(cmd.Args, " "), "explicit") {
+			t.Fatal("password in process arguments")
+		}
+		if cmd.Args[len(cmd.Args)-2] != "--dbname" {
+			t.Fatal("libpq must receive an explicit database argument")
+		}
+		var password string
+		for _, value := range cmd.Env {
+			if strings.HasPrefix(value, "PGPASSWORD=") {
+				password = value
+			}
+		}
+		if password != "PGPASSWORD=explicit" {
+			t.Fatal("explicit password did not override environment")
+		}
+	}
+}
+
+// Use a separate source and destination database, not the suite's shared one.
+// Set PAD_TEST_POSTGRES_TOOLS_URL to a database with matching native clients.
+func TestPostgresBackupRestoreConnection(t *testing.T) {
+	base := os.Getenv("PAD_TEST_POSTGRES_TOOLS_URL")
+	if base == "" {
+		t.Skip("PAD_TEST_POSTGRES_TOOLS_URL not set (requires matching pg_dump/psql clients)")
+	}
+	for _, name := range []string{"pg_dump", "psql"} {
+		if _, err := exec.LookPath(name); err != nil {
+			t.Fatalf("PostgreSQL integration tests require %s: %v", name, err)
+		}
+	}
+	u, err := url.Parse(base)
+	if err != nil || (u.Scheme != "postgres" && u.Scheme != "postgresql") {
+		t.Fatal("PAD_TEST_POSTGRES_TOOLS_URL must be a PostgreSQL URI")
+	}
+	admin, err := sql.Open("pgx", base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { admin.Close() })
+	createDB := func() string {
+		name := "pad_backup_" + strings.ReplaceAll(uuid.NewString(), "-", "")
+		if _, err := admin.Exec("CREATE DATABASE " + name); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() {
+			if _, err := admin.Exec("DROP DATABASE " + name + " WITH (FORCE)"); err != nil {
+				t.Error(err)
+			}
+		})
+		copy := *u
+		copy.Path, copy.RawPath = "/"+name, ""
+		return copy.String()
+	}
+	sourceURL, targetURL := createDB(), createDB()
+	source, err := sql.Open("pgx", sourceURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer source.Close()
+	target, err := sql.Open("pgx", targetURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer target.Close()
+	if _, err := source.Exec("CREATE TABLE recovery_probe (value text); INSERT INTO recovery_probe VALUES ('restored row')"); err != nil {
+		t.Fatal(err)
+	}
+	// A wrong ambient database must not override the explicit URI.
+	t.Setenv("PGDATABASE", "not_the_requested_database")
+	t.Setenv("PGPASSWORD", "not_the_explicit_password")
+	t.Setenv("PGSERVICE", "")
+	if err := os.Unsetenv("PGSERVICE"); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PAD_DB_DRIVER", "postgres")
+	archive := filepath.Join(t.TempDir(), "backup.sql")
+	keyword := func(raw string) string {
+		parsed, err := url.Parse(raw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		quote := func(value string) string {
+			return "'" + strings.NewReplacer("\\", "\\\\", "'", "\\'").Replace(value) + "'"
+		}
+		password, _ := parsed.User.Password()
+		host, port := parsed.Hostname(), parsed.Port()
+		if queryHost := parsed.Query().Get("host"); queryHost != "" {
+			host = queryHost
+		}
+		if port == "" {
+			port = "5432"
+		}
+		return "host=" + quote(host) + " port=" + quote(port) + " dbname=" + quote(strings.TrimPrefix(parsed.Path, "/")) +
+			" user=" + quote(parsed.User.Username()) + " password=" + quote(password) + " sslmode=disable"
+	}
+	for _, format := range []string{"postgres", "postgresql", "keyword"} {
+		convert := func(raw string) string {
+			if format == "keyword" {
+				return keyword(raw)
+			}
+			parsed, _ := url.Parse(raw)
+			parsed.Scheme = format
+			return parsed.String()
+		}
+		t.Setenv("PAD_DATABASE_URL", convert(sourceURL))
+		backup := dbBackupCmd()
+		backup.SetArgs([]string{"--output", archive})
+		if err := backup.Execute(); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("PAD_DATABASE_URL", convert(targetURL))
+		restore := dbRestoreCmd()
+		restore.SetArgs([]string{"--force", archive})
+		if err := restore.Execute(); err != nil {
+			t.Fatal(err)
+		}
+		var value string
+		if err := target.QueryRow("SELECT value FROM recovery_probe").Scan(&value); err != nil || value != "restored row" {
+			t.Fatalf("round trip: value=%q err=%v", value, err)
+		}
+	}
+	missing := *u
+	missing.Path, missing.RawPath = "/pad_missing_"+strings.ReplaceAll(uuid.NewString(), "-", ""), ""
+	t.Setenv("PAD_DATABASE_URL", missing.String())
+	backup := dbBackupCmd()
+	backup.SetArgs([]string{"--output", filepath.Join(t.TempDir(), "missing.sql")})
+	if err := backup.Execute(); err == nil {
+		t.Fatal("backup of missing database succeeded")
+	}
+	t.Log("PostgreSQL backup/restore round trip verified")
+}

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -90,6 +90,14 @@ Requires:
 
 The `--cron` flag uses structured log output suitable for log aggregation systems.
 
+Both PostgreSQL commands accept `postgres://` / `postgresql://` URIs and
+libpq keyword/value connection strings in `PAD_DATABASE_URL`. Database passwords
+are passed to the native client through its environment, not its arguments.
+For a PostgreSQL service configuration, keep the password in that service
+rather than also supplying an inline password; service settings override
+environment defaults. Likewise, configure an SSL key passphrase (`sslpassword`)
+in a service file, since libpq has no corresponding environment variable.
+
 ### Restore
 
 ```bash


### PR DESCRIPTION
## What does this PR do?

Closes #1288.

`pad db backup` and `pad db restore` passed the complete PostgreSQL URI through `PGDATABASE`, which native clients treat as a literal database name. Both commands now use one shared handoff with an explicit `--dbname` connection string and a separate password environment value, so documented connections work without placing database passwords in argv.

The helper preserves native connection options and quoted keyword values. Service credentials remain in the service configuration: inline password/service combinations and inline SSL key passphrases are refused with a specific remedy rather than changing password precedence or exposing them in argv. SQLite behavior is unchanged; no dependencies or schema changes.

## How to test

1. `go test ./cmd/pad -run '^TestPostgresClient' -count=1` covers URI/query and keyword escaping, password handoff, defaults, and invalid input.
2. With matching `pg_dump` and `psql` clients, set `PAD_TEST_POSTGRES_TOOLS_URL` to an isolated PostgreSQL server whose account can create databases, then run `go test ./cmd/pad -run '^TestPostgresBackupRestoreConnection$' -count=2`. The test creates and removes its own source/destination databases; it verifies row contents through real backup→restore round trips for both URI schemes and keyword strings, plus a missing-database failure.
3. Full local Linux SQLite and PostgreSQL suites passed, both normally and with the race detector: `go test -timeout=45m ./... -count=1` and `go test -race -timeout=45m ./... -count=1`, with `PAD_TEST_POSTGRES_URL` set for each PostgreSQL run. All four runs exited 0.

Additional validation: full build; native PostgreSQL 18.4 with SCRAM authentication and an escaped password (six successful round trips); frontend type checks (0 errors, 6 existing warnings); all 2,281 frontend unit tests; browser E2E (204 passed, 192 intentional skips); Linux golangci-lint v2.11.4 (0 issues). The live regression fails with the original command implementation and passes with this patch.

GitHub CI and Nix workflows currently require maintainer approval (`action_required`). Local full Go validation uses Linux/arm64 with Go 1.26.6; the native macOS lint run encountered the existing Linux-only `errProcStatMalformed` unused-symbol issue. No unrelated platform changes are included.

## Checklist

- [x] `make build` passes
- [x] `make test` equivalent passes (full Linux SQLite and PostgreSQL suites)
- [x] Regression tests added
- [x] TypeScript types updated if API changed — not applicable
- [x] CLI help text updated if new command — no new command; backup documentation updated

Validation environment: Go 1.26.6 on Linux/arm64 with PostgreSQL 18.6 for the full matrix; native macOS/arm64 with PostgreSQL 18.4 for the real backup/restore regression. Initial Linux runs were discarded after the VM ran out of disk space; all four complete suites were rerun successfully after expanding its disk. Browser E2E used the standard repository configuration with an isolated server port and a quoted absolute launcher path for the workspace path containing spaces. Native `make install` was replaced by the documented sibling-safe approach: build and exercise this worktree’s binary without stopping other Pad sessions.
