### PR TITLE
fix(server): a refused collection prefix reaches the caller as a 400 naming the rule (BUG-2951)

### DIFF
--- a/internal/mcp/collection_refusal_classification_test.go
+++ b/internal/mcp/collection_refusal_classification_test.go
@@ -1,0 +1,75 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+)
+
+// BUG-2951's load-bearing argument, measured rather than asserted.
+//
+// The stdio transport classifies a CLI failure by matching stderr PROSE. While
+// the collection doors answered "An internal error occurred" for a refused
+// prefix, that text matched none of the validation patterns and the refusal
+// reached an agent as server_error — the RETRYABLE code — so the correct agent
+// response to a permanently-invalid prefix was to retry it forever. That is
+// worse than a lost message: it is a wrong instruction.
+//
+// Nothing in internal/mcp changed for this fix. What changed is that the
+// store's own message now reaches stderr, and the EXISTING `invalid` pattern
+// recognises it. This test is what keeps that true — a reworded refusal that
+// drops the word the classifier matches would silently restore the retry loop,
+// and it would do so with every server-side test still green.
+func TestCollectionPrefixRefusalClassifiesAsValidation(t *testing.T) {
+	// Verbatim shape of what the CLI prints now: "Error: " plus the API's
+	// message, which is store.ValidationError.Reason.
+	const fixedStderr = `Error: invalid prefix "ab1": a collection prefix must start with an uppercase letter and contain only uppercase letters or digits (e.g. TASK, AB1)`
+	const fixedBody = `{"error":{"code":"bad_request","message":"invalid prefix \"ab1\": a collection prefix must start with an uppercase letter and contain only uppercase letters or digits (e.g. TASK, AB1)"}}`
+
+	stdio := classifyExecError(context.Background(), []string{"collection", "update"}, errors.New("exit 1"), fixedStderr, nil)
+	stdioEnv, ok := stdio.StructuredContent.(ErrorEnvelope)
+	if !ok {
+		t.Fatalf("stdio: expected ErrorEnvelope, got %T", stdio.StructuredContent)
+	}
+	if stdioEnv.Error.Code != ErrValidationFailed {
+		t.Errorf("stdio code = %q, want %q — an unmatched refusal lands as server_error and invites an endless retry",
+			stdioEnv.Error.Code, ErrValidationFailed)
+	}
+
+	remote := classifyHTTPStatus(context.Background(), "collection update", http.StatusBadRequest, []byte(fixedBody), nil)
+	remoteEnv, ok := remote.StructuredContent.(ErrorEnvelope)
+	if !ok {
+		t.Fatalf("remote: expected ErrorEnvelope, got %T", remote.StructuredContent)
+	}
+	if remoteEnv.Error.Code != ErrValidationFailed {
+		t.Errorf("remote code = %q, want %q", remoteEnv.Error.Code, ErrValidationFailed)
+	}
+	if stdioEnv.Error.Code != remoteEnv.Error.Code {
+		t.Errorf("one refusal, two codes: stdio=%q remote=%q", stdioEnv.Error.Code, remoteEnv.Error.Code)
+	}
+}
+
+// TestGenericInternalErrorStillClassifiesAsServerError is the negative control
+// for the test above, and the measurement of the defect itself.
+//
+// Without it, the assertion "the fix changes what an agent is told" rests on
+// the claim that the OLD text classified differently — a claim about a
+// codepath, not an observation of one. This drives the same classifier with
+// the exact string the doors used to emit. It must remain server_error: that
+// is correct for a genuine internal failure, and it is precisely why the
+// refusal had to stop wearing that message rather than the classifier being
+// taught to read it as validation.
+func TestGenericInternalErrorStillClassifiesAsServerError(t *testing.T) {
+	const genericStderr = "Error: An internal error occurred"
+
+	stdio := classifyExecError(context.Background(), []string{"collection", "update"}, errors.New("exit 1"), genericStderr, nil)
+	env, ok := stdio.StructuredContent.(ErrorEnvelope)
+	if !ok {
+		t.Fatalf("stdio: expected ErrorEnvelope, got %T", stdio.StructuredContent)
+	}
+	if env.Error.Code != ErrServerError {
+		t.Errorf("code = %q, want %q — this string is what a REAL internal failure says, and a retryable "+
+			"classification is right for it", env.Error.Code, ErrServerError)
+	}
+}

