### PR TITLE
feat(collab): applier-availability pre-check on RoomManager (TASK-2987 / PLAN-2975 unit 1)

### DIFF
--- a/internal/collab/applier.go
+++ b/internal/collab/applier.go
@@ -287,8 +287,20 @@ func (m *RoomManager) ApplyExternalContent(itemID string, markdown string) error
 // THE ERROR DIRECTION IS ASYMMETRIC AND DELIBERATE. A false negative is the defect
 // this exists to prevent: it sends a caller back to apply-then-write, which is
 // BUG-2840 half A verbatim — content in the live Y.Doc, then a refused row write. A
-// false positive costs a partial answer, not corruption. So every judgement call
-// here resolves toward true.
+// false positive costs the caller an honest partial answer instead (PLAN-2975
+// decision 2), which is why every judgement call here resolves toward true.
+//
+// That asymmetry is a statement about THIS function's answer, not a guarantee about
+// everything downstream of it, and the difference matters. A caller that reorders on
+// a true and then meets an apply failure inherits whatever its fallback does — and
+// the fallback that exists today can itself write content past live peers: when
+// applyContentViaCollab exhausts its ErrRoomActiveDuringPrune retries, the PATCH
+// handler falls through to a plain direct write while a live writer may be holding a
+// Y.Doc that will outvote it on the next flush (internal/server/handlers_collab.go's
+// retry cap, consumed by handleUpdateItem's "any other error path" fall-through).
+// That predates this function and is unchanged by it; it is named here because a
+// reader would otherwise take "a false positive costs a partial answer" as a claim
+// about the whole path rather than about this return value (codex round 2, PLAN-2975).
 //
 // That is why an in-progress version restore answers TRUE rather than consulting the
 // conns. ForceRefreshRoom freezes every conn for the duration, and pickApplier skips
@@ -301,10 +313,16 @@ func (m *RoomManager) ApplyExternalContent(itemID string, markdown string) error
 // no window with restoreActive false and conns still frozen.
 //
 // Eligibility is delegated to pickApplier rather than restated, so the hint and the
