### PR TITLE
refactor(web): the keyed single-flight loader has one definition, not two (TASK-2947)

### DIFF
--- a/web/src/lib/stores/collections.svelte.ts
+++ b/web/src/lib/stores/collections.svelte.ts
@@ -2,6 +2,7 @@ import { api } from '$lib/api/client';
 import type { Collection, Item } from '$lib/types';
 import { authStore } from './auth.svelte';
 import { hydrateCollections, persistCollections, readDurableEpoch } from './localIndexPersistence';
+import { createKeyedSingleFlight } from './singleFlight';
 
 let collections = $state<Collection[]>([]);
 let items = $state<Item[]>([]);
@@ -28,39 +29,21 @@ let collectionsWorkspace = $state<string | null>(null);
 let activeItem = $state<Item | null>(null);
 let loading = $state(false);
 
-// Monotonic load generation for `loadCollections`. A workspace switch can
-// leave two list requests in flight (A pending, then B); without a guard a
-// late-resolving A response would overwrite B's `collections` +
-// `collectionsWorkspace` and strand `collectionsAreFreshFor(B)` at false. Each
-// call captures its generation and only commits if it's still the latest
-// (Codex review). Plain counter — not reactive; it only fences async writes.
-let collectionsLoadSeq = 0;
-
-// The workspace and promise of the load that will actually COMMIT — a single
-// slot TAGGED with its workspace, not a per-workspace map (TASK-2200, codex
-// round 3, which read the first draft of this comment as claiming the latter;
-// the comment was wrong, the slot was not).
+// The keyed single-flight loader that fences `loadCollections` (TASK-2947).
+// Generation, join slot and ownership-guarded cleanup all live in
+// `singleFlight.ts` now, shared with `workspace.svelte.ts` — the two stores
+// hand-rolled the same three parts and drifted three times in one afternoon.
 //
-// A map would be the worse structure here, and the reason is the generation
-// guard directly below: `loadCollections` commits only the LATEST call, so once
-// a load for B starts, A's in-flight request is already dead — its response
-// will be dropped by `seq !== collectionsLoadSeq`. Handing an
-// `ensureCollections('A')` caller that request's promise would resolve them
-// against a result that never lands, which is a quieter version of the bug this
-// unit exists to fix. Issuing a fresh A request is the correct answer, and it
-// is what the single slot produces.
+// Keyed by WORKSPACE SLUG, so a joiner asking about A is never handed B's
+// promise. It never coalesces: `run` always issues, and only
+// `ensureCollections` opts into joining via `inFlightFor`. See that method, and
+// `singleFlight.ts`'s own note, for why every other call site must NOT join.
 //
