### PR TITLE
fix(web): scope the pane focus-ring suppression to mobile, where focus is programmatic (TASK-2245 / C119)

### DIFF
--- a/web/src/lib/components/collections/PaneHost.svelte
+++ b/web/src/lib/components/collections/PaneHost.svelte
@@ -735,5 +735,30 @@
 		.pane-divider {
 			display: none;
 		}
+
+		/* No UA focus ring on the overlay itself (TASK-2245 / C119). The open
+		   effect focuses this region programmatically on open, deep-link, refresh
+		   and back — no user gesture behind it — and at this width the region IS
+		   the viewport, so Chromium's ring frames the whole screen and indicates
+		   nothing about where focus is.
+
+		   SCOPED TO THE MEDIA QUERY, not to `:not(:focus-visible)`, and that is a
+		   measurement rather than a preference. Measured at 390x844 on the C119
+		   repro: the programmatic focus matches `:focus-visible` (true) with an
+		   `auto` outline — identical in every selector-visible property to the
+		   desktop Tab bridge, which is a keyboard user deliberately hopping in
+		   and is the one case where the ring is the only signal that the hop
+		   landed. The modality idiom cannot separate them; the viewport can,
+		   because desktop never focuses this region except through that bridge
+		   (measured: desktop deep-link leaves `activeElement` on `<body>`).
+
+		   Indication is not lost here — the mobile trap moves focus to interior
+		   controls on the first Tab, and those keep their own rings. Keep this
+		   inside the media query: hoisting it out silently removes the desktop
+		   keyboard affordance, and nothing in the rendered result would show it. */
+		.item-pane:focus,
+		.item-pane:focus-visible {
+			outline: none;
+		}
 	}
 </style>


### PR DESCRIPTION
Closes C119 of TASK-2245. C118 shipped at `89f55bab`; C82 is still open and needs a design choice, so it is not here.

## The defect

At ≤768px the item pane is a full-screen overlay, and `PaneHost` focuses it programmatically on open / deep-link / refresh / back (`tabindex="-1"` region, PLAN-2105 / TASK-2122). Chromium paints its UA focus ring around that region — which at 390×844 **is the viewport**, so the whole screen gets a ring that indicates nothing about where focus is.

## Why not the fix the item prescribed

The item says `.item-pane:focus, .item-pane:focus-visible { outline: none; }`, unscoped. Measured, that is **wrong in the keyboard arm**: on desktop the only route to a focused `.item-pane` is the deliberate Tab bridge (`[collection]/+page.svelte:2533-2543` → `paneHostEl.focusPaneRegion()`), and there the ring is the *only* signal the hop landed — a `tabindex="-1"` region has no other affordance and the interior controls are one more Tab away.

## Why not `:focus:not(:focus-visible)` either

That was my first instinct and the measurement refuted it. At 390×844 the programmatic focus **matches `:focus-visible`** (Chromium's UA ring is already `:focus-visible`-gated, which is why it paints at all) with an `auto` outline — **identical in every selector-visible property** to the desktop Tab bridge. No modality selector can separate them.

The real discriminator is the **viewport**: on desktop the pane is not focused on a deep-link at all (`activeElement` is `<body>` — PaneHost deliberately keeps focus on the list so j/k navigation is uninterrupted). So mobile focus is always programmatic, desktop focus is always deliberate.

## Measurement

Three legs, `?item=TASK-2245` on the collection route, against binaries serving the **embedded** build (not a dev server):

| leg | unfixed | fixed | rule hoisted out of the media query |
|---|---|---|---|
| 390×844 deep-link, no keyboard | `auto` 1px | **`none`** | `none` |
| 1280×900 Tab bridge from the list | `auto` 1px | **`auto` 1px** (kept) | **`none`** ← the regression |
| 1280×900 deep-link, no keyboard (control) | `none` | `none` | `none` |

The third column is the item's own prescription, built and measured — it is the counterfactual that makes the media-query placement load-bearing rather than incidental, and the reason the code comment says so.

The focus **move** is untouched in both viewports (`activeElement` is still the pane on mobile, `role="dialog"` intact). Only the indicator changes, and only where nothing asked for it. On mobile the trap moves focus to interior controls on the first Tab and those keep their own rings.

## Gates

`vite build` + `make build-go` clean. Verification ran against a binary built from this branch on an isolated port and HOME, so the bytes measured are the bytes that ship. No Go source changed.
