### PR TITLE
fix(cli): `pad server stop` signals only a process it can prove is ours (BUG-2969)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,6 +262,20 @@ jobs:
             if ($shown.title -ne 'Native smoke item') {
               throw "Unexpected item title: $($shown.title)"
             }
+            # Stop through the CLI, not Stop-Process: `pad server stop` is
+            # the only place the Windows PID-file ownership check runs
+            # (BUG-2969 — flock covers Linux and macOS, GetProcessTimes covers
+            # this platform), and a smoke that killed the process directly
+            # would leave that implementation unexercised anywhere. If it
+            # fails, the smoke fails; the finally below is the backstop that
+            # keeps a wedged server from holding the runner.
+            & $binary server stop
+            if (-not $server.HasExited) {
+              $server.WaitForExit(10000) | Out-Null
+            }
+            if (-not $server.HasExited) {
+              throw 'pad server stop did not stop the server'
+            }
           } finally {
             Stop-Process -Id $server.Id -ErrorAction SilentlyContinue
           }

--- a/cmd/pad/cmd_server.go
+++ b/cmd/pad/cmd_server.go
@@ -1031,7 +1031,7 @@ func serveCmd() *cobra.Command {
 			}
 
 			// We hold the port; the file is ours to claim.
-			releasePIDFile := cli.WritePIDFile(cfg.PIDFile(), os.Getpid())
+			releasePIDFile := cli.ClaimPIDFile(cfg.PIDFile())
 			// Backstop for the paths that never reach the shutdown sequence
 			// (Serve returns an error). Safe to call twice: it only removes a
 			// file that still names us, and a second call finds nothing.

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	go.yaml.in/yaml/v4 v4.0.0-rc.6
 	golang.org/x/crypto v0.56.0
 	golang.org/x/image v0.45.0
+	golang.org/x/sys v0.47.0
 	golang.org/x/term v0.45.0
 	golang.org/x/text v0.41.0
 	golang.org/x/time v0.15.0