-// What the workspace TAG is for is the opposite mistake: without it, a joiner
-// asking about A would be handed B's promise and resolve against B's list.
-//
-// `loading` cannot serve either purpose — it is a single global flag with no
-// workspace on it and no promise behind it.
-//
-// Consumed only by `ensureCollections`, and deliberately not by
-// `loadCollections` itself — see that method's note on why coalescing every
-// caller would be wrong.
-let inFlightWs: string | null = null;
-let inFlightLoad: Promise<void> | null = null;
+// `loading` stays a `$state` in this file rather than moving into the loader,
+// because `loadItems` writes the same flag.
+const collectionsFlight = createKeyedSingleFlight<string>({
+	setLoading: (v) => { loading = v; },
+});
 
 export const collectionStore = {
 	get collections() { return collections; },
@@ -127,7 +110,8 @@ export const collectionStore = {
 		// Join, rather than issue a second request for the same answer. The
 		// joined promise settles when THAT request does, which is the semantics
 		// the caller wants: "tell me when a list exists".
-		if (inFlightWs === ws && inFlightLoad) return inFlightLoad;
+		const joined = collectionsFlight.inFlightFor(ws);
+		if (joined) return joined;
 		return collectionStore.loadCollections(ws);
 	},
 
@@ -154,8 +138,6 @@ export const collectionStore = {
 	},
 
 	async loadCollections(ws: string) {
-		const seq = ++collectionsLoadSeq;
-		loading = true;
 		// The DURABLE scope claim before the request, so `persistCollections` can
 		// tell whether a resync landed underneath it — the list carries no scope
 		// of its own and the stamp is borrowed from the row cache, so it is only
@@ -176,14 +158,10 @@ export const collectionStore = {
 		// authenticated one. Same source as every `bootstrap` caller passes, so
 		// the two cannot disagree.
 		const userId = authStore.userId || null;
-		// Published for `ensureCollections` to join, tagged with the workspace
-		// so a joiner asking about A is never handed B's promise. Overwriting a
-		// previous tenant is correct rather than lossy: this assignment happens
-		// after `++collectionsLoadSeq`, so the load being displaced has already
-		// lost the right to commit.
-		inFlightWs = ws;
-		const load = (async () => {
-		try {
+		// ALWAYS ISSUES — `run` never coalesces. The join is `ensureCollections`'s
+		// alone, via `inFlightFor`, because every other caller here knows the list
+		// MOVED and a request issued before that move cannot answer it.
+		return collectionsFlight.run(ws, async ({ isLatest }) => {
 			// STRICTLY BEFORE the request, not concurrently with it (codex round
 			// 3). Running them together looked free and was not: `Promise.all`
 			// starts both, but the durable read RESOLVES later and can observe a
@@ -194,14 +172,14 @@ export const collectionStore = {
 			//
 			// The join `ensureCollections` performs does not depend on the fetch
 			// being issued synchronously; it depends on the in-flight slot, which
-			// is published synchronously above.
+			// `run` publishes synchronously before calling this.
 			const epochBefore = await readDurableEpoch(userId, ws);
 			const result = await api.collections.list(ws);
 			// Drop a stale response: a newer loadCollections (e.g. a workspace
 			// switch that resolved first) has superseded this one, so writing
 			// `collections`/`collectionsWorkspace` here would clobber the newer
 			// workspace's data with this older load (Codex review).
-			if (seq !== collectionsLoadSeq) return;
+			if (!isLatest()) return;
 			collections = result;
 			// Stamp the array with its source workspace so consumers can tell
 			// it apart from a stale previous-workspace load (see
@@ -214,20 +192,7 @@ export const collectionStore = {
 			// durable write here; `persistCollections` itself decides whether the
 			// stamp it would write is honest.
 			void persistCollections(userId, ws, result, epochBefore);
-		} finally {
-			// Only the latest in-flight load owns the `loading` flag — an older
-			// load resolving late must not flip it off while the newer one runs.
-			if (seq === collectionsLoadSeq) loading = false;
-			// Same ownership rule for the join slot: an older load settling late
-			// must not clear a newer one's promise out from under a joiner.
-			if (seq === collectionsLoadSeq) {
-				inFlightWs = null;
-				inFlightLoad = null;
-			}
-		}
-		})();
-		inFlightLoad = load;
-		return load;
+		});
 	},
 
 	async loadItems(ws: string, collectionSlug?: string, params?: Record<string, string | number | boolean | undefined>) {

--- a/web/src/lib/stores/singleFlight.test.ts
+++ b/web/src/lib/stores/singleFlight.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+import { createKeyedSingleFlight } from './singleFlight';
+
+/**
+ * TASK-2947 — the keyed single-flight loader's own contract.
+ *
+ * The two stores that use it have their own tests for what they do with it
+ * (`collectionsEnsure`, `workspaceRecovery`, `workspaceLoadAllOrdering`). These
+ * legs pin the RULE, once, in the place it now has a single definition — which
+ * is the whole point of extracting it: the drift these tests exist to catch is
+ * a future edit to the primitive, not to a caller.
+ *
+ * The CONTROL leg that matters most is "run never coalesces". An over-eager
+ * extraction that made `run` join an in-flight request would look like a
+ * tidy-up and would quietly serve pre-change data to the eighteen
+ * `loadCollections` call sites that are reacting to a change they already know
+ * about.
+ */
+
+function deferred<T = void>() {
+	let resolve!: (value: T) => void;
+	let reject!: (reason: unknown) => void;
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res;
+		reject = rej;
+	});
+	return { promise, resolve, reject };
+}
+
+describe('createKeyedSingleFlight', () => {
+	it('CONTROL — `run` ALWAYS issues; it never coalesces onto an in-flight run', async () => {
+		const flight = createKeyedSingleFlight<string>();
+		let calls = 0;
+		const gate = deferred();
+
+		const a = flight.run('ws', async () => {
+			calls++;
+			await gate.promise;
+		});
+		const b = flight.run('ws', async () => {
+			calls++;
+			await gate.promise;
+		});
+
+		expect(calls).toBe(2);
+		gate.resolve();
+		await Promise.all([a, b]);
+	});
+
+	it('publishes the in-flight run for its OWN key, and not for another', async () => {
+		const flight = createKeyedSingleFlight<string>();
+		const gate = deferred();
+
+		const run = flight.run('alpha', async () => {
+			await gate.promise;
+		});
+
+		expect(flight.inFlightFor('alpha')).toBe(run);
+		expect(flight.inFlightFor('beta')).toBeNull();
+
+		gate.resolve();
+		await run;
+	});
+
+	it('releases the slot once the run settles, so a later joiner is not handed a dead promise', async () => {
+		const flight = createKeyedSingleFlight<string>();
+		const gate = deferred();
+
+		const run = flight.run('alpha', async () => {
+			await gate.promise;
+		});
+		gate.resolve();
+		await run;
+
+		expect(flight.inFlightFor('alpha')).toBeNull();
+	});
+
+	it('releases the slot when the run REJECTS, and propagates the rejection', async () => {
+		const flight = createKeyedSingleFlight<string>();
+
+		const run = flight.run('alpha', async () => {
+			throw new Error('down');
+		});
+
+		await expect(run).rejects.toThrow('down');
+		expect(flight.inFlightFor('alpha')).toBeNull();
+	});
+
+	it('`isLatest` goes false for a run a newer one superseded', async () => {
+		const flight = createKeyedSingleFlight<string>();
+		const gate = deferred();
+		let firstStillLatest: boolean | null = null;
+
+		const first = flight.run('alpha', async ({ isLatest }) => {
+			await gate.promise;
+			firstStillLatest = isLatest();
+		});
+		const second = flight.run('beta', async ({ isLatest }) => {
+			expect(isLatest()).toBe(true);
+		});
+
+		gate.resolve();
+		await Promise.all([first, second]);
+		expect(firstStillLatest).toBe(false);
+	});
+
+	it('an OLDER run settling late does not clear the NEWER one’s slot', async () => {
+		const flight = createKeyedSingleFlight<string>();
+		const older = deferred();
+		const newer = deferred();
+
+		const first = flight.run('alpha', async () => {
+			await older.promise;
+		});
+		const second = flight.run('beta', async () => {
+			await newer.promise;
+		});
+
+		older.resolve();
+		await first;
+
+		// The newer run still owns the slot; a joiner asking for `beta` must get
+		// its promise rather than null.
+		expect(flight.inFlightFor('beta')).toBe(second);
+
+		newer.resolve();
+		await second;
+		expect(flight.inFlightFor('beta')).toBeNull();
+	});
+
+	it('the loading flag is owned by the LATEST run', async () => {
+		const seen: boolean[] = [];
+		const flight = createKeyedSingleFlight<string>({ setLoading: (v) => seen.push(v) });
+		const older = deferred();
+		const newer = deferred();
+
+		const first = flight.run('alpha', async () => {
+			await older.promise;
+		});
+		const second = flight.run('beta', async () => {
+			await newer.promise;
+		});
+
+		older.resolve();
+		await first;
+		// Two starts, and NO false yet — the older run settling must not flip the
+		// spinner off while the newer one is still running.
+		expect(seen).toEqual([true, true]);
+
+		newer.resolve();
+		await second;
+		expect(seen).toEqual([true, true, false]);
+	});
+});

--- a/web/src/lib/stores/singleFlight.test.ts
+++ b/web/src/lib/stores/singleFlight.test.ts
@@ -152,3 +152,56 @@ describe('createKeyedSingleFlight', () => {
 		expect(seen).toEqual([true, true, false]);
 	});
 });
+
+/**
+ * TASK-2947, codex round 2 — the ONE way this extraction is not tick-identical
+ * to the hand-rolled code it replaced, pinned rather than hidden.
+ *
+ * The old versions ran their commit and their `finally` inside ONE async
+ * function, so cleanup followed the commit with no tick between them. Here the
+ * commit happens inside `work`, and `await work(...)` costs a microtask before
+ * the `finally` runs — crossing an async function boundary always does, so no
+ * callback-shaped extraction can avoid it. For one tick after a commit, the
+ * spinner is still true and the slot is still published.
+ *
+ * That window is UNOBSERVABLE AS WRONG, and this leg is why: every consumer
+ * checks its own committed state BEFORE it asks about the in-flight slot
+ * (`ensureCollections` returns early on `collectionsWorkspace === ws`,
+ * `recoverIfMissing` on a non-empty `workspaces`), and a caller that awaits the
+ * returned promise resumes AFTER the finally in both versions. A joiner that
+ * does land inside the window is handed a promise that resolves against the
+ * committed result — stale data is not reachable through it.
+ *
+ * Pinned as the PROPERTY (a joiner never resolves against a lie), not as the
+ * timing (which is an artifact, and which a future tick-identical rewrite
+ * should be free to remove without failing a test).
+ */
+describe('createKeyedSingleFlight — the commit-to-cleanup window', () => {
+	it('a joiner arriving between the commit and the cleanup resolves against the committed result', async () => {
+		const flight = createKeyedSingleFlight<string>();
+		const gate = deferred();
+		let committed: string | null = null;
+
+		const run = flight.run('alpha', async ({ isLatest }) => {
+			await gate.promise;
+			if (!isLatest()) return;
+			committed = 'alpha-result';
+		});
+
+		gate.resolve();
+		// One tick: `work` has finished and committed, but `run`'s finally has
+		// not gone yet — this is exactly the window round 2 named.
+		await Promise.resolve();
+		expect(committed).toBe('alpha-result');
+
+		// Deliberately tolerant of WHETHER the window is open: today it is, and a
+		// future tick-identical rewrite would close it. Either answer is correct;
+		// what must hold is that a joiner never resolves against a lie.
+		const joined = flight.inFlightFor('alpha');
+		if (joined) await joined;
+		expect(committed).toBe('alpha-result');
+
+		await run;
+		expect(flight.inFlightFor('alpha')).toBeNull();
+	});
+});

--- a/web/src/lib/stores/singleFlight.ts
+++ b/web/src/lib/stores/singleFlight.ts
@@ -1,0 +1,133 @@
+/**
+ * A keyed single-flight loader (TASK-2947).
+ *
+ * THE MECHANISM THIS REPLACES. `collections.svelte.ts` and
+ * `workspace.svelte.ts` each hand-rolled the same three parts around a store
+ * load, and the two copies drifted three times in one afternoon — each drift
+ * found by a reviewer rather than by a test (TASK-2200 rounds 3, 4 and 5). The
+ * three parts:
+ *
+ *   1. A monotonic GENERATION, so only the latest call commits. A workspace
+ *      switch can leave two requests in flight; without this an older response
+ *      resolving last overwrites the newer one's data.
+ *   2. A keyed IN-FLIGHT PROMISE, so a caller who only needs "a result exists"
+ *      can JOIN the request already running instead of issuing a duplicate.
+ *   3. CLEANUP GUARDED BY OWNERSHIP, so an older call settling late cannot
+ *      clear a newer one's slot or flip its loading flag off.
+ *
+ * WHAT THIS DELIBERATELY DOES NOT DO: coalesce. `run` ALWAYS issues. Joining is
+ * a separate, opt-in read via `inFlightFor`, and that asymmetry is a property to
+ * preserve rather than an inconsistency to tidy away. `loadCollections` has ~19
+ * call sites and eighteen of them are reacting to a KNOWN CHANGE — an SSE
+ * rename, a settings save, a `collections_changed` flag, a reorder 404 — where a
+ * request issued BEFORE that change cannot answer the caller. Only
+ * `ensureCollections` and `recoverIfMissing` have the join intent, and they ask
+ * for it by name.
+ *
+ * WHY NOT `$lib/attachments/viewFence.ts::createFence`, which is this codebase's
+ * other generation fence. It answers a neighbouring question for a different
+ * consumer: "may this continuation write to the view the user is still looking
+ * at?" — for surfaces that stay MOUNTED while their props change underneath
+ * them, so its identity is CAPTURED from live reactive state and re-compared on
+ * every `stale()` call. A store method has no live identity to capture: the key
+ * arrives as the call's own argument. And a fence has no notion of the JOIN
+ * slot, which is half of what these two stores needed. Sharing the generation
+ * counter is all the two have in common, and wrapping one in the other would
+ * mean synthesising a `ViewIdentity` per key — more machinery than the counter
+ * it replaces. Named here so the next reader does not have to re-derive it.
+ *
+ * The `loading` flag stays OWNED BY THE STORE and is written through the
+ * optional `setLoading` callback, rather than being state on this object. Both
+ * stores share their flag with other methods (`loadItems` next door in
+ * collections), so a flag owned here would have had to either absorb those
+ * writers or answer a different question than the one the UI reads today.
+ */
+export interface SingleFlightRun {
+	/**
+	 * True while this call is still the latest — i.e. its writes may commit.
+	 * Check it AFTER every await that precedes a commit; a `false` answer means
+	 * a newer call has superseded this one and its result must be dropped.
+	 */
+	isLatest(): boolean;
+}
+
+export interface SingleFlightOptions {
+	/**
+	 * Called with `true` when a run starts, and with `false` when the LATEST run
+	 * settles. An older run settling late does not call it — that is the
+	 * ownership rule applied to the spinner.
+	 */
+	setLoading?: (loading: boolean) => void;
+}
+
+export interface KeyedSingleFlight<K> {
+	/**
+	 * The promise of the run currently in flight FOR THIS KEY, or null.
+	 *
+	 * A single slot tagged with its key, not a per-key map, and that is the
+	 * right structure because of the generation guard: once a run for B starts,
+	 * a run for A that is still in flight has already lost the right to commit,
+	 * so handing an A-joiner that promise would resolve them against a result
+	 * that never lands. Issuing a fresh A request is the correct answer, and it
+	 * is what a single slot produces. The key TAG guards the opposite mistake —
+	 * handing an A-joiner B's promise.
+	 */
+	inFlightFor(key: K): Promise<void> | null;
+
+	/**
+	 * Issue a run. ALWAYS issues; never joins an existing one.
+	 *
+	 * `work` receives a handle whose `isLatest()` says whether this run may
+	 * still commit. Guarding the commit is `work`'s job because only `work`
+	 * knows which writes are the commit.
+	 */
+	run(key: K, work: (run: SingleFlightRun) => Promise<void>): Promise<void>;
+}
+
+export function createKeyedSingleFlight<K>(options: SingleFlightOptions = {}): KeyedSingleFlight<K> {
+	const { setLoading } = options;
+
+	// Plain counters and slots — not reactive. They fence async writes; they are
+	// never rendered.
+	let seq = 0;
+	let inFlightKey: K | null = null;
+	let inFlightPromise: Promise<void> | null = null;
+
+	return {
+		inFlightFor(key: K): Promise<void> | null {
+			if (inFlightPromise && inFlightKey === key) return inFlightPromise;
+			return null;
+		},
+
+		run(key: K, work: (run: SingleFlightRun) => Promise<void>): Promise<void> {
+			const mySeq = ++seq;
+			setLoading?.(true);
+			// Published SYNCHRONOUSLY, before the work starts, so a joiner that
+			// asks between this call and the first await is answered. Overwriting
+			// a previous tenant is correct rather than lossy: this happens after
+			// `++seq`, so the run being displaced has already lost the right to
+			// commit.
+			inFlightKey = key;
+			const promise = (async () => {
+				try {
+					await work({ isLatest: () => mySeq === seq });
+				} finally {
+					// Only the LATEST run owns the flag and the slot. An older run
+					// settling late must not flip the spinner off while a newer one
+					// is running, nor clear a newer one's promise out from under a
+					// joiner.
+					if (mySeq === seq) {
+						setLoading?.(false);
+						inFlightKey = null;
+						inFlightPromise = null;
+					}
+				}
+			})();
+			// Assigned after the IIFE, which is safe rather than racy: the async
+			// body runs synchronously only as far as its first await, so the
+			// `finally` above cannot run before this line.
+			inFlightPromise = promise;
+			return promise;
+		},
+	};
+}

--- a/web/src/lib/stores/singleFlight.ts
+++ b/web/src/lib/stores/singleFlight.ts
@@ -126,6 +126,24 @@ export function createKeyedSingleFlight<K>(options: SingleFlightOptions = {}): K
 			// Assigned after the IIFE, which is safe rather than racy: the async
 			// body runs synchronously only as far as its first await, so the
 			// `finally` above cannot run before this line.
+			//
+			// ONE TICK OF NON-EQUIVALENCE with the hand-rolled code this replaced
+			// (codex round 2, TASK-2947), named because it is real. Both old
+			// versions ran commit and `finally` inside ONE async function, so
+			// cleanup followed the commit with no tick between. Here the commit is
+			// inside `work`, and `await work(...)` costs a microtask — crossing an
+			// async function boundary always does, so no callback-shaped extraction
+			// can avoid it. For that tick the spinner reads true and the slot stays
+			// published after the data has landed.
+			//
+			// Unobservable as WRONG, for a reason that is a property of the callers
+			// rather than luck: each checks its own committed state BEFORE asking
+			// about the slot (`ensureCollections` returns early on
+			// `collectionsWorkspace === ws`, `recoverIfMissing` on a non-empty
+			// `workspaces`), and anything awaiting the returned promise resumes
+			// after the `finally` in both versions. A joiner that does land in the
+			// window gets a promise resolving against the committed result. The leg
+			// in `singleFlight.test.ts` pins that property.
 			inFlightPromise = promise;
 			return promise;
 		},

