### PR TITLE
fix(web): unknown membership is not a denial — stop dropping it on a repeat resolve (TASK-2988)

### DIFF
--- a/web/src/lib/components/items/ItemDetail.svelte
+++ b/web/src/lib/components/items/ItemDetail.svelte
@@ -6070,6 +6070,17 @@
 		{/key}
 	{/if}
 
+	<!-- Owner-gated block wrapping a STATEFUL dialog: an unmount here destroys
+	     whatever the user has typed into it, and the returning true cannot
+	     restore it. What keeps that from happening is a guarantee in the STORE,
+	     not anything local — `membershipKnown` never drops to false for a
+	     workspace the session has already answered, so a REPEAT resolution leaves
+	     `isOwner` alone. Before TASK-2988 it did not, and this block unmounted
+	     mid-edit; the reachable route is `recoverIfMissing`, which the workspace
+	     layout calls on every sync result and which re-resolves whenever `current`
+	     names a different workspace — as it does after a create. These four gates
+	     are the consumers relying on that guarantee; if it ever moves, they are
+	     what to re-check. -->
 	{#if isOwner && item}
 		<!-- {#key itemSlug}: remount the item-scoped share dialog on switch. -->
 		{#key itemSlug}
@@ -6116,6 +6127,17 @@
 		</aside>
 	{/if}
 
+	<!-- Owner-gated block wrapping a STATEFUL dialog: an unmount here destroys
+	     whatever the user has typed into it, and the returning true cannot
+	     restore it. What keeps that from happening is a guarantee in the STORE,
+	     not anything local — `membershipKnown` never drops to false for a
+	     workspace the session has already answered, so a REPEAT resolution leaves
+	     `isOwner` alone. Before TASK-2988 it did not, and this block unmounted
+	     mid-edit; the reachable route is `recoverIfMissing`, which the workspace
+	     layout calls on every sync result and which re-resolves whenever `current`
+	     names a different workspace — as it does after a create. These four gates
+	     are the consumers relying on that guarantee; if it ever moves, they are
+	     what to re-check. -->
 	{#if isOwner && collection}
 		<!-- {#key itemSlug}: remount the owner collection-editor modal on item
 		     switch (it's closed on switch anyway; keeps its async loads scoped

--- a/web/src/lib/stores/workspace.svelte.ts
+++ b/web/src/lib/stores/workspace.svelte.ts
@@ -2,6 +2,10 @@ import { api } from '$lib/api/client';
 import type { Workspace, WorkspaceMembership } from '$lib/types';
 import * as perms from '$lib/utils/permissions';
 import { createKeyedSingleFlight } from './singleFlight';
+// Identity, for the membership answer cache below. `auth.svelte.ts` does not
+// import this module, so this direction adds no cycle.
+import { authStore } from './auth.svelte';
+import { untrack } from 'svelte';
 
 let workspaces = $state<Workspace[]>([]);
 let current = $state<Workspace | null>(null);
@@ -14,6 +18,17 @@ let currentMembership = $state<WorkspaceMembership | null>(null);
 // includes resolving the workspace itself, and the part of a create that
 // follows a successful API call — until that call settles: a fetched
 // membership, a 403, or a workspace that did not resolve.
+//
+// EXCEPT for a workspace this session has already answered once, where it
+// stays true across the replacing call and the previous answer keeps being
+// served while the refetch runs (TASK-2988, `answeredMembership` below).
+// Dropping to "unknown" during a repeat resolution unmounted permission-gated
+// blocks that read the store directly, taking the state of any dialog inside
+// one with it. A repeat is not constant — `recoverIfMissing` is CALLED on every
+// sync result but only re-resolves when `current` is null or names a different
+// workspace, and a create makes the latter true while a route stays mounted —
+// but it needs no misuse to happen, and the consumer cannot defend itself
+// because "unknown" and "denied" look identical from outside.
 //
 // A create that THROWS is outside all of that. It changes no state at all,
 // because a failed create says nothing about the workspace you are still
@@ -31,6 +46,135 @@ let loading = $state(false);
 // selection race increments nothing — see the comment in `create` for the three
 // orderings that shapes.
 let membershipSeq = 0;
+
+// The last membership ANSWER settled, per user and workspace slug — for the
+// life of the PAGE, which outlives a sign-out, so the same user returning after
+// a logout can be served an answer from before it
+// (TASK-2988). Populated only by `settleMembership`, which is also the only
+// writer of `membershipKnown = true` — one function so a future settle site
+// cannot record the state without the answer, or the answer without the state.
+//
+// Read on entry to `setCurrent` to answer a REPEAT resolution of a workspace
+// already seen, instead of dropping to "unknown" for the length of the
+// refetch. Keyed by the slug being SET (and by user, below), so it can only ever
+// serve the grants of that workspace — never the previous one, which is what the
+// entry clear exists to prevent.
+//
+// KEYED BY USER AS WELL AS SLUG, and that is a correctness requirement rather
+// than tidiness: logout is an SPA navigation (`authStore.clear()` +
+// `goto('/login')`), so this map outlives a sign-out. Keyed by slug alone, the
+// NEXT user to resolve the same workspace would be served the PREVIOUS user's
+// grants until their own `/me` settled — a cross-account grant leak in the UI
+// (codex round 3). Keying on identity makes the CACHE's invalidation
+// structural: a different user simply has no entry, so no logout path has to
+// remember to clear anything. It does not fence the store's other state —
+// `current`, `workspaces` and a `currentMembership` already published are not
+// identity-scoped, and `authStore.clear()` does not clear them, so a clean
+// account change with no settle in flight can still leave the previous user's
+// live permission state on screen (codex round 6, filed rather than widened
+// into this change).
+//
+// The identity is captured when the CALL starts and carried to its settle, and
+// `settleIfCurrent` discards a settle whose captured id no longer matches the
+// signed-in one. Taking it at settle time instead would let a `/me` issued as
+// one user land under the next user's key — the root layout renders after an
+// auth failure, so an empty id is reachable and is not merely a cache miss.
+//
+// Not a $state: it is never rendered and only ever read here, so tracking it
+// would add invalidations with nothing to invalidate.
+//
+// A cached DENIAL is served too, deliberately — denied is an answer, and a
+// denied workspace flickering to "unknown" is the same defect wearing the
+// opposite sign. Inherited from the settle sites: a transient /me or
+// workspace-resolution failure is recorded as a denial, exactly as those sites
+// already treat it as an answer. A serve is normally corrected by the same
+// call's settle, but not always and not on a bound: a failed workspace GET
+// settles a denial without reaching `/me`, a superseded call returns without
+// settling at all (the newer call settles instead), and a request that never
+// answers leaves the served value standing indefinitely. Nothing SCHEDULES a
+// retry either — `recoverIfMissing` retries on a null or mismatched `current`,
+// not on a null membership, which is pre-existing. The server stays the
+// enforcement boundary throughout; what is at stake here is only what the UI
+// shows.
+const answeredMembership = new Map<string, WorkspaceMembership | null>();
+
+/**
+ * The signed-in user's id, read WITHOUT establishing a reactive dependency.
+ *
+ * `setCurrent` reads this synchronously before its first await, and not every
+ * caller is inside `untrack` — the settings page calls `load(wsSlug)` straight
+ * from an `$effect`. A tracked read there would make that effect re-run on any
+ * session change, which is a dependency the caller never asked for and cannot
+ * see (codex round 4).
+ */
+function currentUserId(): string {
+	return untrack(() => authStore.userId);
+}
+
+/** Cache key for `slug` under `userId`. See `answeredMembership`. */
+function membershipKey(userId: string, slug: string): string {
+	// A newline separator, which appears in neither a user id (uuid) nor a
+	// workspace slug (kebab-case), so no id/slug pair can collide with
+	// another by concatenation.
+	return `${userId}\n${slug}`;
+}
+
+/**
+ * Settle membership for `userId`'s view of `slug`: publish the answer and
+ * remember it. Every path that turns `membershipKnown` true goes through here.
+ *
+ * Reached through `settleIfCurrent` rather than called directly, so the two
+ * fences a settle needs cannot be forgotten at a call site.
+ */
+function settleMembership(userId: string, slug: string, m: WorkspaceMembership | null) {
+	currentMembership = m;
+	membershipKnown = true;
+	answeredMembership.set(membershipKey(userId, slug), m);
+}
+
+/**
+ * Settle only if this call is still the one that speaks for the store.
+ *
+ * TWO fences, for two different races. `seq` is the navigation fence: a slow
+ * `/me` for workspace A must not clobber a membership freshly set for B.
+ * `userId` is the identity fence: logout is an SPA navigation, so a `/me`
+ * issued as one user can settle after another has signed in — and without this
+ * it would both publish that answer and record it under the NEW user's cache
+ * key (codex round 4). Neither fence subsumes the other: a sign-in does not
+ * advance `membershipSeq`, and a navigation does not change the user.
+ *
+ * The two fences DISPOSE of a rejected settle differently, and that asymmetry
+ * is the point. A superseded call returns silently, because a newer call is
+ * already speaking and its state is the right state. An identity mismatch
+ * instead CLEARS to unknown: if the answer we were about to publish belongs to
+ * a user who is no longer signed in, then so does whatever is published right
+ * now — including an answer replayed from the cache a moment ago, which is how
+ * a stale owner read would otherwise survive a sign-out (codex round 5).
+ * Unknown is the fail-safe reading, since the helpers treat it as no access.
+ *
+ * It also drops `current`, which is what makes the clear SELF-HEALING rather
+ * than terminal (codex round 6). `recoverIfMissing` re-resolves on a null
+ * `current` and runs on every sync result, so the new user gets a real answer
+ * at the next one; leaving `current` in place would have left them unknown
+ * until a navigation, and a sign-in that does not navigate would never get one.
+ * The cost is the sidebar's links blanking for that interval — the TASK-2200
+ * shape, and the mechanism built for it is exactly what recovers here.
+ */
+function settleIfCurrent(
+	seq: number,
+	userId: string,
+	slug: string,
+	m: WorkspaceMembership | null,
+) {
+	if (seq !== membershipSeq) return;
+	if (userId !== currentUserId()) {
+		currentMembership = null;
+		membershipKnown = false;
+		current = null;
+		return;
+	}
+	settleMembership(userId, slug, m);
+}
 
 // The keyed single-flight loader fencing `loadAll` (TASK-2947) — the same
 // primitive `collections.svelte.ts` uses, which is the point: generation,
@@ -76,13 +220,22 @@ export const workspaceStore = {
 	get currentMembership() { return currentMembership; },
 
 	/**
-	 * True once membership RESOLUTION has settled for the current workspace, so
-	 * a null `currentMembership` means "no access" rather than "not yet loaded".
+	 * True once membership RESOLUTION has settled for the workspace
+	 * `currentMembership` describes, so a null `currentMembership` means "no
+	 * access" rather than "not yet loaded". Not necessarily `current`: between
+	 * `setCurrent`'s entry and its `current = resolved`, membership already
+	 * names the workspace being SET while `current` still names the previous
+	 * one. Consumers read grants from the helpers and identity from `current`,
+	 * and the grants are the ones for the workspace the route is moving to.
 	 * Resolution, not fetch: a workspace that does not resolve at all settles
 	 * this without any `/me` request being made.
 	 *
 	 * False spans the whole replacing call — workspace resolution and creation
-	 * included, not just the `/me` request itself.
+	 * included, not just the `/me` request itself — for a workspace this
+	 * session has NOT answered before. For one it has, the flag stays true
+	 * across the call and the prior answer is served meanwhile (TASK-2988), so
+	 * a repeat resolution is invisible to consumers. Only a FIRST resolution
+	 * shows "unknown".
 	 *
 	 * Consumers that cache a permission to avoid flickering during that window
 	 * (BUG-2978) must gate on this rather than on `currentMembership !==
@@ -210,10 +363,37 @@ export const workspaceStore = {
 		// membershipSeq comment at top of file.
 		const seq = ++membershipSeq;
 
-		// Clear stale membership immediately so helpers don't briefly answer
-		// "yes" using the previous workspace's grants while /me is in flight.
-		currentMembership = null;
-		membershipKnown = false;
+		// Drop stale membership so helpers can't briefly answer using the
+		// PREVIOUS workspace's grants while /me is in flight — but serve this
+		// workspace's own last answer if the session has one, rather than
+		// dropping to "unknown" (TASK-2988). Both halves matter and they are
+		// about different workspaces: what must never be visible is another
+		// workspace's grants, and `answeredMembership` is keyed by the slug
+		// being set, so what it serves is only ever this workspace's.
+		//
+		// Without this, a REPEAT setCurrent for a workspace already resolved
+		// once made `membershipKnown` false again, and consumers cannot tell
+		// that from "no access" — so a permission-gated block reading the store
+		// DIRECTLY unmounted for the length of a refetch, destroying the state
+		// of any dialog inside one. Consumers holding a sticky copy (the
+		// settings page, the dashboard CTA) rode it out, which is why the four
+		// sites this was found at are the ones that did not.
+		const entrySlug = typeof ws === 'object' ? ws.slug : ws;
+		// Captured once, and used for both the lookup here and the settle below,
+		// so this call records under the identity that ISSUED it rather than
+		// whoever happens to be signed in when its `/me` comes back.
+		const callUser = currentUserId();
+		const entryKey = membershipKey(callUser, entrySlug);
+		if (answeredMembership.has(entryKey)) {
+			// Re-settling the same answer, so this goes through the one settle
+			// function rather than writing the two pieces of state here: it
+			// keeps `settleMembership` the sole writer of `membershipKnown =
+			// true`, which is the claim its own comment makes.
+			settleMembership(callUser, entrySlug, answeredMembership.get(entryKey) ?? null);
+		} else {
+			currentMembership = null;
+			membershipKnown = false;
+		}
 
 		// Resolve the workspace itself. Membership is fetched once we know
 		// the slug.
@@ -246,15 +426,15 @@ export const workspaceStore = {
 		if (resolved) {
 			try {
 				const m = await api.workspaces.me(slug);
-				if (seq === membershipSeq) { currentMembership = m; membershipKnown = true; }
+				settleIfCurrent(seq, callUser, slug, m);
 			} catch {
 				// A 403 or a removed member is an ANSWER, not a pending state.
-				if (seq === membershipSeq) { currentMembership = null; membershipKnown = true; }
+				settleIfCurrent(seq, callUser, slug, null);
 			}
-		} else if (seq === membershipSeq) {
+		} else {
 			// The workspace itself did not resolve (404, or no access): also an
 			// answer, and the same one.
-			membershipKnown = true;
+			settleIfCurrent(seq, callUser, slug, null);
 		}
 	},
 
@@ -288,6 +468,11 @@ export const workspaceStore = {
 		// the newer intent), and a failed create claims nothing and therefore
 		// invalidates nothing.
 		const entrySeq = membershipSeq;
+		// Identity captured BEFORE the POST, not after it. A create issued as one
+		// user can return after another has signed in, and capturing on success
+		// would cache the first user's membership under the SECOND user's key —
+		// which is the leak the key was introduced to close (codex round 5).
+		const callUser = currentUserId();
 		const ws = await api.workspaces.create(data);
 
 		// THE LIST IS ADDITIVE; ONLY THE SELECTION IS RACED (codex round 5).
@@ -312,9 +497,9 @@ export const workspaceStore = {
 		// New workspace — refresh membership for the just-created context.
 		try {
 			const m = await api.workspaces.me(ws.slug);
-			if (seq === membershipSeq) { currentMembership = m; membershipKnown = true; }
+			settleIfCurrent(seq, callUser, ws.slug, m);
 		} catch {
-			if (seq === membershipSeq) { currentMembership = null; membershipKnown = true; }
+			settleIfCurrent(seq, callUser, ws.slug, null);
 		}
 		return ws;
 	}

--- a/web/src/lib/stores/workspaceMembershipKnown.svelte.test.ts
+++ b/web/src/lib/stores/workspaceMembershipKnown.svelte.test.ts
@@ -27,6 +27,13 @@ const WS = { id: 'w1', slug: 'ws', name: 'WS' };
 
 describe('workspaceStore.membershipKnown', () => {
 	beforeEach(() => {
+		// Fresh module registry per test. These tests all resolve the SAME slug,
+		// and since TASK-2988 the store remembers the answer it settled for a
+		// slug — so without this, a test asserting the FIRST-resolution unknown
+		// window would be handed a previous test's answer and fail for a reason
+		// that has nothing to do with what it tests. The isolation is what makes
+		// each `it` mean what it says; it was only ever accidental before.
+		vi.resetModules();
 		vi.resetAllMocks();
 	});
 

--- a/web/src/lib/stores/workspaceRepeatResolve.svelte.test.ts
+++ b/web/src/lib/stores/workspaceRepeatResolve.svelte.test.ts
@@ -1,0 +1,356 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+/**
+ * TASK-2988 — a REPEAT resolution of a workspace this session has already
+ * answered must not drop `membershipKnown` to false.
+ *
+ * Consumers cannot tell "not fetched yet" from "no access" (that is the whole
+ * reason BUG-2978 added the flag), so a false window makes every
+ * permission-gated `{#if}` block unmount for the length of a refetch — taking
+ * the in-progress form state of any dialog inside one with it. The repeat is
+ * routine rather than exotic: the workspace layout calls `recoverIfMissing`
+ * from its sync callback on every sync result, and that calls `setCurrent`
+ * whenever `current` is null or names a different workspace.
+ *
+ * The counterfactual legs matter as much as the regression ones: the entry
+ * clear exists so helpers can never answer with ANOTHER workspace's grants,
+ * and this fix must not weaken that into "membership is always sticky".
+ */
+
+const api = vi.hoisted(() => ({
+	workspaces: {
+		get: vi.fn(),
+		me: vi.fn(),
+		list: vi.fn(),
+		create: vi.fn(),
+	},
+}));
+
+vi.mock('$lib/api/client', () => ({ api }));
+
+// The answer cache is keyed by signed-in user as well as slug, so the identity
+// has to be controllable to test that a second user inherits nothing.
+const auth = vi.hoisted(() => ({ userId: 'user-1' }));
+vi.mock('./auth.svelte', () => ({ authStore: auth }));
+
+const OWNER = { role: 'owner', collection_grants: [], item_grants: [] };
+const VIEWER = { role: 'viewer', collection_grants: [], item_grants: [] };
+const WS = { id: 'w1', slug: 'ws', name: 'WS' };
+const OTHER = { id: 'w2', slug: 'other', name: 'Other' };
+
+/** A promise plus its resolver, so a test can hold `/me` open and observe the window. */
+function deferred<T>() {
+	let resolve!: (v: T) => void;
+	let reject!: (e: unknown) => void;
+	const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej; });
+	return { promise, resolve, reject };
+}
+
+describe('workspaceStore: repeat resolution of an already-answered workspace', () => {
+	beforeEach(() => {
+		// Fresh module registry per test: the answer cache is module state, and a
+		// test that inherited a previous test's cache would pass for the wrong
+		// reason — which is exactly the failure this suite is built to catch.
+		vi.resetModules();
+		vi.resetAllMocks();
+		auth.userId = 'user-1';
+	});
+
+	it('keeps membershipKnown and isOwner true across a second setCurrent for the same slug', async () => {
+		const { workspaceStore } = await import('./workspace.svelte');
+		api.workspaces.get.mockResolvedValue(WS);
+
+		api.workspaces.me.mockResolvedValueOnce(OWNER);
+		await workspaceStore.setCurrent('ws');
+		expect(workspaceStore.membershipKnown).toBe(true);
+		expect(workspaceStore.isOwner).toBe(true);
+
+		// Second resolution, `/me` held open — the window a refetch occupies.
+		const second = deferred<typeof OWNER>();
+		api.workspaces.me.mockReturnValueOnce(second.promise);
+		const pending = workspaceStore.setCurrent('ws');
+
+		expect(workspaceStore.membershipKnown).toBe(true);
+		expect(workspaceStore.isOwner).toBe(true);
+		expect(workspaceStore.currentMembership).toEqual(OWNER);
+
+		second.resolve(OWNER);
+		await pending;
+		expect(workspaceStore.membershipKnown).toBe(true);
+		expect(workspaceStore.isOwner).toBe(true);
+	});
+
+	it('keeps them true through the recoverIfMissing sequence that reaches this in the app', async () => {
+		const { workspaceStore } = await import('./workspace.svelte');
+		api.workspaces.get.mockResolvedValue(WS);
+		api.workspaces.list.mockResolvedValue([WS, OTHER]);
+
+		// On `ws`, membership answered: this is the tab the dialog is open in.
+		api.workspaces.me.mockResolvedValueOnce(OWNER);
+		await workspaceStore.setCurrent('ws');
+		expect(workspaceStore.isOwner).toBe(true);
+
+		// A create points `current` at a DIFFERENT workspace while that route
+		// stays mounted — the step that makes `current.slug !== ws` true.
+		api.workspaces.create.mockResolvedValue(OTHER);
+		api.workspaces.me.mockResolvedValueOnce(OWNER);
+		await workspaceStore.create({ name: 'Other' });
+		expect(workspaceStore.current?.slug).toBe('other');
+
+		// The mounted route's next sync result. `recoverIfMissing` sees the
+		// mismatch and re-resolves `ws`; `/me` is held open so the refetch
+		// window is observable.
+		const refetch = deferred<typeof OWNER>();
+		api.workspaces.me.mockReturnValueOnce(refetch.promise);
+		const pending = workspaceStore.recoverIfMissing('ws');
+
+		// Unfixed, membershipKnown is false here, and every permission-gated
+		// block that reads the store DIRECTLY unmounts. Consumers holding a
+		// sticky copy (the settings page, the dashboard CTA) ride it out — which
+		// is why the four sites this was found at are the ones that did not.
+		expect(workspaceStore.membershipKnown).toBe(true);
+		expect(workspaceStore.isOwner).toBe(true);
+
+		refetch.resolve(OWNER);
+		await pending;
+		expect(workspaceStore.membershipKnown).toBe(true);
+		expect(workspaceStore.isOwner).toBe(true);
+	});
+
+	it('serves a cached DENIAL on repeat rather than flickering to unknown', async () => {
+		const { workspaceStore } = await import('./workspace.svelte');
+		api.workspaces.get.mockResolvedValue(WS);
+
+		api.workspaces.me.mockRejectedValueOnce(new Error('403'));
+		await workspaceStore.setCurrent('ws');
+		expect(workspaceStore.membershipKnown).toBe(true);
+		expect(workspaceStore.currentMembership).toBeNull();
+
+		const second = deferred<unknown>();
+		api.workspaces.me.mockReturnValueOnce(second.promise);
+		const pending = workspaceStore.setCurrent('ws');
+
+		// Denied is an answer: it stays the answer through the refetch, and the
+		// consumer never sees the "wait" state it cannot distinguish from it.
+		expect(workspaceStore.membershipKnown).toBe(true);
+		expect(workspaceStore.currentMembership).toBeNull();
+		expect(workspaceStore.isOwner).toBe(false);
+
+		second.reject(new Error('403'));
+		await pending;
+		expect(workspaceStore.membershipKnown).toBe(true);
+	});
+
+	it('still clears for a workspace this session has NOT answered', async () => {
+		const { workspaceStore } = await import('./workspace.svelte');
+		api.workspaces.get.mockImplementation(async (slug: string) =>
+			slug === 'ws' ? WS : OTHER
+		);
+
+		api.workspaces.me.mockResolvedValueOnce(OWNER);
+		await workspaceStore.setCurrent('ws');
+		expect(workspaceStore.isOwner).toBe(true);
+
+		// Switching to a workspace with no answer yet: the entry clear must
+		// still happen, or `ws`'s grants would answer for `other`.
+		const first = deferred<typeof VIEWER>();
+		api.workspaces.me.mockReturnValueOnce(first.promise);
+		const pending = workspaceStore.setCurrent('other');
+
+		expect(workspaceStore.membershipKnown).toBe(false);
+		expect(workspaceStore.currentMembership).toBeNull();
+		expect(workspaceStore.isOwner).toBe(false);
+
+		first.resolve(VIEWER);
+		await pending;
+		expect(workspaceStore.membershipKnown).toBe(true);
+		expect(workspaceStore.currentRole).toBe('viewer');
+	});
+
+	it('never serves one workspace\'s answer for another, even with both answered', async () => {
+		const { workspaceStore } = await import('./workspace.svelte');
+		api.workspaces.get.mockImplementation(async (slug: string) =>
+			slug === 'ws' ? WS : OTHER
+		);
+
+		api.workspaces.me.mockResolvedValueOnce(OWNER);
+		await workspaceStore.setCurrent('ws');
+		api.workspaces.me.mockResolvedValueOnce(VIEWER);
+		await workspaceStore.setCurrent('other');
+		expect(workspaceStore.currentRole).toBe('viewer');
+
+		// Back to `ws`, refetch held open. The served answer must be `ws`'s
+		// owner, not the `other` viewer that was current a moment ago — this is
+		// the leg that would catch a "sticky whatever was last" regression.
+		const back = deferred<typeof OWNER>();
+		api.workspaces.me.mockReturnValueOnce(back.promise);
+		const pending = workspaceStore.setCurrent('ws');
+		expect(workspaceStore.currentRole).toBe('owner');
+
+		back.resolve(OWNER);
+		await pending;
+		expect(workspaceStore.currentRole).toBe('owner');
+	});
+
+	it('a later answer replaces the cached one, so a role change is not held forever', async () => {
+		const { workspaceStore } = await import('./workspace.svelte');
+		api.workspaces.get.mockResolvedValue(WS);
+
+		api.workspaces.me.mockResolvedValueOnce(OWNER);
+		await workspaceStore.setCurrent('ws');
+		expect(workspaceStore.isOwner).toBe(true);
+
+		// Demoted server-side. The serve is only for the refetch window; the
+		// refetch itself is what the consumer ends up with.
+		api.workspaces.me.mockResolvedValueOnce(VIEWER);
+		await workspaceStore.setCurrent('ws');
+		expect(workspaceStore.isOwner).toBe(false);
+		expect(workspaceStore.currentRole).toBe('viewer');
+
+		// And the NEW answer is what a subsequent repeat serves.
+		const third = deferred<typeof VIEWER>();
+		api.workspaces.me.mockReturnValueOnce(third.promise);
+		const pending = workspaceStore.setCurrent('ws');
+		expect(workspaceStore.currentRole).toBe('viewer');
+		third.resolve(VIEWER);
+		await pending;
+	});
+
+	it('does not serve one user\'s answer to the NEXT user after a logout', async () => {
+		// Logout is an SPA navigation (`authStore.clear()` + `goto('/login')`), so
+		// this module — and the cache in it — outlives a sign-out. Keyed by slug
+		// alone, the next user to open the same workspace would be handed the
+		// previous user's grants until their own /me settled. Found by codex
+		// round 3 on the first version of this fix, which was keyed by slug.
+		const { workspaceStore } = await import('./workspace.svelte');
+		api.workspaces.get.mockResolvedValue(WS);
+
+		api.workspaces.me.mockResolvedValueOnce(OWNER);
+		await workspaceStore.setCurrent('ws');
+		expect(workspaceStore.isOwner).toBe(true);
+
+		// Second user, same workspace slug, /me held open.
+		auth.userId = 'user-2';
+		const theirs = deferred<typeof VIEWER>();
+		api.workspaces.me.mockReturnValueOnce(theirs.promise);
+		const pending = workspaceStore.setCurrent('ws');
+
+		expect(workspaceStore.membershipKnown).toBe(false);
+		expect(workspaceStore.currentMembership).toBeNull();
+		expect(workspaceStore.isOwner).toBe(false);
+
+		theirs.resolve(VIEWER);
+		await pending;
+		expect(workspaceStore.currentRole).toBe('viewer');
+	});
+
+	it('discards a /me that settles after the user changed mid-flight', async () => {
+		// The identity fence, which the cache KEY alone does not provide: keying
+		// stops a later user reading an earlier answer, but a request already in
+		// flight when the user changes would still publish its answer and record
+		// it under the NEW user's key. Two fences, two races — a sign-in does not
+		// advance membershipSeq (codex round 4).
+		const { workspaceStore } = await import('./workspace.svelte');
+		api.workspaces.get.mockResolvedValue(WS);
+
+		const theirs = deferred<typeof OWNER>();
+		api.workspaces.me.mockReturnValueOnce(theirs.promise);
+		const pending = workspaceStore.setCurrent('ws');
+
+		// Sign-in as someone else lands while user-1's /me is still open.
+		auth.userId = 'user-2';
+		theirs.resolve(OWNER);
+		await pending;
+
+		// user-1's owner answer must neither be published...
+		expect(workspaceStore.isOwner).toBe(false);
+		expect(workspaceStore.membershipKnown).toBe(false);
+
+		// ...nor be sitting in the cache under user-2, where user-2's own next
+		// resolution would be served it.
+		const mine = deferred<typeof VIEWER>();
+		api.workspaces.me.mockReturnValueOnce(mine.promise);
+		const second = workspaceStore.setCurrent('ws');
+		expect(workspaceStore.membershipKnown).toBe(false);
+		expect(workspaceStore.isOwner).toBe(false);
+
+		mine.resolve(VIEWER);
+		await second;
+		expect(workspaceStore.currentRole).toBe('viewer');
+	});
+
+	it('clears a replayed answer when the user changes before the refetch settles', async () => {
+		// The serve at entry is correct at the instant it happens, so the fence
+		// on the SETTLE is what has to notice the change — and noticing is not
+		// enough: dropping the late answer silently would leave the replayed
+		// owner read on screen for the previous user. An identity mismatch
+		// therefore clears to unknown rather than returning (codex round 5).
+		const { workspaceStore } = await import('./workspace.svelte');
+		api.workspaces.get.mockResolvedValue(WS);
+
+		api.workspaces.me.mockResolvedValueOnce(OWNER);
+		await workspaceStore.setCurrent('ws');
+		expect(workspaceStore.isOwner).toBe(true);
+
+		// Repeat resolve replays the cached owner answer, then the account
+		// changes while the refetch is still open.
+		const refetch = deferred<typeof OWNER>();
+		api.workspaces.me.mockReturnValueOnce(refetch.promise);
+		const pending = workspaceStore.setCurrent('ws');
+		expect(workspaceStore.isOwner).toBe(true);
+
+		auth.userId = 'user-2';
+		refetch.resolve(OWNER);
+		await pending;
+
+		expect(workspaceStore.isOwner).toBe(false);
+		expect(workspaceStore.membershipKnown).toBe(false);
+		expect(workspaceStore.currentMembership).toBeNull();
+
+		// And `current` is dropped, which is what makes the clear self-healing:
+		// `recoverIfMissing` re-resolves on a null `current` and runs on every
+		// sync result, so the new user gets a real answer without needing a
+		// navigation. Left in place, they would sit unknown indefinitely.
+		expect(workspaceStore.current).toBeNull();
+
+		api.workspaces.me.mockResolvedValueOnce(VIEWER);
+		api.workspaces.list.mockResolvedValue([WS]);
+		await workspaceStore.recoverIfMissing('ws');
+		expect(workspaceStore.membershipKnown).toBe(true);
+		expect(workspaceStore.currentRole).toBe('viewer');
+	});
+
+	it('does not cache a create issued by one user under the next user', async () => {
+		// `create` captures identity BEFORE its POST. Capturing after would key
+		// the first user's membership by the SECOND user's id — the exact leak
+		// the key exists to close, reintroduced through the other door (codex
+		// round 5).
+		const { workspaceStore } = await import('./workspace.svelte');
+		api.workspaces.get.mockResolvedValue(OTHER);
+
+		const created = deferred<typeof OTHER>();
+		api.workspaces.create.mockReturnValueOnce(created.promise);
+		api.workspaces.me.mockResolvedValueOnce(OWNER);
+		const pending = workspaceStore.create({ name: 'Other' });
+
+		// Sign-in as someone else lands while the POST is open.
+		auth.userId = 'user-2';
+		created.resolve(OTHER);
+		await pending;
+
+		// user-1's owner answer must not be published for user-2...
+		expect(workspaceStore.isOwner).toBe(false);
+		expect(workspaceStore.membershipKnown).toBe(false);
+
+		// ...nor be waiting in user-2's cache for their own next resolve.
+		const mine = deferred<typeof VIEWER>();
+		api.workspaces.me.mockReturnValueOnce(mine.promise);
+		const second = workspaceStore.setCurrent('other');
+		expect(workspaceStore.membershipKnown).toBe(false);
+		expect(workspaceStore.isOwner).toBe(false);
+
+		mine.resolve(VIEWER);
+		await second;
+		expect(workspaceStore.currentRole).toBe('viewer');
+	});
+});

--- a/web/src/routes/[username]/[workspace]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/+page.svelte
@@ -59,12 +59,15 @@
 
 	// Owner-gate state for the New Collection trigger.
 	//
-	// Reading `workspaceStore.isOwner` directly would make the trigger button
+	// Reading `workspaceStore.isOwner` directly USED TO make the trigger button
 	// flicker visibility every 30 s: the dashboard's silent poll (and sync
-	// signals) call `load()` → `workspaceStore.setCurrent()`, which clears
-	// `currentMembership` to null before `/me` resolves. During that window
-	// `workspaceStore.isOwner` returns false even for owners, hiding the CTA
-	// and dropping any focus on it.
+	// signals) call `load()` → `workspaceStore.setCurrent()`, which cleared
+	// `currentMembership` to null before `/me` resolved. During that window
+	// `workspaceStore.isOwner` returned false even for owners, hiding the CTA
+	// and dropping any focus on it. TASK-2988 closed that window in the store
+	// for a workspace already answered, which this poll normally is — though not
+	// one that lands before the first membership answer settles. The cache here
+	// is kept as defence in depth and still covers that first resolution.
 	//
 	// Two effects per CONVE-606 (split reactive-state sync from route-change
 	// effects): one resets the cache on a real workspace switch, the other
@@ -706,8 +709,12 @@
 	<!--
 		Mount unconditionally (gated on wsSlug, not isOwner) so an owner editing
 		the modal isn't unmounted mid-edit when the 30s dashboard poll or a sync
-		signal calls load() → workspaceStore.setCurrent(), which transiently
-		clears currentMembership and flips isOwner false until /me resolves.
+		signal calls load() → workspaceStore.setCurrent(). That call used to
+		transiently clear currentMembership and flip isOwner false until /me
+		resolved; TASK-2988 stopped it for a workspace already answered, and
+		found the same unmount-mid-edit defect at four sites that had NOT been
+		written this way. This mount stays unconditional regardless — it does
+		not depend on the store's guarantee.
 		The trigger button is owner-gated above; this matches Sidebar.svelte's
 		pattern, and the server-side owner check (handlers_collections.go:48)
 		remains the enforcement boundary.

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -3568,6 +3568,17 @@
 	{/if}
 </div>
 
+<!-- Owner-gated block wrapping a STATEFUL dialog: an unmount here destroys
+     whatever the user has typed into it, and the returning true cannot
+     restore it. What keeps that from happening is a guarantee in the STORE,
+     not anything local — `membershipKnown` never drops to false for a
+     workspace the session has already answered, so a REPEAT resolution leaves
+     `isOwner` alone. Before TASK-2988 it did not, and this block unmounted
+     mid-edit; the reachable route is `recoverIfMissing`, which the workspace
+     layout calls on every sync result and which re-resolves whenever `current`
+     names a different workspace — as it does after a create. These four gates
+     are the consumers relying on that guarantee; if it ever moves, they are
+     what to re-check. -->
 {#if isOwner && collection}
 	<ShareDialog
 		{wsSlug}
@@ -3578,6 +3589,17 @@
 	/>
 {/if}
 
+<!-- Owner-gated block wrapping a STATEFUL dialog: an unmount here destroys
+     whatever the user has typed into it, and the returning true cannot
+     restore it. What keeps that from happening is a guarantee in the STORE,
+     not anything local — `membershipKnown` never drops to false for a
+     workspace the session has already answered, so a REPEAT resolution leaves
+     `isOwner` alone. Before TASK-2988 it did not, and this block unmounted
+     mid-edit; the reachable route is `recoverIfMissing`, which the workspace
+     layout calls on every sync result and which re-resolves whenever `current`
+     names a different workspace — as it does after a create. These four gates
+     are the consumers relying on that guarantee; if it ever moves, they are
+     what to re-check. -->
 {#if isOwner && collection}
 	<EditCollectionModal
 		bind:open={editCollectionOpen}

--- a/web/src/routes/[username]/[workspace]/settings/settingsPermissionFlicker.svelte.test.ts
+++ b/web/src/routes/[username]/[workspace]/settings/settingsPermissionFlicker.svelte.test.ts
@@ -8,10 +8,12 @@ import { workspaceStore } from '$lib/stores/workspace.svelte';
  * BUG-2978 — the owner-only settings tab was lost whenever the workspace
  * permission went known -> unknown -> known.
  *
- * `workspaceStore.setCurrent` clears `currentMembership` to null before `/me`
- * resolves, and the permission helpers treat unknown as no-access by design.
+ * `workspaceStore.setCurrent` USED TO clear `currentMembership` to null before
+ * `/me` resolves — TASK-2988 stopped it doing that for a workspace the session
+ * has already answered, which is the second call here — and the permission
+ * helpers treat unknown as no-access by design.
  * The settings route calls `setCurrent` twice per load (workspace layout, then
- * the page's own `load()`), so an owner sees `canEditWorkspace` read
+ * the page's own `load()`), so an owner saw `canEditWorkspace` read
  * true -> false -> true. During the false window the Danger Zone tab left the
  * tab set, the hash-restoration effect's snap-back moved `activeTab` off it,
  * and `pendingHash` had already been consumed — so nothing restored it.
@@ -74,7 +76,7 @@ describe('BUG-2978: settings permissions survive the /me window', () => {
 		// singleton, and each test re-establishes its state through `setCurrent`.
 	});
 
-	it('keeps the deep-linked owner-only tab selected when membership goes known -> unknown -> known', async () => {
+	it('keeps the deep-linked owner-only tab selected across the page load\'s second setCurrent', async () => {
 		render(SettingsPage);
 
 		// First /me resolves as owner: the Danger Zone tab appears and the
@@ -88,10 +90,22 @@ describe('BUG-2978: settings permissions survive the /me window', () => {
 		});
 
 		// A SECOND setCurrent — what the page's own load() does after the
-		// layout's — clears membership to null before its /me resolves. This is
-		// the window the bug lived in.
+		// layout's. This USED to clear membership to null before its /me
+		// resolved, and that window is where BUG-2978 lived: the snap-back moved
+		// activeTab off the owner-only tab and consumed pendingHash, so the
+		// correct value arriving 6ms later had nothing left to restore.
+		//
+		// TASK-2988 closed the window in the STORE rather than per consumer:
+		// membership is no longer dropped to "unknown" for a workspace the
+		// session has already answered. So this test now asserts two things at
+		// once, and the first is the load-bearing one — the window does not open
+		// at all. The page keeps its sticky `membershipKnown`-gated read as
+		// defence in depth (and it still covers a FIRST resolution), which is
+		// why the assertion below would also hold if the store fix were
+		// reverted; the membership assertion is what fails in that case.
 		const second = workspaceStore.setCurrent('ws');
-		await waitFor(() => expect(workspaceStore.currentMembership).toBeNull());
+		expect(workspaceStore.currentMembership).toEqual(OWNER);
+		expect(workspaceStore.membershipKnown).toBe(true);
 
 		await resolveMe(1, OWNER);
 		await second;


### PR DESCRIPTION
fix(web): unknown membership is not a denial — stop dropping it on a repeat resolve (TASK-2988)

`workspaceStore.setCurrent` cleared `currentMembership` and `membershipKnown`
on entry so the permission helpers could not answer with the PREVIOUS
workspace's grants. Correct for a switch, wrong for a REPEAT: re-resolving a
workspace the session had already answered dropped it back to "unknown", and
consumers cannot tell unknown from denied — that indistinguishability is the
whole reason BUG-2978 added the flag. So a permission-gated `{#if}` reading the
store directly unmounted for the length of the refetch, destroying the
in-progress state of any dialog inside one. Consumers holding a sticky copy
rode it out, which is why the four sites this was found at are the ones that
did not.

The reachable route is `recoverIfMissing`, which the workspace layout calls
from its sync callback on every sync result and which re-resolves whenever
`current` is null or names a different workspace — as it does after a `create`,
which points `current` at the new workspace while the previous route stays
mounted. Traced sequence: open a collection page, open its ShareDialog or
EditCollectionModal, create a workspace from the topbar, and the next sync
result unmounts the dialog mid-edit. The dashboard's collection-editor modal
already carried a comment about exactly this unmount and dodged it by mounting
unconditionally; four sites had not.

Fixed in the store, not per consumer. `setCurrent` remembers the answer it
settles and serves it while a refetch for the same workspace is in flight, so
`membershipKnown` never drops to false for one already seen. The entry clear
still happens for a workspace with no answer yet, which preserves the original
invariant: the cache is keyed by the slug being SET, so it can only ever serve
that workspace's own grants. A cached denial is served too — denied is an
answer, and a denied workspace flickering to unknown is the same defect with
the opposite sign.

TWO FENCES on a settle, for two different races, behind one `settleIfCurrent`
so a call site cannot forget either. `membershipSeq` is the navigation fence
that already existed. The identity fence is new: logout is an SPA navigation,
so the cache outlives a sign-out and a request issued as one user can settle
after another has signed in. Both `setCurrent` and `create` capture the
identity BEFORE their first await — `create` before its POST, since capturing
on success would key the first user's membership by the second user's id — and
the cache key carries that identity. The fence covers the MEMBERSHIP settle
only; `current`, `workspaces` and an already-published membership are not
identity-scoped, and a sign-out does not clear them, which is BUG-2991.

The fences dispose of a rejected settle DIFFERENTLY, which is the part review
had to find twice. A superseded call returns silently: a newer call is already
speaking. An identity mismatch CLEARS to unknown, because if the answer being
published belongs to a user who is no longer signed in then so does whatever is
published right now — including an answer replayed from the cache moments
earlier, which is how a stale owner read would otherwise survive a sign-out.
Unknown is the fail-safe reading, since the helpers treat it as no access.

The identity read is `untrack`ed. `setCurrent` reads it synchronously before
its first await and not every caller is inside `untrack` — the settings page
calls `load(wsSlug)` straight from an `$effect`, which would otherwise start
re-running on any session change.

What this does NOT bound: a served answer is normally corrected by the same
call's settle, but a failed workspace GET settles a denial without reaching
`/me`, a superseded call settles nothing (its successor does), and a request that never
answers leaves the served value standing. An identity mismatch is the one case
that DOES heal itself: it also drops `current`, which is `recoverIfMissing`'s
retry condition, and that runs on every sync result. The server stays the
enforcement boundary; what is at stake is what the UI shows. Reviewing this
also turned up BUG-2990, a pre-existing dashboard cache gated on
`currentMembership !== null` that never clears on a definitive denial — filed
separately rather than widening this PR, alongside BUG-2991 for the unfenced
`create` mutations and the sign-out that leaves live permission state behind.

Tests: ten legs in `workspaceRepeatResolve.svelte.test.ts`. Five fail against
the unfixed store, verified by reverting it via `git show origin/main:` with a
grep confirming the build under test lacked the fix. Each fence was
mutation-tested individually and each mutant killed exactly one leg: keying by
slug alone kills the cross-user leg; removing the identity check kills the
mid-flight leg; returning instead of clearing on a mismatch kills the
replayed-answer leg; capturing `create`'s identity after its POST kills the
create leg; leaving `current` in place on a mismatch kills the replayed-answer
leg's self-healing half. Two more legs guard the over-reach this could become (one
workspace's answer is never served for another; a later answer replaces the
cached one), and one is the counterfactual that must pass on both builds: a
workspace with no answer yet still clears.

Two existing tests asserted the old behaviour and were updated rather than
softened. `workspaceMembershipKnown` now resets modules per test: its cases all
resolve the same slug and one asserts the FIRST-resolution unknown window,
which a sibling's remembered answer would otherwise satisfy — the isolation was
accidental before. The settings flicker test's known → unknown → known
transition is no longer producible by a second `setCurrent`, so it asserts that
the window does not open, keeping its non-vacuity check; that is an accepted
coverage loss, stated at the test, and its denial sibling still exercises the
discriminating half of the page's sticky read.

Prose the change falsified, swept: the `membershipKnown` doc comment, the
settings test's header, and two dashboard comments that described a repeat
`setCurrent` as clearing membership. Four comments mark the owner-gated blocks
wrapping stateful dialogs as consumers relying on the store guarantee.

Gates: svelte-check 0 errors (1086 files), vitest 153 files / 2342 tests
passed, go test exit 0 with no FAIL, golangci-lint 0 issues, gofmt clean.

Assessment this came out of, and the correction to it: TASK-2982.

Claude-Session: https://claude.ai/code/session_01WS9QAnxk1gA3LBha3PvKVm


---

Review: seven codex rounds, CLEAN at round 7. Rounds 1–2 killed the original comment-only version by refuting its premise; rounds 3–6 each found a real defect in the fix (the cross-account cache key, the reactive dependency, `create`'s late capture, the replayed answer surviving a sign-out, the terminal clear). Two pre-existing defects were filed rather than folded in: BUG-2990 (dashboard owner cache never clears on a denial) and BUG-2991 (unfenced `create` mutations, and a sign-out that leaves live permission state behind).