--- a/internal/server/handlers_collections.go
+++ b/internal/server/handlers_collections.go
@@ -239,6 +239,17 @@ func (s *Server) handleCreateCollection(w http.ResponseWriter, r *http.Request) 
 			writeError(w, http.StatusConflict, "conflict", uniqueCollectionConflictMessage(err))
 			return
 		}
+		// A refusal about what the CALLER asked for is a 400 carrying the
+		// store's own text (BUG-2951). Without this arm the prefix-grammar
+		// refusal — the one message that names the rule and an example — fell
+		// into writeInternalError and reached the caller as "An internal
+		// error occurred", which reads as an outage rather than as "fix your
+		// input". Reason, never err.Error(): the latter carries the sentinel
+		// prefix and any wrapping the call path added.
+		if v, ok := store.AsValidationError(err); ok {
+			writeError(w, http.StatusBadRequest, "bad_request", v.Reason)
+			return
+		}
 		writeInternalError(w, err)
 		return
 	}
@@ -397,6 +408,13 @@ func (s *Server) handleUpdateCollection(w http.ResponseWriter, r *http.Request) 
 			writeError(w, http.StatusConflict, "conflict", uniqueCollectionConflictMessage(err))
 			return
 		}
+		// Same arm as create, and this is the door BUG-2951 was measured on:
+		// `pad collection update docs --prefix "ab1"` answered "An internal
+		// error occurred" while the store had composed the rule and an example.
+		if v, ok := store.AsValidationError(err); ok {
+			writeError(w, http.StatusBadRequest, "bad_request", v.Reason)
+			return
+		}
 		writeInternalError(w, err)
 		return
 	}
@@ -531,8 +549,19 @@ func (s *Server) handleDeleteCollection(w http.ResponseWriter, r *http.Request) 
 			writeError(w, http.StatusNotFound, "not_found", "Collection not found")
 			return
 		}