--- a/web/src/lib/stores/workspace.svelte.ts
+++ b/web/src/lib/stores/workspace.svelte.ts
@@ -1,6 +1,7 @@
 import { api } from '$lib/api/client';
 import type { Workspace, WorkspaceMembership } from '$lib/types';
 import * as perms from '$lib/utils/permissions';
+import { createKeyedSingleFlight } from './singleFlight';
 
 let workspaces = $state<Workspace[]>([]);
 let current = $state<Workspace | null>(null);
@@ -14,26 +15,22 @@ let loading = $state(false);
 // membership for workspace B.
 let membershipSeq = 0;
 
-// The `loadAll` request currently in flight, or null. Consumed by
-// `recoverIfMissing`, which must JOIN it rather than skip past it: acting on a
-// still-empty `workspaces` sends `setCurrent` down its single-workspace
-// fallback for no reason (TASK-2200, codex round 4). Cleared in `loadAll`'s
-// own `finally`, so a failed request does not leave a dead promise behind for
-// the next caller to await.
+// The keyed single-flight loader fencing `loadAll` (TASK-2947) — the same
+// primitive `collections.svelte.ts` uses, which is the point: generation,
+// join slot and ownership-guarded cleanup had been hand-rolled in both stores
+// and drifted three times in one afternoon (TASK-2200 rounds 3, 4 and 5).
 //
