### PR TITLE
fix(nix): gate the vendorHash heal on state, not on the push range (BUG-2974)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,16 @@ jobs:
       - name: Test the Nix vendorHash bump parser
         run: nix/bump-vendor-hash_test.sh
 
+      # The heal job that pushes the parser's output to main (BUG-2974). Gated
+      # here for the same reason and one more: in nix.yml that job runs only
+      # after a real merge has moved the module set, so its defect shipped green
+      # for a day and was found by reading run logs. The suite drives the script
+      # against a real git remote, and its load-bearing case is the one that
+      # shipped — a heal owed by an EARLIER push, on a push that touched no
+      # go.mod/go.sum.
+      - name: Test the Nix vendorHash heal job
+        run: nix/heal-vendor-hash_test.sh
+
       - name: Run golangci-lint
         # only-new-issues: false means CI fails on ANY linter finding,
         # not just findings on PR-changed lines. The IDEA-732 cleanup

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -11,17 +11,21 @@ concurrency:
   # same PR makes the older run's answer worthless.
   #
   # PUSH runs get a group of their OWN, one per commit, and this is deliberate
-  # (TASK-2954). A run on `main` may owe main a vendorHash heal, and losing it
-  # loses the fix SILENTLY: the next push's run recomputes correctly, but its
-  # go.mod/go.sum gate sees only its own commits, so nothing ever retries the
-  # skipped heal. `cancel-in-progress: false` is not enough to prevent that —
+  # (TASK-2954). A run on `main` may owe main a vendorHash heal, and an evicted
+  # run never performs it. `cancel-in-progress: false` is not enough on its own —
   # GitHub holds only ONE pending run per group, so a third push evicts the
   # queued second, and the eviction looks exactly like a run that decided there
   # was nothing to do. A per-commit group cannot be evicted by anything.
   #
+  # What an evicted heal costs is now DELAY, not the fix. Since BUG-2974 the
+  # heal is gated on the committed hash rather than on what the push touched, so
+  # the next push to main meets the same stale hash and heals it from its own
+  # run. The per-commit group is what makes the heal land on the merge that
+  # caused it instead of waiting for whatever lands next.
+  #
   # What that trades for: two main runs can reach the push step at once, and the
   # loser gets a non-fast-forward rejection and goes red. That is the right
