### PR TITLE
fix(cli): `pad server stop` stops the server that is running, or says it is (BUG-2965)

### DIFF
--- a/cmd/pad/cmd_server.go
+++ b/cmd/pad/cmd_server.go
@@ -1004,6 +1004,39 @@ func serveCmd() *cobra.Command {
 					"hint", "cloud bootstrap stays loopback-only by design")
 			}
 
+			// Record this process in the PID file, so `pad server stop` can
+			// address a server started HERE and not only one auto-started by
+			// EnsureServer (BUG-2965). EnsureServer spawns this very command
+			// and writes the child's pid, so the two paths write the same
+			// value and cannot disagree; before this, the same command run by
+			// a human wrote nothing and `stop` answered "not running" about a
+			// live server.
+			//
+			// Written after the listener's prerequisites are up but before
+			// ListenAndServe, and removed on the way out. A SIGKILL leaves it
+			// behind, which is why StopServer treats the file as a handle
+			// rather than as evidence and asks the port when it is missing —
+			// and why a stale file that names a dead process is cleaned up
+			// there rather than trusted.
+			// Bind FIRST, then claim the PID file (BUG-2965, codex round 2).
+			// The file names the process `pad server stop` will signal, so it
+			// must name the one that actually owns the port. Writing before the
+			// bind lets a start that LOSES the race record itself and then, on
+			// its way out, remove the file the winner is relying on — leaving a
+			// healthy server unaddressable, which is this fix's own defect
+			// reintroduced by its own cleanup.
+			ln, lerr := srv.Listen(cfg.Addr())
+			if lerr != nil {
+				return lerr
+			}
+
+			// We hold the port; the file is ours to claim.
+			releasePIDFile := cli.WritePIDFile(cfg.PIDFile(), os.Getpid())
+			// Backstop for the paths that never reach the shutdown sequence
+			// (Serve returns an error). Safe to call twice: it only removes a
+			// file that still names us, and a second call finds nothing.
+			defer releasePIDFile()
+
 			// Graceful shutdown: listen for SIGINT/SIGTERM
 			ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 			defer stop()
