### PR TITLE
fix(server): the op-log prune rides inside the write it justifies (BUG-2840 half B)

### DIFF
--- a/internal/server/handlers_collab.go
+++ b/internal/server/handlers_collab.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"database/sql"
 	"errors"
 	"log/slog"
 	"math/rand"
@@ -14,11 +15,6 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/gorilla/websocket"
 )
-
-// distantFuture is used as a "prune everything" cutoff for the
-// item_yjs_updates table. PruneYjsUpdatesBefore takes a strict-less-
-// than cutoff, so passing a far-future time sweeps the whole row set.
-var distantFuture = time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC)
 
 // collabMembershipRevalInterval is how often an active collab WS
 // re-runs authorizeCollabAccess to catch a mid-stream revocation
@@ -433,7 +429,14 @@ const applyContentMaxRetries = 3
 // on the no-room/no-applier paths, INSIDE the per-item setup lock
 // (so a fresh Join cannot replay stale op-log between prune and
 // content write).
-type directWriteFn func() error
+//
+// It receives the op-log prune as a hook to run INSIDE its own write
+// transaction rather than performing the prune itself, so the two
+// move together or not at all (BUG-2840 half B). The caller must run
+// the hook when it is non-nil; a write that commits without it leaves
+// a stale op-log that a later Join would replay over the content just
+// written, which is the hazard the prune exists to prevent.
+type directWriteFn func(pruneOpLog func(tx *sql.Tx) error) error
 
 func (s *Server) applyContentViaCollab(r *http.Request, itemID, markdown string, directWrite directWriteFn) error {
 	if s.collab == nil {
@@ -520,22 +523,33 @@ func (s *Server) applyContentViaCollabOnce(r *http.Request, itemID, markdown str
 		// ErrAllAppliersTimedOut is intentionally NOT pruned
 		// because peers may still be alive there.
 		paErr := s.collab.PruneAndApply(itemID, func() error {
-			// Prune the (now-stale) op-log. Failure here is logged
-			// but does NOT block the content write — the prune
-			// matters for FUTURE collab sessions, while the
-			// content write is the user's actual intent.
-			if _, perr := s.store.PruneYjsUpdatesBefore(itemID, distantFuture); perr != nil {
-				slog.Warn("collab: failed to prune op-log on direct-write fallback",
-					"item_id", itemID,
-					"error", perr,
-				)
-			}
-			// Write items.content under the same per-item lock so
-			// a concurrent Join can't slip in between prune and
-			// write, replay an empty op-log, then later overwrite
-			// our fresh write from its stale Y.Doc state. Per
-			// Codex review round 8.
-			return directWrite()
+			// The prune runs INSIDE the write's own transaction, via
+			// the hook, so a refused or failed write rolls it back
+			// (BUG-2840 half B). It used to run first, in its own
+			// statement: the justification for pruning is that "any
+			// prior collab state is strictly older than the
+			// items.content the caller is about to write", and that
+			// premise is FALSE on every path where the write then
+			// refuses — the ops were destroyed and nothing replaced
+			// them. That is not hypothetical on this branch: it fires
+			// on ErrNoApplierAvailable, i.e. a room inside its grace
+			// TTL with zero connections, which is exactly the state
+			// where the op-log holds a closed tab's edits that never
+			// reached items.content.
+			//
+			// Same shape, and the same reasoning, as PruneItemOpLogTx's
+			// use by version-restore, whose comment already says a
+			// split prune/commit "leaves a divergent state on any
+			// failure" in EITHER order. This path was the remaining
+			// split.
+			//
+			// Still under the per-item lock, so a concurrent Join
+			// cannot slip between prune and write, replay an empty
+			// op-log, then overwrite the fresh write from its stale
+			// Y.Doc state (Codex review round 8).
+			return directWrite(func(tx *sql.Tx) error {
+				return s.store.PruneItemOpLogTx(tx, itemID)
+			})
 		})
 		switch {
 		case paErr == nil:

--- a/internal/server/handlers_collab_prune_atomicity_test.go
+++ b/internal/server/handlers_collab_prune_atomicity_test.go
@@ -1,0 +1,141 @@
+package server
+
+import (
+	"net/http"
+	"testing"
+)
+
+// BUG-2840 half B. On the no-room / no-applier path a content PATCH prunes the
+// item's Yjs op-log and writes items.content. The prune used to run FIRST, in
+// its own statement, justified by the claim that "any prior collab state is
+// strictly older than the items.content the caller is about to write".
+//
+// That premise is false whenever the write then REFUSES: the ops are destroyed
+// and nothing replaces them. It is not a hypothetical on this branch — it fires
+// on ErrNoApplierAvailable, a room inside its grace TTL with zero connections,
+// which is precisely the state where the op-log holds a closed tab's edits that
+// never reached items.content. Four typed refusals can come out of that write
+// (the open-children guard, the optimistic-concurrency conflict, the
+// rename-cascade byte refusal, and the item-title refusal), so the window is a
+// property of the ORDERING rather than of any one of them.
+//
+// The property, as the lead set it: a refused row write leaves no op that a
+// later flush applies — i.e. a refusal must leave the op-log exactly as it
+// found it, neither pruned nor added to.
+//
+// countOpLog reports how many op-log rows an item currently has.
+func countOpLog(t *testing.T, srv *Server, itemID string) int {
+	t.Helper()
+	updates, err := srv.store.LoadYjsUpdatesSince(itemID, 0)
+	if err != nil {
+		t.Fatalf("LoadYjsUpdatesSince: %v", err)
+	}
+	return len(updates)
+}
+
+// seedOpLog appends rows standing in for a closed tab's unflushed edits —
+// content that exists ONLY in the op-log, because items.content was never
+// updated for it.
+func seedOpLog(t *testing.T, srv *Server, itemID string, n int) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		if _, err := srv.store.AppendYjsUpdate(itemID, []byte{0x00, byte(i)}, "1"); err != nil {
+			t.Fatalf("AppendYjsUpdate: %v", err)
+		}
+	}
+	if got := countOpLog(t, srv, itemID); got != n {
+		t.Fatalf("seeded %d op-log rows, store reports %d", n, got)
+	}
+}
+
+func TestCollabDirectWrite_RefusedWriteLeavesTheOpLogIntact(t *testing.T) {
+	srv := testServerWithCollab(t)
+	slug := createWSWithCollections(t, srv)
+	item := createTaskWithFields(t, srv, slug, "Item", `{"status":"open"}`)
+
+	seedOpLog(t, srv, item.ID, 3)
+
+	// A stale expected_updated_at makes the row write refuse deterministically
+	// (TASK-2022). The PATCH carries CONTENT, so it routes through the collab
+	// branch, and with no room and no applier it takes the direct-write path
+	// that prunes.
+	rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+item.Slug, map[string]interface{}{
+		"expected_updated_at": "2000-01-01T00:00:00Z",
+		"content":             "content the caller was told was not written",
+	})
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("expected 409 from the stale token, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	if got := countOpLog(t, srv, item.ID); got != 3 {
+		t.Errorf("op-log has %d rows after a REFUSED write, want 3 — the prune must roll back with the write, "+
+			"or a closed tab's unflushed edits are destroyed by a request that wrote nothing", got)
+	}
+
+	// The refusal must also be a refusal in the ordinary sense.
+	after, err := srv.store.GetItem(item.ID)
+	if err != nil {
+		t.Fatalf("GetItem: %v", err)
+	}
+	if after.Content == "content the caller was told was not written" {
+		t.Error("items.content was written despite the 409")
+	}
+}
+
+// TestCollabDirectWrite_SuccessfulWriteStillPrunes is the counterfactual, and
+// it is what stops the test above from passing under a fix that simply deletes
+// the prune. The prune exists so a future Join cannot replay superseded ops
+// over the content just written; a refusal must roll it back, a success must
+// keep it.
+func TestCollabDirectWrite_SuccessfulWriteStillPrunes(t *testing.T) {
+	srv := testServerWithCollab(t)
+	slug := createWSWithCollections(t, srv)
+	item := createTaskWithFields(t, srv, slug, "Item", `{"status":"open"}`)
+
+	seedOpLog(t, srv, item.ID, 3)
+
+	rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+item.Slug, map[string]interface{}{
+		"content": "content the caller did write",
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	if got := countOpLog(t, srv, item.ID); got != 0 {
+		t.Errorf("op-log has %d rows after a SUCCESSFUL write, want 0 — ops older than the content just written "+
+			"would be replayed by the next Join and overwrite it", got)
+	}
+
+	after, err := srv.store.GetItem(item.ID)
+	if err != nil {
+		t.Fatalf("GetItem: %v", err)
+	}
+	if after.Content != "content the caller did write" {
+		t.Errorf("items.content = %q, want the written content", after.Content)
+	}
+}
+
+// TestCollabDirectWrite_OpenChildrenRefusalAlsoLeavesTheOpLog covers a SECOND
+// refusal from the same write, because the window is a property of the ordering
+// rather than of one error (CONVE-18: the instance named is a sample). The
+// optimistic-concurrency conflict above is refused before the guard runs; this
+// one is refused by the guard itself, inside the transaction the prune now
+// shares — a different arm reaching the same rollback.
+func TestCollabDirectWrite_OpenChildrenRefusalAlsoLeavesTheOpLog(t *testing.T) {
+	srv := testServerWithCollab(t)
+	slug := createWSWithCollections(t, srv)
+	plan, _ := seedParentAndChildren(t, srv, slug, []string{"open"})
+
+	seedOpLog(t, srv, plan.ID, 2)
+
+	rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+plan.Ref, map[string]interface{}{
+		"fields":  map[string]interface{}{"status": "completed"},
+		"content": "content the caller was told was not written",
+	})
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("expected 409 from the open-children guard, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if got := countOpLog(t, srv, plan.ID); got != 2 {
+		t.Errorf("op-log has %d rows after a guard-refused write, want 2", got)
+	}
+}

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -1888,8 +1888,37 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 		// content-only split lost atomicity and broke
 		// Store.UpdateItem's content-versioning peek at Title.
 		// Per Codex review round 9.
-		err := s.applyContentViaCollab(r, item.ID, *input.Content, func() error {
-			updated, uerr := s.store.UpdateItemWithParentLink(item.ID, input, openChildrenPrecheck, parentLink)
+		err := s.applyContentViaCollab(r, item.ID, *input.Content, func(pruneOpLog func(*sql.Tx) error) error {
+			// The op-log prune rides INSIDE this write's transaction
+			// (BUG-2840 half B): composed onto the precheck hook, which
+			// UpdateItemWithParentLink runs inside the tx, so a refusal
+			// from the guard or from the update itself rolls the prune
+			// back. Before this the prune was a separate statement that
+			// ran FIRST, and a refused write left the op-log emptied with
+			// nothing written to supersede it.
+			precheck := openChildrenPrecheck
+			if pruneOpLog != nil {
+				inner := precheck
+				precheck = func(tx *sql.Tx, existing *models.Item) error {
+					// Guard first — a preference, not an enforced invariant,
+					// and mutation-checked as such: swapping these two
+					// survives the suite because both run in ONE transaction,
+					// so a refusal rolls the prune back either way. The order
+					// buys two smaller things: the DELETE is not done for a
+					// write that is about to refuse, and an error from the
+					// prune cannot mask the guard's refusal as the caller's
+					// answer. Neither is observable without a failing prune,
+					// so this comment claims a preference rather than a rule
+					// nothing enforces.
+					if inner != nil {
+						if err := inner(tx, existing); err != nil {
+							return err
+						}
+					}
+					return pruneOpLog(tx)
+				}
+			}
+			updated, uerr := s.store.UpdateItemWithParentLink(item.ID, input, precheck, parentLink)
 			if uerr != nil {
 				return uerr
 			}


### PR DESCRIPTION
BUG-2840 **half B only** — the half the recon found contained. Half A (a refused PATCH's content reaching `items.content` via the next collab-snapshot flush) is an atomicity change with the BUG-2276 restore machinery downstream, and per the lead it is scoped as its own plan rather than started here.

## The defect

On the no-room / no-applier path a content PATCH pruned the item's Yjs op-log and then wrote `items.content`. The prune ran **first**, in its own statement, justified like this:

> any prior collab state is strictly older than the items.content the caller is about to write

True when the write lands. Four typed refusals can come out of that write — the open-children guard, the optimistic-concurrency conflict, the rename-cascade byte refusal, the item-title refusal — and on every one of them the caller wrote nothing, so the pruned ops were superseded by nothing.

**Not hypothetical on this branch.** It fires on `ErrNoApplierAvailable`: a room inside its 60s grace TTL with zero connections. That is exactly the state where the op-log holds a closed tab's edits that never reached `items.content` — edits that exist nowhere else, destroyed by a request that wrote nothing.

## The fix

The prune runs **inside the write's own transaction**, composed onto the precheck hook `UpdateItemWithParentLink` already runs there, so a refusal rolls it back. `directWriteFn` takes the prune as a hook rather than performing it, keeping the choice of transaction with the caller that owns the write.

This is the shape version-restore already uses. `PruneItemOpLogTx`'s own comment says a split prune/commit "leaves a divergent state on any failure" in **either** order, and closes it by running the wipe in the update's transaction. This path was the remaining split — and the transactional form also closes the window a plain reorder would leave open: a crash between a successful write and a later prune, leaving stale ops to be replayed over fresh content.

**One deliberate behaviour change:** a prune failure now rolls the content write back, where before it was logged and the write proceeded. That leniency assumed the prune was optional cleanup. It is not — a write that commits with a stale op-log is the "resurrect stale content on the next flush" hazard the prune exists to prevent, and this is the same trade the restore path made.

Also removes `internal/server`'s `distantFuture`, whose only use this was (the collab package keeps its own for its own prune). Grepped the repo before deleting rather than inferring deadness from the edit in front of me.

## Evidence

- **Property, as the lead set it:** a refused row write leaves no op that a later flush applies. Three tests: a conflict-refused write leaves the op-log intact, an open-children-refused write does too (a second refusal, because the window is a property of the ORDERING rather than of one error), and — the counterfactual that stops a "fix" that simply deletes the prune — a **successful** write still prunes.
- **Negative control:** restoring the prune-first ordering fails the refusal test. Run, not assumed.
- **Mutants:** never invoking the hook, and passing `nil` for it, are both killed by the success test. A fourth — swapping the guard and the prune inside the hook — **survives**, and the comment now says so: both orders are equivalent while they share a transaction, so that ordering is a preference and not a rule anything enforces.
- `make lint` 0 issues, `make test` green, `make test-pg` green (run because this moves a DELETE into a transaction), codex CLEAN.

https://claude.ai/code/session_01HeChkgZVYb3NTgTcckF5KR