-  # direction — a red job is read, and the next merge's run heals anyway.
+  # direction — a red job is read, and the next push to main heals anyway.
   group: nix-${{ github.event_name == 'push' && github.sha || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
@@ -141,26 +145,38 @@ jobs:
   # WHY ON `push: main` AND NOT ON THE PR (ruled on TASK-2954's trail). A
   # Dependabot PR run gets a read-only token whatever `permissions` says. The
   # merge, though, is authored by a human, so the `push` run that follows is an
-  # ordinary run with an ordinary token. `main` self-heals one commit after the
-  # merge — usually one commit after it; see the non-fast-forward note below for
-  # the case where it takes the next merge instead — and the PR's own check was
-  # already honest because the job above recomputes in the working tree. The two rejected alternatives were a PAT in
-  # the Dependabot secret store (a standing credential for a once-a-week fix) and
-  # enabling write tokens for pull-request workflows (which would give them to
-  # FORK PRs on a public repo — the surface CONVE-2438 exists to keep closed).
+  # ordinary run with an ordinary token. The PR's own check was already honest,
+  # because the job above recomputes in the working tree; `main` is what needs
+  # the committed fix, and it gets it from the run of the merge itself — or,
+  # when that run loses the push race, from the run of the next push to main.
+  # The two rejected alternatives were a PAT in the Dependabot secret store (a
+  # standing credential for a once-a-week fix) and enabling write tokens for
+  # pull-request workflows (which would give them to FORK PRs on a public repo —
+  # the surface CONVE-2438 exists to keep closed).
   #
-  # THE LOOP GUARD IS THE COMMIT'S OWN CONTENTS. This job pushes a commit that
-  # touches `nix/package.nix` and nothing else. That push triggers this workflow
-  # again, the first gate below asks whether go.mod or go.sum moved across the
-  # push's range, and for the bot's own commit the answer is no — so the second
-  # run stops there. The gate is not a heuristic about who pushed; it is the fact
-  # that the fix cannot invalidate the hash it just wrote.
+  # THE LOOP TERMINATES BECAUSE A CORRECTED TREE COMPUTES NO BUMP. This job
+  # pushes a commit that touches `nix/package.nix` and nothing else. That push
+  # triggers this workflow again; the build job above now finds the hash
+  # correct, prints "Build is green; vendorHash is current.", and never sets
+  # `bumped` — so this job is not merely gated, it does not start at all. The
+  # terminator is the FIX's own effect on the build, and it holds regardless of
+  # what any push touched.
+  #
+  # THAT DISTINCTION IS LOAD-BEARING, AND IT WAS GOT WRONG ONCE (BUG-2974). This
+  # comment used to name the loop guard as a gate asking whether the push had
+  # touched `go.mod`/`go.sum`, and that gate existed as a step below. It is the
+  # right question for loop prevention and the WRONG one for recovery: after a
+  # lost push race the tree that needs healing was written by an EARLIER push,
+  # so every later merge that did not itself move the module set refused to fix
+  # it, exited GREEN, and left main carrying a hash a clean nix build rejects.
+  # The gate is gone. The state comparison below is the only gate, and being a
+  # question about state it is equally true for a hash this push broke and one
+  # an earlier push broke and could not land.
   #
   # If another merge lands while this job runs, the push is REJECTED as a
-  # non-fast-forward and this job goes red rather than overwriting anything. The
-  # heal is not lost: that merge's own run recomputes and heals. The window is
-  # the length of a nix build, and the failure mode is loud rather than silent —
-  # which is the same trade the per-commit concurrency group above makes.
+  # non-fast-forward and this job goes RED rather than overwriting anything —
+  # and the heal is genuinely not lost now, because the next push to main meets
+  # the same stale hash, recomputes it, and heals it from its own run.
   #
   # `needs: nix` without `if: always()` is the second half: this runs only when
   # the build job SUCCEEDED, so a module set whose corrected tree still fails
@@ -179,55 +195,27 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # Full history: the gate below asks what THIS PUSH changed, which is
-          # `before..after`, not `HEAD~1..HEAD`. A direct push of several commits
-          # can carry the go.sum change anywhere in the range, and a two-commit
-          # clone would see only the last one and skip a heal that was owed.
+          # Nothing here reads history any more — BUG-2974 removed the gate that
+          # did. The depth stays full rather than dropping to the default shallow
+          # clone: this is the clone the heal commit is pushed from, full depth is
+          # what every run of this job has ever used, and a shallow push is not a
+          # variable worth introducing on a job that runs only when a Go bump
+          # actually moves the module set.
           fetch-depth: 0
 
-      - name: Did this push touch the Go module set?
-        id: gate
-        env:
-          BEFORE: ${{ github.event.before }}
-          AFTER: ${{ github.sha }}
-        run: |
-          # A branch created by this push, or a `before` the clone cannot resolve
-          # (a force push whose old tip is gone), leaves the range unanswerable.
-          # Fall through to the hash comparison rather than skipping: the second
-          # gate is the one that decides, and this one only avoids pointless work.
-          if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ] \
-             || ! git rev-parse --verify -q "$BEFORE^{commit}" >/dev/null; then
-            echo "Push range unresolvable; deferring to the hash comparison."
-            echo "touched=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if git diff --name-only "$BEFORE" "$AFTER" | command grep -qE '^go\.(mod|sum)$'; then
-            echo "touched=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "go.mod/go.sum unchanged across $BEFORE..$AFTER — nothing here could have moved the hash."
-            echo "touched=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        if: steps.gate.outputs.touched == 'true'
         with:
           name: recomputed-package-nix
           path: nix/
 
-      - name: Commit and push
-        if: steps.gate.outputs.touched == 'true'
-        run: |
-          # The second gate. The artifact only exists because the build job found
-          # a mismatch, but comparing here keeps the job honest about the tree it
-          # is actually looking at rather than about what another job reported.
-          if git diff --quiet -- nix/package.nix; then
-            echo "package.nix already matches the recomputed hash; nothing to push."
-            exit 0
-          fi
-          git config user.name 'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add nix/package.nix
-          git commit -m "chore(nix): heal vendorHash for the module set in ${SHA} (TASK-2954)"
-          git push
+      # THE GATE, and the only one, lives in the script: does what main COMMITTED
+      # differ from what the build job RECOMPUTED? The artifact exists only
+      # because the build job found a mismatch, but comparing there keeps the job
+      # honest about the tree it is actually looking at rather than about what
+      # another job reported. It is a file rather than a `run:` block so that
+      # nix/heal-vendor-hash_test.sh can drive it against a real git remote —
+      # BUG-2974 shipped green for a day because nothing could exercise it.
+      - name: Commit and push the recomputed hash
+        run: nix/heal-vendor-hash.sh
         env:
           SHA: ${{ github.sha }}

--- a/Makefile
+++ b/Makefile
@@ -55,11 +55,13 @@ install: build
 test:
 	go test -timeout=45m ./... -v
 
-# The vendorHash bump parser (TASK-2954). Pure bash, no toolchain, ~1s — its own
-# target rather than part of `test`, which means `go test`. CI runs this same
-# script in the Go job so a change to the parser is gated rather than trusted.
+# The vendorHash bump parser (TASK-2954) and the heal job that pushes its output
+# to main (BUG-2974). Pure bash + git, no toolchain, ~3s — their own target
+# rather than part of `test`, which means `go test`. CI runs these same scripts
+# in the Go job so a change to either is gated rather than trusted.
 test-nix-hash:
 	@nix/bump-vendor-hash_test.sh
+	@nix/heal-vendor-hash_test.sh
 
 # Run tests against PostgreSQL (starts a container automatically).
 #

--- a/nix/heal-vendor-hash.sh
+++ b/nix/heal-vendor-hash.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# Commit and push the recomputed `vendorHash` to main. Called by the
+# `push-vendor-hash` job in .github/workflows/nix.yml, with the recomputed
+# nix/package.nix already downloaded over the checked-out one.
+#
+# WHY THIS IS A FILE AND NOT A `run:` BLOCK (BUG-2974). The logic here decides
+# whether main's committed hash gets fixed, and it had a defect that shipped
+# green for a day because nothing could exercise it outside a real merge race.
+# A file can be driven by nix/heal-vendor-hash_test.sh against a real git
+# remote; a `run:` block can only be read. Same reason nix/bump-vendor-hash.sh
+# is a file.
+#
+# THE GATE IS A QUESTION ABOUT STATE: does what main COMMITTED differ from what
+# the build job RECOMPUTED? It used to be a question about the push RANGE — did
+# THIS push touch go.mod/go.sum — which is the right question for loop
+# prevention and the wrong one for recovery. After a lost push race the tree
+# that needs healing was written by an EARLIER push, so every later merge that
+# did not itself move the module set refused to fix it, exited GREEN, and left
+# main carrying a hash a clean `nix build` rejects. That was BUG-2974.
+#
+# The loop still terminates, and never depended on the range: the commit this
+# writes corrects package.nix, so the run it triggers finds the build green,
+# never sets `bumped`, and the calling job does not start at all.
+#
+# Exit 1 is the loud arm and it is deliberate — an unhealed committed hash must
+# leave the run RED saying so, because a green run is indistinguishable from a
+# healthy one and main stays broken for anyone doing a plain `nix build`.
+set -euo pipefail
+
+: "${SHA:?SHA must be set to the commit whose module set was recomputed}"
+
+# This script commits and pushes. Refuse to run outside CI unless a caller says
+# it means it — the test suite sets this, a stray local invocation does not.
+if [ -z "${GITHUB_ACTIONS:-}" ] && [ "${HEAL_ALLOW_LOCAL:-}" != "1" ]; then
+	echo "$0: refusing to run outside GitHub Actions (set HEAL_ALLOW_LOCAL=1 to override)" >&2
+	exit 2
+fi
+
+if git diff --quiet -- nix/package.nix; then
+	echo "::error::The build job reported a vendorHash mismatch, but the recomputed nix/package.nix is byte-identical to the committed one. Those two cannot both be true - a mismatch means the computed hash differs from the committed one. Read the build job's recompute step before trusting either. Nothing pushed."
+	exit 1
+fi
+
+git config user.name 'github-actions[bot]'
+git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+git add nix/package.nix
+git commit -m "chore(nix): heal vendorHash for the module set in ${SHA} (TASK-2954)"
+
+if ! git push; then
+	echo "::error::The vendorHash heal did NOT land - the push was rejected, so another commit reached main during this run. main still carries a vendorHash that a clean nix build rejects. It is not lost: the next push to main meets the same mismatch and heals it from its own run, because the heal is gated on the committed hash rather than on whether that push touched go.mod or go.sum (BUG-2974)."
+	exit 1
+fi

--- a/nix/heal-vendor-hash_test.sh
+++ b/nix/heal-vendor-hash_test.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+#
+# Tests for heal-vendor-hash.sh (BUG-2974), driven against a real git remote.
+#
+# The load-bearing case is CASE 1: a heal that is owed by an EARLIER push, on a
+# push that touched no go.mod/go.sum. That is the shape that shipped green — the
+# pre-fix job gated on the push RANGE, so after a lost push race every later
+# merge refused to fix main and exited 0 while `nix build` from a clean checkout
+# stayed broken. Case 1's pre-fix leg is a FROZEN reproduction of that gate: it
+# is here to show what the fix is for, and it must keep failing to heal.
+#
+# Cases 4 and 5 are the pair that make the design honest rather than merely
+# working: a rejected push must leave the run RED and main UNTOUCHED (4), and
+# the NEXT push to main must then heal it without anyone intervening (5). Case 3
+# covers the contradiction arm — an artifact identical to the committed file
+# means the two jobs disagree about the same tree, which is loud, not a no-op.
+#
+# `git` is the only dependency; no nix, no toolchain, ~2s.
+set -uo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+script="$here/heal-vendor-hash.sh"
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+pass=0
+fail=0
+
+STALE='sha256-STALEcccccccccccccccccccccccccccccccccccccc='
+GOOD='sha256-GOODcccccccccccccccccccccccccccccccccccccccc='
+
+check() {
+	local name="$1" want="$2" got="$3"
+	if [[ "$want" == "$got" ]]; then
+		pass=$((pass + 1))
+	else
+		fail=$((fail + 1))
+		echo "FAIL: $name"
+		echo "  want: $want"
+		echo "  got:  $got"
+	fi
+}
+
+make_pkg() { printf '{\n  pname = "pad";\n\n  vendorHash = "%s";\n}\n' "$1" > "$2"; }
+hash_on_main() { git -C "$1" show origin/main:nix/package.nix | grep -oE 'sha256-[A-Za-z0-9+/]+=*' | head -1; }
+
+# The job under test, with the download-artifact step it depends on.
+heal() { # workdir artifact sha
+	( cd "$1" || exit 9
+	  cp "$2" nix/package.nix
+	  SHA="$3" HEAL_ALLOW_LOCAL=1 "$script" )
+}
+
+# A FROZEN reproduction of the pre-BUG-2974 job: the push-range gate, then the
+# same commit-and-push. Not the shipped code and never will be again — it is the
+# negative control that gives case 1 its meaning.
+heal_prefix_form() { # workdir artifact before after
+	( cd "$1" || exit 9
+	  if ! git diff --name-only "$3" "$4" | command grep -qE '^go\.(mod|sum)$'; then
+		echo "go.mod/go.sum unchanged across $3..$4 — nothing here could have moved the hash."
+		exit 0
+	  fi
+	  cp "$2" nix/package.nix
+	  git diff --quiet -- nix/package.nix && exit 0
+	  git add nix/package.nix
+	  git commit -q -m "chore(nix): heal vendorHash for the module set in $4 (TASK-2954)"
+	  git push -q )
+}
+
+# A remote whose main is STALE, having got there the way BUG-2974 describes: M1
+# moved the module set, M1's heal lost the push race and never landed, and M2
+# then landed touching nothing the hash depends on.
+scenario() { # name -> prints the clone path; writes $d/M1, $d/M2, $d/artifact.nix
+	local name="$1"
+	local d="$work/$name"
+	mkdir -p "$d"
+	git init -q --bare "$d/origin.git"
+	git -C "$d/origin.git" symbolic-ref HEAD refs/heads/main
+	git clone -q "$d/origin.git" "$d/work" 2>/dev/null
+	(
+		cd "$d/work" || exit 9
+		git config user.email pad@test; git config user.name pad
+		mkdir -p nix
+		make_pkg "$GOOD" nix/package.nix
+		echo 'module x' > go.mod; echo 'sum' > go.sum; echo hi > README.md
+		git add -A; git commit -q -m base; git push -q origin HEAD:main
+		git branch -q --set-upstream-to=origin/main "$(git rev-parse --abbrev-ref HEAD)" 2>/dev/null
+
+		# M1 moves the module set, so the committed hash is stale from here on.
+		echo 'module x2' > go.mod
+		make_pkg "$STALE" nix/package.nix
+		git add -A; git commit -q -m M1
+		git rev-parse HEAD > "$d/M1"
+
+		# M2 is an ordinary merge that touches no go.mod/go.sum.
+		echo bye > README.md; git add -A; git commit -q -m M2
+		git rev-parse HEAD > "$d/M2"
+		git push -q origin HEAD:main
+	)
+	make_pkg "$GOOD" "$d/artifact.nix"
+	printf '%s' "$d"
+}
+
+# ---------------------------------------------------------------- case 1
+# The heal is owed by an EARLIER push; this push touched no go.mod/go.sum.
+d="$(scenario case1_prefix)"
+heal_prefix_form "$d/work" "$d/artifact.nix" "$(cat "$d/M1")" "$(cat "$d/M2")" >/dev/null 2>&1
+check "1 pre-fix form: exits 0" "0" "$?"
+git -C "$d/work" fetch -q origin main
+check "1 pre-fix form: leaves main STALE (this is BUG-2974)" "$STALE" "$(hash_on_main "$d/work")"
+
+d="$(scenario case1)"
+heal "$d/work" "$d/artifact.nix" "$(cat "$d/M2")" >/dev/null 2>&1
+check "1: exits 0" "0" "$?"
+git -C "$d/work" fetch -q origin main
+check "1: heals main" "$GOOD" "$(hash_on_main "$d/work")"
+
+# ---------------------------------------------------------------- case 2
+# The ordinary case the pre-fix form also handled: this push moved the module
+# set itself. Must not regress.
+d="$(scenario case2)"
+heal "$d/work" "$d/artifact.nix" "$(cat "$d/M1")" >/dev/null 2>&1
+check "2 same-push heal: exits 0" "0" "$?"
+git -C "$d/work" fetch -q origin main
+check "2 same-push heal: heals main" "$GOOD" "$(hash_on_main "$d/work")"
+
+# ---------------------------------------------------------------- case 3
+# The recomputed artifact is identical to the committed file. The build job said
+# mismatch; both cannot be true, so this is loud rather than a silent success.
+d="$(scenario case3)"
+make_pkg "$STALE" "$d/artifact.nix"
+out="$(heal "$d/work" "$d/artifact.nix" "$(cat "$d/M2")" 2>&1)"
+check "3 contradiction: exits 1" "1" "$?"
+case "$out" in *"::error::"*) got=yes ;; *) got=no ;; esac
+check "3 contradiction: annotates the run" "yes" "$got"
+
+# ---------------------------------------------------------------- case 4
+# A competing commit reaches main mid-job: the push is rejected.
+d="$(scenario case4)"
+git clone -q "$d/origin.git" "$d/rival" 2>/dev/null
+(
+	cd "$d/rival" || exit 9
+	git config user.email rival@test; git config user.name rival
+	git checkout -q -B main origin/main
+	echo rival > RIVAL.md; git add -A; git commit -q -m rival; git push -q origin main
+)
+out="$(heal "$d/work" "$d/artifact.nix" "$(cat "$d/M2")" 2>&1)"
+check "4 lost race: exits 1" "1" "$?"
+case "$out" in *"did NOT land"*) got=yes ;; *) got=no ;; esac
+check "4 lost race: says the heal did not land" "yes" "$got"
+git -C "$d/work" fetch -q origin main
+check "4 lost race: leaves main untouched" "$STALE" "$(hash_on_main "$d/work")"
+
+# ---------------------------------------------------------------- case 5
+# ...and the NEXT push to main heals it, with nobody intervening. This is the
+# recovery the push-range gate refused, and the whole point of gating on state.
+git -C "$d/work" fetch -q origin
+git -C "$d/work" reset -q --hard origin/main
+heal "$d/work" "$d/artifact.nix" "$(git -C "$d/work" rev-parse HEAD)" >/dev/null 2>&1
+check "5 recovery: exits 0" "0" "$?"
+git -C "$d/work" fetch -q origin main
+check "5 recovery: the following run heals main" "$GOOD" "$(hash_on_main "$d/work")"
+
+# ---------------------------------------------------------------- case 6
+# The script commits and pushes; running it by hand outside CI must refuse.
+d="$(scenario case6)"
+out="$( cd "$d/work" && cp "$d/artifact.nix" nix/package.nix && SHA=deadbeef "$script" 2>&1 )"
+check "6 local guard: exits 2" "2" "$?"
+case "$out" in *"refusing to run outside GitHub Actions"*) got=yes ;; *) got=no ;; esac
+check "6 local guard: says why" "yes" "$got"
+
+# ---------------------------------------------------------------- case 7
+# SHA is what the commit message names; an unset one is a usage error, not a
+# commit that says "in ". `set -u` would also stop this — one line later, at
+# `git commit`, with the index already dirty and a message naming a shell
+# variable rather than the missing input. The assertion that discriminates the
+# explicit check from that fallback is WHERE it stops, so this asserts the
+# index, not just the exit code.
+d="$(scenario case7)"
+out="$( cd "$d/work" && cp "$d/artifact.nix" nix/package.nix && HEAL_ALLOW_LOCAL=1 "$script" 2>&1 )"
+check "7 missing SHA: exits non-zero" "1" "$?"
+case "$out" in *SHA*) got=yes ;; *) got=no ;; esac
+check "7 missing SHA: names the missing input" "yes" "$got"
+git -C "$d/work" diff --cached --quiet
+check "7 missing SHA: stops before staging anything" "0" "$?"
+
+echo "heal-vendor-hash: $pass passed, $fail failed"
+[[ $fail -eq 0 ]]

