### PR TITLE
fix(web): title parts are route-scoped, replacing the clear that raced them (TASK-2245 / C118)

### DIFF
--- a/web/e2e/page-title-survives-pane-and-nav.spec.ts
+++ b/web/e2e/page-title-survives-pane-and-nav.spec.ts
@@ -1,0 +1,106 @@
+import { test, expect } from './fixtures';
+import { browserLogin, seedDoc } from './lib/collab-helpers';
+import type { SuiteFixture } from './fixtures';
+
+/**
+ * TASK-2245 / audit cluster C118 — the page title must survive a pane toggle
+ * and a route change.
+ *
+ * THE DEFECT. The workspace layout cleared `section`/`item` from a `$effect`
+ * whose comment claimed it "depends only on `page.url.pathname`". It did not:
+ * reading `page.url.pathname` tracks the reactive `page.url`, so a SEARCH-only
+ * change re-ran it — and opening/closing the item pane (`?item=REF`) is exactly
+ * that, as is a view switch (`?view=`). The leaf then reclaimed its section and
+ * the layout's clear landed AFTER it, so the tab title fell back to
+ * `{Workspace} · Pad` and the mobile context bar fell through to its raw-slug
+ * fallback ("share rig" for "Share Rig", as measured on device).
+ *
+ * The same ordering broke a genuine cross-route navigation too — the leaf set
+ * its section, the clear wiped it — which was PRE-EXISTING and is why the clear
+ * moved out of the effect graph into `beforeNavigate` rather than being made
+ * more careful inside it.
+ *
+ * WHY E2E RATHER THAN A UNIT TEST. Every part of this is real-browser
+ * behaviour: SvelteKit's client router, effect scheduling across a layout and
+ * its leaf, and `document.title` itself. The defect was found with an
+ * instrument in a real browser after two static hypotheses about it were both
+ * wrong, and a jsdom test could not have distinguished them either.
+ *
+ * These legs FAIL against the pre-fix layout: the close leg and the nav leg
+ * both report `"{Workspace} · Pad"`.
+ */
+
+function docsUrl(fixture: SuiteFixture, query = ''): string {
+	return `/${fixture.adminUsername}/${fixture.workspaceSlug}/docs${query}`;
+}
+
+test.describe('page title survives a pane toggle and a route change (TASK-2245)', () => {
+	test.beforeEach(({}, testInfo) => {
+		test.skip(
+			testInfo.project.name !== 'desktop-chromium',
+			'title behaviour is width-independent; one project is enough',
+		);
+	});
+
+	test('closing the item pane restores the collection title, not the bare workspace', async ({
+		page,
+		fixture,
+		request,
+	}) => {
+		await browserLogin(page);
+		await seedDoc(fixture, request, 'Title survives pane');
+		await page.goto(docsUrl(fixture));
+
+		const card = page
+			.locator('.item-card')
+			.filter({ has: page.locator('.card-title', { hasText: 'Title survives pane' }) });
+		await expect(card.first()).toBeVisible();
+
+		// Baseline: the collection owns the title.
+		await expect.poll(() => page.title()).toContain('Docs');
+
+		// Open the pane IN-APP. A `page.goto` would be a full boot and would not
+		// exercise the transition at all.
+		await card.first().click();
+		await expect(page.locator('.item-pane')).toBeVisible();
+		// The pane titles by item REF, not by the item's title (`formatItemRef`),
+		// so this asserts the ref shape rather than the seeded text.
+		await expect.poll(() => page.title()).toMatch(/^DOC-\d+ /);
+
+		// Close it the way a user does.
+		await page.keyboard.press('Escape');
+		await expect.poll(() => new URL(page.url()).searchParams.get('item')).toBeNull();
+
+		// THE ASSERTION. Pre-fix this settles on `{Workspace} · Pad`, because the
+		// layout's clear lands after the collection page reclaims its section.
+		await expect.poll(() => page.title()).toContain('Docs');
+	});
+
+	test('a cross-route SPA navigation keeps the destination section', async ({ page, fixture }) => {
+		await browserLogin(page);
+		await page.goto(docsUrl(fixture));
+		await expect.poll(() => page.title()).toContain('Docs');
+
+		// In-app navigation: dispatched in page so the SvelteKit router handles
+		// it client-side. Off-viewport chrome makes a real click unreliable here,
+		// and the point of the leg is the CLIENT-SIDE path — a full load would
+		// remount everything and pass vacuously.
+		const target = `/${fixture.adminUsername}/${fixture.workspaceSlug}/insights`;
+		await page.evaluate((href) => {
+			const el = document.querySelector(`a[href="${href}"]`);
+			if (el) {
+				el.dispatchEvent(
+					new MouseEvent('click', { bubbles: true, cancelable: true, view: window }),
+				);
+			} else {
+				history.pushState({}, '', href);
+				dispatchEvent(new PopStateEvent('popstate'));
+			}
+		}, target);
+
+		await expect.poll(() => new URL(page.url()).pathname).toBe(target);
+		// Pre-fix this settles on `{Workspace} · Pad` — a separate, pre-existing
+		// instance of the same ordering defect.
+		await expect.poll(() => page.title()).toContain('Insights');
+	});
+});

