### PR TITLE
fix(attachments): a HEIC embed is decided by what can be served and painted, not by an image/ prefix (BUG-2964)

### DIFF
--- a/internal/server/handlers_attachments.go
+++ b/internal/server/handlers_attachments.go
@@ -781,6 +781,46 @@ func (s *Server) handleGetAttachment(w http.ResponseWriter, r *http.Request) {
 	// original. The editor uses thumbnails as an optimization, not a
 	// correctness requirement, so falling back keeps every render path
 	// working as soon as TASK-872 ships.
+	// WHICH variant the caller actually got. The fallback above is SILENT by
+	// design, and until BUG-2964 nothing on the wire distinguished "here is
+	// your thumbnail" from "here is the original, because this build could not
+	// derive one" — a pure-Go build derives no HEIC/AVIF thumbnail, so the
+	// editor was handing the browser HEIC bytes it cannot decode and rendering
+	// a broken image. The embed decision needs the answer per attachment, and
+	// the editor's metadata path is already a HEAD against this endpoint, so a
+	// response header reaches it with no extra request and no per-row lookup on
+	// the list endpoint.
+	servedVariant := models.AttachmentVariantOriginal
+	// Which derived variants EXIST, answered only on the no-variant path.
+	// That path is the editor's metadata HEAD (and plain downloads); the hot
+	// `?variant=thumb-md` image path is untouched and pays nothing. Two indexed
+	// point lookups on a cold path, rather than a new column or a per-row join
+	// on the list endpoint.
+	//
+	// A SENTINEL rather than an empty value for "none": an empty header value is
+	// the one thing a proxy may drop, and the client must be able to tell "this
+	// build says there are none" from "this build predates BUG-2964" — the
+	// second must keep the old MIME-prefix behaviour, or every embed flips to a
+	// chip when talking to an older server.
+	derived := ""
+	if r.URL.Query().Get("variant") == "" {
+		var present []string
+		for _, v := range []string{models.AttachmentVariantThumbSm, models.AttachmentVariantThumbMd} {
+			row, dErr := s.store.GetAttachmentVariant(workspaceID, att.ID, v)
+			if dErr != nil {
+				writeInternalError(w, dErr)
+				return
+			}
+			if row != nil {
+				present = append(present, v)
+			}
+		}
+		if len(present) == 0 {
+			derived = "none"
+		} else {
+			derived = strings.Join(present, ",")
+		}
+	}
 	if variant := r.URL.Query().Get("variant"); variant != "" {
 		if !isKnownVariant(variant) {
 			writeError(w, http.StatusBadRequest, "bad_variant",
@@ -797,6 +837,7 @@ func (s *Server) handleGetAttachment(w http.ResponseWriter, r *http.Request) {
 			return
 		} else if derived != nil {
 			att = derived
+			servedVariant = variant
 		}
 	}
 
@@ -854,6 +895,14 @@ func (s *Server) handleGetAttachment(w http.ResponseWriter, r *http.Request) {
 	// revocation (PLAN-2391 DR-10).
 	w.Header().Set("Cache-Control", "private, max-age=3600")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
+	// Names the variant these BYTES are, not the one that was asked for
+	// (BUG-2964). Set on every response including the no-variant case, so its
+	// ABSENCE means an older build rather than "the original" — a client that
+	// cannot tell those apart would flip every embed on an old server.
+	w.Header().Set("X-Pad-Attachment-Variant", servedVariant)
+	if derived != "" {
+		w.Header().Set("X-Pad-Attachment-Derived", derived)
+	}
 	w.Header().Set("Content-Disposition",
 		fmt.Sprintf(`%s; filename=%q`, disposition, sanitizeHeaderFilename(att.Filename)))
 

--- a/internal/server/handlers_attachments_variant_headers_test.go
+++ b/internal/server/handlers_attachments_variant_headers_test.go
@@ -1,0 +1,106 @@
+package server
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// BUG-2964 — the byte endpoint must SAY which variant it served and whether any
+// derived variant exists.
+//
+// The fallback at the top of the variant block is silent by design: asking for
+// `thumb-md` when no such row exists serves the ORIGINAL and returns 200. That
+// is correct for bytes and useless for the caller, because "here is your
+// thumbnail" and "here is the original, this build could derive nothing" were
+// indistinguishable on the wire. A pure-Go build derives no HEIC thumbnail, so
+// the editor embedded an <img> pointed at HEIC bytes and Chrome/Firefox drew
+// the broken-image icon.
+//
+// These legs pin the two headers the embed decision reads. They reuse
+// mimeDispoFixture / seedStoredRow / serveAttachment from
+// handlers_attachments_download_mime_test.go — same package, same shapes.
+
+func TestDownloadAttachment_ServedVariantHeader(t *testing.T) {
+	srv, slug, wsID, itemID := mimeDispoFixture(t)
+	orig := seedStoredRow(t, srv, wsID, itemID, "image/png", "shot.png", []byte("PNGBYTES"), "", "")
+
+	t.Run("no variant requested names the original", func(t *testing.T) {
+		rr := serveAttachment(t, srv, slug, orig, "GET", "")
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+		}
+		if got := rr.Header().Get("X-Pad-Attachment-Variant"); got != models.AttachmentVariantOriginal {
+			t.Errorf("X-Pad-Attachment-Variant = %q, want %q", got, models.AttachmentVariantOriginal)
+		}
+	})
+
+	t.Run("a variant that does NOT exist still names the ORIGINAL, because that is what the bytes are", func(t *testing.T) {
+		// The whole defect in one assertion: the status is 200 and the body is
+		// the original. Naming the REQUESTED variant here would be a lie that
+		// reintroduces the bug at a different layer.
+		rr := serveAttachment(t, srv, slug, orig, "GET", models.AttachmentVariantThumbMd)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", rr.Code)
+		}
+		if got := rr.Header().Get("X-Pad-Attachment-Variant"); got != models.AttachmentVariantOriginal {
+			t.Errorf("X-Pad-Attachment-Variant = %q, want %q (the fallback served the original)",
+				got, models.AttachmentVariantOriginal)
+		}
+	})
+
+	t.Run("a variant that DOES exist is named", func(t *testing.T) {
+		seedStoredRow(t, srv, wsID, itemID, "image/jpeg", "shot-md.jpg",
+			[]byte("JPEGBYTES"), orig, models.AttachmentVariantThumbMd)
+		rr := serveAttachment(t, srv, slug, orig, "GET", models.AttachmentVariantThumbMd)
+		if got := rr.Header().Get("X-Pad-Attachment-Variant"); got != models.AttachmentVariantThumbMd {
+			t.Errorf("X-Pad-Attachment-Variant = %q, want %q", got, models.AttachmentVariantThumbMd)
+		}
+	})
+}
+
+func TestDownloadAttachment_DerivedHeader(t *testing.T) {
+	t.Run("none when this build derived nothing", func(t *testing.T) {
+		srv, slug, wsID, itemID := mimeDispoFixture(t)
+		// A HEIC on a build whose processor cannot decode it: the row exists,
+		// no variant rows were ever written. This is the state the bug lives in.
+		heic := seedStoredRow(t, srv, wsID, itemID, "image/heic", "beach.heic", []byte("HEICBYTES"), "", "")
+
+		rr := serveAttachment(t, srv, slug, heic, "HEAD", "")
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", rr.Code)
+		}
+		// A SENTINEL, not an empty value: absence must keep meaning "server
+		// predates BUG-2964", because a client that reads absence as "no
+		// variants" would turn every embed into a chip against an older build.
+		if got := rr.Header().Get("X-Pad-Attachment-Derived"); got != "none" {
+			t.Errorf("X-Pad-Attachment-Derived = %q, want %q", got, "none")
+		}
+	})
+
+	t.Run("lists the variants that exist", func(t *testing.T) {
+		srv, slug, wsID, itemID := mimeDispoFixture(t)
+		orig := seedStoredRow(t, srv, wsID, itemID, "image/png", "shot.png", []byte("PNGBYTES"), "", "")
+		seedStoredRow(t, srv, wsID, itemID, "image/jpeg", "sm.jpg", []byte("SM"), orig, models.AttachmentVariantThumbSm)
+		seedStoredRow(t, srv, wsID, itemID, "image/jpeg", "md.jpg", []byte("MD"), orig, models.AttachmentVariantThumbMd)
+
+		rr := serveAttachment(t, srv, slug, orig, "HEAD", "")
+		if got := rr.Header().Get("X-Pad-Attachment-Derived"); got != "thumb-sm,thumb-md" {
+			t.Errorf("X-Pad-Attachment-Derived = %q, want %q", got, "thumb-sm,thumb-md")
+		}
+	})
+
+	t.Run("absent on the variant path, which does not answer this question", func(t *testing.T) {
+		// The availability lookup is deliberately confined to the no-variant
+		// path — the editor's metadata probe. The hot `?variant=thumb-md` image
+		// path pays nothing, and a header there would be answering a question
+		// nobody asked at the cost of two queries per image byte-serve.
+		srv, slug, wsID, itemID := mimeDispoFixture(t)
+		orig := seedStoredRow(t, srv, wsID, itemID, "image/png", "shot.png", []byte("PNGBYTES"), "", "")
+		rr := serveAttachment(t, srv, slug, orig, "GET", models.AttachmentVariantThumbMd)
+		if got := rr.Header().Get("X-Pad-Attachment-Derived"); got != "" {
+			t.Errorf("X-Pad-Attachment-Derived = %q on the variant path, want it unset", got)
+		}
+	})
+}

--- a/internal/server/handlers_capabilities.go
+++ b/internal/server/handlers_capabilities.go
@@ -28,6 +28,38 @@ type serverCapabilities struct {
 	CollectionResolution bool `json:"collection_resolution"`
 }
 
+// WHAT A BUILD THAT CANNOT DECODE A FORMAT ACTUALLY COSTS THE READER
+// (BUG-2964, documented here because this endpoint is where a client asks what
+// this build can do).
+//
+// `Image.ImageFormats` is not only about the rotate/crop affordances. Thumbnail
+// derivation uses the same processor, so a format absent from that list gets NO
+// derived variant on this build — and the pure-Go processor decodes PNG, JPEG,
+// GIF, BMP and TIFF, while HEIC and AVIF need the libvips build. Three
+// consequences follow, and they differ by surface:
+//
+//   - IN THE EDITOR, a HEIC attachment is embedded as a downloadable file chip
+//     rather than an <img>. The byte endpoint falls back to the original when
+//     the variant row is missing, and Chrome and Firefox decode neither HEIC nor
+//     HEIF, so an <img> would render the broken-image icon. AVIF stays an image:
+//     it has no derived variant here either, but browsers decode it. The client
+//     reads `X-Pad-Attachment-Derived` from the byte endpoint to tell these
+//     apart per attachment — see web/src/lib/markdown/attachments.ts.
+//   - ON PUBLIC SHARE LINKS, a HEIC attachment is unreachable: the share read
+//     path serves VARIANTS ONLY and answers 404 when the variant row is missing.
+//     That is deliberate and stays. The variant pipeline is the privacy
+//     boundary — a stripped, normalized derivative rather than the uploader's
+//     original with its EXIF/GPS intact — so serving the original to an
+//     anonymous viewer to fix a rendering complaint would trade a broken image
+//     for a location leak. The correct refusal, and the wrong outcome for the
+//     reader; the fix is to run the libvips build.
+//   - PAD CLOUD IS UNAFFECTED. It runs libvips, derives HEIC thumbnails as
+//     JPEG, and every surface above gets a decodable variant.
+//
+// Uploads of these formats are ACCEPTED regardless (BUG-2961): the allowlist is
+// not build-dependent, Safari decodes HEIC, and refusing at the door would take
+// a working format away from those users to spare others a chip.
+//
 // handleServerCapabilities reports what this build can do to the editor.
 // Accessible without auth — the editor needs to know whether to gate
 // rotate/crop UI before the user even logs in (e.g. on the share page,

--- a/internal/server/render/attachments.go
+++ b/internal/server/render/attachments.go
@@ -28,12 +28,23 @@ type AttachmentMeta struct {
 	SizeBytes int64
 	Width     *int
 	Height    *int
-	// DerivedVariant reports whether the server holds a derived (thumbnail)
-	// variant for this attachment (BUG-2964). Three-valued via the pointer, and
-	// the third value carries meaning: nil means UNKNOWN — a caller that did not
-	// look — and falls back to the pre-BUG-2964 MIME-prefix behaviour. The TS
-	// mirror is `AttachmentMeta.derived_variant?: boolean | undefined`.
-	DerivedVariant *bool
+	// DerivedVariants names the derived (thumbnail) variants the server holds
+	// for this attachment (BUG-2964), e.g. ["thumb-sm","thumb-md"].
+	//
+	// PER-VARIANT, NOT A BOOLEAN, and codex round 1 is why: derivation writes
+	// each variant independently, so "some thumbnail exists" does not mean the
+	// one this render will REQUEST exists. If only thumb-sm were present and the
+	// render asked for thumb-md, a boolean would say "image", the endpoint would
+	// fall back to the undecodable original, and the broken image would be back
+	// with an extra layer of machinery in front of it.
+	//
+	// DerivedKnown separates "the server said none" from "nobody looked" without
+	// a nil-versus-empty-slice subtlety: false means UNKNOWN and falls back to
+	// the pre-BUG-2964 MIME-prefix behaviour. The TS mirror is
+	// `AttachmentMeta.derived_variants?: string[] | undefined`, where undefined
+	// is the same third state.
+	DerivedVariants []string
+	DerivedKnown    bool
 }
 
 // AttachmentResolver looks up an attachment by UUID. Returns nil for
@@ -93,6 +104,12 @@ func IsImageMime(mime string) bool {
 // derives no thumbnail for it. image/svg+xml IS present: an SVG in an <img>
 // runs no script, and it has been embedded that way in existing documents
 // since attachments shipped.
+// imageRenderVariant is the variant this renderer puts in an <img> src. Named
+// once so the embed DECISION and the URL it produces cannot disagree about
+// which variant is being asked for — the exact disagreement codex round 1 found
+// between a boolean availability flag and a specific request.
+const imageRenderVariant = "thumb-md"
+
 var imgPaintableMimes = map[string]bool{
 	"image/png":     true,
 	"image/jpeg":    true,
@@ -104,9 +121,14 @@ var imgPaintableMimes = map[string]bool{
 
 // ShouldEmbedAsImage decides <img> vs file chip (BUG-2964).
 //
-// THE RULE IS A DISJUNCTION: embed as <img> iff a derived variant exists (the
-// server can serve decodable bytes) OR the browser paints the original (no
-// derivative needed).
+// THE RULE IS A DISJUNCTION: embed as <img> iff THE VARIANT THIS RENDER WILL
+// REQUEST exists (the server can serve decodable bytes) OR the browser paints
+// the original (no derivative needed).
+//
+// `wantVariant` is the variant the caller is about to put in the URL, and it
+// must be the same one — asking about a variant you will not request answers a
+// question nobody has (codex round 1). An empty wantVariant means the render
+// points at the original, so only the paintable half can carry it.
 //
 // Not a MIME prefix test, because a pure-Go build derives no HEIC thumbnail and
 // the byte endpoint falls back to the ORIGINAL when the variant row is missing —
@@ -114,13 +136,20 @@ var imgPaintableMimes = map[string]bool{
 // variant availability alone either, because that same build derives no AVIF
 // thumbnail and every current browser decodes AVIF.
 //
-// A nil DerivedVariant means unknown and falls back to the prefix test.
-func ShouldEmbedAsImage(meta *AttachmentMeta) bool {
+// DerivedKnown false means unknown and falls back to the prefix test.
+func ShouldEmbedAsImage(meta *AttachmentMeta, wantVariant string) bool {
 	if meta == nil || !IsImageMime(meta.MimeType) {
 		return false
 	}
-	if meta.DerivedVariant == nil || *meta.DerivedVariant {
+	if !meta.DerivedKnown {
 		return true
+	}
+	if wantVariant != "" {
+		for _, v := range meta.DerivedVariants {
+			if v == wantVariant {
+				return true
+			}
+		}
 	}
 	mime := strings.ToLower(strings.TrimSpace(meta.MimeType))
 	if i := strings.IndexByte(mime, ';'); i >= 0 {
@@ -167,7 +196,7 @@ func RenderAttachmentImage(meta *AttachmentMeta, alt, workspaceSlug string) stri
 	if meta == nil {
 		return ""
 	}
-	src := AttachmentDownloadURL(workspaceSlug, meta.ID, "thumb-md")
+	src := AttachmentDownloadURL(workspaceSlug, meta.ID, imageRenderVariant)
 	altText := alt
 	if strings.TrimSpace(altText) == "" {
 		altText = meta.Filename
@@ -245,7 +274,7 @@ func ResolveAttachmentImage(href, alt, workspaceSlug string, resolve AttachmentR
 	if meta == nil {
 		return RenderAttachmentMissing(uuid, alt)
 	}
-	if ShouldEmbedAsImage(meta) {
+	if ShouldEmbedAsImage(meta, imageRenderVariant) {
 		return RenderAttachmentImage(meta, alt, workspaceSlug)
 	}
 	chipText := alt

--- a/internal/server/render/attachments.go
+++ b/internal/server/render/attachments.go
@@ -28,6 +28,12 @@ type AttachmentMeta struct {
 	SizeBytes int64
 	Width     *int
 	Height    *int
+	// DerivedVariant reports whether the server holds a derived (thumbnail)
+	// variant for this attachment (BUG-2964). Three-valued via the pointer, and
+	// the third value carries meaning: nil means UNKNOWN — a caller that did not
+	// look — and falls back to the pre-BUG-2964 MIME-prefix behaviour. The TS
+	// mirror is `AttachmentMeta.derived_variant?: boolean | undefined`.
+	DerivedVariant *bool
 }
 
 // AttachmentResolver looks up an attachment by UUID. Returns nil for
@@ -68,11 +74,59 @@ func AttachmentDownloadURL(workspaceSlug, attachmentID, variant string) string {
 	return base + "?variant=" + url.QueryEscape(variant)
 }
 
-// IsImageMime reports whether the MIME type renders inline as an image.
+// IsImageMime reports whether the MIME type is LABELLED as an image.
 // Mirrors `image/*` from the server-side allowlist (image/png, image/jpeg,
 // image/gif, image/webp, image/avif, image/heic, image/heif).
+//
+// No longer the embed decision on its own — see ShouldEmbedAsImage.
 func IsImageMime(mime string) bool {
 	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(mime)), "image/")
+}
+
+// imgPaintableMimes are the types a BROWSER paints inside an <img> tag
+// (BUG-2964). Byte-for-byte mirror of IMG_PAINTABLE_MIMES in
+// web/src/lib/markdown/attachments.ts; a test asserts the two agree.
+//
+// HEIC/HEIF are absent deliberately: Chrome and Firefox decode neither, so an
+// <img> pointed at HEIC bytes shows the broken-image icon. AVIF IS present —
+// browsers decode it — which is why AVIF stays an image even on a build that
+// derives no thumbnail for it. image/svg+xml IS present: an SVG in an <img>
+// runs no script, and it has been embedded that way in existing documents
+// since attachments shipped.
+var imgPaintableMimes = map[string]bool{
+	"image/png":     true,
+	"image/jpeg":    true,
+	"image/gif":     true,
+	"image/webp":    true,
+	"image/avif":    true,
+	"image/svg+xml": true,
+}
+
+// ShouldEmbedAsImage decides <img> vs file chip (BUG-2964).
+//
+// THE RULE IS A DISJUNCTION: embed as <img> iff a derived variant exists (the
+// server can serve decodable bytes) OR the browser paints the original (no
+// derivative needed).
+//
+// Not a MIME prefix test, because a pure-Go build derives no HEIC thumbnail and
+// the byte endpoint falls back to the ORIGINAL when the variant row is missing —
+// so image/heic produced an <img> full of bytes the browser cannot decode. Not
+// variant availability alone either, because that same build derives no AVIF
+// thumbnail and every current browser decodes AVIF.
+//
+// A nil DerivedVariant means unknown and falls back to the prefix test.
+func ShouldEmbedAsImage(meta *AttachmentMeta) bool {
+	if meta == nil || !IsImageMime(meta.MimeType) {
+		return false
+	}
+	if meta.DerivedVariant == nil || *meta.DerivedVariant {
+		return true
+	}
+	mime := strings.ToLower(strings.TrimSpace(meta.MimeType))
+	if i := strings.IndexByte(mime, ';'); i >= 0 {
+		mime = strings.TrimSpace(mime[:i])
+	}
+	return imgPaintableMimes[mime]
 }
 
 // FormatAttachmentSize returns a human-readable byte count ("832 B",
@@ -191,7 +245,7 @@ func ResolveAttachmentImage(href, alt, workspaceSlug string, resolve AttachmentR
 	if meta == nil {
 		return RenderAttachmentMissing(uuid, alt)
 	}
-	if IsImageMime(meta.MimeType) {
+	if ShouldEmbedAsImage(meta) {
 		return RenderAttachmentImage(meta, alt, workspaceSlug)
 	}
 	chipText := alt

--- a/internal/server/render/attachments_embed_test.go
+++ b/internal/server/render/attachments_embed_test.go
@@ -1,0 +1,121 @@
+package render
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// BUG-2964 — <img> vs file chip is decided by what can actually be SERVED and
+// PAINTED, not by a `image/` MIME prefix.
+//
+// The defect: a pure-Go build derives no HEIC thumbnail, and the byte endpoint
+// SILENTLY serves the original when the variant row is missing, so a prefix
+// test produced an <img> full of bytes Chrome and Firefox cannot decode.
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestShouldEmbedAsImage(t *testing.T) {
+	cases := []struct {
+		name    string
+		mime    string
+		derived *bool
+		want    bool
+	}{
+		// The defect itself.
+		{"heic with no derived variant is a chip", "image/heic", boolPtr(false), false},
+		{"heif with no derived variant is a chip", "image/heif", boolPtr(false), false},
+		{"heic WITH a derived variant stays an image", "image/heic", boolPtr(true), true},
+
+		// CONTROL. Fails if the rule is collapsed to variant availability
+		// alone — the tempting simplification, and wrong, because the same
+		// pure-Go build derives no AVIF thumbnail and every current browser
+		// decodes AVIF.
+		{"CONTROL avif with no derived variant stays an image", "image/avif", boolPtr(false), true},
+		// CONTROL. SVG is kept out of the in-app viewer for ACTIVE-CONTENT
+		// reasons; an SVG inside an <img> runs no script. Reusing the viewer's
+		// predicate here would turn every existing SVG embed into a chip.
+		{"CONTROL svg with no derived variant stays an image", "image/svg+xml", boolPtr(false), true},
+
+		{"png", "image/png", boolPtr(false), true},
+		{"jpeg", "image/jpeg", boolPtr(false), true},
+		{"gif", "image/gif", boolPtr(false), true},
+		{"webp", "image/webp", boolPtr(false), true},
+
+		{"pdf is never an image", "application/pdf", boolPtr(true), false},
+		{"mime parameters do not defeat the match", "image/svg+xml; charset=utf-8", boolPtr(false), true},
+		{"mime parameters do not defeat the refusal", "image/heic; foo=bar", boolPtr(false), false},
+
+		// UNKNOWN is not FALSE. nil means the caller did not look; falling back
+		// to the prefix rule is what keeps an unprobed render identical to its
+		// pre-BUG-2964 output.
+		{"unknown heic falls back to the prefix rule", "image/heic", nil, true},
+		{"unknown png falls back to the prefix rule", "image/png", nil, true},
+		{"unknown pdf is still not an image", "application/pdf", nil, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ShouldEmbedAsImage(&AttachmentMeta{MimeType: tc.mime, DerivedVariant: tc.derived})
+			if got != tc.want {
+				t.Errorf("ShouldEmbedAsImage(%q, derived=%v) = %v, want %v",
+					tc.mime, tc.derived, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestShouldEmbedAsImage_NilMeta(t *testing.T) {
+	if ShouldEmbedAsImage(nil) {
+		t.Error("ShouldEmbedAsImage(nil) = true, want false")
+	}
+}
+
+// TestImgPaintableMimes_MatchesTypeScript enforces the lock-step this file's
+// header requires, rather than asserting it in a comment (which protects
+// nobody). The Go renderer and the TS renderer must produce byte-identical
+// output for the same input, so the two paintable lists have to be the same
+// list — and a divergence would show up as server-rendered and client-rendered
+// markdown disagreeing about whether a given attachment is an image, which is
+// exactly the class of bug nobody notices until a reader reports it.
+//
+// Reads the TS source rather than a generated artifact so it fails on the edit
+// that causes the drift, in the tree where that edit was made.
+func TestImgPaintableMimes_MatchesTypeScript(t *testing.T) {
+	// internal/server/render -> repo root
+	tsPath := filepath.Join("..", "..", "..", "web", "src", "lib", "markdown", "attachments.ts")
+	src, err := os.ReadFile(tsPath)
+	if err != nil {
+		t.Fatalf("read TS renderer at %s: %v", tsPath, err)
+	}
+
+	block := regexp.MustCompile(`(?s)const IMG_PAINTABLE_MIMES:[^=]*=\s*new Set\(\[(.*?)\]\)`).
+		FindSubmatch(src)
+	if block == nil {
+		t.Fatalf("could not find IMG_PAINTABLE_MIMES in %s — if it was renamed, "+
+			"update this test rather than deleting it; the lock-step is the point", tsPath)
+	}
+
+	var fromTS []string
+	for _, m := range regexp.MustCompile(`'([^']+)'`).FindAllSubmatch(block[1], -1) {
+		fromTS = append(fromTS, string(m[1]))
+	}
+	if len(fromTS) == 0 {
+		t.Fatal("parsed IMG_PAINTABLE_MIMES but found no entries — the regex is wrong, " +
+			"and an empty list would pass vacuously if compared to an empty Go map")
+	}
+
+	var fromGo []string
+	for mime := range imgPaintableMimes {
+		fromGo = append(fromGo, mime)
+	}
+	sort.Strings(fromTS)
+	sort.Strings(fromGo)
+
+	if strings.Join(fromTS, ",") != strings.Join(fromGo, ",") {
+		t.Errorf("paintable MIME lists have drifted:\n  TS: %v\n  Go: %v", fromTS, fromGo)
+	}
+}

--- a/internal/server/render/attachments_embed_test.go
+++ b/internal/server/render/attachments_embed_test.go
@@ -16,61 +16,64 @@ import (
 // SILENTLY serves the original when the variant row is missing, so a prefix
 // test produced an <img> full of bytes Chrome and Firefox cannot decode.
 
-func boolPtr(b bool) *bool { return &b }
-
 func TestShouldEmbedAsImage(t *testing.T) {
 	cases := []struct {
 		name    string
 		mime    string
-		derived *bool
+		derived []string
+		known   bool
 		want    bool
 	}{
 		// The defect itself.
-		{"heic with no derived variant is a chip", "image/heic", boolPtr(false), false},
-		{"heif with no derived variant is a chip", "image/heif", boolPtr(false), false},
-		{"heic WITH a derived variant stays an image", "image/heic", boolPtr(true), true},
+		{"heic with no derived variant is a chip", "image/heic", nil, true, false},
+		{"heif with no derived variant is a chip", "image/heif", nil, true, false},
+		{"heic WITH a derived variant stays an image", "image/heic", []string{"thumb-md"}, true, true},
 
 		// CONTROL. Fails if the rule is collapsed to variant availability
 		// alone — the tempting simplification, and wrong, because the same
 		// pure-Go build derives no AVIF thumbnail and every current browser
 		// decodes AVIF.
-		{"CONTROL avif with no derived variant stays an image", "image/avif", boolPtr(false), true},
+		{"CONTROL avif with no derived variant stays an image", "image/avif", nil, true, true},
 		// CONTROL. SVG is kept out of the in-app viewer for ACTIVE-CONTENT
 		// reasons; an SVG inside an <img> runs no script. Reusing the viewer's
 		// predicate here would turn every existing SVG embed into a chip.
-		{"CONTROL svg with no derived variant stays an image", "image/svg+xml", boolPtr(false), true},
+		{"CONTROL svg with no derived variant stays an image", "image/svg+xml", nil, true, true},
 
-		{"png", "image/png", boolPtr(false), true},
-		{"jpeg", "image/jpeg", boolPtr(false), true},
-		{"gif", "image/gif", boolPtr(false), true},
-		{"webp", "image/webp", boolPtr(false), true},
+		{"png", "image/png", nil, true, true},
+		{"jpeg", "image/jpeg", nil, true, true},
+		{"gif", "image/gif", nil, true, true},
+		{"webp", "image/webp", nil, true, true},
 
-		{"pdf is never an image", "application/pdf", boolPtr(true), false},
-		{"mime parameters do not defeat the match", "image/svg+xml; charset=utf-8", boolPtr(false), true},
-		{"mime parameters do not defeat the refusal", "image/heic; foo=bar", boolPtr(false), false},
+		{"pdf is never an image", "application/pdf", []string{"thumb-md"}, true, false},
+		{"mime parameters do not defeat the match", "image/svg+xml; charset=utf-8", nil, true, true},
+		{"mime parameters do not defeat the refusal", "image/heic; foo=bar", nil, true, false},
 
 		// UNKNOWN is not FALSE. nil means the caller did not look; falling back
 		// to the prefix rule is what keeps an unprobed render identical to its
 		// pre-BUG-2964 output.
-		{"unknown heic falls back to the prefix rule", "image/heic", nil, true},
-		{"unknown png falls back to the prefix rule", "image/png", nil, true},
-		{"unknown pdf is still not an image", "application/pdf", nil, false},
+		{"unknown heic falls back to the prefix rule", "image/heic", nil, false, true},
+		{"unknown png falls back to the prefix rule", "image/png", nil, false, true},
+		{"unknown pdf is still not an image", "application/pdf", nil, false, false},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := ShouldEmbedAsImage(&AttachmentMeta{MimeType: tc.mime, DerivedVariant: tc.derived})
+			got := ShouldEmbedAsImage(&AttachmentMeta{
+				MimeType:        tc.mime,
+				DerivedVariants: tc.derived,
+				DerivedKnown:    tc.known,
+			}, "thumb-md")
 			if got != tc.want {
-				t.Errorf("ShouldEmbedAsImage(%q, derived=%v) = %v, want %v",
-					tc.mime, tc.derived, got, tc.want)
+				t.Errorf("ShouldEmbedAsImage(%q, derived=%v known=%v) = %v, want %v",
+					tc.mime, tc.derived, tc.known, got, tc.want)
 			}
 		})
 	}
 }
 
 func TestShouldEmbedAsImage_NilMeta(t *testing.T) {
-	if ShouldEmbedAsImage(nil) {
-		t.Error("ShouldEmbedAsImage(nil) = true, want false")
+	if ShouldEmbedAsImage(nil, "thumb-md") {
+		t.Error("ShouldEmbedAsImage(nil, …) = true, want false")
 	}
 }
 
@@ -117,5 +120,52 @@ func TestImgPaintableMimes_MatchesTypeScript(t *testing.T) {
 
 	if strings.Join(fromTS, ",") != strings.Join(fromGo, ",") {
 		t.Errorf("paintable MIME lists have drifted:\n  TS: %v\n  Go: %v", fromTS, fromGo)
+	}
+}
+
+// TestShouldEmbedAsImage_RequestedVariant — codex round 1.
+//
+// The question is about THE VARIANT THIS RENDER WILL REQUEST, not about whether
+// any thumbnail exists. Derivation writes thumb-sm and thumb-md independently,
+// so a partial derivation leaves one present and the other absent. A boolean
+// "has a thumbnail" flag answers the wrong question: it says image, the render
+// asks for the missing variant, the endpoint falls back to the undecodable
+// original, and the broken image is back — behind machinery that looks like it
+// should have prevented exactly this.
+func TestShouldEmbedAsImage_RequestedVariant(t *testing.T) {
+	heic := func(have ...string) *AttachmentMeta {
+		return &AttachmentMeta{MimeType: "image/heic", DerivedVariants: have, DerivedKnown: true}
+	}
+
+	if ShouldEmbedAsImage(heic("thumb-sm"), "thumb-md") {
+		t.Error("only thumb-sm exists but a thumb-md render was called an image")
+	}
+	if ShouldEmbedAsImage(heic("thumb-md"), "thumb-sm") {
+		t.Error("only thumb-md exists but a thumb-sm render was called an image")
+	}
+	if !ShouldEmbedAsImage(heic("thumb-sm"), "thumb-sm") {
+		t.Error("a render satisfied by its own variant was called a chip")
+	}
+	if !ShouldEmbedAsImage(heic("thumb-sm", "thumb-md"), "thumb-md") {
+		t.Error("both variants present but the thumb-md render was called a chip")
+	}
+	// An ORIGINAL-pointed render cannot be carried by a variant existing: the
+	// browser gets the uploader's bytes, so only the paintable half can carry it.
+	if ShouldEmbedAsImage(heic("thumb-sm", "thumb-md"), "") {
+		t.Error("an original-pointed HEIC render was called an image")
+	}
+	png := &AttachmentMeta{MimeType: "image/png", DerivedVariants: nil, DerivedKnown: true}
+	if !ShouldEmbedAsImage(png, "") {
+		t.Error("an original-pointed PNG render was called a chip")
+	}
+}
+
+// TestRenderAttachmentImage_UsesTheDecidedVariant pins the coupling that made
+// the round-1 finding possible in the first place: the variant the decision asks
+// about and the variant the URL requests are the same constant.
+func TestRenderAttachmentImage_UsesTheDecidedVariant(t *testing.T) {
+	html := RenderAttachmentImage(&AttachmentMeta{ID: "a1", MimeType: "image/png"}, "alt", "ws")
+	if !strings.Contains(html, "variant="+imageRenderVariant) {
+		t.Errorf("rendered img does not request %q: %s", imageRenderVariant, html)
 	}
 }

--- a/web/src/lib/attachments/display.ts
+++ b/web/src/lib/attachments/display.ts
@@ -315,6 +315,48 @@ const BROWSER_PREVIEW_MIMES: ReadonlySet<string> = new Set([
 	'text/plain'
 ]);
 
+/**
+ * The types a BROWSER paints inside an `<img>` tag (BUG-2964).
+ *
+ * A FOURTH predicate, and it must not be collapsed into `canOpenInViewer`
+ * even though the two sets nearly coincide. They answer different questions
+ * and differ on exactly one entry:
+ *
+ *  - `canOpenInViewer` (DR-16) — may the IN-APP viewer open this? It excludes
+ *    `image/svg+xml` because SVG carries ACTIVE CONTENT and the viewer opens
+ *    it in a context where that matters.
+ *  - this one — will the browser PAINT this in an `<img>`? SVG in an `<img>`
+ *    runs no script, so the active-content reason does not apply, and SVG has
+ *    been embedded this way in existing documents since attachments shipped.
+ *    Collapsing the two would silently turn every existing SVG embed into a
+ *    file chip — a document-visible regression nothing asked for.
+ *
+ * HEIC/HEIF are absent for the reason that motivated BUG-2964: Chrome and
+ * Firefox decode neither (Safari decodes HEIC), so an `<img>` pointed at HEIC
+ * bytes renders the broken-image icon. AVIF IS here — browsers decode it —
+ * which is why AVIF stays an image even on a build that derives no thumbnail
+ * for it. `image/tiff` is likewise absent, and would be a chip if it were ever
+ * added to the upload allowlist.
+ */
+const IMG_PAINTABLE_MIMES: ReadonlySet<string> = new Set([
+	'image/png',
+	'image/jpeg',
+	'image/gif',
+	'image/webp',
+	'image/avif',
+	'image/svg+xml'
+]);
+
+/**
+ * Will a browser paint this MIME inside an `<img>`? (BUG-2964)
+ *
+ * NOT a synonym for `canOpenInViewer` — see IMG_PAINTABLE_MIMES above before
+ * "simplifying" one into the other.
+ */
+export function browserPaintsInImgTag(mime: string | null | undefined): boolean {
+	return IMG_PAINTABLE_MIMES.has(normalizeMime(mime));
+}
+
 /** May this MIME be opened in the in-app image viewer? (DR-16) */
 export function canOpenInViewer(mime: string | null | undefined): boolean {
 	return VIEWER_MIMES.has(normalizeMime(mime));

--- a/web/src/lib/attachments/events.test.ts
+++ b/web/src/lib/attachments/events.test.ts
@@ -445,7 +445,9 @@ describe('parent-restore channel (BUG-2509)', () => {
 			off();
 		}
 
-		expect(observed).toEqual({ status: 'ok', mime: 'image/png', size: 3 });
+		// `derived: 'unknown'` — this fixture sets no `x-pad-attachment-derived`
+		// header, which is the older-server case (BUG-2964).
+		expect(observed).toEqual({ status: 'ok', mime: 'image/png', size: 3, derived: 'unknown' });
 		expect(fetchMock).toHaveBeenCalledTimes(2);
 	});
 

--- a/web/src/lib/components/editor/attachment-metadata.test.ts
+++ b/web/src/lib/components/editor/attachment-metadata.test.ts
@@ -411,23 +411,23 @@ describe('mimeToFormat', () => {
  * against an older build — a far bigger change than the bug being fixed.
  */
 describe('fetchAttachmentMetadata — derived-variant header (BUG-2964)', () => {
-	it('true when the server lists derived variants', async () => {
+	it('the parsed list when the server names derived variants', async () => {
 		const uuid = freshUuid();
 		fetchMock.mockResolvedValue(
 			head(200, { 'content-type': 'image/heic', 'x-pad-attachment-derived': 'thumb-sm,thumb-md' })
 		);
 		const r = await fetchAttachmentMetadata('ws', uuid, url);
-		expect(r).toMatchObject({ status: 'ok', derived: true });
+		expect(r).toMatchObject({ status: 'ok', derived: ['thumb-sm', 'thumb-md'] });
 		invalidateAttachmentMetadata('ws', uuid);
 	});
 
-	it('false on the `none` SENTINEL', async () => {
+	it('an empty list on the `none` SENTINEL', async () => {
 		const uuid = freshUuid();
 		fetchMock.mockResolvedValue(
 			head(200, { 'content-type': 'image/heic', 'x-pad-attachment-derived': 'none' })
 		);
 		const r = await fetchAttachmentMetadata('ws', uuid, url);
-		expect(r).toMatchObject({ status: 'ok', derived: false });
+		expect(r).toMatchObject({ status: 'ok', derived: [] });
 		invalidateAttachmentMetadata('ws', uuid);
 	});
 
@@ -448,8 +448,8 @@ describe('fetchAttachmentMetadata — derived-variant header (BUG-2964)', () => 
 		const r = await fetchAttachmentMetadata('ws', uuid, url);
 		expect(r.status).toBe('ok');
 		if (r.status === 'ok') {
-			expect(r.derived).not.toBe(false);
-			expect(r.derived).not.toBe(true);
+			expect(r.derived).not.toEqual([]);
+			expect(Array.isArray(r.derived)).toBe(false);
 		}
 		invalidateAttachmentMetadata('ws', uuid);
 	});
@@ -461,7 +461,7 @@ describe('fetchAttachmentMetadata — derived-variant header (BUG-2964)', () => 
 			head(200, { 'content-type': 'image/heic', 'x-pad-attachment-derived': '' })
 		);
 		const r = await fetchAttachmentMetadata('ws', uuid, url);
-		expect(r).toMatchObject({ status: 'ok', derived: false });
+		expect(r).toMatchObject({ status: 'ok', derived: [] });
 		invalidateAttachmentMetadata('ws', uuid);
 	});
 });

--- a/web/src/lib/components/editor/attachment-metadata.test.ts
+++ b/web/src/lib/components/editor/attachment-metadata.test.ts
@@ -465,3 +465,64 @@ describe('fetchAttachmentMetadata — derived-variant header (BUG-2964)', () => 
 		invalidateAttachmentMetadata('ws', uuid);
 	});
 });
+
+/**
+ * BUG-2964, codex round 2 — `derived` is NOT a durable fact, and caching it as
+ * one latches a wrong answer.
+ *
+ * Thumbnail derivation runs asynchronously after upload. A probe issued in that
+ * window truthfully sees no variants; the old per-arm rule cached every `ok`
+ * for the page's lifetime, so on a build that CAN derive HEIC a freshly
+ * uploaded HEIC would render as a file chip until reload, with the thumbnail
+ * sitting on the server the whole time.
+ */
+describe('fetchAttachmentMetadata — an empty derived list is PROVISIONAL', () => {
+	it('re-probes after an empty list, and picks up variants that landed since', async () => {
+		const uuid = freshUuid();
+		fetchMock
+			.mockResolvedValueOnce(
+				head(200, { 'content-type': 'image/heic', 'x-pad-attachment-derived': 'none' })
+			)
+			.mockResolvedValueOnce(
+				head(200, {
+					'content-type': 'image/heic',
+					'x-pad-attachment-derived': 'thumb-sm,thumb-md'
+				})
+			);
+
+		const first = await fetchAttachmentMetadata('ws', uuid, url);
+		expect(first).toMatchObject({ status: 'ok', derived: [] });
+
+		// No invalidate call in between: the empty answer must not have been
+		// cached, so this reaches the server and sees the settled state.
+		const second = await fetchAttachmentMetadata('ws', uuid, url);
+		expect(second).toMatchObject({ status: 'ok', derived: ['thumb-sm', 'thumb-md'] });
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+
+		invalidateAttachmentMetadata('ws', uuid);
+	});
+
+	it('CONTROL — a NON-EMPTY list IS cached; variants are never un-derived', async () => {
+		const uuid = freshUuid();
+		fetchMock.mockResolvedValue(
+			head(200, { 'content-type': 'image/heic', 'x-pad-attachment-derived': 'thumb-md' })
+		);
+
+		await fetchAttachmentMetadata('ws', uuid, url);
+		await fetchAttachmentMetadata('ws', uuid, url);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+
+		invalidateAttachmentMetadata('ws', uuid);
+	});
+
+	it("CONTROL — 'unknown' IS cached; it is a fact about the SERVER, not the attachment", async () => {
+		const uuid = freshUuid();
+		fetchMock.mockResolvedValue(head(200, { 'content-type': 'image/png' }));
+
+		await fetchAttachmentMetadata('ws', uuid, url);
+		await fetchAttachmentMetadata('ws', uuid, url);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+
+		invalidateAttachmentMetadata('ws', uuid);
+	});
+});

--- a/web/src/lib/components/editor/attachment-metadata.test.ts
+++ b/web/src/lib/components/editor/attachment-metadata.test.ts
@@ -48,7 +48,9 @@ describe('fetchAttachmentMetadata — result arms', () => {
 
 		const result = await fetchAttachmentMetadata('ws', uuid, url);
 
-		expect(result).toEqual({ status: 'ok', mime: 'image/png', size: 4096 });
+		// `derived: 'unknown'` because these fixtures set no
+		// `x-pad-attachment-derived` header — the older-server case (BUG-2964).
+		expect(result).toEqual({ status: 'ok', mime: 'image/png', size: 4096, derived: 'unknown' });
 		// HEAD, not GET — a GET would pull the whole blob across the wire.
 		expect(fetchMock).toHaveBeenCalledWith(url(uuid), {
 			method: 'HEAD',
@@ -63,7 +65,8 @@ describe('fetchAttachmentMetadata — result arms', () => {
 		expect(await fetchAttachmentMetadata('ws', uuid, url)).toEqual({
 			status: 'ok',
 			mime: 'application/pdf',
-			size: 0
+			size: 0,
+			derived: 'unknown'
 		});
 	});
 
@@ -131,7 +134,8 @@ describe('fetchAttachmentMetadata — caching is per-arm', () => {
 		expect(await fetchAttachmentMetadata('ws', uuid, url)).toEqual({
 			status: 'ok',
 			mime: 'image/jpeg',
-			size: 7
+			size: 7,
+			derived: 'unknown'
 		});
 		expect(fetchMock).toHaveBeenCalledTimes(2);
 	});
@@ -207,7 +211,8 @@ describe('fetchAttachmentMetadata — caching is per-arm', () => {
 		expect(await fetchAttachmentMetadata('ws', uuid, url)).toEqual({
 			status: 'ok',
 			mime: 'image/avif',
-			size: 3
+			size: 3,
+			derived: 'unknown'
 		});
 		expect(fetchMock).toHaveBeenCalledTimes(2);
 	});
@@ -227,7 +232,8 @@ describe('revalidateAttachmentMetadata — existence probes ignore the cache', (
 		expect(await fetchAttachmentMetadata('ws', uuid, url)).toEqual({
 			status: 'ok',
 			mime: 'image/png',
-			size: 10
+			size: 10,
+			derived: 'unknown'
 		});
 
 		// The row is deleted by someone else; the cached `ok` still says live.
@@ -347,6 +353,7 @@ describe('invalidateAttachmentMetadataForWorkspace (BUG-2509)', () => {
 			status: 'ok',
 			mime: 'image/png',
 			size: 7,
+			derived: 'unknown',
 		});
 		expect(fetchMock).toHaveBeenCalledTimes(2);
 	});
@@ -391,5 +398,70 @@ describe('mimeToFormat', () => {
 	it('returns null for non-images and unknown image subtypes', () => {
 		expect(mimeToFormat('application/pdf')).toBeNull();
 		expect(mimeToFormat('image/jxl')).toBeNull();
+	});
+});
+
+/**
+ * BUG-2964 — `derived` is THREE-VALUED, and the third value is the point.
+ *
+ * The embed decision reads this to tell "the server holds a decodable
+ * derivative" from "the only bytes on offer are the original". A server
+ * predating BUG-2964 sends no header at all, and reading that silence as
+ * `false` would flip every image embed in every document to a file chip
+ * against an older build — a far bigger change than the bug being fixed.
+ */
+describe('fetchAttachmentMetadata — derived-variant header (BUG-2964)', () => {
+	it('true when the server lists derived variants', async () => {
+		const uuid = freshUuid();
+		fetchMock.mockResolvedValue(
+			head(200, { 'content-type': 'image/heic', 'x-pad-attachment-derived': 'thumb-sm,thumb-md' })
+		);
+		const r = await fetchAttachmentMetadata('ws', uuid, url);
+		expect(r).toMatchObject({ status: 'ok', derived: true });
+		invalidateAttachmentMetadata('ws', uuid);
+	});
+
+	it('false on the `none` SENTINEL', async () => {
+		const uuid = freshUuid();
+		fetchMock.mockResolvedValue(
+			head(200, { 'content-type': 'image/heic', 'x-pad-attachment-derived': 'none' })
+		);
+		const r = await fetchAttachmentMetadata('ws', uuid, url);
+		expect(r).toMatchObject({ status: 'ok', derived: false });
+		invalidateAttachmentMetadata('ws', uuid);
+	});
+
+	it("'unknown' when the header is ABSENT — an older server, not an answer", async () => {
+		const uuid = freshUuid();
+		fetchMock.mockResolvedValue(head(200, { 'content-type': 'image/heic' }));
+		const r = await fetchAttachmentMetadata('ws', uuid, url);
+		expect(r).toMatchObject({ status: 'ok', derived: 'unknown' });
+		invalidateAttachmentMetadata('ws', uuid);
+	});
+
+	it("'unknown' is NOT false — the two must never collapse", async () => {
+		// A guard against the tempting `derived: derivedHeader !== 'none'`,
+		// which reads absence as true, and against `=== 'none' ? false : true`,
+		// which reads absence as true as well. Both lose the third state.
+		const uuid = freshUuid();
+		fetchMock.mockResolvedValue(head(200, { 'content-type': 'image/png' }));
+		const r = await fetchAttachmentMetadata('ws', uuid, url);
+		expect(r.status).toBe('ok');
+		if (r.status === 'ok') {
+			expect(r.derived).not.toBe(false);
+			expect(r.derived).not.toBe(true);
+		}
+		invalidateAttachmentMetadata('ws', uuid);
+	});
+
+	it('an empty header value is treated as none, not as a list', async () => {
+		// Belt-and-braces for a proxy that strips the value but keeps the name.
+		const uuid = freshUuid();
+		fetchMock.mockResolvedValue(
+			head(200, { 'content-type': 'image/heic', 'x-pad-attachment-derived': '' })
+		);
+		const r = await fetchAttachmentMetadata('ws', uuid, url);
+		expect(r).toMatchObject({ status: 'ok', derived: false });
+		invalidateAttachmentMetadata('ws', uuid);
 	});
 });

--- a/web/src/lib/components/editor/attachment-metadata.ts
+++ b/web/src/lib/components/editor/attachment-metadata.ts
@@ -93,6 +93,40 @@ export type AttachmentMetadataResult =
 const cache = new Map<string, Promise<AttachmentMetadataResult>>();
 
 /**
+ * Is this result a DURABLE fact worth keeping for the page's lifetime?
+ *
+ * `mime` and `size` are durable — the row is content-addressed. `derived` is
+ * NOT, and conflating the two is a real defect (BUG-2964, codex round 2):
+ * thumbnail derivation runs ASYNCHRONOUSLY after upload, so a probe issued in
+ * that window sees no variants yet. Caching that answer as immutable latches it
+ * for the rest of the page — and on a build that CAN derive HEIC, a freshly
+ * uploaded HEIC would then render as a file chip until a reload, even though
+ * the thumbnail landed a second later.
+ *
+ * So an EMPTY derived list is provisional and is not cached; the next probe
+ * asks again. A NON-EMPTY list is durable (variants are never un-derived), and
+ * `'unknown'` is durable too — it is a fact about the SERVER's build, not about
+ * this attachment, and it will not change under a running page.
+ *
+ * The cost is one repeat HEAD per probe for a file this build will never derive
+ * — a HEIC on a pure-Go instance. That is bounded, cheap (HEAD, and the
+ * endpoint is conditional-request friendly), and strictly better than latching
+ * a wrong answer: the alternative trades a permanent visible error for a
+ * request nobody notices.
+ */
+function isDurable(result: AttachmentMetadataResult): boolean {
+	// `missing` stays DURABLE — it is authoritative by design (DR-17), and it is
+	// what keeps editor undo from resurrecting a deleted attachment. Only
+	// `transient` and a provisional empty `derived` are evicted; the first draft
+	// of this helper demoted `missing` along with them, and three existing legs
+	// caught it.
+	if (result.status === 'transient') return false;
+	if (result.status !== 'ok') return true;
+	return result.derived === 'unknown' || result.derived.length > 0;
+}
+
+
+/**
  * Fetch (or read from cache) the MIME + size for an attachment. The
  * server registers HEAD alongside GET (TASK-877); chi doesn't auto-
  * route HEAD on GET handlers, so this must use HEAD — a GET would
@@ -159,7 +193,7 @@ export function fetchAttachmentMetadata(
 	// this from deleting a NEWER entry installed by an invalidate-then-
 	// refetch that raced this promise's resolution.
 	void promise.then((result) => {
-		if (result.status === 'transient' && cache.get(key) === promise) {
+		if (cache.get(key) === promise && !isDurable(result)) {
 			cache.delete(key);
 		}
 	});

--- a/web/src/lib/components/editor/attachment-metadata.ts
+++ b/web/src/lib/components/editor/attachment-metadata.ts
@@ -35,21 +35,24 @@ export interface AttachmentMetadata {
 	mime: string;
 	size: number;
 	/**
-	 * Whether the SERVER holds a derived (thumbnail) variant for this
-	 * attachment — read from the `X-Pad-Attachment-Derived` response header
-	 * (BUG-2964).
+	 * The derived (thumbnail) variants the SERVER holds for this attachment —
+	 * parsed from the `X-Pad-Attachment-Derived` response header (BUG-2964).
 	 *
-	 * THREE-VALUED ON PURPOSE, and the third value is the whole point:
+	 * A LIST, not a boolean (codex round 1): derivation writes each variant
+	 * independently, so a consumer has to ask about the variant IT will request,
+	 * not about whether any thumbnail at all exists.
 	 *
-	 *  - `true`      — at least one derived variant exists.
-	 *  - `false`     — the header said `none`; this build derived nothing for
+	 * THREE-VALUED, and the third value is the whole point:
+	 *
+	 *  - `['thumb-sm','thumb-md']` — these exist.
+	 *  - `[]`        — the header said `none`; this build derived nothing for
 	 *                  this file, so the only bytes on offer are the original.
 	 *  - `'unknown'` — no header at all, i.e. a server predating BUG-2964.
 	 *                  Callers must fall back to their previous behaviour here;
-	 *                  treating it as `false` would flip every embed on an older
+	 *                  treating it as `[]` would flip every embed on an older
 	 *                  server, which is a far bigger change than the bug.
 	 */
-	derived: boolean | 'unknown';
+	derived: string[] | 'unknown';
 }
 
 /**
@@ -142,7 +145,10 @@ export function fetchAttachmentMetadata(
 				derived:
 					derivedHeader === null
 						? ('unknown' as const)
-						: derivedHeader.trim() !== '' && derivedHeader.trim() !== 'none'
+						: derivedHeader
+								.split(',')
+								.map((v) => v.trim())
+								.filter((v) => v !== '' && v !== 'none')
 			};
 		} catch {
 			return { status: 'transient' as const };

--- a/web/src/lib/components/editor/attachment-metadata.ts
+++ b/web/src/lib/components/editor/attachment-metadata.ts
@@ -34,6 +34,22 @@ export type AttachmentUrlBuilder = (uuid: string, variant?: AttachmentVariant) =
 export interface AttachmentMetadata {
 	mime: string;
 	size: number;
+	/**
+	 * Whether the SERVER holds a derived (thumbnail) variant for this
+	 * attachment — read from the `X-Pad-Attachment-Derived` response header
+	 * (BUG-2964).
+	 *
+	 * THREE-VALUED ON PURPOSE, and the third value is the whole point:
+	 *
+	 *  - `true`      — at least one derived variant exists.
+	 *  - `false`     — the header said `none`; this build derived nothing for
+	 *                  this file, so the only bytes on offer are the original.
+	 *  - `'unknown'` — no header at all, i.e. a server predating BUG-2964.
+	 *                  Callers must fall back to their previous behaviour here;
+	 *                  treating it as `false` would flip every embed on an older
+	 *                  server, which is a far bigger change than the bug.
+	 */
+	derived: boolean | 'unknown';
 }
 
 /**
@@ -115,10 +131,18 @@ export function fetchAttachmentMetadata(
 			const ctype = resp.headers.get('content-type') ?? '';
 			const mime = ctype.split(';')[0].trim();
 			const len = parseInt(resp.headers.get('content-length') ?? '0', 10);
+			// `none` is a SENTINEL, not an empty value: an empty header value is
+			// the one a proxy may drop, and absence has to keep meaning "old
+			// server" (see AttachmentMetadata.derived).
+			const derivedHeader = resp.headers.get('x-pad-attachment-derived');
 			return {
 				status: 'ok' as const,
 				mime,
-				size: Number.isFinite(len) && len >= 0 ? len : 0
+				size: Number.isFinite(len) && len >= 0 ? len : 0,
+				derived:
+					derivedHeader === null
+						? ('unknown' as const)
+						: derivedHeader.trim() !== '' && derivedHeader.trim() !== 'none'
 			};
 		} catch {
 			return { status: 'transient' as const };

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -280,7 +280,7 @@
 				mime_type: m.mime,
 				filename: '',
 				size_bytes: m.size,
-				derived_variant: m.derived === 'unknown' ? undefined : m.derived
+				derived_variants: m.derived === 'unknown' ? undefined : m.derived
 			});
 			attMeta = next;
 		});

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -272,7 +272,16 @@
 			// filename is left empty — the markdown alt text is the chip/img
 			// label, and renderAttachmentImage only falls back to filename
 			// when alt is blank.
-			next.set(uuid, { id: uuid, mime_type: m.mime, filename: '', size_bytes: m.size });
+			// `derived` carries the server's answer about thumbnail availability
+			// (BUG-2964); `'unknown'` becomes `undefined` so the renderer falls back
+			// to the old MIME-prefix behaviour against an older server.
+			next.set(uuid, {
+				id: uuid,
+				mime_type: m.mime,
+				filename: '',
+				size_bytes: m.size,
+				derived_variant: m.derived === 'unknown' ? undefined : m.derived
+			});
 			attMeta = next;
 		});
 	}

--- a/web/src/lib/markdown/attachmentEmbedDecision.test.ts
+++ b/web/src/lib/markdown/attachmentEmbedDecision.test.ts
@@ -21,24 +21,29 @@ import {
  * build either and is decoded by every current browser.
  */
 
-function meta(mime: string, derived?: boolean): AttachmentMeta {
+function meta(mime: string, derived?: string[]): AttachmentMeta {
 	return {
 		id: 'att-1',
 		mime_type: mime,
 		filename: 'photo',
 		size_bytes: 1234,
-		derived_variant: derived
+		derived_variants: derived
 	};
 }
 
+/** The variant the body renderer requests. */
+const MD = 'thumb-md' as const;
+/** The variant the timeline renderer requests. */
+const SM = 'thumb-sm' as const;
+
 describe('shouldEmbedAsImage — the defect', () => {
 	it('HEIC with NO derived variant is NOT embedded as an image', () => {
-		expect(shouldEmbedAsImage(meta('image/heic', false))).toBe(false);
-		expect(shouldEmbedAsImage(meta('image/heif', false))).toBe(false);
+		expect(shouldEmbedAsImage(meta('image/heic', []), MD)).toBe(false);
+		expect(shouldEmbedAsImage(meta('image/heif', []), MD)).toBe(false);
 	});
 
 	it('HEIC WITH a derived variant is embedded as an image — libvips builds and Pad Cloud are unaffected', () => {
-		expect(shouldEmbedAsImage(meta('image/heic', true))).toBe(true);
+		expect(shouldEmbedAsImage(meta('image/heic', [MD]), MD)).toBe(true);
 	});
 });
 
@@ -47,7 +52,7 @@ describe('shouldEmbedAsImage — the halves of the disjunction', () => {
 		// Fails if the rule is collapsed to variant availability alone. The
 		// pure-Go processor derives no AVIF thumbnail either, so availability
 		// cannot be the whole rule without turning good AVIF embeds into chips.
-		expect(shouldEmbedAsImage(meta('image/avif', false))).toBe(true);
+		expect(shouldEmbedAsImage(meta('image/avif', []), MD)).toBe(true);
 	});
 
 	it('CONTROL — SVG with NO derived variant is STILL an image', () => {
@@ -55,23 +60,23 @@ describe('shouldEmbedAsImage — the halves of the disjunction', () => {
 		// reusing that predicate here would flip every existing SVG embed in
 		// every existing document to a file chip. An SVG in an `<img>` runs no
 		// script.
-		expect(shouldEmbedAsImage(meta('image/svg+xml', false))).toBe(true);
+		expect(shouldEmbedAsImage(meta('image/svg+xml', []), MD)).toBe(true);
 	});
 
 	it('the browser-paintable formats are images with no variant at all', () => {
 		for (const m of ['image/png', 'image/jpeg', 'image/gif', 'image/webp']) {
-			expect(shouldEmbedAsImage(meta(m, false)), m).toBe(true);
+			expect(shouldEmbedAsImage(meta(m, []), MD), m).toBe(true);
 		}
 	});
 
 	it('a non-image MIME is never an image, variant or not', () => {
-		expect(shouldEmbedAsImage(meta('application/pdf', true))).toBe(false);
-		expect(shouldEmbedAsImage(meta('application/zip', false))).toBe(false);
+		expect(shouldEmbedAsImage(meta('application/pdf', [MD]), MD)).toBe(false);
+		expect(shouldEmbedAsImage(meta('application/zip', []), MD)).toBe(false);
 	});
 
 	it('parameters on the MIME do not defeat the match', () => {
-		expect(shouldEmbedAsImage(meta('image/svg+xml; charset=utf-8', false))).toBe(true);
-		expect(shouldEmbedAsImage(meta('image/heic; foo=bar', false))).toBe(false);
+		expect(shouldEmbedAsImage(meta('image/svg+xml; charset=utf-8', []), MD)).toBe(true);
+		expect(shouldEmbedAsImage(meta('image/heic; foo=bar', []), MD)).toBe(false);
 	});
 });
 
@@ -80,9 +85,9 @@ describe('shouldEmbedAsImage — UNKNOWN is not FALSE', () => {
 		// The compatibility hinge. A server predating BUG-2964 sends no header,
 		// and reading that silence as "no variants exist" would flip every embed
 		// in every document against it — a far bigger change than the bug.
-		expect(shouldEmbedAsImage(meta('image/heic', undefined))).toBe(true);
-		expect(shouldEmbedAsImage(meta('image/png', undefined))).toBe(true);
-		expect(shouldEmbedAsImage(meta('application/pdf', undefined))).toBe(false);
+		expect(shouldEmbedAsImage(meta('image/heic', undefined), MD)).toBe(true);
+		expect(shouldEmbedAsImage(meta('image/png', undefined), MD)).toBe(true);
+		expect(shouldEmbedAsImage(meta('application/pdf', undefined), MD)).toBe(false);
 	});
 });
 
@@ -94,7 +99,7 @@ describe('resolveAttachmentImage — what the reader actually gets', () => {
 			'pad-attachment:att-1',
 			'Beach',
 			'ws',
-			resolver(meta('image/heic', false))
+			resolver(meta('image/heic', []))
 		);
 		expect(html).toContain('class="file-chip"');
 		expect(html).toContain('download=');
@@ -109,8 +114,51 @@ describe('resolveAttachmentImage — what the reader actually gets', () => {
 			'pad-attachment:att-1',
 			'Shot',
 			'ws',
-			resolver(meta('image/avif', false))
+			resolver(meta('image/avif', []))
 		);
 		expect(html).toContain('<img');
+	});
+});
+
+/**
+ * BUG-2964, codex round 1 — the question is about THE VARIANT THIS RENDER WILL
+ * REQUEST, not about whether any thumbnail exists.
+ *
+ * Derivation writes `thumb-sm` and `thumb-md` independently, so a partial
+ * derivation leaves one present and the other absent. A boolean "has a
+ * thumbnail" flag answers the wrong question: it says "image", the render asks
+ * for the variant that is missing, the endpoint silently falls back to the
+ * undecodable original, and the broken image is back — now with a layer of
+ * machinery in front of it that looks like it should have prevented exactly
+ * this.
+ *
+ * The body renderer requests `thumb-md`; the timeline requests `thumb-sm`. Both
+ * directions are here, because a rule that only happens to work for the caller
+ * you were thinking about is the same defect.
+ */
+describe('shouldEmbedAsImage — the requested variant is the one that matters', () => {
+	it('HEIC with ONLY thumb-sm is a chip when the render asks for thumb-md', () => {
+		expect(shouldEmbedAsImage(meta('image/heic', [SM]), MD)).toBe(false);
+	});
+
+	it('HEIC with ONLY thumb-md is a chip when the render asks for thumb-sm', () => {
+		expect(shouldEmbedAsImage(meta('image/heic', [MD]), SM)).toBe(false);
+	});
+
+	it('each render is satisfied by its OWN variant', () => {
+		expect(shouldEmbedAsImage(meta('image/heic', [SM]), SM)).toBe(true);
+		expect(shouldEmbedAsImage(meta('image/heic', [MD]), MD)).toBe(true);
+		expect(shouldEmbedAsImage(meta('image/heic', [SM, MD]), MD)).toBe(true);
+	});
+
+	it('a render pointed at the ORIGINAL cannot be carried by a variant existing', () => {
+		// `original` is not a derivative — asking for it means the browser gets
+		// the uploader's bytes, so only the paintable half can carry the embed.
+		expect(shouldEmbedAsImage(meta('image/heic', [SM, MD]), 'original')).toBe(false);
+		expect(shouldEmbedAsImage(meta('image/png', [SM, MD]), 'original')).toBe(true);
+	});
+
+	it('an omitted wantVariant behaves like the original, not like a wildcard', () => {
+		expect(shouldEmbedAsImage(meta('image/heic', [SM, MD]))).toBe(false);
 	});
 });

--- a/web/src/lib/markdown/attachmentEmbedDecision.test.ts
+++ b/web/src/lib/markdown/attachmentEmbedDecision.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import {
+	shouldEmbedAsImage,
+	resolveAttachmentImage,
+	type AttachmentMeta
+} from './attachments';
+
+/**
+ * BUG-2964 — a HEIC attachment rendered as a broken image on a pure-Go build.
+ *
+ * The chain: `deriveThumbnails` skips a source the processor cannot decode, and
+ * the pure-Go processor decodes PNG/JPEG/GIF/BMP/TIFF but not HEIC. The byte
+ * endpoint then SILENTLY falls back to the original when the variant row is
+ * missing. So an `<img?variant=thumb-md>` chosen on a MIME PREFIX handed the
+ * browser HEIC bytes, which Chrome and Firefox do not decode.
+ *
+ * The rule is a disjunction — a derived variant exists, OR the browser paints
+ * the original — and both halves have a leg here. The AVIF leg is a CONTROL:
+ * it fails if anyone collapses the rule to variant availability alone, which is
+ * the tempting simplification, because AVIF has no derived variant on a pure-Go
+ * build either and is decoded by every current browser.
+ */
+
+function meta(mime: string, derived?: boolean): AttachmentMeta {
+	return {
+		id: 'att-1',
+		mime_type: mime,
+		filename: 'photo',
+		size_bytes: 1234,
+		derived_variant: derived
+	};
+}
+
+describe('shouldEmbedAsImage — the defect', () => {
+	it('HEIC with NO derived variant is NOT embedded as an image', () => {
+		expect(shouldEmbedAsImage(meta('image/heic', false))).toBe(false);
+		expect(shouldEmbedAsImage(meta('image/heif', false))).toBe(false);
+	});
+
+	it('HEIC WITH a derived variant is embedded as an image — libvips builds and Pad Cloud are unaffected', () => {
+		expect(shouldEmbedAsImage(meta('image/heic', true))).toBe(true);
+	});
+});
+
+describe('shouldEmbedAsImage — the halves of the disjunction', () => {
+	it('CONTROL — AVIF with NO derived variant is STILL an image, because the browser paints it', () => {
+		// Fails if the rule is collapsed to variant availability alone. The
+		// pure-Go processor derives no AVIF thumbnail either, so availability
+		// cannot be the whole rule without turning good AVIF embeds into chips.
+		expect(shouldEmbedAsImage(meta('image/avif', false))).toBe(true);
+	});
+
+	it('CONTROL — SVG with NO derived variant is STILL an image', () => {
+		// SVG is excluded from the in-app VIEWER for active-content reasons, and
+		// reusing that predicate here would flip every existing SVG embed in
+		// every existing document to a file chip. An SVG in an `<img>` runs no
+		// script.
+		expect(shouldEmbedAsImage(meta('image/svg+xml', false))).toBe(true);
+	});
+
+	it('the browser-paintable formats are images with no variant at all', () => {
+		for (const m of ['image/png', 'image/jpeg', 'image/gif', 'image/webp']) {
+			expect(shouldEmbedAsImage(meta(m, false)), m).toBe(true);
+		}
+	});
+
+	it('a non-image MIME is never an image, variant or not', () => {
+		expect(shouldEmbedAsImage(meta('application/pdf', true))).toBe(false);
+		expect(shouldEmbedAsImage(meta('application/zip', false))).toBe(false);
+	});
+
+	it('parameters on the MIME do not defeat the match', () => {
+		expect(shouldEmbedAsImage(meta('image/svg+xml; charset=utf-8', false))).toBe(true);
+		expect(shouldEmbedAsImage(meta('image/heic; foo=bar', false))).toBe(false);
+	});
+});
+
+describe('shouldEmbedAsImage — UNKNOWN is not FALSE', () => {
+	it('an unprobed / older-server attachment keeps the old MIME-prefix behaviour', () => {
+		// The compatibility hinge. A server predating BUG-2964 sends no header,
+		// and reading that silence as "no variants exist" would flip every embed
+		// in every document against it — a far bigger change than the bug.
+		expect(shouldEmbedAsImage(meta('image/heic', undefined))).toBe(true);
+		expect(shouldEmbedAsImage(meta('image/png', undefined))).toBe(true);
+		expect(shouldEmbedAsImage(meta('application/pdf', undefined))).toBe(false);
+	});
+});
+
+describe('resolveAttachmentImage — what the reader actually gets', () => {
+	const resolver = (m: AttachmentMeta) => () => m;
+
+	it('renders a downloadable file chip for undecodable HEIC, not a broken img', () => {
+		const html = resolveAttachmentImage(
+			'pad-attachment:att-1',
+			'Beach',
+			'ws',
+			resolver(meta('image/heic', false))
+		);
+		expect(html).toContain('class="file-chip"');
+		expect(html).toContain('download=');
+		expect(html).not.toContain('<img');
+		// The alt text the author wrote is the chip label — the document still
+		// reads correctly, it just offers the file instead of a broken picture.
+		expect(html).toContain('Beach');
+	});
+
+	it('still renders an img for AVIF with no variant', () => {
+		const html = resolveAttachmentImage(
+			'pad-attachment:att-1',
+			'Shot',
+			'ws',
+			resolver(meta('image/avif', false))
+		);
+		expect(html).toContain('<img');
+	});
+});

--- a/web/src/lib/markdown/attachments.ts
+++ b/web/src/lib/markdown/attachments.ts
@@ -29,6 +29,15 @@ export interface AttachmentMeta {
 	size_bytes: number;
 	width?: number | null;
 	height?: number | null;
+	/**
+	 * Whether the SERVER holds a derived (thumbnail) variant for this
+	 * attachment (BUG-2964). Sourced from the `X-Pad-Attachment-Derived`
+	 * response header via `fetchAttachmentMetadata`.
+	 *
+	 * `undefined` means UNKNOWN — an older server, or a caller that never
+	 * probed — and is not the same as `false`. See `shouldEmbedAsImage`.
+	 */
+	derived_variant?: boolean | undefined;
 }
 
 /**
@@ -106,9 +115,68 @@ export function formatAttachmentSize(bytes: number): string {
  * True if the MIME type renders inline as an image. Mirrors `image/*` from
  * the server-side allowlist (image/png, image/jpeg, image/gif, image/webp,
  * image/avif, image/heic, image/heif). Anything else falls back to a chip.
+ *
+ * NO LONGER THE EMBED DECISION on its own — see `shouldEmbedAsImage`. Kept
+ * because it is still the honest answer to "is this labelled as an image",
+ * which the unknown-server fallback needs.
  */
 export function isImageMime(mime: string | null | undefined): boolean {
 	return typeof mime === 'string' && mime.toLowerCase().trimStart().startsWith('image/');
+}
+
+/**
+ * The types a browser paints inside an `<img>` (BUG-2964).
+ *
+ * DUPLICATED from `$lib/attachments/display.ts::IMG_PAINTABLE_MIMES` rather
+ * than imported, and that is deliberate: this module's header requires it to
+ * stay byte-for-byte in lock-step with the Go renderer in
+ * `internal/server/render/attachments.go`, so its inputs have to be things the
+ * Go side can hold too. An import would tie the markdown renderer to the
+ * attachment-UI module and leave the Go copy with nothing to mirror. The two
+ * lists are asserted equal by a test rather than by a comment.
+ */
+const IMG_PAINTABLE_MIMES: ReadonlySet<string> = new Set([
+	'image/png',
+	'image/jpeg',
+	'image/gif',
+	'image/webp',
+	'image/avif',
+	'image/svg+xml'
+]);
+
+/**
+ * Should this attachment be embedded as an `<img>`, or as a downloadable file
+ * chip? (BUG-2964)
+ *
+ * THE RULE IS A DISJUNCTION, and each half is load-bearing:
+ *
+ *   embed as <img>  iff  a derived variant exists          (the server can
+ *                                                           serve decodable
+ *                                                           bytes)
+ *                   OR   the browser paints the original   (no derivative
+ *                                                           needed)
+ *
+ * Why not MIME prefix, which is what this used to be: a pure-Go build derives
+ * no thumbnail for HEIC, and the byte endpoint silently falls back to the
+ * ORIGINAL when the variant row is missing — so `image/heic` produced an
+ * `<img>` pointed at HEIC bytes, which Chrome and Firefox render as the
+ * broken-image icon.
+ *
+ * Why not variant availability alone: the same pure-Go build derives no AVIF
+ * thumbnail either, and AVIF is decoded by every current browser. Availability
+ * alone would turn a perfectly good AVIF embed into a chip. There is a CONTROL
+ * leg for exactly this.
+ *
+ * UNKNOWN (`derived_variant === undefined`) falls back to the old MIME-prefix
+ * behaviour. That is the compatibility hinge: an older server sends no header,
+ * and treating its silence as "no variants" would flip every embed in every
+ * document against it.
+ */
+export function shouldEmbedAsImage(meta: AttachmentMeta): boolean {
+	if (!isImageMime(meta.mime_type)) return false;
+	if (meta.derived_variant === undefined) return true;
+	if (meta.derived_variant) return true;
+	return IMG_PAINTABLE_MIMES.has((meta.mime_type ?? '').toLowerCase().split(';')[0].trim());
 }
 
 /**
@@ -218,7 +286,7 @@ export function resolveAttachmentImage(
 	if (uuid === null) return '';
 	const meta = resolver(uuid);
 	if (!meta) return missing(uuid, alt);
-	if (isImageMime(meta.mime_type))
+	if (shouldEmbedAsImage(meta))
 		return renderAttachmentImage(meta, alt, workspaceSlug, variant, urlBuilder);
 	return renderAttachmentChip(
 		meta,

--- a/web/src/lib/markdown/attachments.ts
+++ b/web/src/lib/markdown/attachments.ts
@@ -30,14 +30,21 @@ export interface AttachmentMeta {
 	width?: number | null;
 	height?: number | null;
 	/**
-	 * Whether the SERVER holds a derived (thumbnail) variant for this
-	 * attachment (BUG-2964). Sourced from the `X-Pad-Attachment-Derived`
-	 * response header via `fetchAttachmentMetadata`.
+	 * The derived (thumbnail) variants the SERVER holds for this attachment
+	 * (BUG-2964), e.g. `['thumb-sm', 'thumb-md']`. Sourced from the
+	 * `X-Pad-Attachment-Derived` response header via `fetchAttachmentMetadata`.
 	 *
-	 * `undefined` means UNKNOWN — an older server, or a caller that never
-	 * probed — and is not the same as `false`. See `shouldEmbedAsImage`.
+	 * PER-VARIANT, NOT A BOOLEAN (codex round 1): derivation writes each variant
+	 * independently, so "some thumbnail exists" is not the same question as "the
+	 * one this render will REQUEST exists". A boolean would say "image" when only
+	 * `thumb-sm` was present and the render asked for `thumb-md`, the endpoint
+	 * would fall back to the undecodable original, and the broken image would be
+	 * back with more machinery in front of it.
+	 *
+	 * `undefined` means UNKNOWN — an older server, or a caller that never probed
+	 * — and is not the same as `[]`. See `shouldEmbedAsImage`.
 	 */
-	derived_variant?: boolean | undefined;
+	derived_variants?: string[] | undefined;
 }
 
 /**
@@ -167,15 +174,29 @@ const IMG_PAINTABLE_MIMES: ReadonlySet<string> = new Set([
  * alone would turn a perfectly good AVIF embed into a chip. There is a CONTROL
  * leg for exactly this.
  *
- * UNKNOWN (`derived_variant === undefined`) falls back to the old MIME-prefix
+ * `wantVariant` MUST be the variant the caller is about to put in the URL.
+ * Asking about a variant you will not request answers a question nobody has —
+ * derivation writes each variant independently, so `thumb-sm` existing says
+ * nothing about `thumb-md` (codex round 1). `'original'` or omitted means the
+ * render points at the original, so only the paintable half can carry it.
+ *
+ * UNKNOWN (`derived_variants === undefined`) falls back to the old MIME-prefix
  * behaviour. That is the compatibility hinge: an older server sends no header,
  * and treating its silence as "no variants" would flip every embed in every
  * document against it.
  */
-export function shouldEmbedAsImage(meta: AttachmentMeta): boolean {
+export function shouldEmbedAsImage(
+	meta: AttachmentMeta,
+	wantVariant?: 'thumb-sm' | 'thumb-md' | 'original'
+): boolean {
 	if (!isImageMime(meta.mime_type)) return false;
-	if (meta.derived_variant === undefined) return true;
-	if (meta.derived_variant) return true;
+	if (meta.derived_variants === undefined) return true;
+	if (
+		wantVariant !== undefined &&
+		wantVariant !== 'original' &&
+		meta.derived_variants.includes(wantVariant)
+	)
+		return true;
 	return IMG_PAINTABLE_MIMES.has((meta.mime_type ?? '').toLowerCase().split(';')[0].trim());
 }
 
@@ -286,7 +307,9 @@ export function resolveAttachmentImage(
 	if (uuid === null) return '';
 	const meta = resolver(uuid);
 	if (!meta) return missing(uuid, alt);
-	if (shouldEmbedAsImage(meta))
+	// The SAME `variant` that renderAttachmentImage is about to put in the URL —
+	// the decision and the request must not disagree about which one is meant.
+	if (shouldEmbedAsImage(meta, variant))
 		return renderAttachmentImage(meta, alt, workspaceSlug, variant, urlBuilder);
 	return renderAttachmentChip(
 		meta,


### PR DESCRIPTION
## Summary

[[BUG-2961]] made HEIC uploadable. It did not settle whether the pixels reach a reader, and on a **pure-Go self-hosted build** they did not. The chain: the pure-Go processor decodes PNG/JPEG/GIF/BMP/TIFF, so `deriveThumbnails` skips HEIC and writes no variant row; the byte endpoint then **silently serves the original** when the requested variant is missing; and the editor chose `<img>` on a **MIME prefix**. Net: an `<img>` full of HEIC bytes, which Chrome and Firefox render as the broken-image icon.

## The server now says what it did

Two response headers on the byte endpoint:

| header | meaning |
|---|---|
| `X-Pad-Attachment-Variant` | what these **bytes** are, not what was asked for. A fallback still reports `original` — naming the requested variant would be a lie that reintroduces the bug one layer down. |
| `X-Pad-Attachment-Derived` | which derived variants **exist**, answered only on the no-variant path (the editor's metadata HEAD). The hot `?variant=thumb-md` image path pays nothing. |

`none` is a **sentinel**, not an empty value: an empty header value is the one a proxy may drop, and **absence has to keep meaning "server predates this fix"** — a client reading absence as "no variants" would turn every image embed in every document into a chip against an older server.

## The rule, in both renderers

Embed as `<img>` iff **the variant this render will request exists** OR **the browser paints the original**. Otherwise a downloadable file chip.

- Not a MIME prefix — that is the bug.
- Not availability alone — the same pure-Go build derives no AVIF thumbnail either, and every current browser decodes AVIF. There is a CONTROL leg for this.
- The second disjunct is a **new, fourth predicate** beside `display.ts`'s three, not a reuse of `canOpenInViewer`: that one excludes `image/svg+xml` for **active-content** reasons, and an SVG inside an `<img>` runs no script. Reusing it would have flipped every existing SVG embed in every existing document to a chip.
- Unknown is not false: it falls back to the pre-fix behaviour, which is what keeps an older server's documents rendering as they do today.

## Verification

**Rig pass on a real HEIF** (`internal/attachments/testdata/still-mif1.heif`) against a pure-Go build, with a **PNG positive control** uploaded to the same instance minutes apart — without it, `none` could just mean derivation never ran:

| file | `X-Pad-Attachment-Derived` | `?variant=thumb-md` |
|---|---|---|
| HEIF | `none` | 200, `Content-Type: image/heif`, variant `original` |
| PNG | `thumb-sm,thumb-md` | 200, variant `thumb-md` |

The HEIF row **is** the defect on a real file: 200 OK with HEIC bytes where an `<img>` asked for a thumbnail. The unit tests seed variant rows by hand and so assume that state; only the rig shows the processor actually declining.

**Counterfactuals, all run:**
- against the old prefix rule — 3 defect legs fail, 7 controls stay green;
- against availability-alone — 5 legs fail, including both CONTROLs (AVIF, SVG);
- against the boolean semantics Codex round 1 flagged — 4 legs fail, both wrong-variant directions among them.

**A comment made true rather than left as a claim:** this module's header requires the TS and Go renderers to stay byte-for-byte in lock-step, enforced by comment only. `TestImgPaintableMimes_MatchesTypeScript` now parses the TS literal from source and compares it to the Go map; negative control run (deleting one entry from the Go map fails it and names the entry), and it fails loudly rather than vacuously if the TS constant is renamed.

## Codex

Round 1 and round 2 each found a real defect **in the fix**, and both were the same shape — a signal answering a narrower question than the claim resting on it:

1. The header carried the **list**; the client collapsed it to a **boolean**. Derivation writes each variant independently, so with only `thumb-sm` present a `thumb-md` render said "image", fell back to the original, and reproduced the broken image *behind machinery that looks like it prevents exactly that*.
2. `derived` was cached as a **durable** fact. Derivation is asynchronous, so a probe that races it latched "no thumbnails" for the page's lifetime — on a build that *can* derive HEIC, a fresh upload rendered as a chip until reload.

Round 3 CLEAN. (The first draft of fix 2 demoted the authoritative `missing` cache arm; three existing legs caught it.)

## Not changed, deliberately

The **share-link 404** stays. That path serves variants only, because the variant pipeline is the privacy boundary — a stripped, normalized derivative rather than the uploader's original with its EXIF/GPS intact. Serving an original to an anonymous viewer to fix a rendering complaint would trade a broken image for a location leak. The limitation is now documented per surface beside the capabilities endpoint, which is where a client asks what a build can do. Upload refusal and upload transcoding stay ruled out.

## Test plan

- [x] `npx vitest run` — 149 files / 2316 tests green
- [x] `npm run check` — 0 errors (6 pre-existing warnings)
- [x] `go test ./internal/server/... ./internal/attachments/...` — green
- [x] `make lint` — 0 issues · `gofmt` clean
- [x] Real-HEIF rig pass with a PNG positive control (table above)
- [x] Codex rounds 1–3, CLEAN

Fixes BUG-2964.

https://claude.ai/code/session_01Xk9M5UVPdc84xL5E1mZkm8