@@ -1011,7 +1044,7 @@ func serveCmd() *cobra.Command {
 			// Start server in a goroutine
 			errCh := make(chan error, 1)
 			go func() {
-				errCh <- srv.ListenAndServe(cfg.Addr())
+				errCh <- srv.Serve(ln)
 			}()
 
 			// Wait for signal or server error
@@ -1023,6 +1056,22 @@ func serveCmd() *cobra.Command {
 				// Received shutdown signal
 				slog.Info("Shutting down server (30s grace period)...")
 				stop() // Reset signal handling so a second signal force-kills
+
+				// Release the PID file BEFORE the listener closes, not after
+				// (codex round 4, P1). Cleanup is a read-then-remove: it checks
+				// the file still names us, then unlinks. Run after the port is
+				// released, a successor can bind and claim between those two
+				// steps, and we then delete ITS entry — the live server ends up
+				// unaddressable, silently. While we still hold the port no
+				// other server can legitimately own this file, so there is
+				// nothing to race with.
+				//
+				// The cost is a window during the drain where a healthy server
+				// has no PID file, so a concurrent `pad server stop` answers
+				// "a server is answering on <addr> but this CLI did not start
+				// it". That is honest and actionable, and it is the trade this
+				// unit is about: a wrong silence for a true message.
+				releasePIDFile()
 
 				// Close event bus first — this terminates SSE handler
 				// goroutines so http.Server.Shutdown won't block on them.

--- a/internal/cli/pid_file_test.go
+++ b/internal/cli/pid_file_test.go
@@ -1,0 +1,130 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+// BUG-2965: `pad server stop` answered "server not running (no PID file)" about
+// a live server, because the file was written by exactly one path —
+// EnsureServer's auto-start branch — and never by `pad server start` itself.
+// EnsureServer spawns THIS command and records the child's pid, so writing our
+// own pid here produces the same value by a second route; what it adds is the
+// case where a human, a service unit, or a refresh recipe ran the command
+// directly.
+func TestWritePIDFile_WritesAndCleansUp(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pad.pid")
+
+	cleanup := WritePIDFile(path, 4242)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("PID file not written: %v", err)
+	}
+	if got := string(data); got != strconv.Itoa(4242) {
+		t.Errorf("PID file contains %q, want %q — StopServer parses this with strconv.Atoi", got, "4242")
+	}
+
+	cleanup()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("PID file survived cleanup (stat err = %v) — a stale file names a dead process to the next stop", err)
+	}
+}
+
+// TestWritePIDFile_UnwritablePathIsNotFatal pins the degradation. The server is
+// what the user asked for; a missing PID file costs them the addressable-stop
+// path and nothing else, so this must not panic and its cleanup must stay safe
+// to call.
+func TestWritePIDFile_UnwritablePathIsNotFatal(t *testing.T) {
+	// A path whose parent is a FILE, not a directory — unwritable without
+	// needing permissions games that behave differently under root.
+	parent := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(parent, []byte("x"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	path := filepath.Join(parent, "pad.pid")
+
+	cleanup := WritePIDFile(path, 4242)
+	if cleanup == nil {
+		t.Fatal("cleanup must never be nil — the caller defers it unconditionally")
+	}
+	cleanup() // must not panic, and must not care that there is nothing to remove
+
+	// Read rather than IsNotExist: a path UNDER a non-directory fails with
+	// ENOTDIR, not ENOENT, so os.IsNotExist is false even though nothing is
+	// there. The claim is "no PID file can be read here", so read.
+	if _, err := os.ReadFile(path); err == nil {
+		t.Errorf("a PID file is readable at %s after a failed write", path)
+	}
+}
+
+// TestWritePIDFile_CleanupToleratesAnAlreadyRemovedFile covers the ordinary
+// double-stop shape: something else (an operator, a stop that raced) removed
+// the file first. Cleanup must be quiet about that rather than logging a
+// failure on every clean shutdown.
+func TestWritePIDFile_CleanupToleratesAnAlreadyRemovedFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pad.pid")
+	cleanup := WritePIDFile(path, 99)
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("pre-remove: %v", err)
+	}
+	cleanup()
+}
+
+// TestWritePIDFile_CleanupDoesNotRemoveSomeoneElsesFile is the P1's second
+// half, and the sharper one. A duplicate start writes the file (the original's
+// pid was stale, or the write raced), fails to bind, and runs its cleanup — if
+// that cleanup is unconditional it deletes whatever is there, including a file
+// another instance has since written, leaving a HEALTHY server unaddressable.
+// That is this fix's own defect, reintroduced by its own cleanup.
+func TestWritePIDFile_CleanupDoesNotRemoveSomeoneElsesFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pad.pid")
+
+	cleanup := WritePIDFile(path, 4242)
+
+	// Another instance takes ownership while we are still running.
+	if err := os.WriteFile(path, []byte("777"), 0o644); err != nil {
+		t.Fatalf("takeover: %v", err)
+	}
+
+	cleanup()
+
+	if got, ok := readPIDFile(path); !ok || got != 777 {
+		t.Errorf("PID file is %v (ok=%v) after our cleanup, want 777 — cleanup must only remove a file it still owns", got, ok)
+	}
+}
+
+// Removed with codex round 3's P2: TestWritePIDFile_LeavesALivePeersFileAlone
+// and TestWritePIDFile_ReplacesAStaleFile pinned a live-pid refusal that is
+// wrong once the caller binds first — no live process can be serving an address
+// this process just bound, so deferring to one strands the real server. The
+// TestProcessIsAlive_* pair went with the predicate they covered, which had no
+// production caller left. Their replacement is the ordering itself, pinned in
+// internal/server (Listen refuses a held port) and exercised end to end against
+// the real binary on BUG-2965's trail.
+
+// TestWritePIDFile_CleanupIsIdempotent covers the shape the shutdown path now
+// relies on: the release runs explicitly before the listener closes AND stays
+// deferred as a backstop for the paths that never reach the shutdown sequence.
+// Calling it twice must be quiet and must not touch a successor's file.
+func TestWritePIDFile_CleanupIsIdempotent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pad.pid")
+	cleanup := WritePIDFile(path, 4242)
+
+	cleanup()
+	if _, ok := readPIDFile(path); ok {
+		t.Fatal("first cleanup left the file behind")
+	}
+
+	// A successor claims the path between the two calls — the ordinary fast
+	// restart. The second call must leave it alone.
+	if err := os.WriteFile(path, []byte("777"), 0o644); err != nil {
+		t.Fatalf("successor write: %v", err)
+	}
+	cleanup()
+	if got, ok := readPIDFile(path); !ok || got != 777 {
+		t.Errorf("second cleanup removed the successor's file (got %v, ok=%v)", got, ok)
+	}
+}

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/exec"
@@ -47,11 +48,14 @@ func EnsureServer(cfg *config.Config) error {
 		return fmt.Errorf("start server: %w", err)
 	}
 
