### PR TITLE
fix(web): a background children refresh keeps its row nodes, so clicks are not swallowed (BUG-2871)

### DIFF
--- a/web/e2e/bug-2871-refresh-preserves-child-rows.spec.ts
+++ b/web/e2e/bug-2871-refresh-preserves-child-rows.spec.ts
@@ -55,9 +55,16 @@ test('BUG-2871: a same-data refresh keeps the child row node', async ({
 
 	// Count children fetches, so "the node survived" can't pass because no
 	// refresh ever happened — which is the way this test would go vacuous.
-	let childrenFetches = 0;
-	page.on('request', (req) => {
-		if (req.method() === 'GET' && /\/items\/[^/]+\/children/.test(req.url())) childrenFetches++;
+	// Count RESPONSES, not requests (codex round 1). A request event can fire
+	// before the component has processed the state change that replaces the
+	// DOM, so polling on requests and asserting immediately could observe the
+	// node still connected on a BROKEN build — a race-dependent false pass.
+	// The replacement happens when the refresh settles, so that is what to wait
+	// for, plus a render turn.
+	let childrenResponses = 0;
+	page.on('response', (res) => {
+		const req = res.request();
+		if (req.method() === 'GET' && /\/items\/[^/]+\/children/.test(res.url())) childrenResponses++;
 	});
 
 	await page.goto(`/${fixture.adminUsername}/${fixture.workspaceSlug}/docs`);
@@ -77,17 +84,22 @@ test('BUG-2871: a same-data refresh keeps the child row node', async ({
 		(window as unknown as { __b2871row?: Element | undefined }).__b2871row = row;
 	}, kidTitle);
 
-	const fetchesBefore = childrenFetches;
+	const responsesBefore = childrenResponses;
 	const unrelated = await request.post(
 		`/api/v1/workspaces/${fixture.workspaceSlug}/collections/docs/items`,
 		{ headers: authHeaders(fixture), data: { title: `B2871 unrelated ${Date.now()}`, content: '' } },
 	);
 	expect(unrelated.ok(), await unrelated.text()).toBeTruthy();
 
-	// Non-vacuity: a refresh must actually have run.
+	// Non-vacuity: a refresh must actually have COMPLETED — otherwise "the node
+	// survived" is a statement about a refresh that never happened.
 	await expect
-		.poll(() => childrenFetches, { timeout: 10_000 })
-		.toBeGreaterThan(fetchesBefore);
+		.poll(() => childrenResponses, { timeout: 10_000 })
+		.toBeGreaterThan(responsesBefore);
+	// ...and give the component its render turn, so a broken build has actually
+	// had the chance to replace the node before this asserts that it did not.
+	await page.evaluate(() => new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(() => r(null)))));
+	await page.waitForTimeout(500);
 
 	const result = await page.evaluate((title) => {
 		const w = window as unknown as { __b2871row?: Element };

--- a/web/e2e/bug-2871-refresh-preserves-child-rows.spec.ts
+++ b/web/e2e/bug-2871-refresh-preserves-child-rows.spec.ts
@@ -1,0 +1,104 @@
+import { test, expect } from './fixtures';
+import { browserLogin, seedDoc } from './lib/collab-helpers';
+import type { APIRequestContext, Page } from '@playwright/test';
+import type { SuiteFixture } from './fixtures';
+
+/**
+ * BUG-2871 — a child row's DOM node must survive a background refresh.
+ *
+ * `loadChildren()` set `loading = true` before every fetch, and the template
+ * swaps the whole list for a spinner while loading. Any `item_created` in the
+ * workspace triggers that refresh (ChildItems' SSE subscription), so with other
+ * people working it fired constantly — and each time, every row node was
+ * destroyed and rebuilt even when the data came back identical.
+ *
+ * A click needs mousedown and mouseup on the SAME node. When a refresh landed
+ * between them the click event never fired at all: no navigation, no in-pane
+ * drill, and no error anywhere. In e2e that presented as the ctrl-click popup
+ * timing out; for a user it silently drops a click on a child row.
+ *
+ * This asserts the property the fix establishes — an unchanged row keeps its
+ * node across a refresh — rather than the symptom, because the symptom is
+ * timing-dependent and the property is not.
+ */
+
+const DESKTOP = { width: 1200, height: 900 };
+
+function authHeaders(fixture: SuiteFixture) {
+	return { Authorization: `Bearer ${fixture.apiToken}` };
+}
+
+function itemCard(page: Page, title: string) {
+	return page.locator('.item-card').filter({ has: page.locator('.card-title', { hasText: title }) });
+}
+
+test('BUG-2871: a same-data refresh keeps the child row node', async ({
+	page,
+	fixture,
+	request,
+}, testInfo) => {
+	test.skip(testInfo.project.name !== 'desktop-chromium', 'the pane is a desktop-split concern');
+
+	await page.setViewportSize(DESKTOP);
+	await browserLogin(page);
+
+	const parent = await seedDoc(fixture, request, 'B2871 refresh parent');
+	const kidTitle = `B2871 refresh kid ${Date.now()}`;
+	const kidResp = await request.post(
+		`/api/v1/workspaces/${fixture.workspaceSlug}/collections/docs/items`,
+		{
+			headers: authHeaders(fixture),
+			data: { title: kidTitle, fields: JSON.stringify({ parent: parent.id }), content: '' },
+		},
+	);
+	expect(kidResp.ok(), await kidResp.text()).toBeTruthy();
+
+	// Count children fetches, so "the node survived" can't pass because no
+	// refresh ever happened — which is the way this test would go vacuous.
+	let childrenFetches = 0;
+	page.on('request', (req) => {
+		if (req.method() === 'GET' && /\/items\/[^/]+\/children/.test(req.url())) childrenFetches++;
+	});
+
+	await page.goto(`/${fixture.adminUsername}/${fixture.workspaceSlug}/docs`);
+	await itemCard(page, 'B2871 refresh parent').first().click();
+	const pane = page.locator('.item-pane');
+	await expect(pane).toBeVisible();
+	await pane.getByRole('tab', { name: 'Relationships' }).click();
+	const childRow = pane.locator('.child-row', { hasText: kidTitle });
+	await expect(childRow).toBeVisible();
+
+	// Hold a reference to the actual node, then trigger a refresh whose result
+	// is identical by creating an UNRELATED item in the same workspace.
+	await page.evaluate((title) => {
+		const row = [...document.querySelectorAll('.item-pane .child-row')].find((el) =>
+			(el.textContent ?? '').includes(title),
+		);
+		(window as unknown as { __b2871row?: Element | undefined }).__b2871row = row;
+	}, kidTitle);
+
+	const fetchesBefore = childrenFetches;
+	const unrelated = await request.post(
+		`/api/v1/workspaces/${fixture.workspaceSlug}/collections/docs/items`,
+		{ headers: authHeaders(fixture), data: { title: `B2871 unrelated ${Date.now()}`, content: '' } },
+	);
+	expect(unrelated.ok(), await unrelated.text()).toBeTruthy();
+
+	// Non-vacuity: a refresh must actually have run.
+	await expect
+		.poll(() => childrenFetches, { timeout: 10_000 })
+		.toBeGreaterThan(fetchesBefore);
+
+	const result = await page.evaluate((title) => {
+		const w = window as unknown as { __b2871row?: Element };
+		const rendered = [...document.querySelectorAll('.item-pane .child-row')].some((el) =>
+			(el.textContent ?? '').includes(title),
+		);
+		return { sameNodeStillConnected: !!w.__b2871row?.isConnected, rendered };
+	}, kidTitle);
+
+	// The row is still on screen either way — the point is that it is the SAME
+	// node, because a replaced node is what swallows an in-flight click.
+	expect(result.rendered, 'the child row disappeared entirely').toBe(true);
+	expect(result.sameNodeStillConnected, 'the child row node was replaced by a refresh').toBe(true);
+});

--- a/web/src/lib/components/ChildItems.svelte
+++ b/web/src/lib/components/ChildItems.svelte
@@ -78,6 +78,11 @@
 	const terminal = $derived(terminalStatuses ?? defaultTerminal);
 
 	let children = $state<Item[]>([]);
+	// Which (workspace, item) the rows in `children` belong to. Plain variables,
+	// not $state: they are read inside loadChildren to decide whether a load is
+	// a refresh or a switch, and nothing renders from them (BUG-2871).
+	let loadedForSlug: string | null = null;
+	let loadedForWs: string | null = null;
 	let loading = $state(true);
 	let error = $state('');
 	let unsubscribeSSE: (() => void) | null = null;
@@ -231,12 +236,32 @@
 		// case: a late load from the old instance must not push stale children
 		// through onChildrenChange into the freshly-mounted parent (Codex).
 		const stale = () => destroyed || seq !== loadSeq || reqSlug !== itemSlug || reqWs !== wsSlug;
-		loading = true;
+		// BUG-2871: only tear the list down when there is nothing valid to show
+		// for THIS item — a first load or an item switch. A same-item REFRESH
+		// keeps the rendered rows mounted.
+		//
+		// `loading` swaps the whole list for a spinner, so flipping it on every
+		// refresh destroyed and rebuilt every row node — and any `item_created`
+		// in the workspace triggers a refresh (the SSE subscription below), so
+		// this fired constantly with other people working. A click needs
+		// mousedown and mouseup on the SAME node: when a refresh landed between
+		// them the click event never fired at all, which silently dropped the
+		// user's click on a child row. Measured on the trail — the row, its
+		// wrapper and its container were all replaced by a refresh whose data
+		// was identical, with the spinner observed in between.
+		//
+		// The switch case still shows the spinner, deliberately: `children` is
+		// not cleared when `itemSlug` changes, so without it the previous item's
+		// rows would sit there looking current until the new load lands.
+		const sameItem = loadedForSlug === reqSlug && loadedForWs === reqWs;
+		if (!sameItem) loading = true;
 		error = '';
 		try {
 			const loaded = await api.items.children(reqWs, reqSlug);
 			if (stale()) return;
 			children = loaded;
+			loadedForSlug = reqSlug;
+			loadedForWs = reqWs;
 			onChildrenChange?.(children);
 		} catch (err) {
 			if (stale()) return;

--- a/web/src/lib/components/ChildItems.svelte
+++ b/web/src/lib/components/ChildItems.svelte
@@ -238,7 +238,7 @@
 		const stale = () => destroyed || seq !== loadSeq || reqSlug !== itemSlug || reqWs !== wsSlug;
 		// BUG-2871: only tear the list down when there is nothing valid to show
 		// for THIS item — a first load or an item switch. A same-item REFRESH
-		// keeps the rendered rows mounted.
+		// keeps the rendered rows mounted, whether it succeeds or fails.
 		//
 		// `loading` swaps the whole list for a spinner, so flipping it on every
 		// refresh destroyed and rebuilt every row node — and any `item_created`
@@ -265,6 +265,20 @@
 			onChildrenChange?.(children);
 		} catch (err) {
 			if (stale()) return;
+			// BUG-2871, codex round 1: a FAILED same-item refresh must not destroy
+			// the rows either. `error` swaps the list for `.error-msg` exactly as
+			// `loading` swaps it for the spinner, so surfacing a transient refresh
+			// failure that way reintroduces this bug through the other branch —
+			// and `onChildrenChange?.([])` would tell the parent we have no
+			// children while `children` still holds them.
+			//
+			// So a background refresh that fails keeps the last good rows and
+			// stays quiet; the next refresh retries, and they arrive constantly
+			// (any item_created in the workspace triggers one). The cost is that
+			// such a failure is invisible, which is a real tradeoff and the
+			// better half of it: the alternative on display here was destroying
+			// the list under the user's pointer.
+			if (sameItem) return;
 			error = err instanceof Error ? err.message : 'Failed to load children';
 			onChildrenChange?.([]);
 		} finally {


### PR DESCRIPTION
Fixes the **Children** instance of BUG-2871, which has been filed as a flaky spec since 2026-09-02. It is not a flaky spec.

**Scope, narrowed after this PR's own CI failed:** the E2E run on this branch failed at `pane-content-link-anchors.spec.ts:194` — the **Relationships** leg, not the Children leg this fixes. That is the same class-B signature and it is NOT caused by this change: the diff touches `ChildItems.svelte` only, and a node-identity probe shows the relationships list KEEPS its nodes across a background refresh, so its trigger is something else. It is also pre-existing — verified from the job log, main's E2E failed at that same `:194` on 2026-09-02 (run 33673588422), a week before this change existed. So BUG-2871's class has at least two triggers and this closes one of them; the item stays open for the other.

## What actually happens

`loadChildren()` sets `loading = true` before every fetch, and the template swaps the whole list for a spinner while loading. **Any `item_created` in the workspace triggers that refresh** via ChildItems' SSE subscription — so with other people (or other e2e specs) working, it fires constantly, and every row node is destroyed and rebuilt each time even when the data comes back identical.

A click needs mousedown and mouseup on the **same node**. When a refresh lands between them, no click event fires at all: no navigation, no in-pane drill, **and no error anywhere**.

- In CI that presented as `pane-content-link-anchors`'s ctrl-click legs timing out on `waitForEvent('page')` — intermittently, at `:143`, `:194` and `:278` over three months.
- For a user it **silently drops a click on a child row**, plain click included. That is why this stopped being a test-only concern the moment the mechanism reproduced.

## How it was found, including the part that was wrong

The trace from the red main run (`34400799293`) was the first one anyone had read for this bug. It ruled things out before it ruled anything in:

- the failure screenshot shows the pane healthy and the child row rendered — so no missing affordance;
- the pane is still on the PARENT, so the in-pane interceptor's modifier bail-out worked and did NOT suppress the default;
- the network log carries **no document request** for the child's page — the popup was never initiated, so this was never a listener missing an event;
- the click-time DOM snapshot shows the anchor carrying `__playwright_target__` and a correct `href`, and Playwright's hit-target check would have failed the click had anything overlaid it.

That snapshot also showed the row's container with `user-select: none; cursor: grab` — the rows live in a `svelte-dnd-action` dndzone. The obvious hypothesis was that a jittered pointer starts a drag and the library swallows the click. **I wrote that prediction down and the experiment refuted it:** a 1px move between mousedown and mouseup still opens the popup. Fixing the drag path would have changed a component that was behaving correctly.

What does reproduce it, deterministically, is replacing the anchor's node identity between down and up — all three CI observations at once. A MutationObserver then showed the real cause: on a same-data refresh the row, its wrapper and its container are all disconnected while the zone element survives, with the loading spinner observed in between.

## The fix

Show the spinner only when there is nothing valid on screen for the current item — a first load or an item switch. A same-item refresh leaves the rendered rows mounted, so an unchanged row keeps its DOM node and an in-flight click survives.

The switch case still tears down **deliberately**: `children` is not cleared when `itemSlug` changes, so without the spinner the previous item's rows would sit there looking current until the new load lands.

## Tests

The regression test asserts the **property** — an unchanged row keeps its node across a refresh — rather than the symptom, because the symptom is timing-dependent and the property is not. It triggers a real refresh by creating an unrelated item, and carries a **non-vacuity guard that a children fetch actually happened**, since "the node survived" would otherwise pass trivially if no refresh ever ran.

**Counterfactual run, not assumed:** against the unfixed component with the binary rebuilt, it fails with `the child row node was replaced by a refresh`.

Gates: web suite 152 files / 2332 tests · `npm run check` 0 errors (6 pre-existing warnings) · e2e bug-2871 1/1.

## Note on scope

This does not touch the dnd path, the interceptor, or the ctrl-click handling — all three were exonerated by measurement before the fix was written. The diff is 26 lines in one function plus two module-level variables.

https://claude.ai/code/session_01WS9QAnxk1gA3LBha3PvKVm
