### PR TITLE
fix(web): wrap the settings tab bar so no tab is hidden at phone width (TASK-2245 / C82)

### DIFF
--- a/web/e2e/task-2245-c82-settings-tabs.spec.ts
+++ b/web/e2e/task-2245-c82-settings-tabs.spec.ts
@@ -29,7 +29,8 @@ type BarProbe = {
 	/** Intrinsic width of the row: tab widths plus the gaps between them. */
 	intrinsicWidth: number;
 	barScrolls: boolean;
-	pageScrollsHorizontally: boolean;
+	/** Ancestors of the bar (up to <html>) that scroll horizontally. */
+	scrollingAncestors: string[];
 	clipped: string[];
 };
 
@@ -50,14 +51,26 @@ async function probeTabBar(page: Page): Promise<BarProbe> {
 				pct: (100 * visible) / r.width,
 			};
 		});
-		const de = document.scrollingElement as HTMLElement;
+		// "No horizontal page scroll" cannot be read off document.scrollingElement
+		// here: the app scrolls in `.main-content`, whose `overflow-y:auto`
+		// computes `overflow-x:auto`, so overflow is contained there and never
+		// reaches the document. Walk the real chain instead. Negative control on
+		// the trail: forcing a 3000px child into `.settings` makes this list
+		// `[div.settings, main.main-content]`, while the document oracle stays
+		// silent — so the empty list below is a measurement, not a tautology.
+		const scrollingAncestors: string[] = [];
+		for (let el = bar.parentElement; el; el = el.parentElement) {
+			if (el.scrollWidth > el.clientWidth + 1) {
+				scrollingAncestors.push(`${el.tagName.toLowerCase()}.${el.className || '(no class)'}`);
+			}
+		}
 		return {
 			tabCount: tabs.length,
 			rows: new Set(tabs.map((t) => t.y)).size,
 			clientWidth: bar.clientWidth,
 			intrinsicWidth: tabs.reduce((sum, t) => sum + t.width, 0) + gap * Math.max(0, tabs.length - 1),
 			barScrolls: bar.scrollWidth > bar.clientWidth,
-			pageScrollsHorizontally: de.scrollWidth > de.clientWidth,
+			scrollingAncestors,
 			clipped: tabs.filter((t) => t.pct < 99.5).map((t) => `${t.label} ${t.pct.toFixed(1)}%`),
 		};
 	});