-	// Write PID file
-	if err := os.WriteFile(cfg.PIDFile(), []byte(strconv.Itoa(cmd.Process.Pid)), 0644); err != nil {
-		logFile.Close()
-		return fmt.Errorf("write PID file: %w", err)
-	}
+	// The PID file is deliberately NOT written here (BUG-2965, codex round 3).
+	// The child claims it AFTER it binds the port, so the file always names the
+	// process that actually owns the address. Writing it from the parent, at
+	// spawn time, records a process that may never bind — and when the port is
+	// held by an existing server that is briefly unhealthy, that write
+	// overwrites the running server's own entry with a pid that is about to
+	// exit, leaving a healthy server unaddressable by `pad server stop`. The
+	// health wait below is what tells us the child got there.
 
 	// Release the process so it doesn't become a zombie
 	cmd.Process.Release()
@@ -69,9 +73,30 @@ func EnsureServer(cfg *config.Config) error {
 }
 
 // StopServer sends a stop signal to the background server process.
+//
+// The PID file is the handle, not the evidence (BUG-2965). It is written by the
+// paths that START a server from this CLI; a server started any other way — a
+// service unit, a direct `pad server start` from before this fix, a relaunch
+// under a supervisor — holds the port with no file to find. Reporting "not
+// running" for one of those is the failure that matters here: the caller
+// believes they stopped something, and the next thing they do is act on that
+// belief.
+//
+// So a missing file asks the port. Only an unhealthy port earns "not running";
+// a healthy one earns an answer that says the server is up, that this CLI
+// cannot address it, and what to do instead. Deliberately NOT "find the
+// listener and kill it": resolving a pid from a port is platform-specific and,
+// more to the point, the process holding it may not be ours — a stop command
+// that kills by port is a stop command that can kill a stranger's process.
 func StopServer(cfg *config.Config) error {
 	pidData, err := os.ReadFile(cfg.PIDFile())
 	if err != nil {
+		if isServerHealthy(cfg.Host, cfg.Port) {
+			return fmt.Errorf(
+				"a server is answering on %s but this CLI did not start it (no PID file at %s) — "+
+					"stop it where it was started, or signal the process listening on that address",
+				cfg.Addr(), cfg.PIDFile())
+		}
 		return fmt.Errorf("server not running (no PID file)")
 	}
 
@@ -118,4 +143,64 @@ func isServerHealthy(host string, port int) bool {
 	}
 	defer resp.Body.Close()
 	return resp.StatusCode == http.StatusOK
+}
+
+// WritePIDFile records pid at path and returns the cleanup that removes it.
+//
+// The PID file is how `pad server stop` addresses a running server, and before
+// BUG-2965 exactly one path wrote it: EnsureServer's auto-start branch. A
+// server started any other way — a service unit, a human running `pad server
+// start`, a refresh recipe relaunching with the killed process's argv — held
+// the port with no file to find, and `stop` answered "not running" about it.
+//
+// CALL IT ONLY AFTER BINDING THE PORT. That ordering is the whole ownership
+// story, and it took two codex rounds to arrive at: whoever holds the address
+// is the process `stop` must signal, so the claim has to follow the bind rather
+// than race it. A write before the bind lets a start that LOSES the race record
+// itself and then, on its way out, remove the file the winner is relying on.
+//
+// Given that ordering, the write is unconditional. An earlier shape refused to
+// replace a PID file naming a live process, which is exactly wrong once the
+// caller has bound: no live process can be serving this address, so the entry
+// is stale or unrelated (pid reuse), and deferring to it would leave the real
+// server unaddressable (codex round 3, P2).
+//
+// Cleanup, by contrast, removes the file only while it still names US — a
+// process whose file was taken over must not delete its successor's entry.
+//
+// Failure to write is NOT fatal: the server is what the caller asked for, and a
+// missing PID file degrades `stop` to its port-probe message rather than
+// breaking anything. The returned cleanup is always safe to call, so callers
+// can defer it unconditionally.
+func WritePIDFile(path string, pid int) func() {
+	if err := os.WriteFile(path, []byte(strconv.Itoa(pid)), 0o644); err != nil {
+		slog.Warn("could not write PID file; `pad server stop` will not be able to address this process",
+			"path", path, "error", err)
+		return func() {}
+	}
+
+	return func() {
+		if current, ok := readPIDFile(path); !ok || current != pid {
+			// Someone else owns it now (or it is already gone). Removing it
+			// would unaddress a server we did not start.
+			return
+		}
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			slog.Warn("could not remove PID file on shutdown", "path", path, "error", err)
+		}
+	}
+}
+
+// readPIDFile returns the pid recorded at path. ok is false when the file is
+// absent or does not parse — both meaning "nothing here owns this path".
+func readPIDFile(path string) (pid int, ok bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, false
+	}
+	pid, err = strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return 0, false
+	}
+	return pid, true
 }