--- a/web/src/lib/stores/title.svelte.ts
+++ b/web/src/lib/stores/title.svelte.ts
@@ -15,14 +15,52 @@
  * Tracked by IDEA-592 / PLAN-601 / TASK-602.
  */
 
+import { page } from '$app/state';
+
 const SEP = ' \u00B7 '; // " · " — U+00B7 middle dot, with surrounding spaces
 const APP_NAME = 'Pad';
 
 let workspace = $state<string | undefined>(undefined);
-let section = $state<string | undefined>(undefined);
-let item = $state<string | undefined>(undefined);
+let sectionValue = $state<string | undefined>(undefined);
+let itemValue = $state<string | undefined>(undefined);
+
+// The pathname each part was set FOR (TASK-2245). `section` and `item` belong
+// to a route; `workspace` does not, and is deliberately unstamped.
+//
+// WHY A STAMP RATHER THAN A CLEAR. The workspace layout used to clear these on
+// route change, and that clear was a race it could lose three different ways:
+//   - it ran on SEARCH-only changes (opening/closing the item pane, switching
+//     view), because reading `page.url.pathname` tracks the whole reactive
+//     `page.url` — so it wiped a section the leaf had just set;
+//   - as an `$effect` it could run AFTER the leaf's effect, since the
+//     parent-before-child guarantee is about mount order, not re-runs;
+//   - moved to `beforeNavigate` to fix that, it then fired for navigations that
+//     were subsequently CANCELLED — the collection page cancels to prompt about
+//     an unsaved draft — leaving the title cleared on a page the user never
+//     left (codex round 1).
+//
+// Stamping removes the clear, and with it all three. A part simply stops
+// counting when the route it was set for is no longer the route being shown, so
+// nothing has to run at the right moment.
+let sectionPath = $state<string | undefined>(undefined);
+let itemPath = $state<string | undefined>(undefined);
+
+/** The route the title is being composed FOR. */
+function currentPath(): string | undefined {
+	// `page` is safe to read during SSR and in tests; guard anyway so a
+	// non-router consumer of this store still composes a sensible title.
+	try {
+		return page.url?.pathname;
+	} catch {
+		return undefined;
+	}
+}
 
 const title = $derived.by(() => {
+	// A part counts only while the route it was set for is the route on screen.
+	const here = currentPath();
+	const item = itemPath === here ? itemValue : undefined;
+	const section = sectionPath === here ? sectionValue : undefined;
 	if (item) {
 		return workspace
 			? `${item}${SEP}${workspace}${SEP}${APP_NAME}`
@@ -51,10 +89,10 @@ export const titleStore = {
 
 	/** Current workspace display name (for debugging/inspection). */
 	get workspace() { return workspace; },
-	/** Current section label (for debugging/inspection). */
-	get section() { return section; },
-	/** Current item ref (for debugging/inspection). */
-	get item() { return item; },
+	/** Current section label (for debugging/inspection), route-scoped. */
+	get section() { return sectionPath === currentPath() ? sectionValue : undefined; },
+	/** Current item ref (for debugging/inspection), route-scoped. */
+	get item() { return itemPath === currentPath() ? itemValue : undefined; },
 
 	/**
 	 * Merge the provided keys into title state.
@@ -72,17 +110,21 @@ export const titleStore = {
 			workspace = parts.workspace ?? undefined;
 		}
 		if ('section' in parts) {
-			section = parts.section ?? undefined;
+			sectionValue = parts.section ?? undefined;
+			sectionPath = currentPath();
 		}
 		if ('item' in parts) {
-			item = parts.item ?? undefined;
+			itemValue = parts.item ?? undefined;
+			itemPath = currentPath();
 		}
 	},
 
 	/** Reset all parts; the resulting title is bare `Pad`. */
 	clearPageTitle() {
 		workspace = undefined;
-		section = undefined;
-		item = undefined;
+		sectionValue = undefined;
+		itemValue = undefined;
+		sectionPath = undefined;
+		itemPath = undefined;
 	},
 };

--- a/web/src/lib/stores/titleRouteScope.svelte.test.ts
+++ b/web/src/lib/stores/titleRouteScope.svelte.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { flushSync } from 'svelte';
+
+/**
+ * TASK-2245 — title parts are ROUTE-SCOPED, which is what replaced the
+ * workspace layout's route-change clear.
+ *
+ * That clear was a race the layout could lose three ways, and the third only
+ * appeared after the first fix for the other two:
+ *
+ *  1. as an `$effect` reading `page.url.pathname` it ran on SEARCH-only changes
+ *     (pane open/close, view switch), wiping a section the leaf had just set —
+ *     reading `.pathname` tracks the whole reactive `page.url`;
+ *  2. as an effect it could run AFTER the leaf's effect; the parent-before-child
+ *     guarantee is about mount order, not re-runs;
+ *  3. moved to `beforeNavigate`, it fired for navigations the app then
+ *     CANCELLED — `[collection]/+page.svelte` cancels to prompt about an unsaved
+ *     draft — clearing the title of a page the user never left (codex round 1).
+ *
+ * Stamping removes the clear, so none of the three has anywhere to happen.
+ * Leg 4 below is the one that pins (3): with no clear, a cancelled navigation
+ * leaves the title alone by construction.
+ */
+
+// REACTIVE on purpose. `$app/state`'s `page` is a reactive object in the real
+// app, so `title`'s `$derived` re-computes when the pathname changes. A plain
+// `let` here would make the derived cache its first read and the legs below
+// would be measuring the STUB's staleness rather than the store's behaviour —
+// the first draft of this file did exactly that and one leg failed for that
+// reason, not for a defect.
+const route = $state({ pathname: '/u/ws/docs' });
+vi.mock('$app/state', () => ({
+	get page() {
+		return { url: { get pathname() { return route.pathname; } } };
+	}
+}));
+
+// Reads happen inside an effect root, and the route mutation is followed by
+// `flushSync`. A `$derived` read from plain module scope with no reactive owner
+// caches its first value — so without this the legs that change the route after
+// reading the title would be asserting against a stale cache rather than
+// against the store. That is a property of how these tests read the value, not
+// of the store, and getting it wrong looked exactly like a defect.
+let dispose: (() => void) | undefined;
+
+async function load() {
+	vi.resetModules();
+	const { titleStore } = await import('./title.svelte');
+	let read!: () => string;
+	dispose = $effect.root(() => {
+		read = () => titleStore.title;
+	});
+	return { store: titleStore, title: () => { flushSync(); return read(); } };
+}
+
+beforeEach(() => {
+	route.pathname = '/u/ws/docs';
+});
+
+afterEach(() => {
+	dispose?.();
+	dispose = undefined;
+});
+
+describe('titleStore — route-scoped parts', () => {
+	it('composes a section set for the CURRENT route', async () => {
+		const { store: t, title } = await load();
+		t.setPageTitle({ workspace: 'WS', section: 'Docs' });
+		expect(title()).toBe('Docs · WS · Pad');
+	});
+
+	it('IGNORES a section set for a DIFFERENT route — no clear needed', async () => {
+		const { store: t, title } = await load();
+		t.setPageTitle({ workspace: 'WS', section: 'Docs' });
+		route.pathname = '/u/ws/settings';
+		// An unwired route inherits nothing and falls back to the workspace,
+		// which is exactly what the deleted clear existed to guarantee.
+		expect(title()).toBe('WS · Pad');
+	});
+
+	it('KEEPS the section across a SEARCH-only change — the pane/view case', async () => {
+		const { store: t, title } = await load();
+		t.setPageTitle({ workspace: 'WS', section: 'Docs' });
+		// Opening the pane changes only the search; the pathname is untouched, so
+		// the stamp still matches. Under the old effect this is the moment the
+		// section was wiped.
+		t.setPageTitle({ item: 'DOC-9' });
+		expect(title()).toBe('DOC-9 · WS · Pad');
+		// And closing it — the leaf reclaims, and nothing races to undo that.
+		t.setPageTitle({ section: 'Docs', item: null });
+		expect(title()).toBe('Docs · WS · Pad');
+	});
+
+	it('a CANCELLED navigation leaves the title intact', async () => {
+		const { store: t, title } = await load();
+		t.setPageTitle({ workspace: 'WS', section: 'Docs' });
+		// A cancelled navigation is, from the store's point of view, no
+		// navigation at all: the pathname never changed, and nothing ran on the
+		// attempt. Under the `beforeNavigate` version this settled on "WS · Pad"
+		// while the user was still looking at Docs.
+		expect(title()).toBe('Docs · WS · Pad');
+		route.pathname = '/u/ws/docs';
+		expect(title()).toBe('Docs · WS · Pad');
+	});
+
+	it('the item part is route-scoped too', async () => {
+		const { store: t } = await load();
+		t.setPageTitle({ workspace: 'WS', item: 'DOC-9' });
+		expect(t.item).toBe('DOC-9');
+		route.pathname = '/u/ws/ideas';
+		// Asserted through the GETTER, not the composed title, and the reason is
+		// a harness limit rather than a difference in the code: reading `title`
+		// once and then changing the route leaves this file's `$derived` holding
+		// its cached value, because nothing in a bare vitest module observes it
+		// the way a component template does. Every other leg here avoids the
+		// pattern by reading once.
+		//
+		// The composed-title version of THIS leg is covered where it is honest —
+		// `e2e/page-title-survives-pane-and-nav.spec.ts`, cross-route leg, which
+		// drives a real client-side navigation and asserts `document.title`, and
+		// which fails against the pre-fix build.
+		expect(t.item).toBeUndefined();
+	});
+
+	it('workspace is deliberately NOT route-scoped — it spans every route in it', async () => {
+		const { store: t, title } = await load();
+		t.setPageTitle({ workspace: 'WS', section: 'Docs' });
+		route.pathname = '/u/ws/roles';
+		expect(title()).toBe('WS · Pad');
+	});
+
+	it('clearPageTitle drops the stamps with the values', async () => {
+		const { store: t, title } = await load();
+		t.setPageTitle({ workspace: 'WS', section: 'Docs', item: 'DOC-9' });
+		t.clearPageTitle();
+		expect(title()).toBe('Pad');
+		// And a later set on the same route still composes — the stamps were
+		// cleared, not poisoned.
+		t.setPageTitle({ workspace: 'WS', section: 'Docs' });
+		expect(title()).toBe('Docs · WS · Pad');
+	});
+});

--- a/web/src/routes/[username]/[workspace]/+layout.svelte
+++ b/web/src/routes/[username]/[workspace]/+layout.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { page } from '$app/state';
-	import { beforeNavigate } from '$app/navigation';
 	import { onMount, onDestroy, untrack } from 'svelte';
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
 	import { collectionStore } from '$lib/stores/collections.svelte';
@@ -164,46 +163,20 @@
 	$effect(() => {
 		titleStore.setPageTitle({ workspace: workspaceStore.current?.name ?? null });
 	});
-	// THE ROUTE-CHANGE CLEAR IS A NAVIGATION HOOK, NOT AN EFFECT (TASK-2245).
+	// THE ROUTE-CHANGE CLEAR IS GONE (TASK-2245). It used to live here as an
+	// `$effect` reading `page.url.pathname`, and it was a race this layout could
+	// lose three ways: it fired on SEARCH-only changes (pane open/close, view
+	// switch) because reading `page.url.pathname` tracks the whole reactive
+	// `page.url`; as an effect it could run AFTER the leaf's effect, since the
+	// parent-before-child guarantee covers mount order and not re-runs; and as a
+	// `beforeNavigate` hook it fired for navigations this app then CANCELLED —
+	// `[collection]/+page.svelte` cancels to prompt about an unsaved draft —
+	// clearing the title of a page the user never left.
 	//
-	// It used to be `$effect(() => { page.url.pathname; setPageTitle({section:
-	// null, item: null}); })`, whose own comment claimed two things that are
-	// both false, and the code is only correct if both are true.
-	//
-	// 1. "depends only on `page.url.pathname`" — it did not. Reading
-	//    `page.url.pathname` tracks the reactive `page.url`, so a SEARCH-only
-	//    change re-ran it with the pathname untouched. Opening and closing the
-	//    item pane is exactly that (`?item=REF` appears and disappears), and so
-	//    is a view switch (`?view=`).
-	// 2. "child effects run after this one — Svelte 5 guarantees parent effects
-	//    run before child effects" — that is about MOUNT order. On a re-run it
-	//    says nothing, and measurement shows the leaf writing FIRST and this
-	//    clear landing after it.
-	//
-	// Both measured with a temporary instrument on `setPageTitle` (writes plus
-	// their author, driven through a real browser):
-	//   - pane close: `[collection]` reclaimed `section: "Bugs"`, then this
-	//     cleared it — tab title `pad · Pad`, mobile bar falling through to its
-	//     raw-slug fallback. That is the reported defect.
-	//   - cross-route SPA nav to /insights: the leaf set `section: "Insights"`,
-	//     then this cleared it — title `pad · Pad`. PRE-EXISTING and present
-	//     before this change too; a guard on the pathname VALUE fixes the first
-	//     case and not this one, which is why the clear moved out of the effect
-	//     graph entirely rather than being made more careful inside it.
-	//
-	// `beforeNavigate` runs BEFORE the navigation commits, so the clear can no
-	// longer land after a leaf has set its section — the ordering the old
-	// comment assumed is now enforced by the hook rather than hoped for. And it
-	// fires only for real navigations, comparing pathnames so a search-only
-	// change (pane toggle, view switch) is not a route change at all.
-	//
-	// Unwired routes still inherit a cleared section and fall back to
-	// `{Workspace} · Pad`, which was the original intent.
-	beforeNavigate((nav) => {
-		if (nav.from?.url.pathname !== nav.to?.url.pathname) {
-			titleStore.setPageTitle({ section: null, item: null });
-		}
-	});
+	// `titleStore` now stamps `section`/`item` with the pathname they were set
+	// for and ignores them elsewhere, so a stale part cannot leak into another
+	// route and nothing has to run at the right moment. Unwired routes still
+	// fall back to `{Workspace} · Pad`, which was this clear's whole purpose.
 
 	// Persist the user's last-visited route per workspace so the workspace
 	// switcher (WorkspaceSwitcher.svelte) can restore it on switch instead

--- a/web/src/routes/[username]/[workspace]/+layout.svelte
+++ b/web/src/routes/[username]/[workspace]/+layout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/state';
+	import { beforeNavigate } from '$app/navigation';
 	import { onMount, onDestroy, untrack } from 'svelte';
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
 	import { collectionStore } from '$lib/stores/collections.svelte';
@@ -163,9 +164,45 @@
 	$effect(() => {
 		titleStore.setPageTitle({ workspace: workspaceStore.current?.name ?? null });
 	});
-	$effect(() => {
-		page.url.pathname;
-		titleStore.setPageTitle({ section: null, item: null });
+	// THE ROUTE-CHANGE CLEAR IS A NAVIGATION HOOK, NOT AN EFFECT (TASK-2245).
+	//
+	// It used to be `$effect(() => { page.url.pathname; setPageTitle({section:
+	// null, item: null}); })`, whose own comment claimed two things that are
+	// both false, and the code is only correct if both are true.
+	//
+	// 1. "depends only on `page.url.pathname`" — it did not. Reading
+	//    `page.url.pathname` tracks the reactive `page.url`, so a SEARCH-only
+	//    change re-ran it with the pathname untouched. Opening and closing the
+	//    item pane is exactly that (`?item=REF` appears and disappears), and so
+	//    is a view switch (`?view=`).
+	// 2. "child effects run after this one — Svelte 5 guarantees parent effects
+	//    run before child effects" — that is about MOUNT order. On a re-run it
+	//    says nothing, and measurement shows the leaf writing FIRST and this
+	//    clear landing after it.
+	//
+	// Both measured with a temporary instrument on `setPageTitle` (writes plus
+	// their author, driven through a real browser):
+	//   - pane close: `[collection]` reclaimed `section: "Bugs"`, then this
+	//     cleared it — tab title `pad · Pad`, mobile bar falling through to its
+	//     raw-slug fallback. That is the reported defect.
+	//   - cross-route SPA nav to /insights: the leaf set `section: "Insights"`,
+	//     then this cleared it — title `pad · Pad`. PRE-EXISTING and present
+	//     before this change too; a guard on the pathname VALUE fixes the first
+	//     case and not this one, which is why the clear moved out of the effect
+	//     graph entirely rather than being made more careful inside it.
+	//
+	// `beforeNavigate` runs BEFORE the navigation commits, so the clear can no
+	// longer land after a leaf has set its section — the ordering the old
+	// comment assumed is now enforced by the hook rather than hoped for. And it
+	// fires only for real navigations, comparing pathnames so a search-only
+	// change (pane toggle, view switch) is not a route change at all.
+	//
+	// Unwired routes still inherit a cleared section and fall back to
+	// `{Workspace} · Pad`, which was the original intent.
+	beforeNavigate((nav) => {
+		if (nav.from?.url.pathname !== nav.to?.url.pathname) {
+			titleStore.setPageTitle({ section: null, item: null });
+		}
 	});
 
 	// Persist the user's last-visited route per workspace so the workspace


### PR DESCRIPTION
## Summary

Audit cluster **C118**: after a view switch the collection page lost its title, and Kite's device pass widened the trigger to **opening and closing the item pane** — the mobile context bar degraded "Share Rig" → "share rig" (its raw-slug fallback) and the tab title fell back to `{Workspace} · Pad`.

The cause was not a missing re-assert. The workspace layout cleared `section`/`item` from an `$effect` whose own comment made two claims, and the code was correct only if both held. **Neither does:**

1. *"depends only on `page.url.pathname`"* — reading `page.url.pathname` tracks the whole reactive `page.url`, so a **search-only** change re-ran it. `?item=REF` appearing and disappearing is exactly that, and so is `?view=`.
2. *"child effects run after this one — Svelte 5 guarantees parent effects run before child effects"* — that is about **mount** order. On a re-run it says nothing, and the leaf writes first.

So the clear landed *after* the leaf reclaimed its section.

## How it was found

I wrote down two hypotheses and the experiment that separates them, then ran it — a temporary instrument on `setPageTitle` logging every write with its author, driven through a real browser against a Vite dev server proxying the live API. **Both hypotheses were wrong**; the instrument named a third component I had not suspected.

The first run was a **failed reconstruction** rather than a refutation: `page.goto`/`goBack` re-booted the app instead of exercising an in-app close, and the title came back correct. The second run clicks a row and presses Escape.

The control then found a **second, pre-existing** instance: a genuine cross-route SPA navigation lost the destination's section the same way (`/insights` titled `{Workspace} · Pad` on the unfixed build).

## Three ways to lose one race

Each fix for one exposed the next, which is what says the mechanism is wrong rather than under-guarded:

| # | shape | how it lost |
|---|---|---|
| 1 | `$effect` on `page.url.pathname` | ran on search-only changes |
| 2 | same effect | could run *after* the leaf's effect |
| 3 | `beforeNavigate` hook | fired for navigations the app then **cancelled** — `[collection]/+page.svelte:1966` cancels to prompt about an unsaved draft, leaving the title cleared on a page the user never left (Codex round 1) |

**The clear is now deleted.** `titleStore` stamps `section`/`item` with the pathname they were set for and ignores them elsewhere, so a stale part cannot leak into another route and nothing has to run at the right moment — there is no moment. `workspace` stays unstamped: it spans every route inside it. Unwired routes still fall back to `{Workspace} · Pad`, which was the clear's whole purpose.

## Test plan

- [x] `e2e/page-title-survives-pane-and-nav.spec.ts` — pane close, and cross-route SPA nav. Both legs run against a **rebuilt** pre-fix binary (the suite serves embedded assets, so reverting source alone would prove nothing) and both fail there with exactly `"E2E Workspace · Pad"`
- [x] 7 store legs including the cancelled-navigation case
- [x] `npx vitest run` — 150 files / 2323 tests green
- [x] `npm run check` — 0 errors (6 pre-existing warnings)
- [x] `pane-a11y-focus.spec.ts` alongside the new spec — 8/8 green
- [x] Codex rounds 1–2, CLEAN

One store leg asserts through the getter rather than the composed title and says why in place: a bare-module `$derived` read once then re-read after a route change holds its cached value, because nothing in vitest observes it the way a template does. The composed-title version of that leg lives in the e2e, where it is honest.

## Scope

C118 only. **C82** (settings tab bar hiding Storage/Danger Zone at phone width) and **C119** (focus ring around the whole viewport) from TASK-2245 are untouched and remain open. `humanize()` still does not title-case its fallback — deliberately: it is cosmetic on this defect and would have made the bar read "Share Rig" while `document.title` stayed `{Workspace} · Pad`, hiding on device precisely the half Kite could see.

Kite re-measures on device after this lands.

https://claude.ai/code/session_01Xk9M5UVPdc84xL5E1mZkm8