-		if strings.Contains(err.Error(), "cannot delete default collection") {
-			writeError(w, http.StatusBadRequest, "bad_request", "Cannot delete a default collection")
+		// Was a strings.Contains match on the store's error text (BUG-2951):
+		// a reworded refusal silently became a 500, and prose matching is the
+		// stopgap this unit exists to stop building on.
+		//
+		// It renders v.Reason rather than a wording of its own, so ONE rule
+		// holds at every door: the caller sees the store's message. Keeping a
+		// handler-side sentence here would have been wrong for a second
+		// reason — DeleteCollection can also refuse a malformed
+		// expected_updated_at, and a fixed string would have answered that
+		// refusal with the default-collection message. The store's Reason
+		// carries the caller-facing wording, so the text is unchanged.
+		if v, ok := store.AsValidationError(err); ok {
+			writeError(w, http.StatusBadRequest, "bad_request", v.Reason)
 			return
 		}
 		writeInternalError(w, err)

--- a/internal/server/handlers_collections_refusal_status_test.go
+++ b/internal/server/handlers_collections_refusal_status_test.go
@@ -1,0 +1,138 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// BUG-2951: the prefix-grammar refusal reached the caller as
+// "An internal error occurred" — a 500 with no text — because the collection
+// doors mapped only conflict shapes and sent everything else to
+// writeInternalError. The refusal kept its data-protection value and lost its
+// entire teaching value, and an MCP agent was told worse than nothing: the
+// stdio classifier reads an unrecognised message as the RETRYABLE server_error
+// code, so the correct agent response was to retry a call that can never work.
+//
+// Every case here asserts the STATUS and the TEXT together. Either alone
+// passes for the wrong reason: a 400 with an empty body is not actionable, and
+// the right message under a 500 still says "the server broke".
+
+// decodeErrorBody pulls the code + message out of the standard error envelope.
+func decodeErrorBody(t *testing.T, body string) (code, message string) {
+	t.Helper()
+	var env struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(body), &env); err != nil {
+		t.Fatalf("decode error envelope: %v (body=%s)", err, body)
+	}
+	// The door must render ValidationError.Reason, never Error(): the latter
+	// carries the "store: validation" sentinel prefix and whatever any layer
+	// wrapped around it. Checked HERE so every caller of this helper inherits
+	// it — a mutation swapping Reason for Error() at any door survived every
+	// assertion this file made about the message text, because the reason is
+	// a SUBSTRING of the error, so a contains-check cannot see the difference.
+	if strings.Contains(env.Error.Message, "store: validation") {
+		t.Errorf("message leaks the internal sentinel prefix: %q (render ValidationError.Reason, not Error())", env.Error.Message)
+	}
+	return env.Error.Code, env.Error.Message
+}
+
+func TestCollectionPrefixRefusal_IsActionableAtEveryDoor(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+	createPath := "/api/v1/workspaces/" + slug + "/collections"
+
+	// The message must name the RULE, not merely report a failure — that is
+	// what makes a refusal teach. Asserting a substring of the store's own
+	// sentence keeps this honest without pinning the whole wording.
+	const rule = "must start with an uppercase letter"
+
+	t.Run("create with an invalid prefix", func(t *testing.T) {
+		rr := doRequest(srv, "POST", createPath, map[string]interface{}{
+			"name":   "Widgets",
+			"prefix": "ab1",
+		})
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400; body = %s", rr.Code, rr.Body.String())
+		}
+		code, msg := decodeErrorBody(t, rr.Body.String())
+		if code != "bad_request" {
+			t.Errorf("code = %q, want bad_request", code)
+		}
+		if !strings.Contains(msg, rule) {
+			t.Errorf("message = %q, want it to name the rule (%q)", msg, rule)
+		}
+		if !strings.Contains(msg, "ab1") {
+			t.Errorf("message = %q, want it to quote the rejected value", msg)
+		}
+	})
+
+	t.Run("update with an invalid prefix", func(t *testing.T) {
+		// Create a collection to update, then rename its prefix badly. This is
+		// the door the bug was measured on.
+		rr := doRequest(srv, "POST", createPath, map[string]interface{}{"name": "Gadgets"})
+		if rr.Code != http.StatusCreated {
+			t.Fatalf("setup create failed: %d %s", rr.Code, rr.Body.String())
+		}
+		var created struct {
+			Slug string `json:"slug"`
+		}
+		if err := json.Unmarshal(rr.Body.Bytes(), &created); err != nil {
+			t.Fatalf("decode created collection: %v", err)
+		}
+
+		rr = doRequest(srv, "PATCH", createPath+"/"+created.Slug, map[string]interface{}{
+			"prefix": "ab1",
+		})
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400; body = %s", rr.Code, rr.Body.String())
+		}
+		code, msg := decodeErrorBody(t, rr.Body.String())
+		if code != "bad_request" {
+			t.Errorf("code = %q, want bad_request", code)
+		}
+		if !strings.Contains(msg, rule) {
+			t.Errorf("message = %q, want it to name the rule (%q)", msg, rule)
+		}
+	})
+
+	t.Run("a valid prefix still succeeds", func(t *testing.T) {
+		// The counterfactual: without it, a door that refused EVERY prefix
+		// would pass both cases above.
+		rr := doRequest(srv, "POST", createPath, map[string]interface{}{
+			"name":   "Sprockets",
+			"prefix": "SPR1",
+		})
+		if rr.Code != http.StatusCreated {
+			t.Fatalf("status = %d, want 201; body = %s", rr.Code, rr.Body.String())
+		}
+	})
+}
+
+// TestDeleteDefaultCollection_RefusalSurvivedTheTypeSwap pins the one door that
+// already answered 400 — by matching the store's prose with strings.Contains.
+// The swap to the typed check must not change what a caller sees, and the
+// message must still be the default-collection one rather than a generic
+// validation string.
+func TestDeleteDefaultCollection_RefusalSurvivedTheTypeSwap(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	rr := doRequest(srv, "DELETE", "/api/v1/workspaces/"+slug+"/collections/tasks", nil)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body = %s", rr.Code, rr.Body.String())
+	}
+	code, msg := decodeErrorBody(t, rr.Body.String())
+	if code != "bad_request" {
+		t.Errorf("code = %q, want bad_request", code)
+	}
+	if !strings.Contains(strings.ToLower(msg), "default collection") {
+		t.Errorf("message = %q, want the default-collection refusal", msg)
+	}
+}