@@ -134,7 +135,6 @@ require (
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
-	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/tools v0.48.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260803160001-6ac0973c030d // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260803160001-6ac0973c030d // indirect

--- a/internal/cli/pid_file_test.go
+++ b/internal/cli/pid_file_test.go
@@ -1,3 +1,5 @@
+//go:build unix
+
 package cli
 
 import (
@@ -5,126 +7,237 @@ import (
 	"path/filepath"
 	"strconv"
 	"testing"
+	"time"
 )
 
-// BUG-2965: `pad server stop` answered "server not running (no PID file)" about
-// a live server, because the file was written by exactly one path —
-// EnsureServer's auto-start branch — and never by `pad server start` itself.
-// EnsureServer spawns THIS command and records the child's pid, so writing our
-// own pid here produces the same value by a second route; what it adds is the
-// case where a human, a service unit, or a refresh recipe ran the command
-// directly.
-func TestWritePIDFile_WritesAndCleansUp(t *testing.T) {
+// BUG-2965 and BUG-2969 together: the PID file must let `pad server stop`
+// address the running server, and must not let it signal anything else.
+//
+// These are the Unix half — ownership here is an advisory lock, so the tests
+// exercise flock behaviour directly. The Windows half (creation-time
+// comparison) is covered by the CI smoke on windows-latest, which runs
+// `pad server stop` against a server it started.
+
+func TestClaimPIDFile_WritesARecordAndReleasesIt(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "pad.pid")
 
-	cleanup := WritePIDFile(path, 4242)
+	release := ClaimPIDFile(path)
 
-	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("PID file not written: %v", err)
+	rec, ok := readPIDRecord(path)
+	if !ok {
+		t.Fatal("no PID record written")
 	}
-	if got := string(data); got != strconv.Itoa(4242) {
-		t.Errorf("PID file contains %q, want %q — StopServer parses this with strconv.Atoi", got, "4242")
+	if rec.PID != os.Getpid() {
+		t.Errorf("record names pid %d, want this process (%d)", rec.PID, os.Getpid())
+	}
+	if rec.StartedAt.IsZero() {
+		t.Error("record has no start time — the human-readable half is what a person reads to identify the process")
+	}
+	if rec.Exe == "" {
+		t.Error("record has no executable path")
 	}
 
-	cleanup()
-	if _, err := os.Stat(path); !os.IsNotExist(err) {
-		t.Errorf("PID file survived cleanup (stat err = %v) — a stale file names a dead process to the next stop", err)
+	release()
+	if _, ok := readPIDRecord(path); ok {
+		t.Error("PID file survived release")
 	}
 }
 
-// TestWritePIDFile_UnwritablePathIsNotFatal pins the degradation. The server is
-// what the user asked for; a missing PID file costs them the addressable-stop
-// path and nothing else, so this must not panic and its cleanup must stay safe
-// to call.
-func TestWritePIDFile_UnwritablePathIsNotFatal(t *testing.T) {
-	// A path whose parent is a FILE, not a directory — unwritable without
-	// needing permissions games that behave differently under root.
-	parent := filepath.Join(t.TempDir(), "not-a-dir")
-	if err := os.WriteFile(parent, []byte("x"), 0o644); err != nil {
+// TestClaimPIDFile_HoldsTheLockWhileRunning is the ownership claim itself: while
+// a server is up, the file reports as OURS, which is the only state in which
+// stop is allowed to signal.
+func TestClaimPIDFile_HoldsTheLockWhileRunning(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pad.pid")
+	release := ClaimPIDFile(path)
+	defer release()
+
+	if _, ok := readPIDRecord(path); !ok {
+		t.Fatal("no PID record written")
+	}
+	if _, got := pidFileOwner(path); got != pidFileOurs {
+		t.Errorf("pidFileOwner = %v while the claim is held, want ours", got)
+	}
+}
+
+// TestPIDFileOwner_UnheldFileIsStale is the defect's core, expressed as a
+// property: a record nobody holds is stale NO MATTER WHAT PID IT NAMES. The pid
+// here is this live test process — the strongest form of the case, because a
+// liveness check would call it ours and signal it.
+func TestPIDFileOwner_UnheldFileIsStale(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pad.pid")
+	rec := pidRecord{PID: os.Getpid()}
+	if err := writePIDRecord(path, rec); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
-	path := filepath.Join(parent, "pad.pid")
 
-	cleanup := WritePIDFile(path, 4242)
-	if cleanup == nil {
-		t.Fatal("cleanup must never be nil — the caller defers it unconditionally")
-	}
-	cleanup() // must not panic, and must not care that there is nothing to remove
-
-	// Read rather than IsNotExist: a path UNDER a non-directory fails with
-	// ENOTDIR, not ENOENT, so os.IsNotExist is false even though nothing is
-	// there. The claim is "no PID file can be read here", so read.
-	if _, err := os.ReadFile(path); err == nil {
-		t.Errorf("a PID file is readable at %s after a failed write", path)
+	if _, got := pidFileOwner(path); got != pidFileStale {
+		t.Errorf("pidFileOwner = %v for an unheld file naming a LIVE pid, want stale — "+
+			"liveness is not ownership, and this is the pid a stranger would hold after reuse", got)
 	}
 }
 
-// TestWritePIDFile_CleanupToleratesAnAlreadyRemovedFile covers the ordinary
-// double-stop shape: something else (an operator, a stop that raced) removed
-// the file first. Cleanup must be quiet about that rather than logging a
-// failure on every clean shutdown.
-func TestWritePIDFile_CleanupToleratesAnAlreadyRemovedFile(t *testing.T) {
+func TestPIDFileOwner_MissingFileIsStale(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "pad.pid")
-	cleanup := WritePIDFile(path, 99)
-	if err := os.Remove(path); err != nil {
-		t.Fatalf("pre-remove: %v", err)
-	}
-	cleanup()
-}
-
-// TestWritePIDFile_CleanupDoesNotRemoveSomeoneElsesFile is the P1's second
-// half, and the sharper one. A duplicate start writes the file (the original's
-// pid was stale, or the write raced), fails to bind, and runs its cleanup — if
-// that cleanup is unconditional it deletes whatever is there, including a file
-// another instance has since written, leaving a HEALTHY server unaddressable.
-// That is this fix's own defect, reintroduced by its own cleanup.
-func TestWritePIDFile_CleanupDoesNotRemoveSomeoneElsesFile(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "pad.pid")
-
-	cleanup := WritePIDFile(path, 4242)
-
-	// Another instance takes ownership while we are still running.
-	if err := os.WriteFile(path, []byte("777"), 0o644); err != nil {
-		t.Fatalf("takeover: %v", err)
-	}
-
-	cleanup()
-
-	if got, ok := readPIDFile(path); !ok || got != 777 {
-		t.Errorf("PID file is %v (ok=%v) after our cleanup, want 777 — cleanup must only remove a file it still owns", got, ok)
+	if _, got := pidFileOwner(path); got != pidFileStale {
+		t.Errorf("pidFileOwner = %v for a missing file, want stale", got)
 	}
 }
 
-// Removed with codex round 3's P2: TestWritePIDFile_LeavesALivePeersFileAlone
-// and TestWritePIDFile_ReplacesAStaleFile pinned a live-pid refusal that is
-// wrong once the caller binds first — no live process can be serving an address
-// this process just bound, so deferring to one strands the real server. The
-// TestProcessIsAlive_* pair went with the predicate they covered, which had no
-// production caller left. Their replacement is the ordering itself, pinned in
-// internal/server (Listen refuses a held port) and exercised end to end against
-// the real binary on BUG-2965's trail.
-
-// TestWritePIDFile_CleanupIsIdempotent covers the shape the shutdown path now
-// relies on: the release runs explicitly before the listener closes AND stays
-// deferred as a backstop for the paths that never reach the shutdown sequence.
-// Calling it twice must be quiet and must not touch a successor's file.
-func TestWritePIDFile_CleanupIsIdempotent(t *testing.T) {
+func TestReadPIDRecord_AcceptsTheLegacyBarePID(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "pad.pid")
-	cleanup := WritePIDFile(path, 4242)
-
-	cleanup()
-	if _, ok := readPIDFile(path); ok {
-		t.Fatal("first cleanup left the file behind")
+	if err := os.WriteFile(path, []byte(strconv.Itoa(4242)+"\n"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
 	}
 
-	// A successor claims the path between the two calls — the ordinary fast
-	// restart. The second call must leave it alone.
-	if err := os.WriteFile(path, []byte("777"), 0o644); err != nil {
-		t.Fatalf("successor write: %v", err)
+	rec, ok := readPIDRecord(path)
+	if !ok {
+		t.Fatal("legacy bare-pid file did not parse — a file written by an older binary is exactly the case this family of bugs is about")
 	}
-	cleanup()
-	if got, ok := readPIDFile(path); !ok || got != 777 {
-		t.Errorf("second cleanup removed the successor's file (got %v, ok=%v)", got, ok)
+	if rec.PID != 4242 {
+		t.Errorf("pid = %d, want 4242", rec.PID)
+	}
+	if !rec.StartedAt.IsZero() {
+		t.Error("a legacy record must carry no fingerprint, so ownership reads as unprovable rather than proven")
+	}
+}
+
+func TestReadPIDRecord_RejectsGarbage(t *testing.T) {
+	for name, body := range map[string]string{
+		"empty":         "",
+		"whitespace":    "   \n",
+		"not a number":  "not-a-pid",
+		"zero":          "0",
+		"negative":      "-1",
+		"broken json":   `{"pid": `,
+		"json zero pid": `{"pid": 0}`,
+	} {
+		path := filepath.Join(t.TempDir(), "pad.pid")
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatalf("%s: seed: %v", name, err)
+		}
+		if _, ok := readPIDRecord(path); ok {
+			t.Errorf("%s: parsed as a valid record", name)
+		}
+	}
+}
+
+// TestClaimPIDFile_ReleaseIsIdempotent covers the shutdown path, which calls
+// release explicitly before the listener closes AND keeps it deferred as a
+// backstop.
+func TestClaimPIDFile_ReleaseIsIdempotent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pad.pid")
+	release := ClaimPIDFile(path)
+	release()
+	release()
+	if _, ok := readPIDRecord(path); ok {
+		t.Error("PID file present after two releases")
+	}
+}
+
+// TestProcessIsGone_LiveAndDead pins the confirmation predicate. The old wait
+// loop asked whether the PORT was quiet, which a port nothing ever served
+// answers instantly — that is how a kill that never touched a pad server
+// reported "Server stopped".
+func TestProcessIsGone_LiveAndDead(t *testing.T) {
+	if processIsGone(os.Getpid()) {
+		t.Error("processIsGone(self) = true")
+	}
+	if !processIsGone(-1) {
+		t.Error("processIsGone(-1) = false")
+	}
+}
+
+// TestPIDFileOwner_ReportsTheRecordItVerified is codex round 1's first race,
+// as a property rather than a timing test: the record the ownership check
+// hands back must be the one it read from the descriptor it probed, so a
+// caller cannot signal a pid whose ownership was never established.
+//
+// A successor claim rewrites the file; the check must then report the
+// SUCCESSOR's pid, never a pid a caller read earlier.
+func TestPIDFileOwner_ReportsTheRecordItVerified(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pad.pid")
+
+	// Predecessor's record, unheld.
+	if err := writePIDRecord(path, pidRecord{PID: 111}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// The successor claims it — same path, its own pid, lock held.
+	release := ClaimPIDFile(path)
+	defer release()
+
+	rec, owner := pidFileOwner(path)
+	if owner != pidFileOurs {
+		t.Fatalf("owner = %v, want ours", owner)
+	}
+	if rec.PID != os.Getpid() {
+		t.Errorf("verified record names pid %d, want the successor (%d) — signalling the earlier pid would "+
+			"send SIGTERM to whatever now holds it", rec.PID, os.Getpid())
+	}
+}
+
+// TestPIDFileOwner_HeldButUnreadableIsUnprovable covers the claim caught
+// mid-write: the lock says held, the bytes do not parse, and there is no pid we
+// can justify signalling.
+func TestPIDFileOwner_HeldButUnreadableIsUnprovable(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pad.pid")
+	release := ClaimPIDFile(path)
+	defer release()
+
+	// Truncate the contents while the lock is still held.
+	if err := os.WriteFile(path, []byte("{"), 0o644); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+
+	if _, owner := pidFileOwner(path); owner != pidFileUnprovable {
+		t.Errorf("owner = %v for a held but unparseable file, want unprovable", owner)
+	}
+}
+
+// TestPIDFileOwner_RemovesTheStaleFileItself pins where cleanup happens. It has
+// to be inside the ownership check, while the lock is held: a caller that
+// removed the file afterwards would race a replacement server's claim and
+// delete ITS record (codex round 2). Asserting the file is gone when the check
+// returns is how that placement stays put.
+func TestPIDFileOwner_RemovesTheStaleFileItself(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pad.pid")
+	if err := writePIDRecord(path, pidRecord{PID: os.Getpid()}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if _, owner := pidFileOwner(path); owner != pidFileStale {
+		t.Fatalf("owner = %v, want stale", owner)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("stale PID file survived the ownership check (stat err = %v) — cleanup must happen while the "+
+			"check holds the lock, not afterwards", err)
+	}
+}
+
+// TestClaimPIDFile_RetriesPastABriefProbe covers the interaction the round-2
+// fix created: `stop`'s ownership probe holds the lock for an instant, and a
+// server claiming in that instant must not lose its claim for the rest of its
+// life. The probe here is a real held lock released while the claim is trying.
+func TestClaimPIDFile_RetriesPastABriefProbe(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pad.pid")
+
+	probe, err := holdPIDFile(path)
+	if err != nil {
+		t.Fatalf("probe hold: %v", err)
+	}
+	done := make(chan struct{})
+	go func() {
+		time.Sleep(60 * time.Millisecond)
+		probe()
+		close(done)
+	}()
+
+	release := ClaimPIDFile(path)
+	defer release()
+	<-done
+
+	rec, ok := readPIDRecord(path)
+	if !ok || rec.PID != os.Getpid() {
+		t.Errorf("claim did not survive a brief foreign hold (record %+v, ok=%v)", rec, ok)
 	}
 }

--- a/internal/cli/pidfile.go
+++ b/internal/cli/pidfile.go
@@ -1,0 +1,140 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// pidRecord is what `pad server start` leaves behind so `pad server stop` can
+// tell OUR server from whatever else happens to hold that pid.
+//
+// BUG-2969: before this, stop read a bare pid and signalled it. os.FindProcess
+// succeeds for any pid on Unix, nothing asked whether the pid was a pad server,
+// and the wait loop then confirmed success by polling the PORT — which is
+// unhealthy from the first poll when nothing was ever serving. Measured: a
+// `sleep 600` whose pid had been written into the file was SIGTERMed, and stop
+// printed "Server stopped." The success check was satisfied by the failure case.
+//
+// The fields divide by who reads them:
+//
+//   - PID is what gets signalled.
+//   - StartedAt and Exe are for a HUMAN opening the file to work out what stop
+//     is talking about. On Windows StartedAt is also the discriminator (see
+//     pidfile_windows.go); on Unix the discriminator is an advisory lock, not
+//     this timestamp, so do not add logic that trusts it there.
+type pidRecord struct {
+	PID       int       `json:"pid"`
+	StartedAt time.Time `json:"started_at"`
+	Exe       string    `json:"exe,omitempty"`
+}
+
+// writePIDRecord serialises rec to path.
+func writePIDRecord(path string, rec pidRecord) error {
+	data, err := json.MarshalIndent(rec, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, append(data, '\n'), 0o644)
+}
+
+// readPIDRecord parses the PID file.
+//
+// It accepts the LEGACY bare-integer form as well, because a server started by
+// an older binary is exactly the case this whole family of bugs is about: the
+// file outlives the build that wrote it. A legacy record carries no fingerprint,
+// which the ownership check treats as unprovable rather than as proof.
+func readPIDRecord(path string) (rec pidRecord, ok bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return pidRecord{}, false
+	}
+	return parsePIDRecord(data)
+}
+
+// readAll reads an already-open PID file from the start. Errors collapse to
+// empty, which parsePIDRecord reports as unreadable — the same answer an
+// absent file gives, and the same refusal follows from it.
+func readAll(f *os.File) []byte {
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return nil
+	}
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return nil
+	}
+	return data
+}
+
+// parsePIDRecord parses PID-file bytes in either form.
+func parsePIDRecord(data []byte) (rec pidRecord, ok bool) {
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "" {
+		return pidRecord{}, false
+	}
+
+	if trimmed[0] == '{' {
+		if err := json.Unmarshal([]byte(trimmed), &rec); err != nil || rec.PID <= 0 {
+			return pidRecord{}, false
+		}
+		return rec, true
+	}
+
+	pid, err := strconv.Atoi(trimmed)
+	if err != nil || pid <= 0 {
+		return pidRecord{}, false
+	}
+	return pidRecord{PID: pid}, true
+}
+
+// currentPIDRecord describes THIS process.
+func currentPIDRecord() pidRecord {
+	rec := pidRecord{PID: os.Getpid(), StartedAt: processStartTime(os.Getpid())}
+	if exe, err := os.Executable(); err == nil {
+		rec.Exe = exe
+	}
+	return rec
+}
+
+// pidFileOwnership is what the platform check reports back to stop.
+type pidFileOwnership int
+
+const (
+	// pidFileOurs: a live pad server owns this file. Signalling is safe.
+	pidFileOurs pidFileOwnership = iota
+	// pidFileStale: nothing owns it. Signal NOTHING — the pid may since have
+	// been reused by a process that has nothing to do with us.
+	pidFileStale
+	// pidFileUnprovable: this platform, or this record, cannot answer. Also
+	// signal nothing: an unprovable claim is not a licence to send SIGTERM.
+	pidFileUnprovable
+)
+
+func (o pidFileOwnership) String() string {
+	switch o {
+	case pidFileOurs:
+		return "ours"
+	case pidFileStale:
+		return "stale"
+	default:
+		return "unprovable"
+	}
+}
+
+// describePIDRecord renders a record for an error message a person has to act
+// on. Kept here so both platforms word it the same way.
+func describePIDRecord(rec pidRecord) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "pid %d", rec.PID)
+	if !rec.StartedAt.IsZero() {
+		fmt.Fprintf(&b, ", recorded at %s", rec.StartedAt.Format(time.RFC3339))
+	}
+	if rec.Exe != "" {
+		fmt.Fprintf(&b, ", %s", rec.Exe)
+	}
+	return b.String()
+}

--- a/internal/cli/pidfile_unix.go
+++ b/internal/cli/pidfile_unix.go
@@ -1,0 +1,127 @@
+//go:build unix
+
+package cli
+
+import (
+	"log/slog"
+	"os"
+	"syscall"
+	"time"
+)
+
+// holdPIDFile takes an exclusive advisory lock on the PID file and keeps it for
+// the process's lifetime. The lock — not the pid, and not the timestamp beside
+// it — is what `pad server stop` uses to tell OUR server from a stranger that
+// inherited the pid (BUG-2969).
+//
+// Why a lock rather than comparing the pid's start time: the lock answers the
+// question directly ("does a live pad server hold THIS file"), where a
+// timestamp comparison infers identity from an attribute of a pid. It is also
+// one implementation for Linux and macOS, where reading another process's start
+// time is two — /proc on Linux, a sysctl on macOS. Same primitive, same
+// package: session_lock_unix.go has used flock for the sessions dir since
+// TASK-2767.
+//
+// The returned release closes the descriptor, which drops the lock. It does not
+// remove the file; the caller owns that ordering.
+func holdPIDFile(path string) (release func(), err error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return nil, err
+	}
+
+	// Retry briefly rather than failing on the first refusal. The only holder
+	// a bound server can legitimately meet here is `pad server stop`'s own
+	// ownership probe, which holds the lock for microseconds; giving up
+	// immediately would let that instant cost a starting server its claim and
+	// leave it unaddressable for its whole life. Bounded, so a genuinely stuck
+	// holder degrades to the documented no-PID-file path instead of hanging
+	// the start.
+	var lockErr error
+	for attempt := 0; attempt < 20; attempt++ {
+		lockErr = syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+		if lockErr == nil {
+			return func() { _ = f.Close() }, nil
+		}
+		if lockErr != syscall.EWOULDBLOCK && lockErr != syscall.EAGAIN {
+			break
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	_ = f.Close()
+	return nil, lockErr
+}
+
+// pidFileOwner reports whether a live pad server holds path.
+//
+// It probes the same lock non-blockingly. Acquiring it proves nobody holds it —
+// the writer is gone, so the record is stale whatever the pid now names.
+// Failing to acquire it proves a live process holds THIS file, and the only
+// thing that takes this lock is a pad server that wrote this record.
+//
+// The probe's own lock is released immediately: it is a question, not a claim.
+func pidFileOwner(path string) (pidRecord, pidFileOwnership) {
+	f, err := os.OpenFile(path, os.O_RDWR, 0o644)
+	if err != nil {
+		// The file vanished. Nothing to own.
+		return pidRecord{}, pidFileStale
+	}
+	defer f.Close()
+
+	lockErr := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+
+	// Read the record from the SAME descriptor whose lock state we just
+	// probed, and read it AFTER probing (codex round 1). Taking the pid from
+	// an earlier, separate read leaves a window in which a successor claims
+	// the file between the two: the lock then reports "held" — truthfully,
+	// about the SUCCESSOR — while the pid handed back is the predecessor's,
+	// and stop signals a process that no longer owns anything.
+	rec, ok := parsePIDRecord(readAll(f))
+
+	if lockErr != nil {
+		// EWOULDBLOCK — someone holds it. Any other error is a filesystem we
+		// cannot lock on (some network mounts), which is unprovable rather
+		// than owned: we will not signal on a lock we could not evaluate.
+		if lockErr == syscall.EWOULDBLOCK || lockErr == syscall.EAGAIN {
+			if !ok {
+				// Held, but the contents are unreadable — a claim caught
+				// mid-write. Unprovable, so nothing is signalled.
+				return pidRecord{}, pidFileUnprovable
+			}
+			return rec, pidFileOurs
+		}
+		return rec, pidFileUnprovable
+	}
+	// Stale. Remove the file WHILE STILL HOLDING the lock (codex round 2):
+	// releasing first leaves a window in which a replacement server claims the
+	// path, and the remove then deletes ITS live record — the same
+	// unaddressable-server bug this fix exists to close, reintroduced by the
+	// cleanup. A claimant that arrives during this instant retries (see
+	// holdPIDFile) rather than losing its claim.
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		slog.Warn("could not remove stale PID file", "path", path, "error", err)
+	}
+	_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+	return rec, pidFileStale
+}
+
+// processStartTime records when this process began, for the human-readable
+// half of the record. Unix does not compare it — the lock is the discriminator
+// — so wall-clock now, taken at write time, is honest enough for a reader.
+func processStartTime(pid int) time.Time {
+	return time.Now().UTC()
+}
+
+// processIsGone reports whether pid has exited. Signal 0 delivers nothing and
+// only performs the existence and permission checks; EPERM means it is alive
+// and not ours to signal, which is emphatically NOT gone.
+func processIsGone(pid int) bool {
+	if pid <= 0 {
+		return true
+	}
+	err := syscall.Kill(pid, 0)
+	if err == nil {
+		return false
+	}
+	return err != syscall.EPERM
+}

--- a/internal/cli/pidfile_windows.go
+++ b/internal/cli/pidfile_windows.go
@@ -1,0 +1,96 @@
+//go:build windows
+
+package cli
+
+import (
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+// holdPIDFile is a no-op on Windows: there is no flock in the pattern this
+// package uses elsewhere (session_lock_other.go documents the same boundary).
+// Ownership here is decided by the recorded creation time instead — see
+// pidFileOwner — so the PID file needs no lock held across the process's life.
+func holdPIDFile(path string) (release func(), err error) {
+	return func() {}, nil
+}
+
+// pidFileOwner reports whether the pid in rec is still the process that wrote
+// the record, by comparing the OS-reported creation time against the one
+// recorded at start.
+//
+// Creation time is the discriminator that survives pid reuse: a reused pid
+// belongs to a process that started later, so the timestamps differ. Compared
+// exactly — both sides come from GetProcessTimes, so there is no clock skew to
+// tolerate and a tolerance window would only admit a collision.
+func pidFileOwner(path string) (pidRecord, pidFileOwnership) {
+	rec, ok := readPIDRecord(path)
+	if !ok {
+		return pidRecord{}, pidFileStale
+	}
+	if rec.StartedAt.IsZero() {
+		// A legacy bare-pid file, or one written before the fingerprint
+		// existed. Unprovable — and unprovable means we do not signal.
+		return rec, pidFileUnprovable
+	}
+
+	started := processStartTime(rec.PID)
+	if started.IsZero() {
+		// No such process (or no rights to ask). Nothing holds this record.
+		return rec, pidFileStale
+	}
+	if started.Equal(rec.StartedAt) {
+		return rec, pidFileOurs
+	}
+	// The pid is live but was created at a different moment: it is a REUSE,
+	// not our server.
+	return rec, pidFileStale
+}
+
+// Windows deliberately does NOT delete a stale PID file, where Unix removes it
+// under the lock it already holds (codex round 3).
+//
+// There is no lock here to make check-then-remove atomic, so a successor that
+// claims the path between the two would have its live record deleted and be
+// unaddressable for the rest of its life. Weigh the two outcomes: a stale file
+// left behind is overwritten by the next `pad server start`, which claims the
+// path unconditionally, and until then `stop` reports it as stale and signals
+// nothing. A wrongly deleted record has no such recovery. So the platform
+// without an atomic primitive does the harmless half and leaves cleanup to the
+// next writer.
+
+// processStartTime returns pid's creation time, or the zero time when the
+// process does not exist or cannot be opened.
+func processStartTime(pid int) time.Time {
+	h, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		return time.Time{}
+	}
+	defer windows.CloseHandle(h)
+
+	var creation, exit, kernel, user windows.Filetime
+	if err := windows.GetProcessTimes(h, &creation, &exit, &kernel, &user); err != nil {
+		return time.Time{}
+	}
+	return time.Unix(0, creation.Nanoseconds()).UTC()
+}
+
+// processIsGone reports whether pid has exited.
+func processIsGone(pid int) bool {
+	if pid <= 0 {
+		return true
+	}
+	h, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		return true
+	}
+	defer windows.CloseHandle(h)
+
+	var code uint32
+	if err := windows.GetExitCodeProcess(h, &code); err != nil {
+		return true
+	}
+	const stillActive = 259 // STILL_ACTIVE
+	return code != stillActive
+}

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -6,8 +6,6 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/PerpetualSoftware/pad/internal/config"
@@ -72,62 +70,106 @@ func EnsureServer(cfg *config.Config) error {
 	return fmt.Errorf("server failed to start within 3 seconds. Check %s for errors", cfg.LogFile())
 }
 
-// StopServer sends a stop signal to the background server process.
+// StopServer stops the server this CLI's config points at — or explains why it
+// will not, which is the harder half.
 //
-// The PID file is the handle, not the evidence (BUG-2965). It is written by the
-// paths that START a server from this CLI; a server started any other way — a
-// service unit, a direct `pad server start` from before this fix, a relaunch
-// under a supervisor — holds the port with no file to find. Reporting "not
-// running" for one of those is the failure that matters here: the caller
-// believes they stopped something, and the next thing they do is act on that
-// belief.
+// The PID file is a HANDLE, not evidence (BUG-2965), and the pid inside it is
+// not proof of identity (BUG-2969). Measured before this changed: a `sleep 600`
+// whose pid had been written into the file was SIGTERMed, and stop printed
+// "Server stopped." — os.FindProcess succeeds for any pid on Unix, nothing
+// asked whether the pid was ours, and the confirmation loop polled the PORT,
+// which is unhealthy from the first poll when nothing was ever serving. The
+// success check was satisfied by the failure case.
 //
-// So a missing file asks the port. Only an unhealthy port earns "not running";
-// a healthy one earns an answer that says the server is up, that this CLI
-// cannot address it, and what to do instead. Deliberately NOT "find the
-// listener and kill it": resolving a pid from a port is platform-specific and,
-// more to the point, the process holding it may not be ours — a stop command
-// that kills by port is a stop command that can kill a stranger's process.
+// So the order is: read the record, ask the PLATFORM whether a live pad server
+// owns it (an advisory lock on Unix, the process creation time on Windows),
+// and signal only on a yes. Stale and unprovable both mean signal nothing.
 func StopServer(cfg *config.Config) error {
-	pidData, err := os.ReadFile(cfg.PIDFile())
-	if err != nil {
+	path := cfg.PIDFile()
+
+	// One read, under the ownership probe: pidFileOwner returns the record it
+	// verified, so the pid signalled below is the pid whose ownership was
+	// established. An earlier separate read left a window for a successor to
+	// claim the file between the two (codex round 1).
+	rec, owner := pidFileOwner(path)
+	if owner == pidFileStale && rec.PID == 0 {
+		// No file at all. A server started outside this CLI still holds the
+		// port, and saying "not running" about it is the BUG-2965 failure.
 		if isServerHealthy(cfg.Host, cfg.Port) {
 			return fmt.Errorf(
 				"a server is answering on %s but this CLI did not start it (no PID file at %s) — "+
 					"stop it where it was started, or signal the process listening on that address",
-				cfg.Addr(), cfg.PIDFile())
+				cfg.Addr(), path)
 		}
 		return fmt.Errorf("server not running (no PID file)")
 	}
 
-	pid, err := strconv.Atoi(strings.TrimSpace(string(pidData)))
-	if err != nil {
-		os.Remove(cfg.PIDFile())
-		return fmt.Errorf("invalid PID file")
+	switch owner {
+	case pidFileStale:
+		// The writer is gone. The pid may since have been reused by something
+		// unrelated, so it does not get signalled on the strength of a file
+		// the dead process left behind.
+		// The file is already gone: pidFileOwner removed it while holding the
+		// lock, which is the only point at which no replacement can have
+		// claimed the path (codex round 2).
+		if isServerHealthy(cfg.Host, cfg.Port) {
+			// Deliberately NOT "the process is gone": the recorded pid may
+			// well be alive — that is the dangerous case, since it is a
+			// stranger that inherited the number — and a reader who checks
+			// will find it running. What is true is that it does not own this
+			// file, so it is not the server answering on that address.
+			//
+			// The message does not claim the file was removed: Unix drops it
+			// under the ownership lock, Windows leaves it for the next start
+			// to overwrite (see pidfile_windows.go), and a message that
+			// asserted a cleanup the platform did not do would be the same
+			// class of lie this whole item is about.
+			return fmt.Errorf(
+				"a server is answering on %s, but the PID file does not belong to it (%s) — "+
+					"nothing was signalled; stop that server where it was started",
+				cfg.Addr(), describePIDRecord(rec))
+		}
+		return fmt.Errorf("server not running (stale PID file: it named %s, which does not own it)", describePIDRecord(rec))
+
+	case pidFileUnprovable:
+		return fmt.Errorf(
+			"cannot confirm that %s belongs to this pad server, so it was not signalled — "+
+				"stop it where it was started, or remove %s if you know the process is gone",
+			describePIDRecord(rec), path)
+
+	case pidFileOurs:
+		// Fall through to the stop.
+	default:
+		return fmt.Errorf("unrecognised PID file ownership state %q", owner)
 	}
 
-	process, err := os.FindProcess(pid)
+	process, err := os.FindProcess(rec.PID)
 	if err != nil {
-		os.Remove(cfg.PIDFile())
 		return fmt.Errorf("process not found")
 	}
-
 	if err := stopProcess(process); err != nil {
-		os.Remove(cfg.PIDFile())
 		return fmt.Errorf("failed to stop server: %w", err)
 	}
 
-	os.Remove(cfg.PIDFile())
-
-	// Wait for it to actually stop
-	for i := 0; i < 20; i++ {
-		time.Sleep(100 * time.Millisecond)
-		if !isServerHealthy(cfg.Host, cfg.Port) {
+	// Wait for OUR PROCESS to exit — not for the port to go quiet. A port that
+	// nothing was serving is quiet immediately, which is how the old loop
+	// confirmed a kill that never touched a pad server.
+	for i := 0; i < 60; i++ {
+		if processIsGone(rec.PID) {
+			// Deliberately NOT removing the file here (codex round 1): the
+			// server removes its own on the way down, and by the time we
+			// observe its exit a successor may already have bound the port and
+			// claimed the path. Deleting then would unaddress the live server.
+			// A file left behind by a crash is handled where it belongs — the
+			// next stop reads it as stale and removes it there.
 			return nil
 		}
+		time.Sleep(100 * time.Millisecond)
 	}
 
-	return nil
+	// Still there after six seconds. The file stays: the process it names is
+	// alive, so the record is still true and still the handle for a retry.
+	return fmt.Errorf("signalled %s but it has not exited after 6s — it may be draining connections", describePIDRecord(rec))
 }
 
 // IsServerRunning checks if the server is currently running.
@@ -145,62 +187,52 @@ func isServerHealthy(host string, port int) bool {
 	return resp.StatusCode == http.StatusOK
 }
 
-// WritePIDFile records pid at path and returns the cleanup that removes it.
-//
-// The PID file is how `pad server stop` addresses a running server, and before
-// BUG-2965 exactly one path wrote it: EnsureServer's auto-start branch. A
-// server started any other way — a service unit, a human running `pad server
-// start`, a refresh recipe relaunching with the killed process's argv — held
-// the port with no file to find, and `stop` answered "not running" about it.
+// ClaimPIDFile records this process in the PID file and holds the platform's
+// ownership marker for as long as it runs. The returned release drops that
+// marker and removes the file.
 //
 // CALL IT ONLY AFTER BINDING THE PORT. That ordering is the whole ownership
-// story, and it took two codex rounds to arrive at: whoever holds the address
-// is the process `stop` must signal, so the claim has to follow the bind rather
-// than race it. A write before the bind lets a start that LOSES the race record
-// itself and then, on its way out, remove the file the winner is relying on.
+// story and it took two codex rounds to arrive at (BUG-2965): whoever holds the
+// address is the process `stop` must signal, so the claim follows the bind
+// rather than racing it. A write before the bind lets a start that LOSES the
+// race record itself and then, on its way out, remove the file the winner
+// relies on.
 //
-// Given that ordering, the write is unconditional. An earlier shape refused to
-// replace a PID file naming a live process, which is exactly wrong once the
-// caller has bound: no live process can be serving this address, so the entry
-// is stale or unrelated (pid reuse), and deferring to it would leave the real
-// server unaddressable (codex round 3, P2).
+// On Unix the marker is an advisory lock held on the file itself, which is what
+// lets `stop` distinguish this server from a stranger that inherited the pid
+// (BUG-2969). On Windows there is no such lock, and the recorded creation time
+// is the discriminator instead.
 //
-// Cleanup, by contrast, removes the file only while it still names US — a
-// process whose file was taken over must not delete its successor's entry.
-//
-// Failure to write is NOT fatal: the server is what the caller asked for, and a
-// missing PID file degrades `stop` to its port-probe message rather than
-// breaking anything. The returned cleanup is always safe to call, so callers
-// can defer it unconditionally.
-func WritePIDFile(path string, pid int) func() {
-	if err := os.WriteFile(path, []byte(strconv.Itoa(pid)), 0o644); err != nil {
-		slog.Warn("could not write PID file; `pad server stop` will not be able to address this process",
+// Failure is NOT fatal: the server is what the caller asked for, and a missing
+// or unlocked PID file degrades `stop` to its port-probe message rather than
+// breaking anything. The returned release is always safe to call, and safe to
+// call twice.
+func ClaimPIDFile(path string) func() {
+	release, err := holdPIDFile(path)
+	if err != nil {
+		slog.Warn("could not claim the PID file; `pad server stop` will not be able to address this process",
 			"path", path, "error", err)
 		return func() {}
 	}
 
-	return func() {
-		if current, ok := readPIDFile(path); !ok || current != pid {
-			// Someone else owns it now (or it is already gone). Removing it
-			// would unaddress a server we did not start.
-			return
-		}
-		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-			slog.Warn("could not remove PID file on shutdown", "path", path, "error", err)
-		}
+	rec := currentPIDRecord()
+	if err := writePIDRecord(path, rec); err != nil {
+		slog.Warn("could not write PID file; `pad server stop` will not be able to address this process",
+			"path", path, "error", err)
+		release()
+		return func() {}
 	}
-}
 
-// readPIDFile returns the pid recorded at path. ok is false when the file is
-// absent or does not parse — both meaning "nothing here owns this path".
-func readPIDFile(path string) (pid int, ok bool) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return 0, false
+	return func() {
+		// Remove BEFORE dropping the lock: while we still hold it, no other
+		// server can have claimed this path, so there is nothing of anyone
+		// else's to delete. Dropping first would reopen the read-then-remove
+		// race that codex round 4 found in the previous shape.
+		if current, ok := readPIDRecord(path); ok && current.PID == rec.PID {
+			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+				slog.Warn("could not remove PID file on shutdown", "path", path, "error", err)
+			}
+		}
+		release()
 	}
-	pid, err = strconv.Atoi(strings.TrimSpace(string(data)))
-	if err != nil {
-		return 0, false
-	}
-	return pid, true
 }

--- a/internal/cli/server_stop_honesty_test.go
+++ b/internal/cli/server_stop_honesty_test.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -107,4 +108,96 @@ func TestStopServer_PIDFilePathIsUnchanged(t *testing.T) {
 	if got, want := cfg.PIDFile(), filepath.Join(dir, "pad.pid"); got != want {
 		t.Errorf("PIDFile() = %q, want %q", got, want)
 	}
+}
+
+// BUG-2969: stop must signal only a pid it can prove is our server.
+//
+// Measured before the fix, on the merged binary: a `sleep 600` whose pid had
+// been written into the PID file was SIGTERMed and stop printed "Server
+// stopped." These pin both halves of the refusal — the stale record naming a
+// LIVE process, and the message that must not claim success.
+
+func TestStopServer_StalePIDFileNamingALiveStrangerIsNotSignalled(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{Host: "127.0.0.1", Port: unusedPort(t), DataDir: dir}
+
+	// The record names THIS process — alive, and emphatically not a pad server.
+	// Nothing holds the file, so ownership is stale and the pid must not be
+	// signalled. If it were, this test process would receive SIGTERM.
+	if err := writePIDRecord(cfg.PIDFile(), pidRecord{PID: os.Getpid()}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	err := StopServer(cfg)
+	if err == nil {
+		t.Fatal("StopServer reported success for a stale record — that is the measured defect: a stranger killed, success printed")
+	}
+	if !strings.Contains(err.Error(), "stale") {
+		t.Errorf("message = %q, want it to name the record as stale", err.Error())
+	}
+	if _, statErr := os.Stat(cfg.PIDFile()); !os.IsNotExist(statErr) {
+		t.Errorf("stale PID file survived (stat err = %v) — it should be removed once it is known to name nothing", statErr)
+	}
+}
+
+// TestStopServer_HeldPIDFileIsAddressable is the counterfactual: without it,
+// "never signal" would be satisfiable by never signalling anything, which would
+// break stop entirely. A held claim must read as ours.
+func TestStopServer_HeldPIDFileIsAddressable(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pad.pid")
+
+	release := ClaimPIDFile(path)
+	defer release()
+
+	if _, ok := readPIDRecord(path); !ok {
+		t.Fatal("claim wrote no record")
+	}
+	if _, got := pidFileOwner(path); got != pidFileOurs {
+		t.Fatalf("a held claim reads as %v, want ours — stop would refuse to address a live server", got)
+	}
+}
+
+// TestStopServer_LegacyRecordIsNotSignalled covers the file an older binary
+// left behind: it carries a pid and no proof. Unprovable is not a licence to
+// send SIGTERM, so stop refuses and says how to proceed.
+func TestStopServer_LegacyRecordIsNotSignalled(t *testing.T) {
+	dir := t.TempDir()
+	cfg := &config.Config{Host: "127.0.0.1", Port: unusedPort(t), DataDir: dir}
+
+	// A legacy bare-pid file naming this live process. On Unix the lock is the
+	// discriminator, so an unheld file is stale regardless of the pid; the
+	// refusal is what matters, and its wording tells the reader which case
+	// they are in.
+	if err := os.WriteFile(cfg.PIDFile(), []byte(strconv.Itoa(os.Getpid())), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	err := StopServer(cfg)
+	if err == nil {
+		t.Fatal("StopServer reported success for a legacy record naming a non-pad process")
+	}
+	for _, want := range []string{strconv.Itoa(os.Getpid())} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("message = %q, want it to name the pid %s it refused to signal", err.Error(), want)
+		}
+	}
+}
+
+// unusedPort returns a port nothing is listening on, so the health probe in
+// StopServer resolves to "nothing there" rather than finding an unrelated
+// server — the mistake my own first live check made, where the probe answered
+// about this box's dev server on 7777.
+func unusedPort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	_, portStr, _ := net.SplitHostPort(ln.Addr().String())
+	port, _ := strconv.Atoi(portStr)
+	if err := ln.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	return port
 }


### PR DESCRIPTION
Fixes BUG-2969.

**Measured on the merged binary before this change:** a `sleep 600` whose pid had been written into the PID file was SIGTERMed, and `stop` printed `Server stopped.` No pad server was running anywhere near that config.

Three things had to be true at once. `os.FindProcess` succeeds for **any** pid on Unix; nothing asked whether the pid belonged to a pad server; and the confirmation loop polled the **port**, which is unhealthy from the first poll when nothing was ever serving — so **the success check was satisfied by the failure case**.

Liveness is the wrong question, and it is the trap the obvious fix falls into: the stranger *was* alive. The question is whether the pid is **ours**.

## The discriminator

**Unix** takes an advisory `flock` on the PID file, held for the server's lifetime. `stop` probes it non-blockingly: acquiring proves nobody holds the file, so the record is stale whatever the pid now names; failing to acquire proves a live pad server holds *this file*. One implementation for Linux and macOS, no new dependency, same primitive `session_lock_unix.go` has used since TASK-2767.

**Windows** compares the process creation time from `GetProcessTimes` against the one recorded at start — the attribute that survives pid reuse.

The lead first ruled start-time comparison on every platform; I objected with the cost (three implementations — `/proc`, a macOS sysctl promoting `x/sys` to a direct dependency, `GetProcessTimes`) and the ruling changed to this hybrid. The cost table is on the item so the next reader sees why the shape moved.

The PID file gains a fingerprint on both platforms — pid, start time, executable path, as JSON — with the legacy bare-integer form still parsed. A legacy record carries no proof, which reads as **unprovable**, and unprovable means nothing is signalled.

## Three races, each found by codex, each the same shape

1. **Read and ownership-check were separate steps.** A successor claiming between them made the lock report "held" — truthfully, about the successor — while the pid handed back was the predecessor's. `pidFileOwner` now returns the record it read from the descriptor it probed.
2. **Removing the file after a successful stop** could delete a fast successor's live record. It no longer removes there at all: the server removes its own on the way down, and a file left by a crash is handled by the next stop.
3. **Removing a stale file after the probe released the lock** had the same window. That removal now happens *inside* the ownership check while the lock is held — the only moment at which no replacement can have claimed the path. A claim arriving in that instant retries for half a second rather than losing its claim for the life of the process.

Windows deliberately does **not** delete a stale file: with no atomic primitive, check-then-remove races a successor, and a stale file the next start overwrites is recoverable where a wrongly deleted record is not.

## Evidence

- **Negative control, and it is literal:** with the ownership check bypassed, `go test` reports `signal: terminated` — the test binary is SIGTERMed by the code under test, because the stale record names the test process itself.
- **Live, in throwaway HOMEs:** a stale record naming a live `sleep` is refused and the sleep survives (it was killed before this change); a stale record with a **healthy port answering** is still refused, nothing signalled, stranger and real server both survive; a server stopped through its own held record stops and its file is gone.
- The **windows-latest smoke now stops the server with `pad server stop`** instead of `Stop-Process` — that is the only place the Windows ownership check runs, and a smoke that killed the process directly would leave `GetProcessTimes` unexercised on every platform.
- `make lint` 0 issues, `make test` green, codex CLEAN in round 4.

**go.mod:** `golang.org/x/sys` moves from indirect to direct (same version, no new module), so the vendor content is unchanged and `nix/package.nix`'s `vendorHash` should not move — the Nix job is the check on that.

https://claude.ai/code/session_01HeChkgZVYb3NTgTcckF5KR
