### PR TITLE
fix(web): user-scoped state and side effects must expire when the user changes (BUG-2990 / BUG-2991 / BUG-3004)

### DIFF
--- a/web/src/lib/components/layout/CreateWorkspaceModal.svelte
+++ b/web/src/lib/components/layout/CreateWorkspaceModal.svelte
@@ -113,6 +113,17 @@
 				description: newDescription.trim() || undefined,
 				template: selectedTemplate || undefined
 			});
+			// NULL means the signed-in user changed while the POST was open, so
+			// this workspace belongs to the session that started the create and
+			// not to whoever is here now (BUG-2991). Close, and navigate
+			// nowhere: sending the new user to the previous user's slug is a
+			// navigation nobody asked for, and the server denies them anyway.
+			// No toast either — nothing failed for the user in front of us, and
+			// they did not start this create.
+			if (!ws) {
+				close();
+				return;
+			}
 			// Fire the Phase F hook BEFORE close + goto so the consumer can
 			// stage state (e.g. uiStore.requestConnectAfterNavigate) that
 			// the destination route will read on mount. Callback is purely

--- a/web/src/lib/components/layout/CreateWorkspaceModal.svelte
+++ b/web/src/lib/components/layout/CreateWorkspaceModal.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+	import { untrack } from 'svelte';
 	import { goto } from '$app/navigation';
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
+	import { authStore } from '$lib/stores/auth.svelte';
 	import { uiStore } from '$lib/stores/ui.svelte';
 	import { api, isPlanLimitError, planLimitMessage } from '$lib/api/client';
 	import { toastStore } from '$lib/stores/toast.svelte';
@@ -58,8 +60,34 @@
 		})).filter((g) => g.templates.length > 0)
 	);
 