-// NOT ADDRESSED HERE, and named rather than left implicit: `loadAll` has no
-// guard on which RESPONSE commits, so two overlapping calls can leave the
-// OLDER list in `workspaces` if it resolves last. `collections.svelte.ts` has
-// exactly that guard (`seq !== collectionsLoadSeq`) and this store does not.
-// Pre-existing, unrelated to the recovery path — the recovery only ever joins,
-// never issues a competing call — and a separate fix with its own test.
-let inFlightLoadAll: Promise<void> | null = null;
-// Monotonic generation for `loadAll`, so its cleanup can tell "I still own the
-// slot" from "a newer call took it" — the same instrument, and the same name
-// shape, as `collectionsLoadSeq` next door. A promise-identity check would read
-// more directly but forces a self-reference the type checker cannot prove is
-// assigned before use.
-let loadAllSeq = 0;
+// `loadAll` takes no argument, so there is one key. It is still the KEYED
+// primitive rather than a bespoke unkeyed one, because a second shape would be
+// the sibling that drifts.
+//
+// `recoverIfMissing` JOINS an in-flight run via `inFlightFor` rather than
+// skipping past it: acting on a still-empty `workspaces` sends `setCurrent`
+// down its single-workspace fallback for no reason (codex round 4).
+const LOAD_ALL_KEY = 'all';
+const loadAllFlight = createKeyedSingleFlight<string>({
+	setLoading: (v) => { loading = v; },
+});
 
 /**
  * Resource-scoped permission helpers (PLAN-1100 / TASK-1101).
@@ -88,37 +85,19 @@ export const workspaceStore = {
 	},
 
 	async loadAll() {
-		const seq = ++loadAllSeq;
-		loading = true;
-		// Published so `recoverIfMissing` can JOIN this request rather than
-		// skip past it — see the note there (codex round 4).
-		const load = (async () => {
-			try {
-				workspaces = await api.workspaces.list();
-			} finally {
-				// OWNERSHIP, by promise identity (codex round 5). Clearing
-				// unconditionally lets an older overlapping request finish first
-				// and clear a NEWER one's slot, after which a concurrent
-				// `recoverIfMissing` starts a third request instead of joining
-				// the load still running — the race round 4 just closed,
-				// reintroduced by its own cleanup.
-				//
-				// This is the same rule `collections.svelte.ts` already applies
-				// to its `loading` flag and join slot, expressed there with a
-				// sequence counter. Third time in this unit that a rule was
-				// applied at one door and not its sibling.
-				//
-				// `loading` moves under the same guard for the same reason: an
-				// older load flipping it off while a newer one runs is the
-				// spinner half of the same mistake.
-				if (seq === loadAllSeq) {
-					loading = false;
-					inFlightLoadAll = null;
-				}
-			}
-		})();
-		inFlightLoadAll = load;
-		return load;
+		return loadAllFlight.run(LOAD_ALL_KEY, async ({ isLatest }) => {
+			const list = await api.workspaces.list();
+			// WHICH RESPONSE COMMITS (TASK-2947, and a behaviour change rather
+			// than a move). Two overlapping calls used to leave the OLDER list in
+			// `workspaces` if it resolved last — this store had the ownership
+			// guard on its CLEANUP and none on its COMMIT, where
+			// `collections.svelte.ts` had both. It was unreachable from the
+			// recovery path, which only ever joins, and it was named in this
+			// store's own comment as pre-existing; extracting the primitive is
+			// where it closes, because the primitive owns the rule.
+			if (!isLatest()) return;
+			workspaces = list;
+		});
 	},
 
 	/**
@@ -163,7 +142,7 @@ export const workspaceStore = {
 				// same "in flight" question `ensureCollections` answers by
 				// joining. Got it right in one place and wrong in the other, in
 				// one unit; they now answer it the same way.
-				await (inFlightLoadAll ?? workspaceStore.loadAll());
+				await (loadAllFlight.inFlightFor(LOAD_ALL_KEY) ?? workspaceStore.loadAll());
 			} catch {
 				// Still unreachable. Leave both pieces of state as they are —
 				// the next sync result asks again, and asking again is the whole

--- a/web/src/lib/stores/workspaceLoadAllOrdering.svelte.test.ts
+++ b/web/src/lib/stores/workspaceLoadAllOrdering.svelte.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Workspace } from '$lib/types';
+
+/**
+ * TASK-2947 — WHICH RESPONSE COMMITS in `workspaceStore.loadAll`.
+ *
+ * This is the behaviour change that rides with the single-flight extraction,
+ * and it gets its own file because it is not a move: before it, two overlapping
+ * `loadAll` calls left the OLDER list in `workspaces` whenever it resolved last.
+ * The store had the ownership guard on its CLEANUP (`seq === loadAllSeq` around
+ * clearing the join slot and the spinner) and none on its COMMIT, where
+ * `collections.svelte.ts` had both — the third instance in one unit of a rule
+ * applied at one door and not its sibling.
+ *
+ * It was unreachable from the recovery path, which only ever joins and never
+ * issues a competing call, and this store's own comment named it as
+ * pre-existing rather than leaving it implicit. Extracting the primitive is
+ * where it closes, because the primitive owns the rule.
+ *
+ * THESE LEGS FAIL AGAINST THE UNFIXED STORE. Verified by reverting the
+ * `if (!isLatest()) return;` line: the ordering leg then reports `['old']`.
+ *
+ * Fresh module per test: the store holds module-level rune state with no reset.
+ */
+
+function ws(slug: string): Workspace {
+	return { id: `id-${slug}`, slug, name: slug, owner_username: 'dave' } as unknown as Workspace;
+}
+
+/** A promise plus the handle to settle it, so a test can choose the order. */
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	let reject!: (reason: unknown) => void;
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res;
+		reject = rej;
+	});
+	return { promise, resolve, reject };
+}
+
+async function load() {
+	vi.resetModules();
+	const { api } = await import('$lib/api/client');
+	const { workspaceStore } = await import('./workspace.svelte');
+	return { api, workspaceStore };
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe('TASK-2947 — loadAll commits the LATEST response, not the last one to arrive', () => {
+	it('drops an older response that resolves AFTER a newer one', async () => {
+		const { api, workspaceStore } = await load();
+
+		const older = deferred<Workspace[]>();
+		const newer = deferred<Workspace[]>();
+		vi.spyOn(api.workspaces, 'list')
+			.mockImplementationOnce(() => older.promise)
+			.mockImplementationOnce(() => newer.promise);
+
+		const first = workspaceStore.loadAll();
+		const second = workspaceStore.loadAll();
+
+		// The NEWER call answers first — this is the ordering the guard exists
+		// for, and it is the one a workspace switch produces.
+		newer.resolve([ws('new')]);
+		await second;
+		expect(workspaceStore.workspaces.map((w) => w.slug)).toEqual(['new']);
+
+		// The older request now arrives. Without the commit guard it overwrites
+		// the newer list, which is the defect.
+		older.resolve([ws('old')]);
+		await first;
+		expect(workspaceStore.workspaces.map((w) => w.slug)).toEqual(['new']);
+	});
+
+	it('CONTROL — the ordinary single call still commits', async () => {
+		const { api, workspaceStore } = await load();
+
+		vi.spyOn(api.workspaces, 'list').mockResolvedValue([ws('alpha'), ws('beta')]);
+		await workspaceStore.loadAll();
+
+		expect(workspaceStore.workspaces.map((w) => w.slug)).toEqual(['alpha', 'beta']);
+	});
+
+	it('CONTROL — a LATER response still commits when it arrives last, so the guard is not just "first wins"', async () => {
+		const { api, workspaceStore } = await load();
+
+		const older = deferred<Workspace[]>();
+		const newer = deferred<Workspace[]>();
+		vi.spyOn(api.workspaces, 'list')
+			.mockImplementationOnce(() => older.promise)
+			.mockImplementationOnce(() => newer.promise);
+
+		const first = workspaceStore.loadAll();
+		const second = workspaceStore.loadAll();
+
+		// Natural order this time: the superseded request answers first and must
+		// NOT commit, then the latest answers and must.
+		older.resolve([ws('old')]);
+		await first;
+		expect(workspaceStore.workspaces).toEqual([]);
+
+		newer.resolve([ws('new')]);
+		await second;
+		expect(workspaceStore.workspaces.map((w) => w.slug)).toEqual(['new']);
+	});
+
+	it('the spinner is owned by the latest call — an older one settling late does not clear it', async () => {
+		const { api, workspaceStore } = await load();
+
+		const older = deferred<Workspace[]>();
+		const newer = deferred<Workspace[]>();
+		vi.spyOn(api.workspaces, 'list')
+			.mockImplementationOnce(() => older.promise)
+			.mockImplementationOnce(() => newer.promise);
+
+		const first = workspaceStore.loadAll();
+		const second = workspaceStore.loadAll();
+		expect(workspaceStore.loading).toBe(true);
+
+		older.resolve([ws('old')]);
+		await first;
+		expect(workspaceStore.loading).toBe(true);
+
+		newer.resolve([ws('new')]);
+		await second;
+		expect(workspaceStore.loading).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

`collections.svelte.ts` and `workspace.svelte.ts` each hand-rolled the same three parts around a store load — a monotonic **generation** so only the latest call commits, a keyed **in-flight promise** so a caller who only needs "a result exists" can join rather than duplicate, and **cleanup guarded by ownership** so an older call settling late cannot clear a newer one's slot or spinner. The two copies drifted three times in one afternoon during TASK-2200, each drift found by a reviewer rather than by a test; rounds 4 and 5 were literally *"you applied this rule in one store and not the other"*.

`createKeyedSingleFlight` is that rule, once. Both stores call it.

**It always issues.** Joining is a separate opt-in read (`inFlightFor`), taken only by `ensureCollections` and `recoverIfMissing`. The asymmetry is load-bearing rather than an inconsistency to tidy away: eighteen of `loadCollections`'s nineteen call sites are reacting to a change they already know about — an SSE rename, a settings save, a `collections_changed` flag, a reorder 404 — and a request issued before that change cannot answer them. `collectionsEnsure`'s CONTROL leg is what catches an over-eager extraction, and it is kept.

## Stated behaviour change

**`workspaceStore.loadAll` now guards which RESPONSE commits.** Two overlapping calls previously left the OLDER list in `workspaces` when it resolved last: this store had the ownership guard on its cleanup and none on its commit, where `collections.svelte.ts` had both. It was unreachable from the recovery path (which only ever joins, never issues a competing call) and was named in the store's own comment as pre-existing. `workspaceLoadAllOrdering.svelte.test.ts` is its test, and both discriminating legs were run against the unguarded store first — they report `['old']`.

Everything else in this PR is a move.

## The one non-equivalence, named rather than papered over

Codex round 2 found it: both old versions ran commit and `finally` inside one async function, so cleanup followed the commit with no tick between. Here the commit is inside `work`, and `await work(...)` costs a microtask — crossing an async boundary always does, so no callback-shaped extraction can avoid it. For that tick the spinner reads true and the slot stays published after the data lands.

Kept, because it is unobservable as *wrong* for a reason that is a property of the callers rather than luck: each checks its own committed state **before** asking about the slot, and anything awaiting the returned promise resumes after the `finally` in both versions. The test leg pins that property and is deliberately tolerant of whether the window is open, so a future tick-identical rewrite can close it without failing a test.

## Population and boundary (CONVE-18)

Two sites carry all three parts; both are here. **Twenty-two** files carry a generation guard **alone**, with no join slot — route pages, `starred`, `itemRowMerge`, `localIndexPersistence`, and `workspace`'s own `membershipSeq` — deliberately untouched, since supersede-only is a different question and none of them had drifted. `viewFence.ts::createFence` is this codebase's other generation fence; why it is not the same abstraction is recorded in `singleFlight.ts`'s header.

## Test plan

- [x] `npx vitest run` — 148 files / 2293 tests green
- [x] `npm run check` — 0 errors (6 pre-existing warnings)
- [x] `npx vite build` — green
- [x] `go build ./...` — green (no Go files touched)
- [x] Mutation matrix on the primitive, **BUILD OK asserted before every outcome**: key check ignored → detected by 3 legs; cleanup unguarded → 4; `isLatest` always true → 3; `run` coalesces → 6, including the CONTROL leg the task named
- [x] Codex: round 1 CLEAN, round 2 one finding (the microtask window) addressed, round 3 CLEAN

Implements TASK-2947.

https://claude.ai/code/session_01Xk9M5UVPdc84xL5E1mZkm8