--- a/internal/server/handlers_import_bundle.go
+++ b/internal/server/handlers_import_bundle.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/PerpetualSoftware/pad/internal/attachments"
 	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/store"
 )
 
 // defaultImportBundleMaxBytes caps an uploaded bundle. Mirrors the
@@ -321,6 +322,20 @@ func (s *Server) importBundle(ctx context.Context, r io.Reader, newName string, 
 			}
 			ws, err = s.store.ImportWorkspace(&export, newName, ownerID, mint.Source)
 			if err != nil {
+				// A refusal about the bundle the caller supplied gets this
+				// door's own envelope carrying the store's Reason, exactly as
+				// the mint-payload check above does. Falling through to the
+				// generic wrap would render err.Error() — which since BUG-2951
+				// carries the "store: validation" sentinel prefix, so the very
+				// change that made this refusal actionable on the JSON door
+				// would have made it uglier here. A producer change is only
+				// finished when its consumers have been read (codex round 1).
+				if v, ok := store.AsValidationError(err); ok {
+					return nil, &importStatusError{
+						status: http.StatusBadRequest, code: "bad_bundle",
+						message: "Bundle pad-export.json is not importable: " + v.Reason,
+					}
+				}
 				return nil, fmt.Errorf("import workspace: %w", err)
 			}
 			oldItemIDToSlug = make(map[string]string, len(export.Items))