+	// Reset on the OPEN TRANSITION, not on every run of this effect.
+	//
+	// It used to reset whenever it re-ran with `createWorkspaceOpen` true — and
+	// it re-runs on its own, because the body READS `templates.length` and
+	// WRITES `templates` from the response. So the templates request, which is
+	// fired by this very effect on open, wiped the typed name, the chosen
+	// template, the expanded state and any selected import bundle a moment
+	// later. Anyone typing faster than that round-trip lost what they typed.
+	//
+	// Found while writing the identity tests for this modal (BUG-2991): every
+	// click-driven case failed because the state under test was reset out from
+	// under it. It is also the shape CONVE-1688 names — an `$effect` that reads
+	// a `$state` it also writes — which in a production build can wedge Svelte's
+	// scheduler rather than merely misbehaving.
+	//
+	// The writes are `untrack`ed so nothing in the body can invalidate the
+	// effect, and the marker makes the reset a real edge rather than a
+	// steady-state condition.
+	let wasOpen = false;
 	$effect(() => {
-		if (uiStore.createWorkspaceOpen) {
+		const open = uiStore.createWorkspaceOpen;
+		if (!open) {
+			wasOpen = false;
+			return;
+		}
+		if (wasOpen) return;
+		wasOpen = true;
+		untrack(() => {
 			// Reset state on open
 			mode = 'create';
 			newName = '';
@@ -73,9 +101,9 @@
 				loadingTemplates = true;
 				api.templates.list().then(t => templates = t).catch(() => {}).finally(() => loadingTemplates = false);
 			}
-			// Focus name input
-			requestAnimationFrame(() => nameInputEl?.focus());
-		}
+		});
+		// Focus name input
+		requestAnimationFrame(() => nameInputEl?.focus());
 	});
 
 	function close() {
@@ -143,8 +171,24 @@
 	async function importWorkspace() {
 		if (!importFile) return;
 		importing = true;
+		// Captured before the upload, checked after it (BUG-2991, codex round
+		// 4). Import is `create`'s sibling — it mints a workspace through the
+		// same server path — and it had none of the same fencing: an import
+		// issued by user A that returns after B has signed in fired the Phase F
+		// hook for B, toasted A's workspace name at them, and navigated them to
+		// A's slug. The server denies them, so it is not a bypass; it is a
+		// navigation nobody asked for, carrying another account's workspace name
+		// in the toast and the URL.
+		//
+		// The store is safe on its own — `loadAll` has its own identity fence —
+		// so this guards the SIDE EFFECTS: the callback, the toast and the goto.
+		const callUser = authStore.userId;
 		try {
 			const ws = await api.workspaces.importBundle(importFile, newName.trim() || undefined);
+			if (authStore.userId !== callUser) {
+				close();
+				return;
+			}
 			await workspaceStore.loadAll();
 			// Same Phase F hook as create — claim code is equally useful for
 			// imported workspaces, and the user explicitly opted into this

--- a/web/src/lib/components/layout/CreateWorkspaceModal.svelte
+++ b/web/src/lib/components/layout/CreateWorkspaceModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { untrack } from 'svelte';
+	import { onMount, untrack } from 'svelte';
 	import { goto } from '$app/navigation';
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
 	import { authStore } from '$lib/stores/auth.svelte';
@@ -114,6 +114,19 @@
 		uiStore.closeCreateWorkspace();
 	}
 
+	// A DRAFT IS PER-USER TOO (codex round 7). The operations are fenced, but a
+	// modal left open by one user kept their typed workspace name, description,
+	// chosen template and selected import FILE on screen for whoever signed in
+	// next — visible, and submittable by them. Closing is the whole fix,
+	// because the reset above runs on the next open transition; there is no
+	// separate teardown to keep in step with it.
+	//
+	// Registered here rather than folded into the store's own listener because
+	// this is component state, and it unsubscribes on destroy.
+	onMount(() => authStore.onIdentityChange(() => {
+		if (uiStore.createWorkspaceOpen) close();
+	}));
+
 	function selectBlank() {
 		selectedTemplate = 'blank';
 	}
@@ -139,6 +152,9 @@
 
 	async function createWorkspace() {
 		if (!newName.trim()) return;
+		// Captured for the FAILURE path only — the success path is fenced in the
+		// store, which returns null when the user changed (codex round 7).
+		const createUser = authStore.userId;
 		try {
 			const ws = await workspaceStore.create({
 				name: newName.trim(),
@@ -164,6 +180,12 @@
 			close();
 			goto(`/${ws.owner_username}/${ws.slug}`);
 		} catch (err: unknown) {
+			// Same fence on the failure path as on the success path (codex
+			// round 7). A create that rejects after the signed-in user changed
+			// reported the previous session's failure to whoever is here now,
+			// and the plan-limit branch is worse than the generic one — it
+			// would tell B their plan is full because A's was.
+			if (authStore.userId !== createUser) return;
 			if (isPlanLimitError(err)) {
 				toastStore.show(planLimitMessage(err) + ' Upgrade to Pro', 'error', 6000, '/console/billing');
 			} else {
@@ -213,6 +235,14 @@
 			toastStore.show(`Imported workspace "${ws.name}"`, 'success');
 			goto(`/${ws.owner_username}/${ws.slug}`);
 		} catch (err) {
+			// The FAILURE path needs the same fence (codex round 7). An import
+			// that rejects after the signed-in user changed reported A's error
+			// to B — an error for an operation B never started, naming a file
+			// they never chose. The comment above claimed the fence covered
+			// "the callback, the toast and the goto"; the toast down here was
+			// unconditional, which made that comment a claim the code did not
+			// keep. The same applies when `loadAll` is what rejected.
+			if (authStore.userId !== callUser) return;
 			toastStore.show(`Import failed: ${err instanceof Error ? err.message : 'Unknown error'}`, 'error');
 		} finally {
 			importing = false;

--- a/web/src/lib/components/layout/CreateWorkspaceModal.svelte
+++ b/web/src/lib/components/layout/CreateWorkspaceModal.svelte
@@ -44,6 +44,8 @@
 	let templates = $state<WorkspaceTemplate[]>([]);
 	let loadingTemplates = $state(false);
 	let importing = $state(false);
+	// Monotonic token for the import in flight — see `importWorkspace`.
+	let importOp = 0;
 	let importFile = $state<File | null>(null);
 	let fileInputEl = $state<HTMLInputElement>();
 	let nameInputEl = $state<HTMLInputElement>();
@@ -201,6 +203,15 @@
 
 	async function importWorkspace() {
 		if (!importFile) return;
+		// OPERATION TOKEN, because `importing` is COMPONENT state and the
+		// component outlives the operation (codex round 9). A stale import's
+		// `finally` used to clear it unconditionally, so: A starts an import,
+		// identity changes, B opens the modal and starts their own — and when
+		// A's promise settles it re-enabled B's button mid-upload, offering
+		// them a duplicate submit. A token rather than an identity check
+		// because it also covers a same-user restart, which has the identical
+		// shape and no identity change to notice.
+		const myImport = ++importOp;
 		importing = true;
 		// Captured before the upload, checked after it (BUG-2991, codex round
 		// 4). Import is `create`'s sibling — it mints a workspace through the
@@ -248,7 +259,7 @@
 			if (authStore.userId !== callUser) return;
 			toastStore.show(`Import failed: ${err instanceof Error ? err.message : 'Unknown error'}`, 'error');
 		} finally {
-			importing = false;
+			if (myImport === importOp) importing = false;
 		}
 	}
 

--- a/web/src/lib/components/layout/CreateWorkspaceModal.svelte
+++ b/web/src/lib/components/layout/CreateWorkspaceModal.svelte
@@ -1,3 +1,25 @@
+<script module lang="ts">
+	/**
+	 * Monotonic token for the create/import operation in flight, MODULE-SCOPED
+	 * rather than per instance (BUG-2991, codex round 10).
+	 *
+	 * An instance-local counter fences one component's own state and nothing
+	 * else, and this modal is destroyed and remounted routinely — a logout, a
+	 * navigation between the console and workspace shells. So: A starts an
+	 * import, the modal unmounts, A signs back in and a NEW instance mounts,
+	 * the OLD instance's request resolves — its identity check passes, because
+	 * it really is the same user, and it fires the Phase F callback, the toast,
+	 * `close()` and a `goto` to a workspace nobody is currently asking for,
+	 * dismissing the new instance's modal on the way.
+	 *
+	 * Identity cannot answer this: the user did not change. What changed is
+	 * that this continuation stopped being the operation anyone is waiting on.
+	 * Module scope is what makes the token outlive the instance, which is
+	 * exactly the lifetime the defect lives in.
+	 */
+	let opSeq = 0;
+</script>
+
 <script lang="ts">
 	import { onMount, untrack } from 'svelte';
 	import { goto } from '$app/navigation';
@@ -44,8 +66,6 @@
 	let templates = $state<WorkspaceTemplate[]>([]);
 	let loadingTemplates = $state(false);
 	let importing = $state(false);
-	// Monotonic token for the import in flight — see `importWorkspace`.
-	let importOp = 0;
 	let importFile = $state<File | null>(null);
 	let fileInputEl = $state<HTMLInputElement>();
 	let nameInputEl = $state<HTMLInputElement>();
@@ -125,6 +145,16 @@
 	//
 	// Registered here rather than folded into the store's own listener because
 	// this is component state, and it unsubscribes on destroy.
+	// This instance's own lifetime. A module-scoped token says whether a NEWER
+	// operation has superseded this one; it cannot say whether the instance that
+	// started this one still exists, because a remount that starts nothing
+	// advances no counter (codex round 10, and the first version of that fix
+	// missed exactly this). A destroyed instance's continuation must not fire a
+	// callback, a toast, a close or a navigation on behalf of a component
+	// nobody is looking at.
+	let alive = true;
+	onMount(() => () => { alive = false; });
+
 	onMount(() => authStore.onIdentityChange(() => {
 		if (uiStore.createWorkspaceOpen) close();
 	}));
@@ -157,6 +187,7 @@
 		// Captured for the FAILURE path only — the success path is fenced in the
 		// store, which returns null when the user changed (codex round 7).
 		const createUser = authStore.userId;
+		const myOp = ++opSeq;
 		try {
 			const ws = await workspaceStore.create({
 				name: newName.trim(),
@@ -170,6 +201,11 @@
 			// navigation nobody asked for, and the server denies them anyway.
 			// No toast either — nothing failed for the user in front of us, and
 			// they did not start this create.
+			// Not the operation anyone is waiting on any more (codex round 10) —
+			// a later create/import, or a remount that started one, has
+			// superseded this. Silent return: no callback, no navigation, no
+			// close.
+			if (!alive || myOp !== opSeq) return;
 			if (!ws) {
 				// RETURN WITHOUT CLOSING (codex round 8). `close()` is global —
 				// it writes `uiStore.createWorkspaceOpen` — and by the time we
@@ -192,6 +228,7 @@
 			// reported the previous session's failure to whoever is here now,
 			// and the plan-limit branch is worse than the generic one — it
 			// would tell B their plan is full because A's was.
+			if (!alive || myOp !== opSeq) return;
 			if (authStore.userId !== createUser) return;
 			if (isPlanLimitError(err)) {
 				toastStore.show(planLimitMessage(err) + ' Upgrade to Pro', 'error', 6000, '/console/billing');
@@ -211,7 +248,7 @@
 		// them a duplicate submit. A token rather than an identity check
 		// because it also covers a same-user restart, which has the identical
 		// shape and no identity change to notice.
-		const myImport = ++importOp;
+		const myOp = ++opSeq;
 		importing = true;
 		// Captured before the upload, checked after it (BUG-2991, codex round
 		// 4). Import is `create`'s sibling — it mints a workspace through the
@@ -227,6 +264,7 @@
 		const callUser = authStore.userId;
 		try {
 			const ws = await api.workspaces.importBundle(importFile, newName.trim() || undefined);
+			if (!alive || myOp !== opSeq) return;
 			// Return without closing — see the create path for why (codex round
 			// 8): the identity listener has already closed this modal, and a
 			// second `close()` would dismiss the fresh one the new user may
@@ -240,6 +278,7 @@
 			// per-operation — the same reason `create` needs two checks rather
 			// than one — so the guard sits immediately before the side effects
 			// it protects rather than at the top of the block.
+			if (!alive || myOp !== opSeq) return;
 			if (authStore.userId !== callUser) return;
 			// Same Phase F hook as create — claim code is equally useful for
 			// imported workspaces, and the user explicitly opted into this
@@ -256,10 +295,11 @@
 			// "the callback, the toast and the goto"; the toast down here was
 			// unconditional, which made that comment a claim the code did not
 			// keep. The same applies when `loadAll` is what rejected.
+			if (!alive || myOp !== opSeq) return;
 			if (authStore.userId !== callUser) return;
 			toastStore.show(`Import failed: ${err instanceof Error ? err.message : 'Unknown error'}`, 'error');
 		} finally {
-			if (myImport === importOp) importing = false;
+			if (alive && myOp === opSeq) importing = false;
 		}
 	}
 

--- a/web/src/lib/components/layout/CreateWorkspaceModal.svelte
+++ b/web/src/lib/components/layout/CreateWorkspaceModal.svelte
@@ -169,7 +169,12 @@
 			// No toast either — nothing failed for the user in front of us, and
 			// they did not start this create.
 			if (!ws) {
-				close();
+				// RETURN WITHOUT CLOSING (codex round 8). `close()` is global —
+				// it writes `uiStore.createWorkspaceOpen` — and by the time we
+				// are here the identity listener has already closed this modal.
+				// If the new user has since opened a FRESH one, closing again
+				// dismisses THEIR modal and their draft. There is nothing left
+				// for this continuation to close.
 				return;
 			}
 			// Fire the Phase F hook BEFORE close + goto so the consumer can
@@ -211,10 +216,11 @@
 		const callUser = authStore.userId;
 		try {
 			const ws = await api.workspaces.importBundle(importFile, newName.trim() || undefined);
-			if (authStore.userId !== callUser) {
-				close();
-				return;
-			}
+			// Return without closing — see the create path for why (codex round
+			// 8): the identity listener has already closed this modal, and a
+			// second `close()` would dismiss the fresh one the new user may
+			// have opened in the meantime.
+			if (authStore.userId !== callUser) return;
 			await workspaceStore.loadAll();
 			// CHECKED AGAIN AFTER `loadAll` (codex round 5). One check after the
 			// upload is not enough: `loadAll` is a second await, and a swap
@@ -223,10 +229,7 @@
 			// per-operation — the same reason `create` needs two checks rather
 			// than one — so the guard sits immediately before the side effects
 			// it protects rather than at the top of the block.
-			if (authStore.userId !== callUser) {
-				close();
-				return;
-			}
+			if (authStore.userId !== callUser) return;
 			// Same Phase F hook as create — claim code is equally useful for
 			// imported workspaces, and the user explicitly opted into this
 			// modal so opening the Connect modal post-import isn't surprising.

--- a/web/src/lib/components/layout/CreateWorkspaceModal.svelte
+++ b/web/src/lib/components/layout/CreateWorkspaceModal.svelte
@@ -97,7 +97,11 @@
 			importFile = null;
 			importing = false;
 			// Load templates
-			if (templates.length === 0) {
+			// Guarded on `loadingTemplates` as well as emptiness (codex round
+			// 5): close-and-reopen, or a destroy-and-remount, before the first
+			// response lands would otherwise issue a second request while the
+			// first is still in flight.
+			if (templates.length === 0 && !loadingTemplates) {
 				loadingTemplates = true;
 				api.templates.list().then(t => templates = t).catch(() => {}).finally(() => loadingTemplates = false);
 			}
@@ -190,6 +194,17 @@
 				return;
 			}
 			await workspaceStore.loadAll();
+			// CHECKED AGAIN AFTER `loadAll` (codex round 5). One check after the
+			// upload is not enough: `loadAll` is a second await, and a swap
+			// landing inside it put the callback, the toast and the navigation
+			// back in the new user's session. The rule is per-AWAIT, not
+			// per-operation — the same reason `create` needs two checks rather
+			// than one — so the guard sits immediately before the side effects
+			// it protects rather than at the top of the block.
+			if (authStore.userId !== callUser) {
+				close();
+				return;
+			}
 			// Same Phase F hook as create — claim code is equally useful for
 			// imported workspaces, and the user explicitly opted into this
 			// modal so opening the Connect modal post-import isn't surprising.

--- a/web/src/lib/components/layout/createWorkspaceModalIdentity.svelte.test.ts
+++ b/web/src/lib/components/layout/createWorkspaceModalIdentity.svelte.test.ts
@@ -361,6 +361,53 @@ describe('BUG-2991: the create-workspace modal does not act for a session that e
 		expect(goto).not.toHaveBeenCalled();
 	});
 
+	it('does not re-enable the NEXT user\'s in-flight import when a stale one settles', async () => {
+		// codex round 9. `importing` is COMPONENT state and the component
+		// outlives the operation, so a stale import's `finally` cleared it
+		// unconditionally: A starts an import, identity changes, B opens the
+		// modal and starts their own, and A's promise settling re-enabled B's
+		// button mid-upload — offering a duplicate submit.
+		let resolveA!: (v: typeof WS) => void;
+		api.workspaces.importBundle.mockReturnValueOnce(
+			new Promise((res) => { resolveA = res; }),
+		);
+
+		const { container } = render(CreateWorkspaceModal, { props: {} });
+		await attachBundle(container);
+		btn(container, /Import Workspace/).click();
+		await settle();
+		expect(api.workspaces.importBundle).toHaveBeenCalledTimes(1);
+
+		// Identity changes; the listener closes A's modal.
+		authStore.clear();
+		await settle();
+
+		// B opens a fresh modal and starts their own import.
+		uiStore.openCreateWorkspace();
+		await settle();
+		await attachBundle(container);
+		let resolveB!: (v: typeof WS) => void;
+		api.workspaces.importBundle.mockReturnValueOnce(
+			new Promise((res) => { resolveB = res; }),
+		);
+		btn(container, /Import Workspace/).click();
+		await settle();
+		expect(api.workspaces.importBundle).toHaveBeenCalledTimes(2);
+
+		// PRECONDITION: B's button really is disabled while B's upload runs.
+		expect(btn(container, /Importing/).disabled).toBe(true);
+
+		// Now A's stale import settles.
+		resolveA(WS);
+		await settle();
+
+		// B's button must still be disabled — their upload is still running.
+		expect(btn(container, /Importing/).disabled).toBe(true);
+
+		resolveB(WS);
+		await settle();
+	});
+
 	it('navigates when the user is unchanged during an IMPORT', async () => {
 		api.workspaces.importBundle.mockResolvedValue(WS);
 		const onWorkspaceCreated = vi.fn();

--- a/web/src/lib/components/layout/createWorkspaceModalIdentity.svelte.test.ts
+++ b/web/src/lib/components/layout/createWorkspaceModalIdentity.svelte.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, fireEvent } from '@testing-library/svelte';
+import { tick } from 'svelte';
+
+/**
+ * BUG-2991 — the create-workspace modal's two post-await side effects.
+ *
+ * `create` and `import` both mint a workspace and then fire the Phase F
+ * callback and NAVIGATE. If the signed-in user changed while the request was
+ * open, that callback and that navigation belong to the session that ended:
+ * the new user is sent to a slug that is not theirs, with the other account's
+ * workspace name in the toast and the URL. The server denies them, so it is
+ * never a bypass — it is a navigation nobody asked for.
+ *
+ * `create` is fenced in the STORE (it returns null); `import` calls the API
+ * directly, so its fence lives in the component. Both are asserted HERE,
+ * because the defect is in what the component does with the answer (CONVE-19)
+ * — the store test cannot see a `goto`.
+ */
+
+const api = vi.hoisted(() => ({
+	auth: { session: vi.fn() },
+	templates: { list: vi.fn() },
+	workspaces: {
+		create: vi.fn(),
+		importBundle: vi.fn(),
+		list: vi.fn(),
+		get: vi.fn(),
+		me: vi.fn(),
+	},
+}));
+
+const goto = vi.hoisted(() => vi.fn());
+
+vi.mock('$lib/api/client', () => ({
+	api,
+	isPlanLimitError: () => false,
+	planLimitMessage: () => '',
+}));
+vi.mock('$app/navigation', () => ({ goto }));
+
+import CreateWorkspaceModal from './CreateWorkspaceModal.svelte';
+import { authStore } from '$lib/stores/auth.svelte';
+import { uiStore } from '$lib/stores/ui.svelte';
+
+const WS = { id: 'w1', slug: 'other', name: 'Other', owner_username: 'alice' };
+
+function deferred<T>() {
+	let resolve!: (v: T) => void;
+	const promise = new Promise<T>((res) => { resolve = res; });
+	return { promise, resolve };
+}
+
+/** Bounded microtask + effect flush. No timers, so nothing can hang on one. */
+async function settle(): Promise<void> {
+	for (let i = 0; i < 24; i++) {
+		await Promise.resolve();
+		await tick();
+	}
+}
+
+function btn(container: HTMLElement, label: RegExp): HTMLButtonElement {
+	const found = [...container.querySelectorAll('button')].find((b) =>
+		label.test(b.textContent?.trim() ?? ''),
+	);
+	if (!found) throw new Error(`no button matching ${label}`);
+	return found as HTMLButtonElement;
+}
+
+async function attachBundle(container: HTMLElement): Promise<void> {
+	// Native `.click()` rather than `fireEvent.click`: Svelte 5 delegates
+	// events from the mount root, and a synthetic MouseEvent dispatched at the
+	// element did not reach the delegated handler here — the tab stayed on
+	// `Create` and the import panel never rendered.
+	btn(container, /^Import$/).click();
+	await settle();
+	const input = container.querySelector('input[type="file"]');
+	if (!input) throw new Error('import panel did not render');
+	const file = new File(['x'], 'bundle.tar.gz', { type: 'application/gzip' });
+	Object.defineProperty(input, 'files', { value: [file], configurable: true });
+	await fireEvent.input(input);
+	await settle();
+}
+
+beforeEach(async () => {
+	goto.mockClear();
+	api.templates.list.mockResolvedValue([]);
+	api.workspaces.list.mockResolvedValue([]);
+	api.workspaces.get.mockResolvedValue(WS);
+	api.workspaces.me.mockResolvedValue(null);
+	api.workspaces.create.mockReset();
+	api.workspaces.importBundle.mockReset();
+	authStore.clear();
+	api.auth.session.mockResolvedValue({
+		authenticated: true,
+		user: { id: 'u1', email: 'u1@example.com' },
+	});
+	await authStore.load();
+	// The modal's `open` comes from the ui store, not a prop.
+	uiStore.openCreateWorkspace();
+});
+
+afterEach(() => {
+	cleanup();
+	uiStore.closeCreateWorkspace();
+	authStore.clear();
+});
+
+describe('the modal resets on the OPEN TRANSITION, not on every effect run', () => {
+	it('keeps what the user typed when the templates response lands', async () => {
+		// Found while writing the identity cases below: every click-driven test
+		// failed because the reset effect re-ran and wiped the state under test.
+		//
+		// The effect READ `templates.length` and WROTE `templates` from its own
+		// response, so it invalidated itself — the templates request it fires on
+		// open came back a moment later and reset the typed name, the chosen
+		// template, the expanded state and any selected bundle. Anyone typing
+		// faster than that round-trip lost what they typed. It is also the shape
+		// CONVE-1688 names, which in a production build can wedge the scheduler
+		// rather than merely misbehaving.
+		const templates = deferred<unknown[]>();
+		api.templates.list.mockReturnValue(templates.promise);
+
+		const { container } = render(CreateWorkspaceModal, { props: {} });
+		const name = container.querySelector('#ws-create-name') as HTMLInputElement;
+		await fireEvent.input(name, { target: { value: 'Typed before templates' } });
+		await settle();
+
+		// The response the effect asked for on open arrives now.
+		templates.resolve([]);
+		await settle();
+
+		expect((container.querySelector('#ws-create-name') as HTMLInputElement).value)
+			.toBe('Typed before templates');
+	});
+
+	it('keeps the Import tab selected when the templates response lands', async () => {
+		const templates = deferred<unknown[]>();
+		api.templates.list.mockReturnValue(templates.promise);
+
+		const { container } = render(CreateWorkspaceModal, { props: {} });
+		btn(container, /^Import$/).click();
+		await settle();
+		expect(container.querySelector('input[type="file"]')).not.toBeNull();
+
+		templates.resolve([]);
+		await settle();
+
+		expect(container.querySelector('input[type="file"]')).not.toBeNull();
+	});
+});
+
+describe('BUG-2991: the create-workspace modal does not act for a session that ended', () => {
+	it('does not navigate when the user changes during a CREATE', async () => {
+		const created = deferred<typeof WS>();
+		api.workspaces.create.mockReturnValue(created.promise);
+		const onWorkspaceCreated = vi.fn();
+
+		const { container } = render(CreateWorkspaceModal, { props: { onWorkspaceCreated } });
+		const name = container.querySelector('#ws-create-name') as HTMLInputElement;
+		await fireEvent.input(name, { target: { value: 'Other' } });
+		await fireEvent.click(btn(container, /Create Workspace/));
+
+		// The POST is open. The session ends.
+		authStore.clear();
+		created.resolve(WS);
+		await settle();
+
+		expect(goto).not.toHaveBeenCalled();
+		expect(onWorkspaceCreated).not.toHaveBeenCalled();
+	});
+
+	it('navigates when the user is unchanged during a CREATE', async () => {
+		// The counterfactual: the fence must not make every create inert.
+		api.workspaces.create.mockResolvedValue(WS);
+		const onWorkspaceCreated = vi.fn();
+
+		const { container } = render(CreateWorkspaceModal, { props: { onWorkspaceCreated } });
+		const name = container.querySelector('#ws-create-name') as HTMLInputElement;
+		await fireEvent.input(name, { target: { value: 'Other' } });
+		await fireEvent.click(btn(container, /Create Workspace/));
+		await settle();
+
+		expect(goto).toHaveBeenCalledWith('/alice/other');
+		expect(onWorkspaceCreated).toHaveBeenCalledWith(WS);
+	});
+
+	it('does not navigate when the user changes during an IMPORT', async () => {
+		const imported = deferred<typeof WS>();
+		api.workspaces.importBundle.mockReturnValue(imported.promise);
+		const onWorkspaceCreated = vi.fn();
+
+		const { container } = render(CreateWorkspaceModal, { props: { onWorkspaceCreated } });
+		await attachBundle(container);
+		await fireEvent.click(btn(container, /Import Workspace/));
+
+		authStore.clear();
+		imported.resolve(WS);
+		await settle();
+
+		expect(goto).not.toHaveBeenCalled();
+		expect(onWorkspaceCreated).not.toHaveBeenCalled();
+	});
+
+	it('navigates when the user is unchanged during an IMPORT', async () => {
+		api.workspaces.importBundle.mockResolvedValue(WS);
+		const onWorkspaceCreated = vi.fn();
+
+		const { container } = render(CreateWorkspaceModal, { props: { onWorkspaceCreated } });
+		await attachBundle(container);
+		await fireEvent.click(btn(container, /Import Workspace/));
+		await settle();
+
+		expect(goto).toHaveBeenCalledWith('/alice/other');
+		expect(onWorkspaceCreated).toHaveBeenCalledWith(WS);
+	});
+});

--- a/web/src/lib/components/layout/createWorkspaceModalIdentity.svelte.test.ts
+++ b/web/src/lib/components/layout/createWorkspaceModalIdentity.svelte.test.ts
@@ -162,6 +162,14 @@ describe('BUG-2991: the create-workspace modal does not act for a session that e
 		await fireEvent.click(btn(container, /Create Workspace/));
 
 		// The POST is open. The session ends.
+		// NON-VACUITY, and it is not decoration: before BUG-3004 was fixed the
+		// reset wiped the typed name, the submit button was disabled, the click
+		// did nothing, and this exact assertion pair passed for that reason
+		// (codex round 5 flagged the shape; the first version of this test had
+		// it). "Did not navigate" is trivially true of a submit that never
+		// happened.
+		expect(api.workspaces.create).toHaveBeenCalled();
+
 		authStore.clear();
 		created.resolve(WS);
 		await settle();
@@ -194,8 +202,37 @@ describe('BUG-2991: the create-workspace modal does not act for a session that e
 		await attachBundle(container);
 		await fireEvent.click(btn(container, /Import Workspace/));
 
+		// NON-VACUITY, same reason as the create case above.
+		expect(api.workspaces.importBundle).toHaveBeenCalled();
+
 		authStore.clear();
 		imported.resolve(WS);
+		await settle();
+
+		expect(goto).not.toHaveBeenCalled();
+		expect(onWorkspaceCreated).not.toHaveBeenCalled();
+	});
+
+	it('does not navigate when the user changes during the import\'s loadAll', async () => {
+		// The SECOND await (codex round 5). One check after the upload is not
+		// enough: `loadAll` is another await, and a swap landing inside it put
+		// the callback, the toast and the navigation back in the new user's
+		// session. The rule is per-await, not per-operation.
+		api.workspaces.importBundle.mockResolvedValue(WS);
+		const listing = deferred<unknown[]>();
+		api.workspaces.list.mockReturnValue(listing.promise);
+		const onWorkspaceCreated = vi.fn();
+
+		const { container } = render(CreateWorkspaceModal, { props: { onWorkspaceCreated } });
+		await attachBundle(container);
+		btn(container, /Import Workspace/).click();
+		await settle();
+
+		expect(api.workspaces.importBundle).toHaveBeenCalled();
+		// The upload is done and the identity check after it has passed; we are
+		// sitting inside `loadAll`.
+		authStore.clear();
+		listing.resolve([]);
 		await settle();
 
 		expect(goto).not.toHaveBeenCalled();

--- a/web/src/lib/components/layout/createWorkspaceModalIdentity.svelte.test.ts
+++ b/web/src/lib/components/layout/createWorkspaceModalIdentity.svelte.test.ts
@@ -39,6 +39,11 @@ vi.mock('$lib/api/client', () => ({
 }));
 vi.mock('$app/navigation', () => ({ goto }));
 
+const toastShow = vi.hoisted(() => vi.fn());
+vi.mock('$lib/stores/toast.svelte', () => ({
+	toastStore: { show: toastShow, dismiss: vi.fn(), get toasts() { return []; } },
+}));
+
 import CreateWorkspaceModal from './CreateWorkspaceModal.svelte';
 import { authStore } from '$lib/stores/auth.svelte';
 import { uiStore } from '$lib/stores/ui.svelte';
@@ -84,6 +89,7 @@ async function attachBundle(container: HTMLElement): Promise<void> {
 
 beforeEach(async () => {
 	goto.mockClear();
+	toastShow.mockClear();
 	api.templates.list.mockResolvedValue([]);
 	api.workspaces.list.mockResolvedValue([]);
 	api.workspaces.get.mockResolvedValue(WS);
@@ -237,6 +243,81 @@ describe('BUG-2991: the create-workspace modal does not act for a session that e
 
 		expect(goto).not.toHaveBeenCalled();
 		expect(onWorkspaceCreated).not.toHaveBeenCalled();
+	});
+
+	it('does not report a FAILED import to the user who did not start it', async () => {
+		// codex round 7. The success path was fenced and the failure path was
+		// not, so an import that rejected after the signed-in user changed
+		// showed A's error to B — an error for an operation B never started,
+		// naming a file they never chose.
+		const imported = deferred<typeof WS>();
+		let rejectImport!: (e: unknown) => void;
+		api.workspaces.importBundle.mockReturnValue(new Promise((_res, rej) => { rejectImport = rej; }));
+		void imported;
+
+		const { container } = render(CreateWorkspaceModal, { props: {} });
+		await attachBundle(container);
+		btn(container, /Import Workspace/).click();
+		await settle();
+		expect(api.workspaces.importBundle).toHaveBeenCalled();
+
+		authStore.clear();
+		rejectImport(new Error('boom'));
+		await settle();
+
+		expect(toastShow).not.toHaveBeenCalled();
+	});
+
+	it('DOES report a failed import to the user who started it', async () => {
+		// The counterfactual: the fence must not swallow real errors.
+		api.workspaces.importBundle.mockRejectedValue(new Error('boom'));
+
+		const { container } = render(CreateWorkspaceModal, { props: {} });
+		await attachBundle(container);
+		btn(container, /Import Workspace/).click();
+		await settle();
+
+		expect(toastShow).toHaveBeenCalled();
+		expect(String(toastShow.mock.calls[0]?.[0])).toContain('Import failed');
+	});
+
+	it('does not report a FAILED create to the user who did not start it', async () => {
+		let rejectCreate!: (e: unknown) => void;
+		api.workspaces.create.mockReturnValue(new Promise((_res, rej) => { rejectCreate = rej; }));
+
+		const { container } = render(CreateWorkspaceModal, { props: {} });
+		const name = container.querySelector('#ws-create-name') as HTMLInputElement;
+		await fireEvent.input(name, { target: { value: 'Other' } });
+		btn(container, /Create Workspace/).click();
+		await settle();
+		expect(api.workspaces.create).toHaveBeenCalled();
+
+		authStore.clear();
+		rejectCreate(new Error('boom'));
+		await settle();
+
+		expect(toastShow).not.toHaveBeenCalled();
+	});
+
+	it('closes itself when the signed-in user changes, so no draft is inherited', async () => {
+		// codex round 7. The OPERATIONS were fenced; the DRAFT was not. A modal
+		// left open by one user kept their typed name, description, chosen
+		// template and selected bundle on screen for whoever signed in next —
+		// visible to them, and submittable by them.
+		const { container } = render(CreateWorkspaceModal, { props: {} });
+		const name = container.querySelector('#ws-create-name') as HTMLInputElement;
+		await fireEvent.input(name, { target: { value: 'A private project name' } });
+		await settle();
+		expect(uiStore.createWorkspaceOpen).toBe(true);
+
+		authStore.clear();
+		await settle();
+
+		expect(uiStore.createWorkspaceOpen).toBe(false);
+		// And reopening starts clean rather than restoring the draft.
+		uiStore.openCreateWorkspace();
+		await settle();
+		expect((container.querySelector('#ws-create-name') as HTMLInputElement).value).toBe('');
 	});
 
 	it('navigates when the user is unchanged during an IMPORT', async () => {

--- a/web/src/lib/components/layout/createWorkspaceModalIdentity.svelte.test.ts
+++ b/web/src/lib/components/layout/createWorkspaceModalIdentity.svelte.test.ts
@@ -408,6 +408,48 @@ describe('BUG-2991: the create-workspace modal does not act for a session that e
 		await settle();
 	});
 
+	it('does not act on a stale operation after the modal is remounted, same user', async () => {
+		// codex round 10. The token used to be instance-local, so a remount —
+		// a logout, or navigating between the console and workspace shells —
+		// reset it while an older promise still held the old value. Identity
+		// cannot answer this case: the user did NOT change. What changed is
+		// that the continuation stopped being the operation anyone is waiting
+		// on, and it would otherwise have fired the Phase F callback, a toast,
+		// `close()` and a `goto` to a workspace nobody asked for.
+		let resolveOld!: (v: typeof WS) => void;
+		api.workspaces.importBundle.mockReturnValueOnce(
+			new Promise((res) => { resolveOld = res; }),
+		);
+		const onWorkspaceCreated = vi.fn();
+
+		const first = render(CreateWorkspaceModal, { props: { onWorkspaceCreated } });
+		await attachBundle(first.container);
+		btn(first.container, /Import Workspace/).click();
+		await settle();
+		expect(api.workspaces.importBundle).toHaveBeenCalledTimes(1);
+
+		// The modal is destroyed and a new instance mounts — same user
+		// throughout, which is the point.
+		cleanup();
+		uiStore.openCreateWorkspace();
+		const second = render(CreateWorkspaceModal, { props: { onWorkspaceCreated } });
+		await settle();
+		// PRECONDITION: the new instance is really up and open, or "nothing
+		// happened" would be true of an empty page.
+		expect(second.container.querySelector('#ws-create-name')).not.toBeNull();
+		expect(uiStore.createWorkspaceOpen).toBe(true);
+
+		// Now the FIRST instance's import lands.
+		resolveOld(WS);
+		await settle();
+
+		expect(goto).not.toHaveBeenCalled();
+		expect(onWorkspaceCreated).not.toHaveBeenCalled();
+		expect(toastShow).not.toHaveBeenCalled();
+		// ...and the new instance's modal is still open.
+		expect(uiStore.createWorkspaceOpen).toBe(true);
+	});
+
 	it('navigates when the user is unchanged during an IMPORT', async () => {
 		api.workspaces.importBundle.mockResolvedValue(WS);
 		const onWorkspaceCreated = vi.fn();

--- a/web/src/lib/components/layout/createWorkspaceModalIdentity.svelte.test.ts
+++ b/web/src/lib/components/layout/createWorkspaceModalIdentity.svelte.test.ts
@@ -235,6 +235,12 @@ describe('BUG-2991: the create-workspace modal does not act for a session that e
 		await settle();
 
 		expect(api.workspaces.importBundle).toHaveBeenCalled();
+		// PRECONDITION, not decoration (codex round 8): without it a regression
+		// that returned right after the FIRST identity check would satisfy every
+		// assertion below, and this test exists for the SECOND one. Reaching
+		// `api.workspaces.list` is what proves we are past the first check and
+		// inside `loadAll`.
+		expect(api.workspaces.list).toHaveBeenCalled();
 		// The upload is done and the identity check after it has passed; we are
 		// sitting inside `loadAll`.
 		authStore.clear();
@@ -318,6 +324,41 @@ describe('BUG-2991: the create-workspace modal does not act for a session that e
 		uiStore.openCreateWorkspace();
 		await settle();
 		expect((container.querySelector('#ws-create-name') as HTMLInputElement).value).toBe('');
+	});
+
+	it('does not close the NEXT user\'s freshly opened modal when a stale create lands', async () => {
+		// codex round 8. `close()` is global — it writes
+		// `uiStore.createWorkspaceOpen` — so a continuation belonging to the
+		// previous session dismissed the modal the NEW user had just opened,
+		// taking their draft with it. By then the identity listener has already
+		// closed the previous user's modal, so there is nothing left for the
+		// continuation to close.
+		const created = deferred<typeof WS>();
+		api.workspaces.create.mockReturnValue(created.promise);
+
+		const { container } = render(CreateWorkspaceModal, { props: {} });
+		const name = container.querySelector('#ws-create-name') as HTMLInputElement;
+		await fireEvent.input(name, { target: { value: 'Other' } });
+		btn(container, /Create Workspace/).click();
+		await settle();
+		expect(api.workspaces.create).toHaveBeenCalled();
+
+		// Identity changes: the listener closes the modal.
+		authStore.clear();
+		await settle();
+		expect(uiStore.createWorkspaceOpen).toBe(false);
+
+		// The new user opens a fresh one...
+		uiStore.openCreateWorkspace();
+		await settle();
+		expect(uiStore.createWorkspaceOpen).toBe(true);
+
+		// ...and only THEN does the previous session's create land.
+		created.resolve(WS);
+		await settle();
+
+		expect(uiStore.createWorkspaceOpen).toBe(true);
+		expect(goto).not.toHaveBeenCalled();
 	});
 
 	it('navigates when the user is unchanged during an IMPORT', async () => {

--- a/web/src/lib/stores/auth.svelte.ts
+++ b/web/src/lib/stores/auth.svelte.ts
@@ -13,6 +13,51 @@ let inflight: Promise<AuthSession | null> | null = null;
 // state when the generation they captured at fetch-start still matches.
 let generation = 0;
 
+// Identity-change subscribers (BUG-2991).
+//
+// `workspace.svelte.ts` holds state that BELONGS to the signed-in user but is
+// not keyed by them — `current`, `workspaces`, and a `currentMembership` that
+// has already been published. Logout is an SPA navigation, so none of it is
+// torn down by a page load, and a clean account change with no `/me` in flight
+// left the previous user's workspace list and live permission state on screen.
+// `settleIfCurrent`'s identity fence only covers the case where a settle is
+// racing the change; it cannot cover the case where nothing is racing at all.
+//
+// A subscription rather than a call at each sign-out site, for the same reason
+// `answeredMembership` is keyed by user rather than cleared on logout: it makes
+// the invalidation STRUCTURAL. There are two `authStore.clear()` sites today
+// and a third would not have to remember anything, and it fires on sign-IN as a
+// different user too, which no logout path could have covered.
+//
+// The direction of the dependency is unchanged: `workspace.svelte.ts` imports
+// this module and registers here, so this module still imports nothing of it.
+const identityListeners = new Set<() => void>();
+// The id whose listeners have already been notified. Compared rather than
+// assumed, so a `load()` that returns the SAME user (the common case — the root
+// layout fetches the session on every cold start) notifies nobody and cannot
+// clear a store mid-session.
+let notifiedUserId = '';
+// Whether an identity has been ESTABLISHED yet. The first resolution of the
+// session is not a change from anything, and firing on it would be a live
+// hazard rather than a no-op: the root layout loads the session and the
+// workspace list concurrently, so a cold start whose `/auth/session` lands
+// second would clear a `workspaces` array that had just been populated. A
+// cold start has nothing stale to drop, so the first answer only records the
+// baseline. Every later transition — including back to '' on sign-out — fires.
+let identityEstablished = false;
+
+function notifyIdentityChange() {
+	const id = session?.user?.id ?? '';
+	if (!identityEstablished) {
+		identityEstablished = true;
+		notifiedUserId = id;
+		return;
+	}
+	if (id === notifiedUserId) return;
+	notifiedUserId = id;
+	for (const fn of identityListeners) fn();
+}
+
 export const authStore = {
 	get session() { return session; },
 	get user() { return session?.user ?? null; },
@@ -52,11 +97,17 @@ export const authStore = {
 		const isCurrent = () => generation === myGeneration;
 		inflight = api.auth.session()
 			.then((s) => {
-				if (isCurrent()) session = s;
+				if (isCurrent()) {
+					session = s;
+					notifyIdentityChange();
+				}
 				return session;
 			})
 			.catch((err) => {
-				if (isCurrent()) session = null;
+				if (isCurrent()) {
+					session = null;
+					notifyIdentityChange();
+				}
 				throw err; // Re-throw so callers can distinguish fetch errors from "not authenticated".
 			})
 			.finally(() => {
@@ -80,9 +131,23 @@ export const authStore = {
 		return this.load();
 	},
 
+	/**
+	 * Register a listener fired when the SIGNED-IN USER changes — sign-out,
+	 * sign-in, or a swap between two accounts. Returns an unsubscribe function.
+	 *
+	 * Fired only on a real change of user id, so a session refetch that returns
+	 * the same user is silent. See `identityListeners` above for why this exists
+	 * rather than a call at each sign-out site.
+	 */
+	onIdentityChange(fn: () => void): () => void {
+		identityListeners.add(fn);
+		return () => identityListeners.delete(fn);
+	},
+
 	clear() {
 		session = null;
 		generation++;
+		notifyIdentityChange();
 		// Drop the in-flight promise reference so the next ensureLoaded()/load()
 		// call fires a fresh fetch rather than attaching to a pre-logout request.
 		// The old promise may still resolve/reject in the background; the

--- a/web/src/lib/stores/auth.svelte.ts
+++ b/web/src/lib/stores/auth.svelte.ts
@@ -104,10 +104,27 @@ export const authStore = {
 				return session;
 			})
 			.catch((err) => {
-				if (isCurrent()) {
-					session = null;
-					notifyIdentityChange();
-				}
+				if (isCurrent()) session = null;
+				// DELIBERATELY NO `notifyIdentityChange()` HERE (BUG-2991, codex
+				// round 9). A rejection is a FETCH ERROR, not an identity
+				// signal: "not authenticated" comes back as a resolved session
+				// (that is what the re-throw below exists to distinguish), so a
+				// rejected `/auth/session` says a request failed and nothing
+				// about who is signed in.
+				//
+				// Treating it as a sign-out was destructive rather than merely
+				// wrong. Listeners drop the workspace store, re-arm the layout's
+				// load latch and CLOSE the create-workspace modal, and an
+				// in-flight create or import then returns without a toast, a
+				// navigation or a close — so a user who is still legitimately
+				// signed in lost a successful operation, silently, because one
+				// session poll failed. `/console/billing` polls `load()`, so
+				// this is reachable in ordinary use rather than exotic.
+				//
+				// `session = null` still happens, because that is the state the
+				// rest of the app already had for a failed load; what changes is
+				// that nobody is told an identity CHANGED. A real sign-out goes
+				// through `clear()`, which does notify.
 				throw err; // Re-throw so callers can distinguish fetch errors from "not authenticated".
 			})
 			.finally(() => {

--- a/web/src/lib/stores/authIdentityChange.svelte.test.ts
+++ b/web/src/lib/stores/authIdentityChange.svelte.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+/**
+ * BUG-2991 — `authStore.onIdentityChange`, the notification the workspace store
+ * hangs its identity reset on.
+ *
+ * The subscription exists so no sign-out site has to remember to clear
+ * user-scoped state. That only works if it fires on every real change of user
+ * AND stays silent otherwise, because its listeners are destructive: a
+ * spurious fire wipes a live store.
+ */
+
+const session = vi.hoisted(() => ({ value: null as unknown }));
+
+vi.mock('$lib/api/client', () => ({
+	api: { auth: { session: vi.fn(async () => session.value) } },
+}));
+
+function user(id: string) {
+	return { authenticated: true, user: { id, email: `${id}@example.com` } };
+}
+
+describe('authStore.onIdentityChange', () => {
+	beforeEach(() => {
+		vi.resetModules();
+		session.value = null;
+	});
+
+	it('stays silent on the FIRST resolution of the session', async () => {
+		// The root layout loads the session and the workspace list concurrently.
+		// A cold start has nothing stale to drop, and firing here would clear a
+		// `workspaces` array that had just been populated by the other request —
+		// so the first answer only records the baseline.
+		const { authStore } = await import('./auth.svelte');
+		const fired = vi.fn();
+		authStore.onIdentityChange(fired);
+
+		session.value = user('u1');
+		await authStore.load();
+
+		expect(authStore.userId).toBe('u1');
+		expect(fired).not.toHaveBeenCalled();
+	});
+
+	it('fires on sign-OUT after an established identity', async () => {
+		const { authStore } = await import('./auth.svelte');
+		session.value = user('u1');
+		await authStore.load();
+
+		const fired = vi.fn();
+		authStore.onIdentityChange(fired);
+		authStore.clear();
+
+		expect(fired).toHaveBeenCalledTimes(1);
+		expect(authStore.userId).toBe('');
+	});
+
+	it('fires on a swap to a different user with no sign-out in between', async () => {
+		const { authStore } = await import('./auth.svelte');
+		session.value = user('u1');
+		await authStore.load();
+
+		const fired = vi.fn();
+		authStore.onIdentityChange(fired);
+
+		session.value = user('u2');
+		await authStore.load();
+
+		expect(fired).toHaveBeenCalledTimes(1);
+		expect(authStore.userId).toBe('u2');
+	});
+
+	it('stays silent when a refetch returns the SAME user', async () => {
+		// The common case: the layout refetches the session and nothing changed.
+		// Firing here would clear the store mid-session for no reason.
+		const { authStore } = await import('./auth.svelte');
+		session.value = user('u1');
+		await authStore.load();
+
+		const fired = vi.fn();
+		authStore.onIdentityChange(fired);
+
+		session.value = user('u1');
+		await authStore.load();
+
+		expect(fired).not.toHaveBeenCalled();
+	});
+
+	it('fires once, not twice, for a sign-out followed by a sign-in as the same user', async () => {
+		const { authStore } = await import('./auth.svelte');
+		session.value = user('u1');
+		await authStore.load();
+
+		const fired = vi.fn();
+		authStore.onIdentityChange(fired);
+
+		authStore.clear();
+		expect(fired).toHaveBeenCalledTimes(1);
+
+		session.value = user('u1');
+		await authStore.load();
+		// Back to u1 from '' is a real transition and must fire: the store was
+		// cleared in between, so it has to be re-resolved.
+		expect(fired).toHaveBeenCalledTimes(2);
+	});
+
+	it('unsubscribes', async () => {
+		const { authStore } = await import('./auth.svelte');
+		session.value = user('u1');
+		await authStore.load();
+
+		const fired = vi.fn();
+		const off = authStore.onIdentityChange(fired);
+		off();
+		authStore.clear();
+
+		expect(fired).not.toHaveBeenCalled();
+	});
+});

--- a/web/src/lib/stores/authIdentityChange.svelte.test.ts
+++ b/web/src/lib/stores/authIdentityChange.svelte.test.ts
@@ -150,6 +150,27 @@ describe('authStore.onIdentityChange', () => {
 		expect(fired).toHaveBeenCalledTimes(1);
 	});
 
+	it('fires on a RESOLVED unauthenticated session, which is what a real sign-out looks like', async () => {
+		// The other half of the rejection rule, and the one that keeps it
+		// honest (codex round 10). `/auth/session` is public and answers 200
+		// with `authenticated: false` for a missing or expired session, so an
+		// ordinary sign-out arrives RESOLVED. If silencing the rejection path
+		// had also silenced this, the whole identity reset would have stopped
+		// working for the commonest case there is.
+		const { authStore } = await import('./auth.svelte');
+		session.value = user('u1');
+		await authStore.load();
+
+		const fired = vi.fn();
+		authStore.onIdentityChange(fired);
+
+		session.value = { authenticated: false, user: null };
+		await authStore.load();
+
+		expect(authStore.userId).toBe('');
+		expect(fired).toHaveBeenCalledTimes(1);
+	});
+
 	it('unsubscribes', async () => {
 		const { authStore } = await import('./auth.svelte');
 		session.value = user('u1');

--- a/web/src/lib/stores/authIdentityChange.svelte.test.ts
+++ b/web/src/lib/stores/authIdentityChange.svelte.test.ts
@@ -104,6 +104,52 @@ describe('authStore.onIdentityChange', () => {
 		expect(fired).toHaveBeenCalledTimes(2);
 	});
 
+	it('does NOT fire when the session request FAILS', async () => {
+		// BUG-2991, codex round 9. A rejection is a fetch error, not an identity
+		// signal — "not authenticated" comes back as a RESOLVED session, which
+		// is what `load`'s re-throw exists to distinguish. Treating a failed
+		// poll as a sign-out was destructive: listeners drop the workspace
+		// store, re-arm the layout's load latch and close the create-workspace
+		// modal, so a user who is still signed in lost an in-flight create or
+		// import with no toast, no navigation and no close. `/console/billing`
+		// polls `load()`, so a single flaky request reached it.
+		const { authStore } = await import('./auth.svelte');
+		const api = (await import('$lib/api/client')).api as unknown as {
+			auth: { session: ReturnType<typeof vi.fn> };
+		};
+		session.value = user('u1');
+		await authStore.load();
+
+		const fired = vi.fn();
+		authStore.onIdentityChange(fired);
+
+		api.auth.session.mockRejectedValueOnce(new Error('network'));
+		await expect(authStore.load()).rejects.toThrow('network');
+
+		expect(fired).not.toHaveBeenCalled();
+	});
+
+	it('still fires on a real sign-out that follows a failed request', async () => {
+		// The counterfactual: silencing the failure path must not silence the
+		// real one that comes after it.
+		const { authStore } = await import('./auth.svelte');
+		const api = (await import('$lib/api/client')).api as unknown as {
+			auth: { session: ReturnType<typeof vi.fn> };
+		};
+		session.value = user('u1');
+		await authStore.load();
+
+		const fired = vi.fn();
+		authStore.onIdentityChange(fired);
+
+		api.auth.session.mockRejectedValueOnce(new Error('network'));
+		await expect(authStore.load()).rejects.toThrow('network');
+		expect(fired).not.toHaveBeenCalled();
+
+		authStore.clear();
+		expect(fired).toHaveBeenCalledTimes(1);
+	});
+
 	it('unsubscribes', async () => {
 		const { authStore } = await import('./auth.svelte');
 		session.value = user('u1');

--- a/web/src/lib/stores/workspace.svelte.ts
+++ b/web/src/lib/stores/workspace.svelte.ts
@@ -278,6 +278,15 @@ export const workspaceStore = {
 
 	async loadAll() {
 		return loadAllFlight.run(LOAD_ALL_KEY, async ({ isLatest }) => {
+			// Captured before the request, compared after it (BUG-2991, codex
+			// round 1). `isLatest` is a NAVIGATION fence — its generation only
+			// advances when a newer `loadAll` starts — so it says nothing about
+			// whether the same USER is still signed in. Without this, A's list
+			// resolving after A signed out and B signed in commits A's
+			// workspaces into B's store, which is the identity reset's own
+			// defect arriving through the one door the reset cannot close: the
+			// request was issued before the reset and commits after it.
+			const callUser = currentUserId();
 			const list = await api.workspaces.list();
 			// WHICH RESPONSE COMMITS (TASK-2947, and a behaviour change rather
 			// than a move). Two overlapping calls used to leave the OLDER list in
@@ -288,6 +297,7 @@ export const workspaceStore = {
 			// store's own comment as pre-existing; extracting the primitive is
 			// where it closes, because the primitive owns the rule.
 			if (!isLatest()) return;
+			if (currentUserId() !== callUser) return;
 			workspaces = list;
 		});
 	},
@@ -487,14 +497,21 @@ export const workspaceStore = {
 		// sign-in does not advance `membershipSeq`, which is the same reason
 		// `settleIfCurrent` needs two fences rather than one.
 		//
-		// Refusing to touch the store is the whole fix. The workspace was really
-		// created, so `ws` is still returned rather than thrown — the caller
-		// asked for a workspace and got one — and what it does with it is
-		// outside this store. `authStore.onIdentityChange` has already reset the
-		// store for the new user by the time we get here, so there is nothing to
-		// clear and nothing to re-resolve; the membership fetch below is skipped
-		// with it, since it would settle for a user who is not signed in.
-		if (currentUserId() !== callUser) return ws;
+		// Returns NULL rather than the workspace (codex round 1). Refusing to
+		// touch the store is most of the fix, but not all of it: the only caller
+		// navigates to whatever comes back, so returning `ws` sent the NEW user
+		// to the PREVIOUS user's workspace. The server denies them, so it is not
+		// a bypass — it is a navigation nobody asked for, to a slug that leaks
+		// the other account's workspace name in the URL.
+		//
+		// Null says "no workspace for THIS session", which is the honest answer:
+		// the workspace was really created, but not for whoever is signed in
+		// now. Throwing would have been worse — it renders as "Failed to create
+		// workspace" over a create that succeeded.
+		//
+		// The membership fetch below is skipped with the rest: a `/me` for a
+		// user who is no longer signed in has nowhere to land.
+		if (currentUserId() !== callUser) return null;
 
 		// THE LIST IS ADDITIVE; ONLY THE SELECTION IS RACED (codex round 5).
 		// Two concurrent creates both succeed on the server, so both workspaces

--- a/web/src/lib/stores/workspace.svelte.ts
+++ b/web/src/lib/stores/workspace.svelte.ts
@@ -539,6 +539,18 @@ export const workspaceStore = {
 		} catch {
 			settleIfCurrent(seq, callUser, ws.slug, null);
 		}
+
+		// SECOND identity check, for the `/me` phase (codex round 2). The check
+		// above covers the POST; this one covers everything after it. A swap
+		// landing while the membership request is open leaves the store correct
+		// — `settleIfCurrent` refuses the write and the reset listener has
+		// already cleared what `create` wrote — but the RETURN VALUE was still
+		// A's workspace, and the caller navigates to whatever comes back.
+		//
+		// Two checks rather than one at the end: the first has to run before the
+		// store writes, and the second has to run after the last await. Neither
+		// position answers for the other.
+		if (currentUserId() !== callUser) return null;
 		return ws;
 	}
 };

--- a/web/src/lib/stores/workspace.svelte.ts
+++ b/web/src/lib/stores/workspace.svelte.ts
@@ -69,10 +69,11 @@ let membershipSeq = 0;
 // structural: a different user simply has no entry, so no logout path has to
 // remember to clear anything. It does not fence the store's other state —
 // `current`, `workspaces` and a `currentMembership` already published are not
-// identity-scoped, and `authStore.clear()` does not clear them, so a clean
-// account change with no settle in flight can still leave the previous user's
-// live permission state on screen (codex round 6, filed rather than widened
-// into this change).
+// identity-scoped. That used to mean a clean account change with no settle in
+// flight left the previous user's live permission state on screen (codex round
+// 6); BUG-2991 closed it the same structural way, with the
+// `authStore.onIdentityChange` subscription at the foot of this file, so the
+// drop happens whether or not anything is racing.
 //
 // The identity is captured when the CALL starts and carried to its settle, and
 // `settleIfCurrent` discards a settle whose captured id no longer matches the
@@ -475,6 +476,26 @@ export const workspaceStore = {
 		const callUser = currentUserId();
 		const ws = await api.workspaces.create(data);
 
+		// IDENTITY FENCE, BEFORE ANY STORE MUTATION (BUG-2991).
+		//
+		// The append below is unconditional and the selection is guarded only by
+		// the sequence token — and neither of those is an identity question. A
+		// create issued by user A that returns after user B has signed in
+		// (logout is an SPA navigation, so no page load tears the store down)
+		// put A's workspace into B's list, and, absent an intervening sequence
+		// claim, made it B's `current`. The sequence token cannot catch it: a
+		// sign-in does not advance `membershipSeq`, which is the same reason
+		// `settleIfCurrent` needs two fences rather than one.
+		//
+		// Refusing to touch the store is the whole fix. The workspace was really
+		// created, so `ws` is still returned rather than thrown — the caller
+		// asked for a workspace and got one — and what it does with it is
+		// outside this store. `authStore.onIdentityChange` has already reset the
+		// store for the new user by the time we get here, so there is nothing to
+		// clear and nothing to re-resolve; the membership fetch below is skipped
+		// with it, since it would settle for a user who is not signed in.
+		if (currentUserId() !== callUser) return ws;
+
 		// THE LIST IS ADDITIVE; ONLY THE SELECTION IS RACED (codex round 5).
 		// Two concurrent creates both succeed on the server, so both workspaces
 		// exist and both belong in `workspaces` — but only one can be the
@@ -504,3 +525,30 @@ export const workspaceStore = {
 		return ws;
 	}
 };
+
+/**
+ * Drop everything scoped to the signed-in user when the signed-in user changes
+ * (BUG-2991).
+ *
+ * `answeredMembership` is deliberately NOT cleared: it is keyed by user id, so
+ * the next user has no entry and the previous user's answers are still correct
+ * for them if they sign back in — which is the invalidation TASK-2988 made
+ * structural, and clearing it here would undo it.
+ *
+ * `membershipSeq` is advanced so that anything already in flight — a `/me`, a
+ * `setCurrent`, the tail of a `create` — is superseded rather than allowed to
+ * write into the new user's store. `settleIfCurrent` would reject those on its
+ * own identity fence; the bump also covers the writes that happen BEFORE a
+ * settle, which is the half `create` was missing.
+ *
+ * Registered at module scope rather than called from each sign-out site, so a
+ * future sign-out path cannot forget it. Never unsubscribed: this module lives
+ * as long as the page does.
+ */
+authStore.onIdentityChange(() => {
+	membershipSeq++;
+	workspaces = [];
+	current = null;
+	currentMembership = null;
+	membershipKnown = false;
+});

--- a/web/src/lib/stores/workspaceAuthResetWiring.svelte.test.ts
+++ b/web/src/lib/stores/workspaceAuthResetWiring.svelte.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+/**
+ * BUG-2991 — the WIRING between the two stores, with neither of them mocked.
+ *
+ * `workspaceIdentityReset` fires a mocked `onIdentityChange`, and
+ * `authIdentityChange` checks when the real one fires. Both can pass while the
+ * registration that joins them is gone: the workspace store subscribes at
+ * module scope, and nothing in either suite observes that subscription
+ * actually happening (CONVE-19 — a direct-call test vouches for the component,
+ * not for its binding). Codex round 1 named this gap.
+ *
+ * So this file mocks ONLY the API client and drives a real `authStore.clear()`.
+ */
+
+const api = vi.hoisted(() => ({
+	auth: { session: vi.fn() },
+	workspaces: {
+		get: vi.fn(),
+		me: vi.fn(),
+		list: vi.fn(),
+		create: vi.fn(),
+	},
+}));
+
+vi.mock('$lib/api/client', () => ({ api }));
+
+const OWNER = { role: 'owner', collection_grants: [], item_grants: [] };
+const WS = { id: 'w1', slug: 'ws', name: 'WS' };
+
+describe('BUG-2991 wiring: a real sign-out clears the real workspace store', () => {
+	beforeEach(() => {
+		vi.resetModules();
+		vi.resetAllMocks();
+	});
+
+	it('drops workspaces, selection and membership on authStore.clear()', async () => {
+		const { authStore } = await import('./auth.svelte');
+		const { workspaceStore } = await import('./workspace.svelte');
+
+		api.auth.session.mockResolvedValue({
+			authenticated: true,
+			user: { id: 'u1', email: 'u1@example.com' },
+		});
+		api.workspaces.list.mockResolvedValue([WS]);
+		api.workspaces.get.mockResolvedValue(WS);
+		api.workspaces.me.mockResolvedValue(OWNER);
+
+		await authStore.load();
+		await workspaceStore.loadAll();
+		await workspaceStore.setCurrent('ws');
+
+		// Non-vacuity: there has to be something to lose.
+		expect(authStore.userId).toBe('u1');
+		expect(workspaceStore.workspaces).toEqual([WS]);
+		expect(workspaceStore.current).toEqual(WS);
+		expect(workspaceStore.isOwner).toBe(true);
+
+		authStore.clear();
+
+		expect(workspaceStore.workspaces).toEqual([]);
+		expect(workspaceStore.current).toBeNull();
+		expect(workspaceStore.currentMembership).toBeNull();
+		expect(workspaceStore.membershipKnown).toBe(false);
+		expect(workspaceStore.isOwner).toBe(false);
+	});
+
+	it('drops it on a sign-in as a DIFFERENT user with no sign-out in between', async () => {
+		const { authStore } = await import('./auth.svelte');
+		const { workspaceStore } = await import('./workspace.svelte');
+
+		api.auth.session.mockResolvedValue({
+			authenticated: true,
+			user: { id: 'u1', email: 'u1@example.com' },
+		});
+		api.workspaces.list.mockResolvedValue([WS]);
+		api.workspaces.get.mockResolvedValue(WS);
+		api.workspaces.me.mockResolvedValue(OWNER);
+
+		await authStore.load();
+		await workspaceStore.setCurrent('ws');
+		expect(workspaceStore.isOwner).toBe(true);
+
+		api.auth.session.mockResolvedValue({
+			authenticated: true,
+			user: { id: 'u2', email: 'u2@example.com' },
+		});
+		await authStore.load();
+
+		expect(workspaceStore.current).toBeNull();
+		expect(workspaceStore.membershipKnown).toBe(false);
+	});
+
+	it('leaves the store alone when the session refetch returns the SAME user', async () => {
+		// The counterfactual, and the one that would bite hardest in production:
+		// the root layout refetches the session routinely, and a reset there
+		// would blank the sidebar mid-session for no reason.
+		const { authStore } = await import('./auth.svelte');
+		const { workspaceStore } = await import('./workspace.svelte');
+
+		api.auth.session.mockResolvedValue({
+			authenticated: true,
+			user: { id: 'u1', email: 'u1@example.com' },
+		});
+		api.workspaces.list.mockResolvedValue([WS]);
+		api.workspaces.get.mockResolvedValue(WS);
+		api.workspaces.me.mockResolvedValue(OWNER);
+
+		await authStore.load();
+		await workspaceStore.loadAll();
+		await workspaceStore.setCurrent('ws');
+
+		await authStore.load();
+
+		expect(workspaceStore.workspaces).toEqual([WS]);
+		expect(workspaceStore.current).toEqual(WS);
+		expect(workspaceStore.isOwner).toBe(true);
+	});
+
+	it('does not clear a workspace list loaded BEFORE the first session answer', async () => {
+		// The cold-start ordering the `identityEstablished` guard exists for: the
+		// root layout loads the session and the list concurrently, and the
+		// session can land second.
+		const { authStore } = await import('./auth.svelte');
+		const { workspaceStore } = await import('./workspace.svelte');
+
+		api.workspaces.list.mockResolvedValue([WS]);
+		await workspaceStore.loadAll();
+		expect(workspaceStore.workspaces).toEqual([WS]);
+
+		api.auth.session.mockResolvedValue({
+			authenticated: true,
+			user: { id: 'u1', email: 'u1@example.com' },
+		});
+		await authStore.load();
+
+		expect(workspaceStore.workspaces).toEqual([WS]);
+	});
+});

--- a/web/src/lib/stores/workspaceIdentityReset.svelte.test.ts
+++ b/web/src/lib/stores/workspaceIdentityReset.svelte.test.ts
@@ -177,6 +177,13 @@ describe('workspaceStore: identity change drops the previous user\'s state', () 
 		await pending;
 
 		expect(workspaceStore.workspaces).toEqual([]);
+
+		// And the fence must not have poisoned the door: user-2's OWN list still
+		// commits. Asserting only the empty array would pass against a `loadAll`
+		// that had stopped committing anything at all (codex round 2).
+		api.workspaces.list.mockResolvedValue([OTHER]);
+		await workspaceStore.loadAll();
+		expect(workspaceStore.workspaces).toEqual([OTHER]);
 	});
 
 	it('still commits a workspace list that completes under the same user', async () => {
@@ -204,6 +211,33 @@ describe('workspaceStore: identity change drops the previous user\'s state', () 
 		created.resolve(OTHER);
 
 		await expect(pending).resolves.toBeNull();
+	});
+
+	it('returns null when the user changes during the create\'s /me phase', async () => {
+		// The window AFTER the post-POST identity check (codex round 2). The
+		// store is protected there — `settleIfCurrent` refuses the write and the
+		// reset has already cleared what `create` wrote — but the RETURN VALUE
+		// was still the previous user's workspace, and the caller navigates to
+		// whatever comes back. Two checks are needed, and neither position
+		// answers for the other.
+		const { workspaceStore } = await import('./workspace.svelte');
+		api.workspaces.create.mockResolvedValue(OTHER);
+		const me = deferred<typeof OWNER>();
+		api.workspaces.me.mockReturnValueOnce(me.promise);
+
+		const pending = workspaceStore.create({ name: 'Other' });
+		// Let the POST resolve and the store writes happen under user-1.
+		await Promise.resolve();
+		await Promise.resolve();
+
+		auth.userId = 'user-2';
+		auth.fireIdentityChange();
+		me.resolve(OWNER);
+
+		await expect(pending).resolves.toBeNull();
+		expect(workspaceStore.workspaces).toEqual([]);
+		expect(workspaceStore.current).toBeNull();
+		expect(workspaceStore.membershipKnown).toBe(false);
 	});
 
 	it('still lists and selects a create that completes under the same user', async () => {

--- a/web/src/lib/stores/workspaceIdentityReset.svelte.test.ts
+++ b/web/src/lib/stores/workspaceIdentityReset.svelte.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+/**
+ * BUG-2991 — store state that BELONGS to the signed-in user was not scoped to
+ * them, and nothing dropped it when the user changed.
+ *
+ * `current`, `workspaces` and an already-published `currentMembership` are not
+ * identity-keyed. Logout is an SPA navigation (`authStore.clear()` +
+ * `goto('/login')`), so no page load tears them down, and TASK-2988's identity
+ * fence only fires when a settle is racing the change — it cannot cover a clean
+ * account swap with nothing in flight.
+ *
+ * Two halves, tested separately because they fail independently:
+ *
+ *  1. the `authStore.onIdentityChange` subscription drops the previous user's
+ *     workspaces, selection and permission state;
+ *  2. `create` fences its post-await store writes on the identity that ISSUED
+ *     the POST — the append used to run unconditionally, ahead of every fence,
+ *     so one user's new workspace landed in the next user's list.
+ */
+
+const api = vi.hoisted(() => ({
+	workspaces: {
+		get: vi.fn(),
+		me: vi.fn(),
+		list: vi.fn(),
+		create: vi.fn(),
+	},
+}));
+
+vi.mock('$lib/api/client', () => ({ api }));
+
+// A real minimal `onIdentityChange`, not a stub: the store registers its reset
+// through it at module scope, and a stub that swallowed the registration would
+// let every assertion here pass against a store with no reset at all.
+const auth = vi.hoisted(() => {
+	const listeners = new Set<() => void>();
+	return {
+		userId: 'user-1',
+		onIdentityChange(fn: () => void) {
+			listeners.add(fn);
+			return () => listeners.delete(fn);
+		},
+		/** Fire what `authStore.clear()` / a sign-in as someone else would fire. */
+		fireIdentityChange() {
+			for (const fn of listeners) fn();
+		},
+		/** Drop registrations left by a previous `vi.resetModules()`. */
+		resetListeners() {
+			listeners.clear();
+		},
+	};
+});
+vi.mock('./auth.svelte', () => ({ authStore: auth }));
+
+const OWNER = { role: 'owner', collection_grants: [], item_grants: [] };
+const WS = { id: 'w1', slug: 'ws', name: 'WS' };
+const OTHER = { id: 'w2', slug: 'other', name: 'Other' };
+
+function deferred<T>() {
+	let resolve!: (v: T) => void;
+	const promise = new Promise<T>((res) => { resolve = res; });
+	return { promise, resolve };
+}
+
+describe('workspaceStore: identity change drops the previous user\'s state', () => {
+	beforeEach(() => {
+		// Fresh module registry per test — the store's state is module state.
+		vi.resetModules();
+		vi.resetAllMocks();
+		// Before the re-import registers again: a leftover listener closes over
+		// the PREVIOUS module's state, so firing would reset a store no test is
+		// looking at while leaving this one untouched.
+		auth.resetListeners();
+		auth.userId = 'user-1';
+	});
+
+	it('clears workspaces, selection and membership when the signed-in user changes', async () => {
+		const { workspaceStore } = await import('./workspace.svelte');
+		api.workspaces.get.mockResolvedValue(WS);
+		api.workspaces.me.mockResolvedValue(OWNER);
+		api.workspaces.list.mockResolvedValue([WS]);
+
+		await workspaceStore.loadAll();
+		await workspaceStore.setCurrent('ws');
+
+		// Non-vacuity: there must be something to lose, or the assertions below
+		// hold on an empty store for the wrong reason.
+		expect(workspaceStore.workspaces).toEqual([WS]);
+		expect(workspaceStore.current).toEqual(WS);
+		expect(workspaceStore.membershipKnown).toBe(true);
+		expect(workspaceStore.isOwner).toBe(true);
+
+		// A clean account change with NOTHING in flight — the case
+		// `settleIfCurrent`'s fence cannot reach, because it only runs when a
+		// settle arrives to be rejected.
+		auth.userId = 'user-2';
+		auth.fireIdentityChange();
+
+		expect(workspaceStore.workspaces).toEqual([]);
+		expect(workspaceStore.current).toBeNull();
+		expect(workspaceStore.currentMembership).toBeNull();
+		// Unknown, not "denied": the helpers read unknown as no access, which is
+		// the fail-safe direction, and the next resolve supplies a real answer.
+		expect(workspaceStore.membershipKnown).toBe(false);
+		expect(workspaceStore.isOwner).toBe(false);
+	});
+
+	it('does not serve the previous user a replayed answer after the swap', async () => {
+		// The answer cache is keyed by user, so user-2 has no entry — but the
+		// reset must not have cleared user-1's, or signing back in would refetch
+		// what TASK-2988 exists to avoid.
+		const { workspaceStore } = await import('./workspace.svelte');
+		api.workspaces.get.mockResolvedValue(WS);
+		api.workspaces.me.mockResolvedValue(OWNER);
+
+		await workspaceStore.setCurrent('ws');
+		expect(workspaceStore.membershipKnown).toBe(true);
+
+		auth.userId = 'user-2';
+		auth.fireIdentityChange();
+		expect(workspaceStore.membershipKnown).toBe(false);
+
+		// user-1 returns. Their own answer is still cached, so the resolve is
+		// answered from it rather than dropping to unknown for the refetch.
+		auth.userId = 'user-1';
+		auth.fireIdentityChange();
+		const held = deferred<typeof OWNER>();
+		api.workspaces.me.mockReturnValueOnce(held.promise);
+		const back = workspaceStore.setCurrent('ws');
+		expect(workspaceStore.membershipKnown).toBe(true);
+		expect(workspaceStore.isOwner).toBe(true);
+		held.resolve(OWNER);
+		await back;
+	});
+
+	it('keeps a created workspace out of the next user\'s list', async () => {
+		const { workspaceStore } = await import('./workspace.svelte');
+		api.workspaces.get.mockResolvedValue(OTHER);
+
+		const created = deferred<typeof OTHER>();
+		api.workspaces.create.mockReturnValueOnce(created.promise);
+		const pending = workspaceStore.create({ name: 'Other' });
+
+		// The swap lands while the POST is open, exactly as a sign-out plus
+		// sign-in during a slow create would.
+		auth.userId = 'user-2';
+		auth.fireIdentityChange();
+		created.resolve(OTHER);
+		await pending;
+
+		// The append used to happen BEFORE any fence, so user-1's workspace
+		// landed in user-2's list even when the selection was rejected.
+		expect(workspaceStore.workspaces).toEqual([]);
+		expect(workspaceStore.current).toBeNull();
+		expect(workspaceStore.membershipKnown).toBe(false);
+		// And no `/me` was issued for it: an answer for a user who is no longer
+		// signed in has nowhere to go.
+		expect(api.workspaces.me).not.toHaveBeenCalled();
+	});
+
+	it('still lists and selects a create that completes under the same user', async () => {
+		// The counterfactual for the fence: it must not turn every create into a
+		// no-op. Same user throughout, which is the ordinary case.
+		const { workspaceStore } = await import('./workspace.svelte');
+		api.workspaces.create.mockResolvedValue(OTHER);
+		api.workspaces.me.mockResolvedValue(OWNER);
+
+		const ws = await workspaceStore.create({ name: 'Other' });
+
+		expect(ws).toEqual(OTHER);
+		expect(workspaceStore.workspaces).toEqual([OTHER]);
+		expect(workspaceStore.current).toEqual(OTHER);
+		expect(workspaceStore.membershipKnown).toBe(true);
+		expect(workspaceStore.isOwner).toBe(true);
+	});
+});

--- a/web/src/lib/stores/workspaceIdentityReset.svelte.test.ts
+++ b/web/src/lib/stores/workspaceIdentityReset.svelte.test.ts
@@ -159,6 +159,53 @@ describe('workspaceStore: identity change drops the previous user\'s state', () 
 		expect(api.workspaces.me).not.toHaveBeenCalled();
 	});
 
+	it('refuses to commit a workspace list fetched for the previous user', async () => {
+		// `loadAll` is guarded by a single-flight GENERATION, which only advances
+		// when a newer `loadAll` starts — it says nothing about the user. The
+		// request is issued before the reset and commits after it, which is the
+		// one door the reset itself cannot close (codex round 1).
+		const { workspaceStore } = await import('./workspace.svelte');
+		const listing = deferred<typeof WS[]>();
+		api.workspaces.list.mockReturnValueOnce(listing.promise);
+
+		const pending = workspaceStore.loadAll();
+
+		auth.userId = 'user-2';
+		auth.fireIdentityChange();
+		// user-1's listing arrives after the swap.
+		listing.resolve([WS]);
+		await pending;
+
+		expect(workspaceStore.workspaces).toEqual([]);
+	});
+
+	it('still commits a workspace list that completes under the same user', async () => {
+		// The counterfactual for the fence above: it must not make `loadAll` a
+		// no-op in the ordinary case.
+		const { workspaceStore } = await import('./workspace.svelte');
+		api.workspaces.list.mockResolvedValue([WS]);
+
+		await workspaceStore.loadAll();
+
+		expect(workspaceStore.workspaces).toEqual([WS]);
+	});
+
+	it('returns null from a create whose user changed, so the caller navigates nowhere', async () => {
+		// The store refusing to mutate is not enough on its own: the only caller
+		// navigates to whatever comes back, so returning the workspace sent the
+		// NEW user to the PREVIOUS user's slug (codex round 1).
+		const { workspaceStore } = await import('./workspace.svelte');
+		const created = deferred<typeof OTHER>();
+		api.workspaces.create.mockReturnValueOnce(created.promise);
+
+		const pending = workspaceStore.create({ name: 'Other' });
+		auth.userId = 'user-2';
+		auth.fireIdentityChange();
+		created.resolve(OTHER);
+
+		await expect(pending).resolves.toBeNull();
+	});
+
 	it('still lists and selects a create that completes under the same user', async () => {
 		// The counterfactual for the fence: it must not turn every create into a
 		// no-op. Same user throughout, which is the ordinary case.

--- a/web/src/lib/stores/workspaceRepeatResolve.svelte.test.ts
+++ b/web/src/lib/stores/workspaceRepeatResolve.svelte.test.ts
@@ -30,7 +30,29 @@ vi.mock('$lib/api/client', () => ({ api }));
 
 // The answer cache is keyed by signed-in user as well as slug, so the identity
 // has to be controllable to test that a second user inherits nothing.
-const auth = vi.hoisted(() => ({ userId: 'user-1' }));
+//
+// `onIdentityChange` is a REAL minimal implementation rather than a no-op stub
+// (BUG-2991): the store registers a reset through it at module scope, and a
+// stub that swallowed the registration would make every test here pass against
+// a store whose identity reset had been deleted.
+const auth = vi.hoisted(() => {
+	const listeners = new Set<() => void>();
+	return {
+		userId: 'user-1',
+		onIdentityChange(fn: () => void) {
+			listeners.add(fn);
+			return () => listeners.delete(fn);
+		},
+		/** Test-only: fire what `authStore.clear()` / a sign-in would fire. */
+		fireIdentityChange() {
+			for (const fn of listeners) fn();
+		},
+		/** Test-only: drop registrations from a previous `vi.resetModules()`. */
+		resetListeners() {
+			listeners.clear();
+		},
+	};
+});
 vi.mock('./auth.svelte', () => ({ authStore: auth }));
 
 const OWNER = { role: 'owner', collection_grants: [], item_grants: [] };
@@ -53,6 +75,10 @@ describe('workspaceStore: repeat resolution of an already-answered workspace', (
 		// reason — which is exactly the failure this suite is built to catch.
 		vi.resetModules();
 		vi.resetAllMocks();
+		// Before the module re-registers: each fresh import of the store adds a
+		// listener, and leftovers from previous tests close over THAT module's
+		// state, so firing would reset a store no test is looking at.
+		auth.resetListeners();
 		auth.userId = 'user-1';
 	});
 
@@ -330,6 +356,13 @@ describe('workspaceStore: repeat resolution of an already-answered workspace', (
 
 		const created = deferred<typeof OTHER>();
 		api.workspaces.create.mockReturnValueOnce(created.promise);
+		// Staged and expected to go UNCONSUMED. Before BUG-2991 the create ran
+		// on past its POST and issued this `/me`, and the only thing standing
+		// between user-1's answer and user-2's store was `settleIfCurrent`
+		// rejecting it at the very end. The fence now returns before the fetch:
+		// a `/me` for a user who is no longer signed in has no answer worth
+		// having, and every write that used to happen ahead of that rejection —
+		// the list append, the selection — no longer happens either.
 		api.workspaces.me.mockResolvedValueOnce(OWNER);
 		const pending = workspaceStore.create({ name: 'Other' });
 
@@ -338,11 +371,23 @@ describe('workspaceStore: repeat resolution of an already-answered workspace', (
 		created.resolve(OTHER);
 		await pending;
 
+		// The create is fenced at the identity check, so no membership was even
+		// requested for it.
+		expect(api.workspaces.me).not.toHaveBeenCalled();
 		// user-1's owner answer must not be published for user-2...
 		expect(workspaceStore.isOwner).toBe(false);
 		expect(workspaceStore.membershipKnown).toBe(false);
+		// ...and user-1's workspace must not be in user-2's list or selected
+		// (BUG-2991: the append used to run unconditionally, ahead of every
+		// fence, so it landed even when the selection was rejected).
+		expect(workspaceStore.workspaces).toEqual([]);
+		expect(workspaceStore.current).toBeNull();
 
 		// ...nor be waiting in user-2's cache for their own next resolve.
+		// The staged OWNER above is dropped rather than left to be picked up by
+		// the `setCurrent` below, which would answer this leg for the wrong
+		// reason.
+		api.workspaces.me.mockReset();
 		const mine = deferred<typeof VIEWER>();
 		api.workspaces.me.mockReturnValueOnce(mine.promise);
 		const second = workspaceStore.setCurrent('other');

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -37,6 +37,14 @@
 	// is down. Recovery belongs where it can be gated on a CONDITION rather than
 	// on a flag: `workspaceStore.recoverIfMissing`, driven by the workspace
 	// layout's sync subscriber.
+	// One-shot latch so the effect below issues `loadAll` once per session
+	// rather than on every re-run. RE-ARMED ON AN IDENTITY CHANGE (BUG-2991,
+	// codex round 1): the workspace store now drops the previous user's list
+	// when the signed-in user changes, and this latch is what would otherwise
+	// stop the new user's list ever being fetched — logout is an SPA
+	// navigation, so this layout stays mounted and the latch stays true. The
+	// symptom would be TASK-2200's exactly: an empty sidebar with no links and
+	// nothing but F5 to fix it.
 	let workspacesRequested = $state(false);
 	let authLoadFailed = $state(false);
 	let isAuthPage = $derived(
@@ -85,6 +93,21 @@
 	// toast-store import, matching the access-revoked split above.
 	setRateLimitHandler((retryAfterMs) => {
 		notifyServerBusy(retryAfterMs);
+	});
+
+	onMount(() => {
+		// Re-arm the one-shot workspace-load latch whenever the signed-in user
+		// changes (BUG-2991, codex round 1). Registered here rather than folded
+		// into the store's own listener because the latch is THIS component's
+		// state: the store drops the list, and the component has to be willing
+		// to ask for it again. Returned unsubscribe runs on destroy.
+		//
+		// Deliberately outside the async body below — an `onMount` that returns
+		// a Promise has its resolved value ignored, so a cleanup returned from
+		// an async `onMount` is never called.
+		return authStore.onIdentityChange(() => {
+			workspacesRequested = false;
+		});
 	});
 
 	onMount(async () => {

--- a/web/src/routes/[username]/[workspace]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/+page.svelte
@@ -224,6 +224,15 @@
 			dashboardSlug = null;
 			collections = [];
 			dashError = null;
+			// The aha-highlight track goes with the data it describes (codex
+			// round 9). It is keyed on `dashboardSlug`, which does NOT change
+			// on a same-route identity change, so the previous user's
+			// `onboarding: true` was still standing when the new user's first
+			// response arrived with `false` — read as the true→false edge, and
+			// the new user's items were highlighted as though they had just
+			// created them.
+			onboardingTrack = null;
+			justCreatedSlugs = new Set();
 			if (wsSlug) load(wsSlug);
 		});
 	});

--- a/web/src/routes/[username]/[workspace]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/+page.svelte
@@ -71,7 +71,7 @@
 	//
 	// Two effects per CONVE-606 (split reactive-state sync from route-change
 	// effects): one resets the cache on a real workspace switch, the other
-	// updates it only when membership is definitively known (non-null).
+	// updates it only when membership is definitively known.
 	// Initial default is `false` so we never flash owner-only UI before /me
 	// confirms ownership. Server enforcement (handlers_collections.go:48)
 	// remains the security boundary; this is purely a stability fix for the
@@ -85,8 +85,20 @@
 		}
 	});
 	$effect(() => {
-		const mem = workspaceStore.currentMembership;
-		if (mem !== null) isOwner = mem.role === 'owner';
+		// Gated on `membershipKnown`, NOT on `currentMembership !== null`
+		// (BUG-2990). Null means both "not fetched yet" and "no access", so
+		// gating on non-null holds the last good answer forever once the answer
+		// becomes a definitive DENIAL: an owner removed from the workspace, or
+		// a `/me` that 403s, kept the New Collection CTA and the collection
+		// editor's trigger on screen for the life of the page. `membershipKnown`
+		// is false for the span of any call that will replace membership, which
+		// is exactly the window this cache exists to ride out, and true for an
+		// answer of either sign — so a denial now clears the cache.
+		//
+		// Read through the store's `isOwner` getter rather than re-deriving the
+		// role test, matching settings/+page.svelte: the helpers mirror the
+		// server's ResolveUserPermission and must not be forked.
+		if (workspaceStore.membershipKnown) isOwner = workspaceStore.isOwner;
 	});
 
 	// Post IDEA-1516 / TASK-1530: the canonical onboarding signal is

--- a/web/src/routes/[username]/[workspace]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/+page.svelte
@@ -43,6 +43,14 @@
 	let dashboardSlug = $state<string | null>(null);
 	let collections = $state<Collection[]>([]);
 
+	// Memoised so the effects below re-run on a change of USER and not on every
+	// replacement of the session object (codex round 3). `authStore.userId`
+	// reads the reactive `session`, so any `authStore.load()` — including the
+	// routine refetch that returns the same user — assigns a new object and
+	// would otherwise re-fire both. A `$derived` propagates only when its value
+	// actually changes.
+	let sessionUserId = $derived(authStore.userId);
+
 	// Scroll position restoration (BUG-1425). Dashboard renders progressively
 	// (active items, attention list, etc.) — wait for the initial dashboard
 	// fetch before applying a saved offset so the document is tall enough.
@@ -89,7 +97,7 @@
 	// on a path that does not exist yet.
 	let lastOwnerKey: string | null = null;
 	$effect(() => {
-		const key = `${authStore.userId}\n${wsSlug}`;
+		const key = `${sessionUserId}\n${wsSlug}`;
 		if (key !== lastOwnerKey) {
 			lastOwnerKey = key;
 			isOwner = false;
@@ -196,6 +204,13 @@
 	// the dashboard to refetch + re-render — a visible flicker. Wrap in
 	// `untrack` so the only tracked dep is `wsSlug` from the if-check.
 	$effect(() => {
+		// Keyed on the USER as well as the slug (BUG-2991, codex round 3). A
+		// sign-in as somebody else on the same route changes no route param, so
+		// without this the board kept showing the previous user's items,
+		// counts and activity. Re-running `load` both hides them — a
+		// non-silent load flips `loading`, and the loading branch is first in
+		// the template — and refetches as the new user.
+		sessionUserId;
 		if (wsSlug) untrack(() => load(wsSlug));
 	});
 

--- a/web/src/routes/[username]/[workspace]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/+page.svelte
@@ -77,10 +77,21 @@
 	// remains the security boundary; this is purely a stability fix for the
 	// UX gate.
 	let isOwner = $state(false);
-	let lastOwnerSlug: string | null = null;
+	// KEYED ON (USER, WORKSPACE), not on workspace alone (BUG-2991, codex
+	// round 2). A sticky permission is an answer about a PERSON as much as
+	// about a workspace, and since BUG-2991 the store drops membership to
+	// UNKNOWN when the signed-in user changes. Unknown does not update the
+	// cache — that is the whole point of the `membershipKnown` gate below — so
+	// keyed on slug alone the previous owner's `true` survived a sign-in as
+	// somebody else on the same route, and the new user saw owner-only chrome
+	// until their own `/me` landed. Adding identity to the key closes it
+	// declaratively: no subscription, no lifecycle, and it cannot be forgotten
+	// on a path that does not exist yet.
+	let lastOwnerKey: string | null = null;
 	$effect(() => {
-		if (wsSlug !== lastOwnerSlug) {
-			lastOwnerSlug = wsSlug;
+		const key = `${authStore.userId}\n${wsSlug}`;
+		if (key !== lastOwnerKey) {
+			lastOwnerKey = key;
 			isOwner = false;
 		}
 	});

--- a/web/src/routes/[username]/[workspace]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/+page.svelte
@@ -203,15 +203,29 @@
 	// calls `workspaceStore.loadAll()`) would re-fire this effect and cause
 	// the dashboard to refetch + re-render — a visible flicker. Wrap in
 	// `untrack` so the only tracked dep is `wsSlug` from the if-check.
+	// Keyed on (USER, WORKSPACE) — see `lastOwnerKey` above for the identity
+	// half (BUG-2991, codex round 3). A sign-in as somebody else on the same
+	// route changes no route param, so without the user in this key the board
+	// kept showing the previous user's items, counts and activity.
+	//
+	// The DATA IS DROPPED before the reload, not merely hidden behind `loading`
+	// (codex round 5). Relying on the loading branch was a fail-open: if the
+	// new user's dashboard request FAILS, `loading` goes false with `dashboard`
+	// still holding the previous key's board, and the template renders it —
+	// the `dashError` branch sits after it. So the previous user's data came
+	// back on a 500 or a 403, which is the worst moment for it to.
+	let lastLoadKey: string | null = null;
 	$effect(() => {
-		// Keyed on the USER as well as the slug (BUG-2991, codex round 3). A
-		// sign-in as somebody else on the same route changes no route param, so
-		// without this the board kept showing the previous user's items,
-		// counts and activity. Re-running `load` both hides them — a
-		// non-silent load flips `loading`, and the loading branch is first in
-		// the template — and refetches as the new user.
-		sessionUserId;
-		if (wsSlug) untrack(() => load(wsSlug));
+		const key = `${sessionUserId}\n${wsSlug}`;
+		if (key === lastLoadKey) return;
+		lastLoadKey = key;
+		untrack(() => {
+			dashboard = null;
+			dashboardSlug = null;
+			collections = [];
+			dashError = null;
+			if (wsSlug) load(wsSlug);
+		});
 	});
 
 	// Workspace home shows only the workspace-level title — clear section/item.

--- a/web/src/routes/[username]/[workspace]/settings/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/settings/+page.svelte
@@ -102,6 +102,13 @@
 	// when membership is definitively known). Default false so owner-only chrome
 	// never flashes before `/me` confirms; the server-side owner check remains
 	// the enforcement boundary, this is a stability fix.
+	// Memoised so the effects below re-run on a change of USER and not on every
+	// replacement of the session object (BUG-2991, codex round 3).
+	// `authStore.userId` reads the reactive `session`, so any `authStore.load()`
+	// — the routine same-user refetch included — assigns a new object and would
+	// otherwise re-fire them. A `$derived` propagates only on a real change.
+	let sessionUserId = $derived(authStore.userId);
+
 	let canEditWs = $state(false);
 	// Same treatment, same reason: read straight from the store these flip false
 	// during that window too, so on an ordinary owner load the Save buttons, the
@@ -116,23 +123,29 @@
 	// same-route sign-in as somebody else.
 	//
 	// NOT COVERED BY A DISCRIMINATING TEST, and that is stated here rather than
-	// left for a reader to discover. On THIS page the defect is masked: the
-	// identity reset also nulls `workspaceStore.current`, and this page renders
-	// nothing at all without it, so the owner-only chrome vanishes during the
-	// unknown window whether the key carries identity or not. A mutant dropping
-	// identity from the key SURVIVES every DOM assertion available here — the
-	// first version of that test asserted the tab was gone and passed against a
-	// blanked page, which is the vacuous-fixture shape (CONVE-34).
+	// left for a reader to discover. The defect is MASKED on this page: an
+	// identity change re-fires the load effect below, which sets `loading` and
+	// swaps the whole page for the loading branch, so the owner-only chrome
+	// vanishes during the unknown window whether or not the key carries
+	// identity. A mutant dropping identity from this key SURVIVES every DOM
+	// assertion available here — a test asserting the Danger Zone tab is gone
+	// passes against a page that is rendering nothing at all, which is the
+	// vacuous-fixture shape (CONVE-34).
+	//
+	// (An earlier version of this comment blamed a null `workspaceStore
+	// .current`. That was wrong — rendering is gated on `loading` alone — and
+	// the claim was written from an observation rather than from reading the
+	// template. The observation was right and the mechanism was not, which is
+	// the more dangerous half to leave behind.)
 	//
 	// The guard stays because the class does: the dashboard's instance IS
-	// discriminated (`workspaceDashboardOwnerDenial`, which keeps rendering its
-	// own data through the window and so can tell the two apart), the two pages
-	// are the same pattern, and the masking here is incidental — it depends on
-	// this page having nothing to render without `current`, which is not a
-	// property anyone promised to preserve.
+	// discriminated (`workspaceDashboardOwnerDenial` — that page keeps its own
+	// data on screen through the window and so can tell the two apart), the two
+	// pages are the same pattern, and the masking here depends on a rendering
+	// decision nobody promised to preserve.
 	let lastPermKey: string | null = null;
 	$effect(() => {
-		const key = `${authStore.userId}\n${wsSlug}`;
+		const key = `${sessionUserId}\n${wsSlug}`;
 		if (key !== lastPermKey) {
 			lastPermKey = key;
 			// ONE reset for every sticky permission on this page. A second
@@ -193,6 +206,19 @@
 	}
 
 	$effect(() => {
+		// Keyed on the USER as well as the slug (BUG-2991, codex round 3). This
+		// page's own data — workspace name, members, invitations, collections,
+		// the context editor — is local state that the store's identity reset
+		// does not touch, so a sign-in as somebody else on the same route would
+		// otherwise leave the previous user's members list on screen.
+		//
+		// It already re-fired by ACCIDENT: `load` calls `workspaceStore
+		// .setCurrent`, which synchronously reads `workspaces` before its first
+		// await, so emptying that array on the reset happened to invalidate this
+		// effect. That is a dependency nobody declared and the dashboard's twin
+		// deliberately suppresses with `untrack`. Naming the real key makes the
+		// behaviour survive someone fixing the accident.
+		sessionUserId;
 		if (wsSlug) load(wsSlug);
 	});
 

--- a/web/src/routes/[username]/[workspace]/settings/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/settings/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
-	import { onMount, onDestroy } from 'svelte';
+	import { onMount, onDestroy, untrack } from 'svelte';
 	import { api, isPlanLimitError, planLimitMessage } from '$lib/api/client';
 	import { sseService } from '$lib/services/sse.svelte';
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
@@ -205,21 +205,37 @@
 		history.replaceState(null, '', `#${tabId}`);
 	}
 
+	// Keyed on (USER, WORKSPACE) (BUG-2991, codex round 3). This page's own data
+	// — workspace name, members, invitations, collections, the context editor —
+	// is local state that the store's identity reset does not touch, so a
+	// sign-in as somebody else on the same route would otherwise leave the
+	// previous user's MEMBERS LIST on screen.
+	//
+	// It already re-fired by ACCIDENT: `load` calls `workspaceStore.setCurrent`,
+	// which synchronously reads `workspaces` before its first await, so emptying
+	// that array on the reset happened to invalidate this effect. That is a
+	// dependency nobody declared, and the dashboard's twin deliberately
+	// suppresses exactly it with `untrack`. Naming the real key makes the
+	// behaviour survive someone fixing the accident.
+	//
+	// The DATA IS DROPPED before the reload, not merely hidden behind `loading`
+	// (codex round 5). `load`'s catch allows a partial render and its `finally`
+	// clears `loading` regardless, so a FAILED load for the new user left the
+	// previous user's name, members and invitations on screen the moment the
+	// spinner went away.
+	let lastLoadKey: string | null = null;
 	$effect(() => {
-		// Keyed on the USER as well as the slug (BUG-2991, codex round 3). This
-		// page's own data — workspace name, members, invitations, collections,
-		// the context editor — is local state that the store's identity reset
-		// does not touch, so a sign-in as somebody else on the same route would
-		// otherwise leave the previous user's members list on screen.
-		//
-		// It already re-fired by ACCIDENT: `load` calls `workspaceStore
-		// .setCurrent`, which synchronously reads `workspaces` before its first
-		// await, so emptying that array on the reset happened to invalidate this
-		// effect. That is a dependency nobody declared and the dashboard's twin
-		// deliberately suppresses with `untrack`. Naming the real key makes the
-		// behaviour survive someone fixing the accident.
-		sessionUserId;
-		if (wsSlug) load(wsSlug);
+		const key = `${sessionUserId}\n${wsSlug}`;
+		if (key === lastLoadKey) return;
+		lastLoadKey = key;
+		untrack(() => {
+			wsName = '';
+			contextEditor = '';
+			collections = [];
+			members = [];
+			invitations = [];
+			if (wsSlug) load(wsSlug);
+		});
 	});
 
 	// BUG-2265: keep the collections list fresh when another client changes a

--- a/web/src/routes/[username]/[workspace]/settings/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/settings/+page.svelte
@@ -5,6 +5,7 @@
 	import { api, isPlanLimitError, planLimitMessage } from '$lib/api/client';
 	import { sseService } from '$lib/services/sse.svelte';
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
+	import { authStore } from '$lib/stores/auth.svelte';
 	import type { Collection, WorkspaceContext } from '$lib/types';
 	import { parseSchema } from '$lib/types';
 	import CreateCollectionModal from '$lib/components/collections/CreateCollectionModal.svelte';
@@ -107,13 +108,36 @@
 	// invite form and the delete controls go readonly and then come back.
 	let isOwner = $state(false);
 	let canExport = $state(false);
-	let lastPermSlug: string | null = null;
+	// KEYED ON (USER, WORKSPACE), not on workspace alone (BUG-2991, codex
+	// round 2). Same hole the dashboard had, for the same reason and found in
+	// the same sweep: since BUG-2991 the store drops membership to UNKNOWN when
+	// the signed-in user changes, unknown deliberately does not update these
+	// caches, and keyed on slug alone the previous user's answers survive a
+	// same-route sign-in as somebody else.
+	//
+	// NOT COVERED BY A DISCRIMINATING TEST, and that is stated here rather than
+	// left for a reader to discover. On THIS page the defect is masked: the
+	// identity reset also nulls `workspaceStore.current`, and this page renders
+	// nothing at all without it, so the owner-only chrome vanishes during the
+	// unknown window whether the key carries identity or not. A mutant dropping
+	// identity from the key SURVIVES every DOM assertion available here — the
+	// first version of that test asserted the tab was gone and passed against a
+	// blanked page, which is the vacuous-fixture shape (CONVE-34).
+	//
+	// The guard stays because the class does: the dashboard's instance IS
+	// discriminated (`workspaceDashboardOwnerDenial`, which keeps rendering its
+	// own data through the window and so can tell the two apart), the two pages
+	// are the same pattern, and the masking here is incidental — it depends on
+	// this page having nothing to render without `current`, which is not a
+	// property anyone promised to preserve.
+	let lastPermKey: string | null = null;
 	$effect(() => {
-		if (wsSlug !== lastPermSlug) {
-			lastPermSlug = wsSlug;
+		const key = `${authStore.userId}\n${wsSlug}`;
+		if (key !== lastPermKey) {
+			lastPermKey = key;
 			// ONE reset for every sticky permission on this page. A second
-			// effect testing the same `wsSlug !== lastPermSlug` could never
-			// fire — whichever ran first would have already updated the marker.
+			// effect testing the same key could never fire — whichever ran
+			// first would have already updated the marker.
 			canEditWs = false;
 			isOwner = false;
 			canExport = false;

--- a/web/src/routes/layoutWorkspaceReloadOnIdentity.svelte.test.ts
+++ b/web/src/routes/layoutWorkspaceReloadOnIdentity.svelte.test.ts
@@ -46,6 +46,9 @@ import { page } from '$app/state';
 
 const childSnippet = createRawSnippet(() => ({ render: () => `<div>child</div>` }));
 
+const U1_WS = { id: 'w1', slug: 'ws', name: 'WS' };
+const U2_WS = { id: 'w2', slug: 'other', name: 'Other' };
+
 function sessionFor(id: string) {
 	return { authenticated: true, user: { id, email: `${id}@example.com` } };
 }
@@ -63,7 +66,7 @@ beforeEach(() => {
 	// A protected app page: not an auth page, not a share page, so the layout's
 	// load effect is allowed to fire.
 	page.url = new URL('http://localhost/alice/ws');
-	api.workspaces.list.mockResolvedValue([{ id: 'w1', slug: 'ws', name: 'WS' }]);
+	api.workspaces.list.mockResolvedValue([U1_WS]);
 	api.auth.session.mockResolvedValue(sessionFor('u1'));
 });
 
@@ -85,11 +88,19 @@ describe('BUG-2991: the root layout refetches workspaces when the user changes',
 
 		// A different user signs in. The store's own listener empties the list;
 		// this layout's listener re-arms the latch so the effect asks again.
+		//
+		// The second response is DIFFERENT DATA, deliberately (codex round 2).
+		// A call count alone is a weak oracle: returning the same fixture twice
+		// would let this pass even if the second call committed nothing, or
+		// committed the first user's list. Asserting the store ends up holding
+		// u2's workspace is the claim that actually matters.
+		api.workspaces.list.mockResolvedValue([U2_WS]);
 		api.auth.session.mockResolvedValue(sessionFor('u2'));
 		await authStore.load();
 		await settle();
 
 		expect(api.workspaces.list).toHaveBeenCalledTimes(2);
+		expect(workspaceStore.workspaces).toEqual([U2_WS]);
 	});
 
 	it('does NOT refetch when the session refetch returns the same user', async () => {
@@ -103,5 +114,25 @@ describe('BUG-2991: the root layout refetches workspaces when the user changes',
 		await settle();
 
 		expect(api.workspaces.list).toHaveBeenCalledTimes(1);
+		expect(workspaceStore.workspaces).toEqual([U1_WS]);
+	});
+
+	it('refetches after a real sign-out and sign-in as someone else', async () => {
+		// The logout path specifically, which the first case skips by going
+		// straight from one user to another.
+		render(Layout, { props: { children: childSnippet } });
+		await settle();
+		expect(api.workspaces.list).toHaveBeenCalledTimes(1);
+
+		authStore.clear();
+		await settle();
+		expect(workspaceStore.workspaces).toEqual([]);
+
+		api.workspaces.list.mockResolvedValue([U2_WS]);
+		api.auth.session.mockResolvedValue(sessionFor('u2'));
+		await authStore.load();
+		await settle();
+
+		expect(workspaceStore.workspaces).toEqual([U2_WS]);
 	});
 });

--- a/web/src/routes/layoutWorkspaceReloadOnIdentity.svelte.test.ts
+++ b/web/src/routes/layoutWorkspaceReloadOnIdentity.svelte.test.ts
@@ -1,0 +1,107 @@
+// Runs in the jsdom vitest project (filename ends `.svelte.test.ts`).
+//
+// BUG-2991, codex round 1 — the root layout issues `workspaceStore.loadAll()`
+// once, behind a one-shot `workspacesRequested` latch.
+//
+// The store now DROPS the previous user's workspace list when the signed-in
+// user changes. Logout is an SPA navigation, so this layout stays mounted and
+// the latch stays true — which means the fix, on its own, would leave the NEW
+// user with an empty list and nothing to refill it. That is TASK-2200's symptom
+// exactly: a sidebar with no links, and only F5 to fix it.
+//
+// So the latch is re-armed on an identity change, and this file is the only
+// place that binding is observable (CONVE-19).
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import { createRawSnippet, tick } from 'svelte';
+
+const api = vi.hoisted(() => ({
+	auth: { session: vi.fn() },
+	workspaces: { list: vi.fn(), get: vi.fn(), me: vi.fn(), create: vi.fn() },
+}));
+
+vi.mock('$lib/api/client', () => ({
+	api,
+	setAccessRevokedHandler: () => {},
+	setRateLimitHandler: () => {},
+	isPlanLimitError: () => false,
+	planLimitMessage: () => '',
+}));
+
+// `goto` must not run: the unauthenticated branches call it, and jsdom has no
+// navigation. Nothing here asserts on it.
+vi.mock('$app/navigation', () => ({
+	goto: vi.fn(),
+	beforeNavigate: () => {},
+	afterNavigate: () => {},
+	invalidateAll: vi.fn(),
+	pushState: vi.fn(),
+	replaceState: vi.fn(),
+}));
+
+import Layout from './+layout.svelte';
+import { authStore } from '$lib/stores/auth.svelte';
+import { workspaceStore } from '$lib/stores/workspace.svelte';
+import { page } from '$app/state';
+
+const childSnippet = createRawSnippet(() => ({ render: () => `<div>child</div>` }));
+
+function sessionFor(id: string) {
+	return { authenticated: true, user: { id, email: `${id}@example.com` } };
+}
+
+/** Let onMount's await chain, the effect and the store's promises land. */
+async function settle(): Promise<void> {
+	for (let i = 0; i < 10; i++) {
+		await Promise.resolve();
+		await tick();
+	}
+}
+
+beforeEach(() => {
+	vi.resetAllMocks();
+	// A protected app page: not an auth page, not a share page, so the layout's
+	// load effect is allowed to fire.
+	page.url = new URL('http://localhost/alice/ws');
+	api.workspaces.list.mockResolvedValue([{ id: 'w1', slug: 'ws', name: 'WS' }]);
+	api.auth.session.mockResolvedValue(sessionFor('u1'));
+});
+
+afterEach(() => {
+	cleanup();
+	authStore.clear();
+});
+
+describe('BUG-2991: the root layout refetches workspaces when the user changes', () => {
+	it('re-arms its one-shot load latch on an identity change', async () => {
+		render(Layout, { props: { children: childSnippet } });
+		await settle();
+
+		// Non-vacuity: the latch has to have been SET for re-arming it to mean
+		// anything, and the list has to have been loaded for the reset to have
+		// something to clear.
+		expect(api.workspaces.list).toHaveBeenCalledTimes(1);
+		expect(workspaceStore.workspaces).toHaveLength(1);
+
+		// A different user signs in. The store's own listener empties the list;
+		// this layout's listener re-arms the latch so the effect asks again.
+		api.auth.session.mockResolvedValue(sessionFor('u2'));
+		await authStore.load();
+		await settle();
+
+		expect(api.workspaces.list).toHaveBeenCalledTimes(2);
+	});
+
+	it('does NOT refetch when the session refetch returns the same user', async () => {
+		// The counterfactual. Re-arming unconditionally would turn every routine
+		// session refetch into a second list request.
+		render(Layout, { props: { children: childSnippet } });
+		await settle();
+		expect(api.workspaces.list).toHaveBeenCalledTimes(1);
+
+		await authStore.load();
+		await settle();
+
+		expect(api.workspaces.list).toHaveBeenCalledTimes(1);
+	});
+});

--- a/web/src/routes/workspaceDashboardOwnerDenial.svelte.test.ts
+++ b/web/src/routes/workspaceDashboardOwnerDenial.svelte.test.ts
@@ -62,21 +62,30 @@ const OWNER = { role: 'owner', collection_grants: [], item_grants: [] };
  * one throws during render and leaves the page blank, which would read exactly
  * like "the owner card did not render" and make the denial leg pass vacuously.
  */
-function dashboard() {
+function dashboard(over: { needs_onboarding?: boolean; active_items?: unknown[] } = {}) {
 	return {
 		summary: { total_items: 0, by_collection: {} },
-		active_items: [],
+		active_items: over.active_items ?? [],
 		starred_items: [],
 		active_plans: [],
 		attention: [],
 		recent_activity: [],
 		suggested_next: [],
 		has_agent_activity: false,
-		needs_onboarding: false,
+		needs_onboarding: over.needs_onboarding ?? false,
 		degraded: false,
 		degraded_sections: []
 	};
 }
+
+const ITEM = {
+	slug: 'a-thing',
+	title: 'A thing',
+	collection_slug: 'tasks',
+	status: 'open',
+	priority: 'medium',
+	updated_at: new Date().toISOString(),
+};
 
 let host: HTMLElement;
 let app: Record<string, unknown> | null = null;
@@ -288,6 +297,41 @@ describe('BUG-2990: dashboard owner chrome expires on a definitive denial', () =
 		expect(host.querySelector('.dash-error')).not.toBeNull();
 		expect(host.textContent).toContain('Retry');
 		expect(host.querySelector('.coll-grid')).toBeNull();
+	});
+
+	it('does not highlight the new user\'s items as if they had just created them', async () => {
+		// codex round 9. The aha-highlight track is keyed on `dashboardSlug`,
+		// which does NOT change on a same-route identity change, so the previous
+		// user's `needs_onboarding: true` was still standing when the new user's
+		// first response arrived with `false`. That reads as the true→false
+		// edge the highlight exists for, and the NEW user's existing items were
+		// badged as though they had just created them.
+		await authStore.load();
+		dashboardGet.mockResolvedValue(dashboard({ needs_onboarding: true }));
+		app = mount(DashboardPage, { target: host, props: {} }) as Record<string, unknown>;
+		flushSync();
+		const i0 = await nextMe(0);
+		meCalls[i0]!(OWNER);
+		await settle();
+
+		// u2 signs in and their board is a normal, already-onboarded one.
+		dashboardGet.mockResolvedValue(
+			dashboard({ needs_onboarding: false, active_items: [ITEM] }),
+		);
+		sessionGet.mockResolvedValue({
+			authenticated: true,
+			user: { id: 'u2', email: 'u2@example.com' },
+		});
+		await authStore.load();
+		await settle();
+		const i1 = await nextMe(meCalls.length - 1);
+		meCalls[i1]!(OWNER);
+		await settle();
+
+		// PRECONDITION: u2's item really did render, or "no highlight" is true
+		// of an empty page and proves nothing.
+		expect(host.querySelector('.active-card')).not.toBeNull();
+		expect(host.querySelector('.just-created')).toBeNull();
 	});
 
 	it('keeps the card up across the window a refetch opens', async () => {

--- a/web/src/routes/workspaceDashboardOwnerDenial.svelte.test.ts
+++ b/web/src/routes/workspaceDashboardOwnerDenial.svelte.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { flushSync, mount, unmount, tick } from 'svelte';
+import { page } from '$app/state';
+import { workspaceStore } from '$lib/stores/workspace.svelte';
+
+/**
+ * BUG-2990 — the dashboard's sticky owner cache gated on
+ * `currentMembership !== null`, and a DENIAL is delivered as null.
+ *
+ * So once the cache held `true` it never cleared: an owner removed from the
+ * workspace, or a `/me` that 403s, kept the owner-only "New Collection" card on
+ * screen for the life of the page. BUG-2978 had already fixed the settings page
+ * this way (`membershipKnown`, which is true for an answer of EITHER sign); the
+ * dashboard predates it and was never brought across.
+ *
+ * Asserted through the PAGE (CONVE-19). The store's own suites cover
+ * `membershipKnown`; what is untested without this file is the BINDING — that
+ * this page's cache reads the flag rather than the nullness, which is invisible
+ * to every test of the store.
+ *
+ * Bound: UI only. `handlers_collections.go:48` is the enforcement boundary and
+ * the CTA 403s on click either way. The defect is that the UI lies, and that
+ * the lie does not expire.
+ */
+
+const meCalls: Array<(value: unknown) => void> = [];
+const meRejects: Array<(reason: unknown) => void> = [];
+
+const dashboardGet = vi.hoisted(() => vi.fn<(slug: string) => Promise<unknown>>());
+
+vi.mock('$lib/services/sync.svelte', () => ({
+	syncService: { onSync: () => () => {}, start: () => {}, stop: () => {} }
+}));
+
+vi.mock('$lib/api/client', () => ({
+	api: {
+		dashboard: { get: (slug: string) => dashboardGet(slug) },
+		collections: { list: vi.fn().mockResolvedValue([]) },
+		workspaces: {
+			get: vi.fn().mockResolvedValue({ id: 'w1', slug: 'ws', name: 'WS' }),
+			me: vi.fn(() => new Promise((resolve, reject) => {
+				meCalls.push(resolve);
+				meRejects.push(reject);
+			})),
+			list: vi.fn().mockResolvedValue([])
+		}
+	},
+	PadApiError: class extends Error {}
+}));
+
+const { default: DashboardPage } = await import('./[username]/[workspace]/+page.svelte');
+
+const OWNER = { role: 'owner', collection_grants: [], item_grants: [] };
+
+/**
+ * A complete DashboardResponse. Every array is present because the page reads
+ * `.length` on them unconditionally in its section guards — a payload missing
+ * one throws during render and leaves the page blank, which would read exactly
+ * like "the owner card did not render" and make the denial leg pass vacuously.
+ */
+function dashboard() {
+	return {
+		summary: { total_items: 0, by_collection: {} },
+		active_items: [],
+		starred_items: [],
+		active_plans: [],
+		attention: [],
+		recent_activity: [],
+		suggested_next: [],
+		has_agent_activity: false,
+		needs_onboarding: false,
+		degraded: false,
+		degraded_sections: []
+	};
+}
+
+let host: HTMLElement;
+let app: Record<string, unknown> | null = null;
+
+/** Let mount effects, the dashboard fetch and the store's settles all land. */
+async function settle(): Promise<void> {
+	for (let i = 0; i < 6; i++) {
+		await Promise.resolve();
+		await tick();
+	}
+	flushSync();
+}
+
+/**
+ * Spin the microtask/effect loop until a `/me` beyond `from` has been ISSUED,
+ * and return its index.
+ *
+ * Indices are captured rather than assumed: mounting the page issues a `/me` of
+ * its own before any test touches the store, so `meCalls[0]` is NOT the call a
+ * test just started. Resolving by a hardcoded index resolves someone else's
+ * promise and the test hangs on its own — which is how this helper came to
+ * exist.
+ *
+ * Deliberately not `vi.waitFor`: its polling is timer-based, and everything
+ * this suite waits on is a microtask plus a Svelte flush.
+ */
+async function nextMe(from: number): Promise<number> {
+	for (let i = 0; i < 50 && meCalls.length <= from; i++) {
+		await Promise.resolve();
+		await tick();
+	}
+	expect(meCalls.length).toBeGreaterThan(from);
+	return from;
+}
+
+/** The owner-only "New Collection" card in the Collections grid. */
+function ownerCard(): Element | null {
+	return host.querySelector('.coll-card-new');
+}
+
+beforeEach(async () => {
+	meCalls.length = 0;
+	meRejects.length = 0;
+	host = document.createElement('div');
+	document.body.appendChild(host);
+	page.params.workspace = 'ws';
+	page.params.username = 'alice';
+	dashboardGet.mockReset();
+	dashboardGet.mockResolvedValue(dashboard());
+});
+
+afterEach(() => {
+	if (app) unmount(app as never);
+	app = null;
+	host.remove();
+	// The store is a module-scoped singleton shared with every other suite in
+	// this file's worker. Deliberately NOT `vi.resetModules()` — see the note in
+	// settingsPermissionFlicker: a fresh module graph brings a second copy of
+	// the Svelte runtime and the remount dies with `effect_orphan`.
+});
+
+describe('BUG-2990: dashboard owner chrome expires on a definitive denial', () => {
+	/**
+	 * Mount the page and answer the `/me` its own `load()` issues.
+	 *
+	 * `load()` AWAITS `workspaceStore.setCurrent(slug)` before fetching the
+	 * dashboard, so leaving that first `/me` open leaves `dashboard` null and
+	 * the Collections grid unrendered — a state in which "the owner card is
+	 * absent" is true for a reason that has nothing to do with permissions.
+	 */
+	async function mountAsOwner(): Promise<void> {
+		app = mount(DashboardPage, { target: host, props: {} }) as Record<string, unknown>;
+		flushSync();
+		const i = await nextMe(0);
+		meCalls[i]!(OWNER);
+		await settle();
+		// The grid is the precondition for every assertion below: without it the
+		// card cannot render for reasons unrelated to this bug.
+		expect(host.querySelector('.coll-grid')).not.toBeNull();
+		expect(ownerCard()).not.toBeNull();
+	}
+
+	it('drops the owner-only New Collection card when membership becomes a denial', async () => {
+		await mountAsOwner();
+
+		// The answer CHANGES to "no access", delivered the way the store
+		// delivers it — a rejected `/me`, which settles membership to null.
+		// Same user and slug, so TASK-2988 replays the previous OWNER answer
+		// while the refetch runs: the card correctly stays up through the
+		// window, and it is the SETTLE that must take it down.
+		const at = meCalls.length;
+		const second = workspaceStore.setCurrent('ws');
+		const i = await nextMe(at);
+		meRejects[i]!(new Error('403'));
+		await second;
+		await settle();
+
+		// A denial is an ANSWER: known, and null.
+		expect(workspaceStore.membershipKnown).toBe(true);
+		expect(workspaceStore.currentMembership).toBeNull();
+		// The assertion this file exists for. Gated on `currentMembership !==
+		// null` the cache still reads true here and the card is still on screen.
+		expect(ownerCard()).toBeNull();
+	});
+
+	it('keeps the card up across the window a refetch opens', async () => {
+		// The complement, and the reason the sticky cache exists at all: the
+		// fix must not turn "unknown" into "not an owner".
+		await mountAsOwner();
+
+		// A refetch begins and does NOT resolve. The card must stay.
+		const at = meCalls.length;
+		const second = workspaceStore.setCurrent('ws');
+		const i = await nextMe(at);
+		await settle();
+		expect(ownerCard()).not.toBeNull();
+
+		meCalls[i]!(OWNER);
+		await second;
+		await settle();
+		expect(ownerCard()).not.toBeNull();
+	});
+});

--- a/web/src/routes/workspaceDashboardOwnerDenial.svelte.test.ts
+++ b/web/src/routes/workspaceDashboardOwnerDenial.svelte.test.ts
@@ -220,6 +220,40 @@ describe('BUG-2990: dashboard owner chrome expires on a definitive denial', () =
 		expect(ownerCard()).toBeNull();
 	});
 
+	it('stops showing the previous user\'s board the moment a different user signs in', async () => {
+		// BUG-2991, codex round 3 — the half the store's reset could not reach.
+		//
+		// The store drops `current`, `workspaces` and membership on an identity
+		// change, but this page's `dashboard` and `collections` are LOCAL state
+		// and survived it, and its load effect is `untrack`ed and keyed on the
+		// route slug — which does not change when someone else signs in on the
+		// same route. So user B sat looking at A's items, counts and activity
+		// while the store already said "unknown". Nothing about server
+		// authorization was involved: the bytes were already in the tab.
+		await authStore.load();
+		await mountAsOwner();
+
+		// `/me` is the observable for "a load was issued", NOT `dashboard.get`:
+		// `load()` awaits `workspaceStore.setCurrent` first, and that awaits the
+		// membership request, which this suite holds open. Asserting on
+		// `dashboard.get` measured a call that cannot have happened yet, and it
+		// failed for that reason rather than for the product's.
+		const meBefore = meCalls.length;
+
+		sessionGet.mockResolvedValue({
+			authenticated: true,
+			user: { id: 'u2', email: 'u2@example.com' },
+		});
+		await authStore.load();
+		await settle();
+
+		// A's board is off screen...
+		expect(host.querySelector('.coll-grid')).toBeNull();
+		// ...and a fresh load was issued for B rather than the page simply
+		// going blank forever.
+		expect(meCalls.length).toBeGreaterThan(meBefore);
+	});
+
 	it('keeps the card up across the window a refetch opens', async () => {
 		// The complement, and the reason the sticky cache exists at all: the
 		// fix must not turn "unknown" into "not an owner".

--- a/web/src/routes/workspaceDashboardOwnerDenial.svelte.test.ts
+++ b/web/src/routes/workspaceDashboardOwnerDenial.svelte.test.ts
@@ -254,6 +254,35 @@ describe('BUG-2990: dashboard owner chrome expires on a definitive denial', () =
 		expect(meCalls.length).toBeGreaterThan(meBefore);
 	});
 
+	it('does not bring the previous user\'s board back when the new user\'s load FAILS', async () => {
+		// BUG-2991, codex round 5. Hiding A's board behind `loading` was a
+		// fail-open: `loading` goes false when the new user's request settles
+		// EITHER WAY, and on a failure `dashboard` still held A's data with the
+		// template rendering it ahead of the `dashError` branch. So A's items,
+		// counts and activity came back on a 500 or a 403 — the worst moment
+		// for them to. The data is dropped at the transition now.
+		await authStore.load();
+		await mountAsOwner();
+		expect(host.querySelector('.coll-grid')).not.toBeNull();
+
+		// B signs in, and everything B asks for fails.
+		dashboardGet.mockRejectedValue(new Error('500'));
+		sessionGet.mockResolvedValue({
+			authenticated: true,
+			user: { id: 'u2', email: 'u2@example.com' },
+		});
+		await authStore.load();
+		await settle();
+
+		// Answer B's membership request so the load gets past `setCurrent` and
+		// reaches the failing dashboard fetch, then settles.
+		const i = await nextMe(meCalls.length - 1 < 0 ? 0 : meCalls.length - 1);
+		meCalls[i]!(OWNER);
+		await settle();
+
+		expect(host.querySelector('.coll-grid')).toBeNull();
+	});
+
 	it('keeps the card up across the window a refetch opens', async () => {
 		// The complement, and the reason the sticky cache exists at all: the
 		// fix must not turn "unknown" into "not an owner".

--- a/web/src/routes/workspaceDashboardOwnerDenial.svelte.test.ts
+++ b/web/src/routes/workspaceDashboardOwnerDenial.svelte.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { flushSync, mount, unmount, tick } from 'svelte';
 import { page } from '$app/state';
 import { workspaceStore } from '$lib/stores/workspace.svelte';
+import { authStore } from '$lib/stores/auth.svelte';
 
 /**
  * BUG-2990 — the dashboard's sticky owner cache gated on
@@ -32,8 +33,11 @@ vi.mock('$lib/services/sync.svelte', () => ({
 	syncService: { onSync: () => () => {}, start: () => {}, stop: () => {} }
 }));
 
+const sessionGet = vi.hoisted(() => vi.fn<() => Promise<unknown>>());
+
 vi.mock('$lib/api/client', () => ({
 	api: {
+		auth: { session: () => sessionGet() },
 		dashboard: { get: (slug: string) => dashboardGet(slug) },
 		collections: { list: vi.fn().mockResolvedValue([]) },
 		workspaces: {
@@ -122,12 +126,20 @@ beforeEach(async () => {
 	page.params.username = 'alice';
 	dashboardGet.mockReset();
 	dashboardGet.mockResolvedValue(dashboard());
+	sessionGet.mockReset();
+	sessionGet.mockResolvedValue({
+		authenticated: true,
+		user: { id: 'u1', email: 'u1@example.com' },
+	});
 });
 
 afterEach(() => {
 	if (app) unmount(app as never);
 	app = null;
 	host.remove();
+	// The auth store is a module singleton too, and an identity left over from
+	// one test would silently change the reset key the next one starts from.
+	authStore.clear();
 	// The store is a module-scoped singleton shared with every other suite in
 	// this file's worker. Deliberately NOT `vi.resetModules()` — see the note in
 	// settingsPermissionFlicker: a fresh module graph brings a second copy of
@@ -175,6 +187,36 @@ describe('BUG-2990: dashboard owner chrome expires on a definitive denial', () =
 		expect(workspaceStore.currentMembership).toBeNull();
 		// The assertion this file exists for. Gated on `currentMembership !==
 		// null` the cache still reads true here and the card is still on screen.
+		expect(ownerCard()).toBeNull();
+	});
+
+	it('drops the card the moment a DIFFERENT user signs in, before their /me lands', async () => {
+		// BUG-2991, codex round 2 — the hole `membershipKnown` alone leaves open.
+		//
+		// An identity change drops membership to UNKNOWN, and unknown
+		// deliberately does not update this cache; that is what the gate is
+		// for. The slug did not change either, so the reset effect keyed on
+		// `wsSlug` alone never fired. Net: the previous owner's `true` survived
+		// a sign-in as somebody else on the same route, and the new user saw
+		// owner-only chrome until their own `/me` landed. The cache is keyed on
+		// (user, workspace) now.
+		//
+		// This is the UNKNOWN window, not a settled denial — the other test
+		// covers the settled case, and neither subsumes the other.
+		await authStore.load();
+		await mountAsOwner();
+
+		sessionGet.mockResolvedValue({
+			authenticated: true,
+			user: { id: 'u2', email: 'u2@example.com' },
+		});
+		await authStore.load();
+		await settle();
+
+		// Membership really is unknown here — no answer has arrived for u2. If
+		// this read `true` the assertion below would be about a settled state
+		// and would prove something else.
+		expect(workspaceStore.membershipKnown).toBe(false);
 		expect(ownerCard()).toBeNull();
 	});
 

--- a/web/src/routes/workspaceDashboardOwnerDenial.svelte.test.ts
+++ b/web/src/routes/workspaceDashboardOwnerDenial.svelte.test.ts
@@ -280,6 +280,13 @@ describe('BUG-2990: dashboard owner chrome expires on a definitive denial', () =
 		meCalls[i]!(OWNER);
 		await settle();
 
+		// NON-VACUITY (codex round 6). "The grid is absent" is also true of a
+		// page still sitting in its loading branch, which would prove nothing
+		// about whether the old board was restored. Pin the state precisely:
+		// the load has SETTLED into its error branch, with the Retry affordance
+		// up and the previous user's board gone.
+		expect(host.querySelector('.dash-error')).not.toBeNull();
+		expect(host.textContent).toContain('Retry');
 		expect(host.querySelector('.coll-grid')).toBeNull();
 	});
 


### PR DESCRIPTION
Two client-side fail-open defects, both found by codex while reviewing TASK-2988 (#1313), both pre-existing on `main`. Taken as one unit because they are the same shape: **state cached for the user you WERE, outliving the moment you stopped being them.**

Eleven adversarial review rounds. **Twenty-four findings, six of them defects an earlier fix in this branch introduced.** Round 11 returned nothing.

## The two filed bugs

**BUG-2990** — the dashboard's sticky owner cache updated only when `currentMembership !== null`, and a DENIAL is delivered as null. Once it held `true` it never cleared, so an owner removed from the workspace — or a `/me` that 403s — kept the owner-only **New Collection** CTA on screen for the life of the page. Gated on `membershipKnown` now, which is true for an answer of either sign. Same fix BUG-2978 applied to the settings page; the dashboard predates it.

**BUG-2991** — `workspaceStore.create` mutated `workspaces` and `current` after its POST with no identity fence, and the append ran ahead of every guard, so a create issued by user A returning after B signed in put A's workspace into B's list. Plus the half the report named: `authStore.clear()` left `current`, `workspaces` and a published `currentMembership` in place, so a clean account change with nothing in flight left the previous user's permission state on screen.

**BUG-3004** (filed separately, fixed here because it blocked this unit's own tests) — `CreateWorkspaceModal`'s open-reset `$effect` read `templates.length` and wrote `templates` from its own response, so it invalidated itself and re-ran the reset while the modal stayed open. The typed name, description, chosen template and selected import bundle were wiped one round-trip after opening.

## What the eleven rounds turned this into

The unit began as two gates and became one rule: **user-scoped state and user-scoped side effects must both expire when the user changes.** What is in the branch:

| layer | mechanism |
|---|---|
| `authStore` | `onIdentityChange` — a subscription fired on a real change of signed-in user. A rejection is NOT one; a resolved `{authenticated:false}` is |
| `workspaceStore` | module-scope reset listener; identity fences on `create` (POST *and* `/me`) and on `loadAll`'s commit |
| root layout | one-shot workspace-load latch re-armed on identity change |
| dashboard + settings | sticky permission caches keyed on `(user, workspace)`; load effects keyed the same; local data DROPPED at the transition, not merely hidden behind `loading` |
| create/import modal | identity fences on success *and* failure paths, per-await; module-scoped operation token; per-instance liveness flag; closes on identity change |

**Six of the findings were mine, introduced by an earlier fix in this same branch.** Closing the modal on identity change (r7) made stale continuations dismiss the *next* user's modal (r8) and re-enable their in-flight import (r9). The identity notification (r1) turned a transient `/auth/session` failure into a silent sign-out that killed in-flight operations (r9). The instance-local operation token (r9) could not see a remount (r10). Each pair was correct in isolation.

## Deliberately NOT here

- **BUG-3005** — `collectionStore`, `starredStore` and `localIndex` hold per-user state across an identity change. `collectionStore` is the sharpest: global `collections`/`items`/`activeItem`, slug-keyed loader, no identity fence.
- **BUG-3006** — the settings page fences its LOAD and none of its MUTATIONS: six handler families plus a global Undo toast that outlives the page, so B can click A's Undo, restore A's deleted workspace and be navigated to A's owner URL.

Both refute this branch's earlier claim that the class was closed. Scope closed by lead ruling at round 10: fix defects in fences this PR owns, file the rest.

## Bound

UI and client state only. The server enforces per request and the owner-only CTA 403s on click either way. What was wrong is that the UI lied, and that the lie did not expire.

## Instruments

Every guard mutation-verified, **every mutant confirmed to BUILD before its outcome was read**. Highlights:

- the dashboard denial gate, the load-effect key, the cache key, the store reset, both `create` fences, `loadAll`'s fence, the layout latch, the import fences (success *and* failure), the operation token and the liveness flag — each killed by a named test
- **two guards documented as SURVIVING**: the settings identity cache key (the page is entirely behind `loading` during the window, so no DOM assertion discriminates it) and, earlier, a dashboard commit-time fence that was **deleted** rather than kept as decoration when no ordering could make it the guard that mattered
- **five vacuous assertions found and fixed**, all one shape: an absence asserted with no assertion that the thing producing it happened. A click that never fired, a submit that never reached its API, a load that never settled, a page still loading, a first-check return standing in for a second

## Gates — all on this worktree's own build, on the reviewed tip `9c75bb6e`

| gate | result |
|---|---|
| `npm run check` | 1087 files, **0 errors** (6 pre-existing warnings) |
| `npx vitest run` | **160 files / 2395 tests**, exit 0 |
| `npx vite build` here → `make build-go` | built — no copied-in `web/build`, because this is a `web/src` change |
| `make lint` | 0 issues |
| `make test` | exit 0, **0 FAIL** across 30 packages |
| playwright ×4 | `dashboard`, `account-delete`, `account-export`, `bug-2978-settings-hash-deeplink` — green **against that binary** |
| `make test-pg` | not run, deliberately: no SQL touched |

`account-delete` and `bug-2978-settings-hash-deeplink` are the load-bearing two: the first drives a real `authStore.clear()` end to end, the second is what breaks if the settings load effect starts re-firing spuriously.