--- a/internal/cli/server_stop_honesty_test.go
+++ b/internal/cli/server_stop_honesty_test.go
@@ -1,0 +1,110 @@
+package cli
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/config"
+)
+
+// BUG-2965. StopServer read the PID file and, on any read error, answered
+// "server not running (no PID file)" — without asking whether anything was
+// listening. The file is written by the paths that START a server from this
+// CLI, so a server started any other way (a service unit, a direct `pad server
+// start` from before this fix, a supervisor relaunch) held the port with no
+// file to find, and `stop` told the caller it was not running.
+//
+// That is the failure that matters: the caller believes they stopped something
+// and acts on the belief. The refresh recipe in CONVE-2687 works around it by
+// killing the pid found from the port; a human following the docs does not.
+
+// healthyServerConfig starts a stub answering the health probe and returns a
+// config pointed at it, with a PID-file path inside a temp dir (absent unless a
+// test writes one).
+func healthyServerConfig(t *testing.T) *config.Config {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/health" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	host, portStr, err := net.SplitHostPort(strings.TrimPrefix(srv.URL, "http://"))
+	if err != nil {
+		t.Fatalf("split %q: %v", srv.URL, err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("port %q: %v", portStr, err)
+	}
+	return &config.Config{Host: host, Port: port, DataDir: t.TempDir()}
+}
+
+func TestStopServer_NoPIDFileButServerIsUp_SaysSoAndDoesNotClaimItIsStopped(t *testing.T) {
+	cfg := healthyServerConfig(t)
+
+	err := StopServer(cfg)
+	if err == nil {
+		t.Fatal("StopServer returned nil for a server it cannot address — the caller would believe it stopped")
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "not running") {
+		t.Errorf("message says the server is not running while it is answering on %s: %q", cfg.Addr(), msg)
+	}
+	// The message has to be actionable: name the address, and name the file
+	// whose absence is the reason this CLI cannot address the process.
+	if !strings.Contains(msg, cfg.Addr()) {
+		t.Errorf("message does not name the address the server is answering on: %q", msg)
+	}
+	if !strings.Contains(msg, cfg.PIDFile()) {
+		t.Errorf("message does not name the missing PID file: %q", msg)
+	}
+}
+
+// TestStopServer_NoPIDFileAndNothingListening keeps the original answer for the
+// case it was always right about. Without this, "never say not running" would
+// be satisfiable by deleting the phrase, which would leave `stop` unable to say
+// the one true thing it says today.
+func TestStopServer_NoPIDFileAndNothingListening(t *testing.T) {
+	// A port nothing is listening on: bind one, read it, release it.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	_, portStr, _ := net.SplitHostPort(ln.Addr().String())
+	port, _ := strconv.Atoi(portStr)
+	if cerr := ln.Close(); cerr != nil {
+		t.Fatalf("close: %v", cerr)
+	}
+
+	cfg := &config.Config{Host: "127.0.0.1", Port: port, DataDir: t.TempDir()}
+
+	err = StopServer(cfg)
+	if err == nil {
+		t.Fatal("expected an error when there is no PID file and nothing is listening")
+	}
+	if !strings.Contains(err.Error(), "not running") {
+		t.Errorf("message = %q, want it to say the server is not running", err.Error())
+	}
+}
+
+// TestStopServer_PIDFilePathIsUnchanged guards the join the two halves of this
+// fix share: `pad server start` writes cfg.PIDFile() and StopServer reads it.
+// They are the same call, so this is cheap insurance against a future change
+// moving one and not the other.
+func TestStopServer_PIDFilePathIsUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{DataDir: dir}
+	if got, want := cfg.PIDFile(), filepath.Join(dir, "pad.pid"); got != want {
+		t.Errorf("PIDFile() = %q, want %q", got, want)
+	}
+}