--- a/internal/server/handlers_workspace_import_refusal_status_test.go
+++ b/internal/server/handlers_workspace_import_refusal_status_test.go
@@ -1,0 +1,167 @@
+package server
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// BUG-2951, the fourth door. The workspace-import path answered 500
+// import_failed for EVERY failure, including the prefix-grammar refusal —
+// whose message names the offending collection and tells the caller to edit
+// the prefix in the export and import again. An actionable instruction
+// delivered under a status that says "the server broke, try later" is a
+// refusal a caller cannot act on and a retry loop for anything automated.
+//
+// The sibling bundle-import door already answered 400 for this class, so the
+// two doors onto one refusal disagreed; this pins the alignment.
+func TestImportWorkspace_UnimportablePrefixIs400WithTheReason(t *testing.T) {
+	srv, user := importLimitFixture(t, 0)
+
+	// A collection whose prefix cannot be derived OR validated: "!!" is not a
+	// legal prefix, and a name of "!!" leaves DerivePrefix nothing to work
+	// with either, so the import must refuse rather than seed a workspace
+	// whose ids could never be formed.
+	body, err := json.Marshal(models.WorkspaceExport{
+		Version:   1,
+		Workspace: models.WorkspaceExportMeta{Name: "Imported", Slug: "imported"},
+		Collections: []models.CollectionExport{{
+			Name:   "!!",
+			Slug:   "bad-prefix",
+			Prefix: "!!",
+			Schema: `{"fields":[]}`,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("marshal export: %v", err)
+	}
+
+	rr := importRequest(t, srv, user, "application/json", body)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body = %s", rr.Code, rr.Body.String())
+	}
+	var env struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode error envelope: %v (body=%s)", err, rr.Body.String())
+	}
+	if env.Error.Code != "import_failed" {
+		t.Errorf("code = %q, want import_failed (unchanged — only the status moved)", env.Error.Code)
+	}
+	// The instruction is the point: a caller must learn WHICH collection to
+	// edit and what to edit it to. Status alone would pass with an empty body.
+	if strings.Contains(env.Error.Message, "store: validation") {
+		t.Errorf("message leaks the internal sentinel prefix: %q (render ValidationError.Reason, not Error())", env.Error.Message)
+	}
+	for _, want := range []string{"import collection", "edit the prefix"} {
+		if !strings.Contains(env.Error.Message, want) {
+			t.Errorf("message = %q, want it to contain %q", env.Error.Message, want)
+		}
+	}
+}
+
+// TestImportWorkspace_RealFailuresStayA500 is the counterfactual. Mapping the
+// caller-input refusal to 400 must not turn every import failure into one — a
+// server-side fault under a 4xx tells the caller to fix input that was fine.
+// Version 0 is refused inside ImportWorkspace as an unsupported export, which
+// is not a ValidationError, so it must still surface as a 500.
+func TestImportWorkspace_RealFailuresStayA500(t *testing.T) {
+	srv, user := importLimitFixture(t, 0)
+
+	body, err := json.Marshal(models.WorkspaceExport{
+		Workspace: models.WorkspaceExportMeta{Name: "Imported", Slug: "imported"},
+	})
+	if err != nil {
+		t.Fatalf("marshal export: %v", err)
+	}
+
+	rr := importRequest(t, srv, user, "application/json", body)
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500 for a non-validation import failure; body = %s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestImportBundle_UnimportablePrefixKeepsTheReasonClean is the consumer
+// codex round 1 caught: the tar.gz door renders a bundle failure through its
+// own envelope, and its fallback path wraps err.Error(). Making the JSON door
+// actionable moved the sentinel prefix INTO that text, so the change that
+// improved one door would have made its sibling's message worse — the producer
+// change was not finished until the consumers had been read.
+func TestImportBundle_UnimportablePrefixKeepsTheReasonClean(t *testing.T) {
+	// The bundle door needs attachment storage configured — without it the
+	// request is refused 503 before it reaches the import at all, which is how
+	// the first version of this test "failed" for a reason unrelated to what
+	// it asserts.
+	srv, _ := testServerWithAttachments(t)
+	user, uerr := srv.store.CreateUser(models.UserCreate{
+		Email: "bundle-importer@example.com", Name: "Importer",
+		Password: "correct-horse-battery-staple", Role: "member",
+	})
+	if uerr != nil {
+		t.Fatalf("create user: %v", uerr)
+	}
+
+	export := models.WorkspaceExport{
+		Version:   1,
+		Workspace: models.WorkspaceExportMeta{Name: "Bundled", Slug: "bundled"},
+		Collections: []models.CollectionExport{{
+			Name:   "!!",
+			Slug:   "bad-prefix",
+			Prefix: "!!",
+			Schema: `{"fields":[]}`,
+		}},
+	}
+	exportJSON, err := json.Marshal(export)
+	if err != nil {
+		t.Fatalf("marshal export: %v", err)
+	}
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	if err := tw.WriteHeader(&tar.Header{Name: "pad-export.json", Mode: 0o600, Size: int64(len(exportJSON))}); err != nil {
+		t.Fatalf("tar header: %v", err)
+	}
+	if _, err := tw.Write(exportJSON); err != nil {
+		t.Fatalf("tar write: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tar close: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+
+	rr := importRequest(t, srv, user, "application/gzip", buf.Bytes())
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body = %s", rr.Code, rr.Body.String())
+	}
+	var env struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode error envelope: %v (body=%s)", err, rr.Body.String())
+	}
+	if strings.Contains(env.Error.Message, "store: validation") {
+		t.Errorf("message leaks the internal sentinel prefix: %q", env.Error.Message)
+	}
+	if !strings.Contains(env.Error.Message, "edit the prefix") {
+		t.Errorf("message = %q, want the actionable instruction", env.Error.Message)
+	}
+}

--- a/internal/server/handlers_workspaces.go
+++ b/internal/server/handlers_workspaces.go
@@ -902,6 +902,17 @@ func (s *Server) handleImportWorkspace(w http.ResponseWriter, r *http.Request) {
 	userID := mint.OwnerID
 	ws, err := s.store.ImportWorkspace(&data, newName, userID, mint.Source)
 	if err != nil {
+		// A refusal about the EXPORT the caller supplied is a 400, not a 500
+		// (BUG-2951). This door answered 500 for every failure, including the
+		// prefix-grammar refusal whose message tells the caller which
+		// collection to edit and re-import — an actionable instruction
+		// delivered under a status that says "the server broke, try later".
+		// The sibling bundle-import door (handlers_import_bundle.go) already
+		// answers 400 for this class; this aligns the two.
+		if v, ok := store.AsValidationError(err); ok {
+			writeError(w, http.StatusBadRequest, "import_failed", v.Reason)
+			return
+		}
 		writeError(w, http.StatusInternalServerError, "import_failed", err.Error())
 		return
 	}

--- a/internal/store/collections.go
+++ b/internal/store/collections.go
@@ -67,7 +67,7 @@ func (s *Store) CreateCollection(workspaceID string, input models.CollectionCrea
 		// `--prefix "AB!"` still produced items whose printed issue ID no
 		// surface could resolve.
 		if !collections.IsValidPrefix(prefix) {
-			return nil, fmt.Errorf("invalid prefix %q: a collection prefix must start with an uppercase letter and contain only uppercase letters or digits (e.g. TASK, AB1)", prefix)
+			return nil, invalidf("invalid prefix %q: a collection prefix must start with an uppercase letter and contain only uppercase letters or digits (e.g. TASK, AB1)", prefix)
 		}
 	} else {
 		prefix = collections.DerivePrefix(input.Name)
@@ -486,7 +486,7 @@ func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*mod
 		// reaches for to FIX a bad prefix, so it has to reject a bad
 		// replacement rather than swap one unresolvable id-space for another.
 		if !collections.IsValidPrefix(*input.Prefix) {
-			return nil, fmt.Errorf("invalid prefix %q: a collection prefix must start with an uppercase letter and contain only uppercase letters or digits (e.g. TASK, AB1)", *input.Prefix)
+			return nil, invalidf("invalid prefix %q: a collection prefix must start with an uppercase letter and contain only uppercase letters or digits (e.g. TASK, AB1)", *input.Prefix)
 		}
 		sets = append(sets, "prefix = ?")
 		args = append(args, *input.Prefix)
@@ -650,7 +650,7 @@ func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*mod
 	if input.ExpectedUpdatedAt != "" {
 		expected, perr := time.Parse(time.RFC3339, input.ExpectedUpdatedAt)
 		if perr != nil {
-			return nil, fmt.Errorf("invalid expected_updated_at %q: %w", input.ExpectedUpdatedAt, perr)
+			return nil, invalidf("expected_updated_at must be an RFC3339 timestamp, got %q", input.ExpectedUpdatedAt)
 		}
 		if !current.Equal(expected) {
 			return nil, &CollectionUpdateConflictError{
@@ -722,7 +722,7 @@ func (s *Store) DeleteCollection(id string, expectedUpdatedAt string) error {
 		return fmt.Errorf("check collection: %w", err)
 	}
 	if isDefault {
-		return fmt.Errorf("cannot delete default collection")
+		return invalidf("Cannot delete a default collection")
 	}
 
 	ts := now()
@@ -730,7 +730,7 @@ func (s *Store) DeleteCollection(id string, expectedUpdatedAt string) error {
 	if expectedUpdatedAt != "" {
 		expected, perr := time.Parse(time.RFC3339, expectedUpdatedAt)
 		if perr != nil {
-			return fmt.Errorf("invalid expected_updated_at %q: %w", expectedUpdatedAt, perr)
+			return invalidf("expected_updated_at must be an RFC3339 timestamp, got %q", expectedUpdatedAt)
 		}
 		tx, terr := s.db.Begin()
 		if terr != nil {

--- a/internal/store/export.go
+++ b/internal/store/export.go
@@ -613,7 +613,7 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 			prefix = "ITEM"
 		}
 		if !collections.IsValidPrefix(prefix) {
-			return nil, fmt.Errorf("import collection %q: prefix %q cannot be resolved — a collection prefix must start with an uppercase letter and contain only uppercase letters or digits; edit the prefix for this collection in the export and import again", c.Name, c.Prefix)
+			return nil, invalidf("import collection %q: prefix %q cannot be resolved — a collection prefix must start with an uppercase letter and contain only uppercase letters or digits; edit the prefix for this collection in the export and import again", c.Name, c.Prefix)
 		}
 		if hasDigit(prefix) {
 			// Accepted only because the parser widened for this fix. Logged so

--- a/internal/store/items_test.go
+++ b/internal/store/items_test.go
@@ -324,8 +324,17 @@ func TestCollectionDeleteDefaultRefused(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when deleting default collection")
 	}
-	if err.Error() != "cannot delete default collection" {
-		t.Errorf("unexpected error: %v", err)
+	// Was `err.Error() != "cannot delete default collection"`. The refusal is
+	// now a typed ValidationError so the HTTP layer can map it to a 400
+	// carrying this text instead of matching the prose (BUG-2951), which moves
+	// the sentinel prefix into Error(). Reason is the caller-facing contract,
+	// so that is what this asserts.
+	v, ok := AsValidationError(err)
+	if !ok {
+		t.Fatalf("DeleteCollection error is not a ValidationError: %v", err)
+	}
+	if v.Reason != "Cannot delete a default collection" {
+		t.Errorf("unexpected reason: %q", v.Reason)
 	}
 }
 

--- a/internal/store/validation_error.go
+++ b/internal/store/validation_error.go
@@ -1,0 +1,58 @@
+package store
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrValidation reports a write the store refused because of what the CALLER
+// asked for, as opposed to anything that went wrong inside the server.
+//
+// The distinction is the whole point of the type. A handler that cannot tell
+// the two apart has one honest option — 500 with no text — and that is what
+// three of the four collection doors did with the prefix-grammar refusal
+// (BUG-2951): the store composed a message naming the rule and the example,
+// and the caller was told "An internal error occurred", which reads as an
+// outage rather than as "fix your input". An MCP agent is told worse than
+// that: internal/mcp/errors.go classifies stdio failures by matching CLI
+// stderr prose, the generic message matches none of its validation patterns,
+// so the refusal arrives as the RETRYABLE server_error code and the correct
+// agent response to it is to retry a call that can never succeed.
+var ErrValidation = errors.New("store: validation")
+
+// ValidationError carries the caller-facing reason a write was refused.
+//
+// Reason is the contract: a door renders THAT field, never Error(), because
+// Error() carries the sentinel prefix and any wrapping a call path has added,
+// and none of that is addressed to the caller. Same rule, and for the same
+// reason, as InvalidDocumentTitleError's Reason (documents.go).
+//
+// Constructing this type is the per-site DECISION that a message is safe to
+// show — it says "this text quotes the caller's own input and the rule it
+// broke, and nothing about how the server is built". The alternative shape,
+// where a door returns err.Error() for anything it does not recognise, makes
+// that decision by default for every error any layer might add later, which
+// is how internal detail escapes.
+type ValidationError struct{ Reason string }
+
+func (e *ValidationError) Error() string { return ErrValidation.Error() + ": " + e.Reason }
+
+func (e *ValidationError) Unwrap() error { return ErrValidation }
+
+// AsValidationError reports whether err is (or wraps) a ValidationError, and
+// returns it. Doors use this instead of a bare errors.As so the Reason-not-
+// Error() rule has one place to be stated.
+func AsValidationError(err error) (*ValidationError, bool) {
+	var v *ValidationError
+	if errors.As(err, &v) {
+		return v, true
+	}
+	return nil, false
+}
+
+// invalidf builds a ValidationError. Unexported: the store decides what is
+// caller-visible, and a caller-supplied Reason from outside the package would
+// be a text-injection channel into 4xx bodies.
+func invalidf(format string, args ...any) error {
+	return &ValidationError{Reason: fmt.Sprintf(format, args...)}
+}


### PR DESCRIPTION
Fixes BUG-2951. BUG-2943 made the store refuse a collection prefix outside the grammar with a message naming the rule and an example. Three of the four doors onto that refusal threw the message away, so `pad collection update docs --prefix "ab1"` answered **"An internal error occurred"** — measured on the merged binary, not inferred. The refusal kept its data-protection value and lost its entire teaching value: a 500 with no text reads as an outage, so the honest user response is to retry or report one.

**An MCP agent was told something worse than nothing.** `internal/mcp` classifies a stdio failure by matching CLI stderr prose; the generic message matches none of the validation patterns, so a permanently-invalid prefix arrived as the **retryable** `server_error` code and the correct agent response was to retry a call that can never succeed. Nothing in `internal/mcp` changes here — the store's own message now reaches stderr and the existing `invalid` pattern recognises it. Both directions are pinned, including the negative control that the *old* generic string still classifies as `server_error`, which is right for a real internal failure and is exactly why the refusal had to stop wearing that message.

## The population, read door by door

The first recon comment on the item said "six refusal sites in one file"; that was a grep, not a reachability check, and the trail carries the correction. What is actually there:

| door | before |
|---|---|
| `POST /collections` | 500, no text |
| `PATCH /collections/{slug}` | 500, no text — the door the bug was measured on |
| `DELETE /collections/{slug}` | 400 with a message, via `strings.Contains` on the store's error text |
| `POST /workspaces/import` (JSON) | text preserved, under a **500** |
| `POST /workspaces/import` (tar.gz) | text preserved — and this one was *made worse* by the fix until codex caught it |

Two store sites are deliberately **not** converted, both read and left rather than missed: the template-seeding trait validation checks first-party template code (a 500 is honest there), and the two `expected_updated_at` refusals are unreachable through HTTP because both doors validate the token at the boundary.

## Shape

`store.ValidationError` carries the caller-facing `Reason`, with `AsValidationError` for the doors — the `InvalidDocumentTitleError` precedent already in that package. **Constructing the type is the per-site decision that a message is safe to show.** The alternative shape, where a door returns `err.Error()` for anything it does not recognise, makes that decision by default for every error any layer may later add.

Doors render `Reason`, never `Error()`, because `Error()` carries the sentinel prefix and whatever a call path wrapped around it. That rule is guarded: a mutant swapping `Reason` for `Error()` survived every message assertion in the first pass, because the reason is a *substring* of the error and a contains-check cannot see the difference. The helper now asserts no response body contains the sentinel.

## WIRE CHANGE

`POST /workspaces/import` answers **400** for a caller-input refusal where it answered 500. The code string (`import_failed`) and the message are unchanged, and the sibling bundle-import door has always answered 400 for this class — this aligns two doors onto one refusal. Ruled by the lead rather than decided here. `Cannot delete a default collection` stays 400.

## Evidence

- `make lint` 0 issues, `make test` pass over 30 packages, `make test-pg` pass — all on this tree. PG run because this touches store code, even though no SQL changed.
- **Negative control:** each door arm removed in turn; the matching test fails.
- **Mutation matrix, eleven mutants, each compiled and run:** every door-arm removal, every store site reverted to `fmt.Errorf`, both `Reason`→`Error()` swaps, and the bundle door falling through to the generic wrap — all killed by a named test. One attribution was wrong on the first pass (a store test appeared as a casualty of a server-side mutant); re-running it in isolation showed the mutant does not touch it, and the runner had attributed every `--- FAIL` line in a two-package run to the mutation.
- **Codex:** round 1 found the tar.gz consumer this change created — the fix that made one door actionable moved the sentinel prefix into its sibling's message. Fixed with a test and a mutant; round 2 CLEAN.

Rebased onto 49d1bfcd before the gates, so the green measures the tree this would merge onto.

https://claude.ai/code/session_01HeChkgZVYb3NTgTcckF5KR