--- a/nix/heal-vendor-hash_test.sh
+++ b/nix/heal-vendor-hash_test.sh
@@ -23,6 +23,13 @@ script="$here/heal-vendor-hash.sh"
 work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT
 
+# The suite owns the script's run-location guard, so neither variable may reach
+# it from the caller's environment. This matters in exactly one direction and it
+# is the direction CI runs in: GitHub Actions always sets GITHUB_ACTIONS=true, so
+# an inherited value would satisfy the guard and case 6 would pass locally and
+# fail in the Go job. Every case below opts in explicitly instead.
+unset GITHUB_ACTIONS HEAL_ALLOW_LOCAL
+
 pass=0
 fail=0
 
@@ -168,6 +175,13 @@ out="$( cd "$d/work" && cp "$d/artifact.nix" nix/package.nix && SHA=deadbeef "$s
 check "6 local guard: exits 2" "2" "$?"
 case "$out" in *"refusing to run outside GitHub Actions"*) got=yes ;; *) got=no ;; esac
 check "6 local guard: says why" "yes" "$got"
+
+# ...and the arm that lets the real job through: in Actions, no override needed.
+d="$(scenario case6b)"
+( cd "$d/work" && cp "$d/artifact.nix" nix/package.nix && SHA=deadbeef GITHUB_ACTIONS=true "$script" ) >/dev/null 2>&1
+check "6b in Actions: runs without an override" "0" "$?"
+git -C "$d/work" fetch -q origin main
+check "6b in Actions: heals main" "$GOOD" "$(hash_on_main "$d/work")"
 
 # ---------------------------------------------------------------- case 7
 # SHA is what the commit message names; an unset one is a usage error, not a