@@ -81,7 +94,7 @@ test('TASK-2245 C82: no settings tab is clipped at phone width', async ({ page, 
 
 	expect(bar.clipped, 'settings tabs clipped out of view').toEqual([]);
 	expect(bar.barScrolls, 'tab bar still scrolls horizontally').toBe(false);
-	expect(bar.pageScrollsHorizontally, 'settings page scrolls horizontally').toBe(false);
+	expect(bar.scrollingAncestors, 'wrapping pushed horizontal scroll onto an ancestor').toEqual([]);
 	expect(bar.rows).toBeGreaterThan(1);
 });
 
@@ -96,5 +109,5 @@ test('TASK-2245 C82: the wrap rule is inert on desktop', async ({ page, fixture 
 
 	expect(bar.rows, 'desktop tab bar wrapped when it did not need to').toBe(1);
 	expect(bar.clipped).toEqual([]);
-	expect(bar.pageScrollsHorizontally).toBe(false);
+	expect(bar.scrollingAncestors).toEqual([]);
 });

--- a/web/e2e/task-2245-c82-settings-tabs.spec.ts
+++ b/web/e2e/task-2245-c82-settings-tabs.spec.ts
@@ -1,0 +1,100 @@
+import { expect, type Page } from '@playwright/test';
+import { test } from './fixtures';
+
+/**
+ * TASK-2245 / C82 — the workspace settings tab bar scrolled horizontally with
+ * its scrollbar hidden (`overflow-x:auto` + `scrollbar-width:none`), so at
+ * phone widths it ended after a tab with clean trailing whitespace and LOOKED
+ * complete. Measured at 390x844 on the unfixed build: the five owner tabs are
+ * 562px intrinsic in a 342px box, Storage 9.3% visible and Danger Zone 0% —
+ * workspace export and deletion reachable only by a swipe nothing advertised.
+ *
+ * The fix is `flex-wrap: wrap` with no media query. Two legs, because the rule
+ * carries two claims:
+ *
+ *  - mobile: nothing is clipped, and the bar does not scroll.
+ *  - desktop: the rule is INERT. `flex-wrap` does nothing while the row fits,
+ *    so the desktop bar must still be a single row. This is the leg that fails
+ *    if someone "simplifies" the fix into something that wraps unconditionally.
+ *
+ * Both legs assert a non-vacuity precondition first: a viewport where the tabs
+ * happen to fit would pass the mobile leg trivially, and one where they never
+ * fit would pass the desktop leg trivially.
+ */
+
+type BarProbe = {
+	tabCount: number;
+	rows: number;
+	clientWidth: number;
+	/** Intrinsic width of the row: tab widths plus the gaps between them. */
+	intrinsicWidth: number;
+	barScrolls: boolean;
+	pageScrollsHorizontally: boolean;
+	clipped: string[];
+};
+
+async function probeTabBar(page: Page): Promise<BarProbe> {
+	return page.evaluate(() => {
+		const bar = document.querySelector('.tab-bar') as HTMLElement;
+		const barBox = bar.getBoundingClientRect();
+		const gap = parseFloat(getComputedStyle(bar).columnGap || '0') || 0;
+		const tabs = [...bar.querySelectorAll('.tab')].map((t) => {
+			const r = t.getBoundingClientRect();
+			// How much of this tab is inside the bar's own box — clipping does
+			// not shrink getBoundingClientRect, so the overlap is the oracle.
+			const visible = Math.max(0, Math.min(r.right, barBox.right) - Math.max(r.left, barBox.left));
+			return {
+				label: (t.textContent ?? '').trim(),
+				y: Math.round(r.y),
+				width: r.width,
+				pct: (100 * visible) / r.width,
+			};
+		});
+		const de = document.scrollingElement as HTMLElement;
+		return {
+			tabCount: tabs.length,
+			rows: new Set(tabs.map((t) => t.y)).size,
+			clientWidth: bar.clientWidth,
+			intrinsicWidth: tabs.reduce((sum, t) => sum + t.width, 0) + gap * Math.max(0, tabs.length - 1),
+			barScrolls: bar.scrollWidth > bar.clientWidth,
+			pageScrollsHorizontally: de.scrollWidth > de.clientWidth,
+			clipped: tabs.filter((t) => t.pct < 99.5).map((t) => `${t.label} ${t.pct.toFixed(1)}%`),
+		};
+	});
+}
+
+async function openSettings(page: Page, username: string, workspace: string) {
+	await page.goto(`/${username}/${workspace}/settings`);
+	// Danger Zone is owner-only and arrives with /me, so waiting on the fifth
+	// tab is what makes the measurement one of the FULL bar.
+	await expect(page.locator('.tab-bar .tab')).toHaveCount(5);
+}
+
+test('TASK-2245 C82: no settings tab is clipped at phone width', async ({ page, fixture }, testInfo) => {
+	test.skip(testInfo.project.name !== 'mobile-chromium', 'the clipping only occurs below ~610px');
+
+	await openSettings(page, fixture.adminUsername, fixture.workspaceSlug);
+	const bar = await probeTabBar(page);
+
+	// Non-vacuous: the tabs genuinely cannot fit on one row at this width.
+	expect(bar.intrinsicWidth).toBeGreaterThan(bar.clientWidth);
+
+	expect(bar.clipped, 'settings tabs clipped out of view').toEqual([]);
+	expect(bar.barScrolls, 'tab bar still scrolls horizontally').toBe(false);
+	expect(bar.pageScrollsHorizontally, 'settings page scrolls horizontally').toBe(false);
+	expect(bar.rows).toBeGreaterThan(1);
+});
+
+test('TASK-2245 C82: the wrap rule is inert on desktop', async ({ page, fixture }, testInfo) => {
+	test.skip(testInfo.project.name !== 'desktop-chromium', 'this is the desktop control leg');
+
+	await openSettings(page, fixture.adminUsername, fixture.workspaceSlug);
+	const bar = await probeTabBar(page);
+
+	// Non-vacuous: at this width the tabs fit, so a single row is a real claim.
+	expect(bar.intrinsicWidth).toBeLessThanOrEqual(bar.clientWidth);
+
+	expect(bar.rows, 'desktop tab bar wrapped when it did not need to').toBe(1);
+	expect(bar.clipped).toEqual([]);
+	expect(bar.pageScrollsHorizontally).toBe(false);
+});

--- a/web/e2e/task-2245-c82-settings-tabs.spec.ts
+++ b/web/e2e/task-2245-c82-settings-tabs.spec.ts
@@ -54,13 +54,21 @@ async function probeTabBar(page: Page): Promise<BarProbe> {
 		// "No horizontal page scroll" cannot be read off document.scrollingElement
 		// here: the app scrolls in `.main-content`, whose `overflow-y:auto`
 		// computes `overflow-x:auto`, so overflow is contained there and never
-		// reaches the document. Walk the real chain instead. Negative control on
-		// the trail: forcing a 3000px child into `.settings` makes this list
-		// `[div.settings, main.main-content]`, while the document oracle stays
-		// silent — so the empty list below is a measurement, not a tautology.
+		// reaches the document. Walk the real chain instead.
+		//
+		// Overflow alone is not the test — an `overflow-x:visible` ancestor
+		// reports scrollWidth > clientWidth for any wide descendant while being
+		// unable to scroll, so the element must ALSO be a scroll container. The
+		// negative control on the trail shows both halves: forcing a 3000px child
+		// into `.settings` lists only `main.main-content` (the real container),
+		// `.settings` itself is filtered out as visible-overflow, and the document
+		// oracle stays silent throughout. The empty list below is a measurement,
+		// not a tautology.
 		const scrollingAncestors: string[] = [];
 		for (let el = bar.parentElement; el; el = el.parentElement) {
-			if (el.scrollWidth > el.clientWidth + 1) {
+			const overflowX = getComputedStyle(el).overflowX;
+			const canScroll = overflowX === 'auto' || overflowX === 'scroll';
+			if (canScroll && el.scrollWidth > el.clientWidth + 1) {
 				scrollingAncestors.push(`${el.tagName.toLowerCase()}.${el.className || '(no class)'}`);
 			}
 		}

--- a/web/src/routes/[username]/[workspace]/settings/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/settings/+page.svelte
@@ -918,8 +918,9 @@
 	   overflowed — and with the scrollbar hidden it overflowed INVISIBLY. Measured
 	   at 390x844 before the fix: Storage 9.3% visible, Danger Zone 0%, i.e. workspace
 	   export and deletion reachable only by a swipe nothing advertised. Wrapping is
-	   what makes every label legible at once; any scrolling shape leaves a tab clipped
-	   by construction.
+	   what makes every label legible at once; a scrolling row that opens at
+	   scrollLeft=0 leaves the later tabs clipped in the initial view, which is the
+	   view the user is given.
 	   Deliberately NOT inside a media query: flex-wrap is inert when the row fits, and
 	   that is measured, not assumed — the trail carries the counterfactual at eight
 	   widths, where 640/768/1024/1280 stay one row at 34px, identical to the scrolling

--- a/web/src/routes/[username]/[workspace]/settings/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/settings/+page.svelte
@@ -913,16 +913,24 @@
 	.settings-header { margin-bottom: var(--space-4); }
 	.settings-header h1 { font-size: 1.6em; }
 	/* ── Tab bar ──── */
+	/* C82 (TASK-2245): the five owner tabs are 562px intrinsic while the bar's
+	   box is viewport minus the page's 48px of padding, so below ~610px the row
+	   overflowed — and with the scrollbar hidden it overflowed INVISIBLY. Measured
+	   at 390x844 before the fix: Storage 9.3% visible, Danger Zone 0%, i.e. workspace
+	   export and deletion reachable only by a swipe nothing advertised. Wrapping is
+	   what makes every label legible at once; any scrolling shape leaves a tab clipped
+	   by construction.
+	   Deliberately NOT inside a media query: flex-wrap is inert when the row fits, and
+	   that is measured, not assumed — the trail carries the counterfactual at eight
+	   widths, where 640/768/1024/1280 stay one row at 34px, identical to the scrolling
+	   version, and only 320-430 wrap. */
 	.tab-bar {
 		display: flex;
+		flex-wrap: wrap;
 		gap: var(--space-1);
 		border-bottom: 1px solid var(--border);
 		margin-bottom: var(--space-6);
-		overflow-x: auto;
-		scrollbar-width: none;
-		-webkit-overflow-scrolling: touch;
 	}
-	.tab-bar::-webkit-scrollbar { display: none; }
 	.tab {
 		padding: var(--space-2) var(--space-4);
 		font-size: 0.9em;


### PR DESCRIPTION
Closes the last open cluster on TASK-2245.

## The defect

The workspace settings tab bar scrolled horizontally with its scrollbar hidden (`overflow-x:auto` + `scrollbar-width:none` + a `::-webkit-scrollbar{display:none}` rule), so at phone widths the row ended after a tab with clean trailing whitespace and **looked complete**. Workspace export and deletion live behind Danger Zone.

Measured on the unfixed build (Playwright/chromium, owner session, embedded assets):

| viewport | tabs clipped | least-visible tab |
|---|---|---|
| 320 | 3 | 0% |
| 360 | 3 | 0% |
| **390** | **2** | **Storage 9.3%, Danger Zone 0%** |
| 430 | 2 | Danger Zone 0% |
| 640 / 768 / 1024 / 1280 | 0 | — |

Five owner tabs are **562px** intrinsic; the bar's box is the viewport minus the page's 48px of padding. The cliff is at ~610px — not a declared breakpoint.

## Why wrap, and not the other two shapes

The item proposed three, and the ruled property is: *at 390px every tab reachable and legible with its full label, none hidden by clipping, no horizontal page scroll, current tab visible without a gesture.*

| shape | clipped @390 | bar height @390 | @320 | @>=640 |
|---|---|---|---|---|
| edge fade + always-clipped next tab | **>=1 by construction** | 35px | 35px | unchanged |
| **`flex-wrap: wrap`** (this PR) | **0** | 73px (2 rows) | 111px (3 rows) | **inert: 35px, 1 row** |
| picker (native select) | 0 | 32px | 32px | needs a media query |

No single-row shape can hold the full labels — 562px does not fit 342px, and dropping `.tab` padding to 10px still needs two rows. The fade fails the no-clipping clause outright. The picker is the cheapest vertically but keeps four of five labels off screen until a tap, which is the defect C82 describes. Wrap costs **+38px** of content offset at 390 (`.section` top 184.6 -> 222.6) and +76px at 320.

## The rule is outside any media query, and that is measured

`flex-wrap` is inert while the row fits, so the fix needs no breakpoint. Verified rather than asserted — the counterfactual matrix at eight widths against two real binaries (unfixed = main at `cbfc073e`, fixed = this branch, both serving EMBEDDED assets):

| width | unfixed | fixed |
|---|---|---|
| 320 / 360 | 1 row, 35px, 3 clipped | 3 rows, 111px, **0 clipped** |
| 390 / 430 | 1 row, 35px, 2 clipped | 2 rows, 73px, **0 clipped** |
| 640 / 768 / 1024 / 1280 | 1 row, 35px, 0 clipped | **1 row, 35px, 0 clipped — content top unmoved at 184.6** |

No leg scrolls the page horizontally, in either build.

## Tests

Two e2e legs, each with a non-vacuity precondition so neither can pass trivially:

- **mobile-chromium** — nothing clipped, the bar no longer scrolls, more than one row. Precondition: the tabs' intrinsic width genuinely exceeds the bar's box at this viewport.
- **desktop-chromium** — the inertness claim: still exactly one row. Precondition: the tabs fit. This leg is what fails if the rule is ever widened into an unconditional wrap that also reflows desktop.

**Counterfactual run, not assumed:** with the CSS reverted and the binary rebuilt (`vite build` + `build-go`, since e2e serves the embedded bundle), the mobile leg FAILS with `["💾 Storage 31.8%", "⚠️ Danger Zone 0.0%"]` at the Pixel 7 viewport, and the desktop leg passes — correct, it is a control. Restored and rebuilt, both pass.

Gates on this tree: `make test` exit 0, zero FAIL lines · `make lint` 0 issues · `make web-test` 150 files / 2323 tests passed · `npm run check` 0 errors (6 pre-existing warnings, none in the touched files).

## Filed separately, not folded in

**BUG-2978** — `#danger` deep-linking lands on General for owners: **0/10** loads (5 at 390, 5 at 1280) while `#storage` and `#members` are 10/10. Mechanism left explicitly unverified. It matters here because the hash was the only gesture-free route to a tab that was 0% visible.

https://claude.ai/code/session_01WS9QAnxk1gA3LBha3PvKVm
