### PR TITLE
docs: CLAUDE.md described pad auth login as an email/password prompt; it is browser-based

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,7 @@ User-based authentication with email/password. When no users exist (fresh instal
 pad auth setup         # Create the first admin account on the server host
 
 # Subsequent logins
-pad auth login         # Email + password prompt
+pad auth login         # Browser-based login (add -i for an email + password prompt)
 pad auth whoami        # Show current user
 pad auth logout        # Sign out
 pad auth reset-password user@example.com  # Recover a locked-out account (run ON THE SERVER HOST)


### PR DESCRIPTION
docs: CLAUDE.md described pad auth login as an email/password prompt; it is browser-based

`pad auth login` opens the browser-based CLI auth flow. The email/password
prompt is behind `-i` — the flag's own help says so: "Use email/password prompt
instead of browser-based login" (`cmd/pad/cmd_auth.go`, where the RunE branches
on `interactive` and otherwise calls `doBrowserLogin`).

The line mattered because it is the one an agent reads before telling a
locked-out user what to run, and on a headless box the wrong answer wastes the
attempt. Found while writing TASK-2984's README paragraph, where I made the
same mistake in my own first draft and had to check the code to catch it.

Scope: one line. The neighbouring claim at CLAUDE.md:112 — that minting is
gated because "a token that can mint tokens outlives its own revocation" — was
also flagged in review as loose, since it is the tokens the mint PRODUCES that
outlive the parent's revocation. Left alone deliberately: it is imprecise
phrasing of a true fact, not a statement that is wrong about the code, and this
change is for the latter.

Claude-Session: https://claude.ai/code/session_01WS9QAnxk1gA3LBha3PvKVm



https://claude.ai/code/session_01WS9QAnxk1gA3LBha3PvKVm