-// elector cannot drift: read-only conns, frozen conns, and unanchored conns are
-// excluded here because they are excluded there. Passing a nil tried-set asks
-// "is ANY conn electable", which is the condition for the applier path being
-// attempted at all.
+// elector cannot disagree about the RULE: read-only conns, frozen conns, and
+// unanchored conns are excluded here because they are excluded there, and a future
+// change to that predicate reaches both. They can still disagree about the ANSWER,
+// because the room's state moves between the two calls — this is a point-in-time
+// read, not a reservation. Known routes by which a false NO becomes a live applier:
+// a fresh writer joins; an unanchored conn finishes replay and flips replayDone; a
+// view-only conn is promoted by the collab handler's periodic revalidation
+// (SetConnWritable); a restore rolls back and unfreezes (covered by the clause
+// above). Passing a nil tried-set asks "is ANY conn electable", which is the
+// condition for the applier path being attempted at all.
 func (m *RoomManager) HasElectableApplier(itemID string) bool {
 	m.mu.Lock()
 	if m.closed {

--- a/internal/collab/applier.go
+++ b/internal/collab/applier.go
@@ -265,6 +265,64 @@ func (m *RoomManager) ApplyExternalContent(itemID string, markdown string) error
 	return ErrNoApplierAvailable
 }
 
+// HasElectableApplier reports whether an external content update for itemID would,
+// at this instant, route through a designated applier rather than fall back to a
+// direct items.content write. It is a HINT for ordering a caller's row write ahead
+// of the apply (PLAN-2975 decision 1) — never a lock, a reservation, or a promise.
+//
+// It mutates nothing: no admission is taken (enterApplierGate / finishAdmission are
+// deliberately NOT involved), no pending-ack entry is registered, no election is
+// recorded. A concurrent ApplyExternalContent is neither blocked by nor visible to
+// it. Lock discipline: m.mu, then restoreMu, then room.mu, each released before the
+// next is taken, so restoreMu stays a leaf and the itemLock -> appendMu -> room.mu
+// order is untouched.
+//
+// WHAT IT ANSWERS vs WHAT A CALLER USUALLY WANTS. It answers "is at least one conn
+// electable right now". It does not answer "the apply will succeed", and cannot:
+// after a true, ApplyExternalContent can still return ErrNoApplierAvailable (the last
+// candidate's write fails and it is evicted), ErrAllAppliersTimedOut, or
+// ErrApplierAmbiguous. A caller that reorders on a true owes an honest answer for
+// each of those (PLAN-2975 decision 2).
+//
+// THE ERROR DIRECTION IS ASYMMETRIC AND DELIBERATE. A false negative is the defect
+// this exists to prevent: it sends a caller back to apply-then-write, which is
+// BUG-2840 half A verbatim — content in the live Y.Doc, then a refused row write. A
+// false positive costs a partial answer, not corruption. So every judgement call
+// here resolves toward true.
+//
+// That is why an in-progress version restore answers TRUE rather than consulting the
+// conns. ForceRefreshRoom freezes every conn for the duration, and pickApplier skips
+// frozen conns, so a bare pickApplier check answers false for the whole restore
+// window — and on a restore ROLLBACK the conns are unfrozen and an applier is
+// elected, making that false the dangerous direction in exactly the window this is
+// required to compose with. On the success path the conns stay frozen and are
+// force-closed, so the room ends with no applier: a false positive, the tolerable
+// direction. Rollback unfreezes before the deferred resolveRestore runs, so there is
+// no window with restoreActive false and conns still frozen.
+//
+// Eligibility is delegated to pickApplier rather than restated, so the hint and the
+// elector cannot drift: read-only conns, frozen conns, and unanchored conns are
+// excluded here because they are excluded there. Passing a nil tried-set asks
+// "is ANY conn electable", which is the condition for the applier path being
+// attempted at all.
+func (m *RoomManager) HasElectableApplier(itemID string) bool {
+	m.mu.Lock()
+	if m.closed {
+		m.mu.Unlock()
+		return false
+	}
+	room := m.rooms[itemID]
+	m.mu.Unlock()
+
+	if room == nil {
+		return false
+	}
+	if room.restoreInProgress() {
+		return true
+	}
+	return room.pickApplier(nil) != nil
+}
+
 // electAndApply runs one designated-applier election (first attempt + one retry)
 // against the room, gated on the restore coordinator. It returns (err, superseded):
 // superseded==true means a version restore interrupted the election and has resolved,

--- a/internal/collab/applier_precheck_test.go
+++ b/internal/collab/applier_precheck_test.go
@@ -123,6 +123,45 @@ func TestHasElectableApplierManagerClosed(t *testing.T) {
 	}
 }
 
+// TestHasElectableApplierClosedFlagAloneAnswersFalse pins the m.closed guard itself.
+//
+// It exists because the guard is UNREACHABLE as a distinct answer through the public
+// API: Close sets m.closed and replaces m.rooms with an empty map inside ONE m.mu
+// critical section, so after a real Close the room lookup already answers nil and the
+// test above passes with the guard deleted (measured — that mutant survived).
+//
+// So this constructs a state Close does not currently produce: closed set, rooms map
+// left populated. That is not a state to defend against today; it is the coupling the
+// guard exists to break. Without it, HasElectableApplier's correctness depends on an
+// invariant living in Close that nothing enforces, and a future Close that stops
+// clearing the map would silently hand out appliers from a dead manager.
+func TestHasElectableApplierClosedFlagAloneAnswersFalse(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	mgr := NewRoomManager(&fakeOpLog{}, bus)
+	defer mgr.Close()
+
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	conn := dialWS(t, srv, "item-a")
+	defer conn.Close()
+	waitElectable(t, mgr, "item-a", 1)
+
+	mgr.mu.Lock()
+	mgr.closed = true
+	mgr.mu.Unlock()
+	defer func() {
+		mgr.mu.Lock()
+		mgr.closed = false
+		mgr.mu.Unlock()
+	}()
+
+	if mgr.HasElectableApplier("item-a") {
+		t.Fatal("a manager whose closed flag is set must answer false even while its rooms map still holds an electable conn")
+	}
+}
+
 // TestHasElectableApplierGraceTTLNoConns: the room outlives its last conn for
 // graceTTL. ApplyExternalContent answers ErrNoApplierAvailable there, so the hint
 // must answer false — this is the path whose direct write also prunes the op-log.