### PR DESCRIPTION
Closes the durable half of BUG-2974. The immediate half (main's stale hash) was fixed by the lead's direct commit `5ce11039`; this is the mechanism so it cannot recur.

## The defect

`push-vendor-hash` gated on the push RANGE — did *this* push touch `go.mod`/`go.sum`. Right question for loop prevention, wrong one for recovery: after a lost push race the tree that needs healing was written by an **earlier** push, so every later merge that did not itself move the module set refused to fix it and **exited 0**. Observed on `b7235a1a` → `bc543a1d`: the first run committed the heal and lost the push race, the second run recomputed the identical mismatch and skipped with `go.mod/go.sum unchanged across b7235a1a..bc543a1d`.

CI could not report it, and that is by design working correctly: the recompute repairs the hash in the **working tree** before the build steps judge it (TASK-2954's red-baseline fix), so `nix flake check`, `nix build`, the smoke test and the vulnerability scan all pass against a corrected tree while the committed file stays wrong.

## The fix

**Gate on STATE.** Does what main COMMITTED differ from what the build job RECOMPUTED? That question is equally true for a hash this push broke and one an earlier push broke and could not land, so the run after a lost race heals it.

**The loop guard never depended on the range.** The heal commit corrects `package.nix`, so the run it triggers finds the build green, never sets `bumped`, and the job does not start at all. The old comment named the range gate as the loop guard; it was not, and that mis-description is what made the gate look safe to rely on.

**An unhealed hash is LOUD.** A rejected push, and a recomputed artifact byte-identical to the committed file, both end the run RED with an `::error::` naming the state — instead of the silent `exit 0` that hid this. Property, as ruled on the bug's trail: *within one main run of any merge that moves the hash, either `nix/package.nix` on main carries the new hash or the run is red saying so.*

**The step is a script, not a `run:` block.** `nix/heal-vendor-hash.sh`, same shape as `nix/bump-vendor-hash.sh`. That is what lets it be tested — the defect shipped green for a day precisely because nothing outside a real merge race could exercise it.

## Verification

`nix/heal-vendor-hash_test.sh` — 18 assertions, driven against a real git remote, `git` the only dependency (~2s). Wired into the Go job beside the parser suite and into `make test-nix-hash`.

The load-bearing case is the one that shipped, and it carries a **frozen reproduction of the pre-fix gate as a negative control**: that leg exits 0 and leaves main stale, which is the bug, and it will keep doing so.

| case | asserts |
|---|---|
| 1 | heal owed by an EARLIER push, this push touched no `go.mod` — pre-fix form exits 0 and leaves main STALE; new form heals |
| 2 | the ordinary same-push heal still works (no regression) |
| 3 | artifact identical to the committed file → exit 1 + `::error::`, not a silent no-op |
| 4 | lost push race → exit 1, says the heal did not land, main untouched |
| 5 | the NEXT push to main then heals it with nobody intervening |
| 6 | the script refuses to run outside CI (it commits and pushes) |
| 7 | missing `SHA` fails before staging anything, naming the input |

**Mutation matrix — 6 mutants, all killed.** Contradiction arm exits 0 → case 3. Bare `git push` → case 4. Push-range gate re-introduced → 6 assertions. State comparison inverted → 8. Local-run guard removed → case 6. `SHA` requirement removed → survived at first (near-equivalent under `set -u`), so case 7 was strengthened to assert *where* it stops, not just the exit code; then killed.

Gates: `make test-nix-hash` green unpiped (40 parser + 18 heal). Both workflow files parse. No Go or web source changed.

## Also folded in

The two prose warts parked on TASK-2954's trail, per that trail's instruction to fold them into the next `nix.yml` touch:

- the doubled clause at `nix.yml:144` (*"self-heals one commit after the merge — usually one commit after it"*), and its over-long line;
- the comment naming the loop guard as the commit's own contents via the range gate — corrected to name the real terminator.

The second one turned out to be this bug rather than a wording problem, which is the reason it is worth saying explicitly in the file.

## Deliberately NOT here

**A rebase-and-retry on the rejected push.** It was listed on the bug as a shape worth weighing and it would make the losing run heal instead of deferring, but it needs an arm deciding whether the new tip moved the module set (our recomputed hash is only right if it did not), and neither arm can be exercised on this box. State-gating already makes the next push recover it, which is the property that was asked for. Worth a separate item if the deferral is ever felt.