--- a/internal/server/listen_serve_test.go
+++ b/internal/server/listen_serve_test.go
@@ -1,0 +1,61 @@
+package server
+
+import (
+	"errors"
+	"net"
+	"net/http"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// BUG-2965 codex round 2: `pad server start` must be able to tell "we own this
+// port" from "we are about to try", because the PID file it writes names the
+// process `pad server stop` will signal. Splitting Listen from Serve is what
+// makes that distinguishable; these pin the split itself.
+
+func TestListen_RefusesAPortAlreadyHeld(t *testing.T) {
+	held, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("seed listener: %v", err)
+	}
+	defer held.Close()
+
+	srv := testServer(t)
+	ln, err := srv.Listen(held.Addr().String())
+	if err == nil {
+		ln.Close()
+		t.Fatal("Listen succeeded on a held port — a losing start would then claim the PID file")
+	}
+	if !errors.Is(err, syscall.EADDRINUSE) {
+		t.Logf("bind error is %v (not EADDRINUSE); the refusal is what matters", err)
+	}
+}
+
+func TestListenAndServe_StillServes(t *testing.T) {
+	srv := testServer(t)
+	ln, err := srv.Listen("127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = ln.Close() })
+
+	// The split must not have changed what a bound server does: it answers.
+	client := &http.Client{Timeout: 2 * time.Second}
+	var resp *http.Response
+	for i := 0; i < 20; i++ {
+		resp, err = client.Get("http://" + ln.Addr().String() + "/api/v1/health")
+		if err == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("health probe never succeeded: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("health status = %d, want 200", resp.StatusCode)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2125,7 +2125,24 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // (network blip, scheduler hiccup) before tripping the deadline.
 const httpIdleTimeout = 120 * time.Second
 
+// ListenAndServe binds addr and serves until the server is shut down.
+//
+// It is Listen followed by Serve; callers that need to act BETWEEN the bind and
+// the first request — recording a PID file, say, which must name the process
+// that actually owns the port (BUG-2965) — should call the two halves instead.
 func (s *Server) ListenAndServe(addr string) error {
+	ln, err := s.Listen(addr)
+	if err != nil {
+		return err
+	}
+	return s.Serve(ln)
+}
+
+// Listen builds the HTTP server and binds addr, returning the listener without
+// accepting on it yet. A failure here is the "address already in use" case, and
+// separating it from Serve is what lets a caller distinguish "we own this port"
+// from "we are about to try".
+func (s *Server) Listen(addr string) (net.Listener, error) {
 	s.ensureRouter()
 
 	s.httpServer = &http.Server{
@@ -2142,8 +2159,18 @@ func (s *Server) ListenAndServe(addr string) error {
 		// Non-SSE handlers should use per-request context deadlines.
 	}
 
-	slog.Info("Pad server listening", "addr", addr)
-	return s.httpServer.ListenAndServe()
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+	return ln, nil
+}
+
+// Serve accepts connections on ln until the server is shut down. Pair it with
+// Listen; ListenAndServe is the two together.
+func (s *Server) Serve(ln net.Listener) error {
+	slog.Info("Pad server listening", "addr", ln.Addr().String())
+	return s.httpServer.Serve(ln)
 }
 
 // Shutdown gracefully drains in-flight requests and stops the HTTP server.


### PR DESCRIPTION
Fixes BUG-2965, reported from the CONVE-2687 refresh where `pad server stop` said "server not running (no PID file)" about a server that was very much running.

## The defect

`StopServer` read the PID file and, on any read error, answered "not running" — without asking whether anything was listening. The file was written in exactly one place: `EnsureServer`'s auto-start branch. A server started any other way held the port with no file to find — a service unit, a human running `pad server start`, the seats' refresh recipe relaunching with the killed process's argv.

A stop command that says "not running" about a running process leaves the caller believing they stopped something, and the next thing they do rests on that belief.

## The fix, two halves

- **A missing PID file asks the port.** Only an unhealthy address earns "not running"; a healthy one earns a message naming the address, the missing file, and what to do instead. Deliberately **not** "find the listener and kill it" — resolving a pid from a port is platform-specific, and the process holding it may not be ours. A stop that kills by port can kill a stranger's process.
- **`pad server start` claims the file itself**, so it exists for every start path.

## Four codex rounds, each finding the previous shape reintroducing the defect

| round | shape | what it broke |
|---|---|---|
| 1 | write-then-defer-remove | a duplicate start overwrote a running server's entry, then deleted it on the way out |
| 2 | refuse to replace a live pid | mirror image — the start that LOST the port could still own the file |
| 3 | (fixed by binding first) | `EnsureServer`'s parent-side write became stale, and the live-pid refusal actively wrong |
| 4 | cleanup after the listener closes | read-then-remove let a successor claim between the steps and lose its file to us |

The resolution is **ordering, not arbitration**: bind first, then claim, so the file always names the process that owns the address. `internal/server` grows `Listen` and `Serve` for that; `ListenAndServe` is now the two together. Cleanup runs *before* the listener closes, while nothing else can legitimately own the file — the cost is a drain-window where a healthy server has no PID file and `stop` says exactly that, which is a true message in place of a silent wrong one.

Removed on the way: `EnsureServer`'s parent-side write, the live-pid refusal, and `processIsAlive`, whose only remaining callers were its own tests. The tests that pinned the retired rule are deleted with a note naming them and why.

## Evidence

**Live, against the built binary in a throwaway HOME, both shapes:**

1. `server start` → PID file written, naming the serving process.
2. Second `start` against the held port → `bind: address already in use`, **first server's file intact**.
3. `server stop` → `Server stopped.`, health 000, process gone, file removed.
4. `server stop` again → `server not running (no PID file)` — the one true use of that message survives.
5. File moved aside while running → `a server is answering on 127.0.0.1:7911 but this CLI did not start it (no PID file at …)`.

The first live run also caught a flaw in my own method: `stop` reads the *config's* port, so the probe answered about `127.0.0.1:7777` — this box's dev server — until re-run with `PAD_PORT` set. Worth knowing because it means `stop` addresses whatever the config points at; that is pre-existing and filed separately rather than widened into this unit.

**Mutants**, each compiled and run: health check removed; health branch still answering "not running"; empty PID file; cleanup that does not remove; cleanup that removes a successor's file — all killed by a named test. The call site is wiring a unit test cannot vouch for (CONVE-19), which is what the live runs cover, and the Listen/Serve split is pinned in `internal/server`.

`make lint` 0 issues, `make test` green, codex CLEAN in round 5.

https://claude.ai/code/session_01HeChkgZVYb3NTgTcckF5KR