--- a/internal/collab/applier_precheck_test.go
+++ b/internal/collab/applier_precheck_test.go
@@ -1,0 +1,320 @@
+package collab
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// pickApplierOnly is the NEGATIVE CONTROL for HasElectableApplier: the formulation
+// this unit rejected, which asks the conns directly and omits the restore clause.
+// It exists so the table below can demonstrate that it DISCRIMINATES — a table both
+// implementations pass would be evidence about neither (CONVE-30).
+func pickApplierOnly(m *RoomManager, itemID string) bool {
+	m.mu.Lock()
+	if m.closed {
+		m.mu.Unlock()
+		return false
+	}
+	room := m.rooms[itemID]
+	m.mu.Unlock()
+	if room == nil {
+		return false
+	}
+	return room.pickApplier(nil) != nil
+}
+
+// waitNoConns polls until the room for itemID has zero connections but is still
+// registered with the manager — the grace-TTL window, which is the state that
+// produces ErrNoApplierAvailable rather than ErrNoActiveRoom.
+func waitNoConns(t *testing.T, mgr *RoomManager, itemID string, d time.Duration) *Room {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		mgr.mu.Lock()
+		room := mgr.rooms[itemID]
+		mgr.mu.Unlock()
+		if room != nil {
+			room.mu.Lock()
+			n := len(room.conns)
+			room.mu.Unlock()
+			if n == 0 {
+				return room
+			}
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("room %s did not reach zero conns within deadline", itemID)
+	return nil
+}
+
+// waitConnCount polls until the room holds exactly n connections.
+func waitConnCount(t *testing.T, room *Room, n int, d time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		room.mu.Lock()
+		c := len(room.conns)
+		room.mu.Unlock()
+		if c == n {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("room did not reach %d conns within deadline", n)
+}
+
+// waitAllFrozen polls until the room holds at least one conn and EVERY conn is
+// frozen — the state ForceRefreshRoom establishes before it runs its transaction,
+// and the state in which pickApplier alone answers false.
+func waitAllFrozen(t *testing.T, room *Room, d time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		room.mu.Lock()
+		n := len(room.conns)
+		all := n > 0
+		for _, rc := range room.conns {
+			if !rc.frozen.Load() {
+				all = false
+			}
+		}
+		room.mu.Unlock()
+		if all {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatal("conns did not all reach frozen within deadline")
+}
+
+// TestHasElectableApplierNoRoom: the manager has never seen the item.
+func TestHasElectableApplierNoRoom(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	mgr := NewRoomManager(&fakeOpLog{}, bus)
+	defer mgr.Close()
+
+	if mgr.HasElectableApplier("item-a") {
+		t.Fatal("no room for the item must answer false (the caller's direct write is the right path)")
+	}
+}
+
+// TestHasElectableApplierManagerClosed: a closed manager elects nobody, so the
+// answer must be false rather than a stale true read off the rooms map.
+func TestHasElectableApplierManagerClosed(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	mgr := NewRoomManager(&fakeOpLog{}, bus)
+
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	conn := dialWS(t, srv, "item-a")
+	defer conn.Close()
+	waitElectable(t, mgr, "item-a", 1)
+
+	if !mgr.HasElectableApplier("item-a") {
+		t.Fatal("precondition: a healthy writer must answer true before the manager closes")
+	}
+	mgr.Close()
+	if mgr.HasElectableApplier("item-a") {
+		t.Fatal("a closed manager must answer false")
+	}
+}
+
+// TestHasElectableApplierGraceTTLNoConns: the room outlives its last conn for
+// graceTTL. ApplyExternalContent answers ErrNoApplierAvailable there, so the hint
+// must answer false — this is the path whose direct write also prunes the op-log.
+func TestHasElectableApplierGraceTTLNoConns(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	mgr := NewRoomManagerWithConfig(&fakeOpLog{}, bus, RoomManagerConfig{GraceTTL: 30 * time.Second})
+	defer mgr.Close()
+
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	conn := dialWS(t, srv, "item-a")
+	waitElectable(t, mgr, "item-a", 1)
+	_ = conn.Close()
+
+	room := waitNoConns(t, mgr, "item-a", 2*time.Second)
+	if room == nil {
+		t.Fatal("room went away entirely; this test needs the grace-TTL window")
+	}
+	if mgr.HasElectableApplier("item-a") {
+		t.Fatal("a room inside its grace TTL with zero conns must answer false")
+	}
+}
+
+// TestHasElectableApplierReadOnlyOnly: a view-only participant is never an eligible
+// applier (its sync frames are dropped by the read-only gate), so a room holding
+// only viewers must answer false.
+func TestHasElectableApplierReadOnlyOnly(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	mgr := NewRoomManager(&fakeOpLog{}, bus)
+	defer mgr.Close()
+
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	conn := dialWSReadOnly(t, srv, "item-a")
+	defer conn.Close()
+
+	room := roomFor(t, mgr, "item-a")
+	waitConnCount(t, room, 1, 2*time.Second)
+
+	if mgr.HasElectableApplier("item-a") {
+		t.Fatal("a room holding only read-only participants must answer false")
+	}
+}
+
+// TestHasElectableApplierUnanchoredOnly: a conn in the room map whose replay has not
+// finished buffers Y.Doc updates client-side and would ack a frame that never went
+// out, so pickApplier excludes it — and so must the hint.
+func TestHasElectableApplierUnanchoredOnly(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	mgr := NewRoomManager(&fakeOpLog{}, bus)
+	defer mgr.Close()
+
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	conn := dialWS(t, srv, "item-a")
+	defer conn.Close()
+	waitElectable(t, mgr, "item-a", 1)
+
+	room := roomFor(t, mgr, "item-a")
+	room.mu.Lock()
+	for _, rc := range room.conns {
+		rc.replayDone.Store(false)
+	}
+	room.mu.Unlock()
+
+	if mgr.HasElectableApplier("item-a") {
+		t.Fatal("an unanchored conn is not electable, so the hint must answer false")
+	}
+}
+
+// TestHasElectableApplierHealthyWriter is the positive leg: one anchored writer.
+func TestHasElectableApplierHealthyWriter(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	mgr := NewRoomManager(&fakeOpLog{}, bus)
+	defer mgr.Close()
+
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	conn := dialWS(t, srv, "item-a")
+	defer conn.Close()
+	waitElectable(t, mgr, "item-a", 1)
+
+	if !mgr.HasElectableApplier("item-a") {
+		t.Fatal("one anchored writable conn must answer true")
+	}
+}
+
+// TestHasElectableApplierDuringRestoreAnswersTrue is the DISCRIMINATING leg, and the
+// reason the restore clause exists.
+//
+// ForceRefreshRoom freezes every conn for the duration of its transaction, and
+// pickApplier skips frozen conns. So while a restore holds the room, the conns look
+// un-electable — yet on a ROLLBACK they are unfrozen and an applier IS elected. A
+// false answer here is the dangerous direction: it would send the caller back to
+// apply-then-write, which is BUG-2840 half A.
+//
+// The test drives a restore that blocks inside commit (restoreActive set, conns
+// frozen), probes both implementations, then releases the commit into a rollback.
+// The negative control MUST disagree — a table both formulations pass would be
+// evidence about neither.
+func TestHasElectableApplierDuringRestoreAnswersTrue(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	mgr := NewRoomManager(&fakeOpLog{}, bus)
+	defer mgr.Close()
+
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	conn := dialWS(t, srv, "item-a")
+	defer conn.Close()
+	waitElectable(t, mgr, "item-a", 1)
+	room := roomFor(t, mgr, "item-a")
+
+	releaseCommit := make(chan struct{})
+	restoreDone := make(chan error, 1)
+	go func() {
+		restoreDone <- mgr.ForceRefreshRoom("item-a",
+			func() (int64, int64, error) {
+				<-releaseCommit
+				return 0, 0, errors.New("commit: rolled back")
+			}, nil)
+	}()
+
+	waitRestoreActive(t, room, 2*time.Second)
+	waitAllFrozen(t, room, 2*time.Second)
+
+	// The probe runs in a goroutine so a hypothetical blocking implementation fails
+	// as a legible assertion rather than as a package-level test timeout: this hint
+	// sits on a request path and MUST NOT wait out a restore transaction.
+	got := make(chan bool, 1)
+	go func() { got <- mgr.HasElectableApplier("item-a") }()
+	select {
+	case v := <-got:
+		if !v {
+			t.Fatal("a room held by an in-progress restore must answer TRUE: a rollback unfreezes the conns and elects an applier, so false is the direction that reintroduces BUG-2840")
+		}
+	case <-time.After(2 * time.Second):
+		close(releaseCommit)
+		t.Fatal("HasElectableApplier blocked on an in-progress restore; it must be a point-in-time read, never a gate")
+	}
+
+	if pickApplierOnly(mgr, "item-a") {
+		t.Fatal("negative control is not discriminating: the pickApplier-only formulation was supposed to answer false here, so this table would prove nothing about the restore clause")
+	}
+
+	close(releaseCommit)
+	select {
+	case err := <-restoreDone:
+		if err == nil {
+			t.Fatal("this restore was supposed to roll back")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("ForceRefreshRoom did not return")
+	}
+}
+
+// TestHasElectableApplierTakesNoAdmission pins that the hint is not a gate entry: it
+// must leave admittedUnregistered untouched, or a concurrent beginRestore would
+// drain against a round-trip that will never register (BUG-2276 residual 2, P1).
+func TestHasElectableApplierTakesNoAdmission(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	mgr := NewRoomManager(&fakeOpLog{}, bus)
+	defer mgr.Close()
+
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	conn := dialWS(t, srv, "item-a")
+	defer conn.Close()
+	waitElectable(t, mgr, "item-a", 1)
+	room := roomFor(t, mgr, "item-a")
+
+	for i := 0; i < 5; i++ {
+		if !mgr.HasElectableApplier("item-a") {
+			t.Fatalf("probe %d: want true", i)
+		}
+	}
+
+	room.restoreMu.Lock()
+	admitted := room.admittedUnregistered
+	room.restoreMu.Unlock()
+	if admitted != 0 {
+		t.Fatalf("the hint must take no admission; admittedUnregistered = %d after 5 probes", admitted)
+	}
+}

--- a/internal/collab/restore_coord.go
+++ b/internal/collab/restore_coord.go
@@ -131,6 +131,19 @@ func (r *Room) finishAdmission() {
 	r.restoreMu.Unlock()
 }
 
+// restoreInProgress reports whether a version restore currently holds the room.
+//
+// Unlike enterApplierGate it NEVER blocks and never admits: it is a point-in-time
+// read for HasElectableApplier, whose caller is on a request path that must not wait
+// out a restore-tx before deciding how to order its write. The answer is stale the
+// instant it returns, which is sound only because the caller treats true as a hint
+// biased toward the safe ordering (see HasElectableApplier).
+func (r *Room) restoreInProgress() bool {
+	r.restoreMu.Lock()
+	defer r.restoreMu.Unlock()
+	return r.restoreActive
+}
+
 // waitRestoreResolved blocks until the in-progress restore (if any) resolves. Called
 // by a round-trip the restore finalized to not-persisted, so it doesn't re-elect
 // until the restore's effects (unfreeze on rollback / force-close on commit) are in


### PR DESCRIPTION
PLAN-2975 unit 1 (decision 1). Adds `RoomManager.HasElectableApplier` — the pre-check that lets `handleUpdateItem` learn it is on the designated-applier path **before** it writes the row.

## Why the surface has to exist

BUG-2840 half A: on the applier path the content half is pushed into the live Y.Doc by `ApplyExternalContent` **before** the row write, so any of the four typed refusals from `UpdateItemWithParentLink` — open-children, OCC conflict, cascade-too-large, invalid title — answers 4xx while the content has already reached the collaborative document and will reach `items.content` on the next `?source=collab-snapshot` flush. A refused PATCH must not change the item.

The reorder needs to know it is on that path before applying, and today the only way to learn that is to apply: `applyContentViaCollabOnce` discovers the path by calling `ApplyExternalContent`, which has already applied by the time it returns.

**No caller in this PR.** The handler reorder and the typed partial answer are units 2–4; landing the surface alone keeps this unit's mandated codex round pointed at the interaction the plan named.

## What it is, and what it deliberately is not

True iff the manager is open, a room exists, and **either** a version restore is in progress on that room **or** `pickApplier(nil) != nil`.

It is a **hint**. It registers nothing, takes no admission (`enterApplierGate` / `finishAdmission` are not involved), enters no gate, and holds no lock across anything. It answers *"is at least one conn electable right now"*, which is narrower than *"the apply will take the applier path"* — after a true, the apply can still return `ErrNoApplierAvailable`, `ErrAllAppliersTimedOut`, or `ErrApplierAmbiguous`, and PLAN-2975 decision 2 owes an honest answer for each.

## The restore clause is the whole design decision

The error direction is asymmetric. A **false NO** is the defect — it sends the caller back to apply-then-write, which is BUG-2840 verbatim. A **false YES** costs the caller a partial answer.

`ForceRefreshRoom` freezes every conn for the duration of a restore, and `pickApplier` skips frozen conns — so a bare `pickApplier` check answers NO for the entire restore window, and on a restore **rollback** those conns are unfrozen and an applier is elected. That is the dangerous direction in exactly the window this unit was told to compose with, so an in-progress restore answers TRUE without consulting the conns. On the success path the conns stay frozen and are force-closed, so the room ends with no applier — a false YES, the tolerable direction. Verified there is no window with `restoreActive == false` and conns still frozen: every rollback path unfreezes before the deferred `resolveRestore` runs.

## Evidence

**Gates on the final tip (`60a9148a`):** `go test ./internal/collab/ -race` ok; `make test` exit 0; `make lint` 0 issues; `gofmt` clean. No store/SQL/migration code is touched, so the Postgres leg has nothing here it could discriminate — CI runs it regardless.

**Mutation matrix — 5 mutants, BUILD OK stated before every outcome, 5/5 detected:**

| mutant | build | detected by |
|---|---|---|
| drop the `m.closed` guard | OK | `ClosedFlagAloneAnswersFalse` |
| drop the restore clause (bare `pickApplier`) | OK | `DuringRestoreAnswersTrue` |
| restore clause answers false | OK | `DuringRestoreAnswersTrue` |
| `restoreInProgress` always true | OK | grace-TTL / read-only / unanchored |
| invert the `pickApplier` predicate | OK | six legs |

Harness negative control: a comment-only mutation SURVIVES, so a DETECTED verdict is not the harness reporting failure for any edit.

**The `m.closed` mutant SURVIVED on the first run, and that was the unit's real finding.** `Close` sets `m.closed` and replaces `m.rooms` with an empty map inside one `m.mu` critical section, so after a genuine `Close` the room lookup already answers nil — the manager-closed leg was measuring the nil-room path, not the guard. The guard still earns its place: without it this function's correctness depends on an invariant that lives in `Close` and is enforced nowhere. So the added leg constructs closed-with-rooms-populated, a state `Close` does not produce, and says so in the test body.

**Three codex rounds; the last returned nothing new.** Round 1 (the interaction the plan mandates: `ErrApplierAmbiguous`, the bracket protocol, admission counting, lock order, every exit from `ForceRefreshRoom`) found nothing. Round 2, pointed adversarially at this unit's own claims, found two sentences of mine that claimed more than the code supports, both fixed in `60a9148a`:

- *"a false positive costs a partial answer, not corruption"* was a claim about the whole path stated as a claim about this return value. The fallback that exists today **can** write content past live peers — when `applyContentViaCollab` exhausts its `ErrRoomActiveDuringPrune` retries the handler falls through to a plain direct write while a live writer may hold a Y.Doc that outvotes it. That predates this function; the comment now names it instead of implying it cannot happen.
- *"the hint and the elector cannot drift"* reads as *cannot disagree*. They cannot disagree about the **rule** (the predicate is shared); they can about the **answer**. The routes are now enumerated in the comment and were confirmed exhaustive against `pickApplier`'s three predicates in round 3: a fresh writer joins, an unanchored conn finishes replay, a view-only conn is promoted by the periodic revalidation, a restore rolls back.

Round 3 also refuted one round-2 claim on my reading: a committing restore does **not** clobber a fields-only row write — restore supplies only `Content` plus restore metadata, and the store touches `fields` only when `input.Fields` is non-nil. It does bump `updated_at` / `seq`, which is a live input to unit 2's OCC story.

## Carried forward to unit 4, not fixed here

The pre-check alone does not close BUG-2840. `applyContentViaCollabOnce` returns `ErrRoomActiveDuringPrune` when a peer joins between the availability check and `PruneAndApply`'s re-check, and the retry loop then re-calls `ApplyExternalContent`, which can succeed through the fresh applier — after which the handler's row write still runs last. So a NO that was correct when taken can still end in apply-then-write. The reorder must either re-decide at the top of the handler branch or make the NO path's `directWrite` the only writer for that request.

Closes TASK-2987.

https://claude.ai/code/session_01GqaEDuCtRiSJfa7eppWecn
