### PR TITLE
chore(deps): bump google.golang.org/grpc 1.83.0 -> 1.83.2 (BUG-2986)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -137,7 +137,7 @@ require (
 	golang.org/x/tools v0.48.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260803160001-6ac0973c030d // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260803160001-6ac0973c030d // indirect
-	google.golang.org/grpc v1.83.0 // indirect
+	google.golang.org/grpc v1.83.2 // indirect
 	google.golang.org/protobuf v1.36.12 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -937,8 +937,8 @@ google.golang.org/grpc v1.31.1/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM
 google.golang.org/grpc v1.33.2/go.mod h1:JMHMWHQWaTccqQQlmk3MJZS+GWXOdAesneDmEnv2fbc=
 google.golang.org/grpc v1.34.0/go.mod h1:WotjhfgOW/POjDeRt8vscBtXq+2VjORFy659qA51WJ8=
 google.golang.org/grpc v1.35.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
-google.golang.org/grpc v1.83.0 h1:JeNZEKJFbQxArAMl+hiytHauacDNqJUllNfmIMmpqnQ=
-google.golang.org/grpc v1.83.0/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
+google.golang.org/grpc v1.83.2 h1:EManeRomTObA0BU7I8vXgg/78uE5MJ9M8B39EX2WscU=
+google.golang.org/grpc v1.83.2/go.mod h1:YPI1hK3kDked6iHvgX3tR0y+nX/qpMFKhPgFsokw1S8=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=


### PR DESCRIPTION

Branch `bug-2986-grpc-bump`, commit `07184aa1`, worktree `docapp-2986`, branched from `9839884b`. Not pushed yet — this is the packet you review before the GO.

### What moved

One line of `go.mod`, two of `go.sum`. `google.golang.org/grpc v1.83.0 -> v1.83.2`, indirect. Nothing else in the module graph moved: `go get` + `go mod tidy` produced a 3-line diff and dragged no transitive companions.

### Why

| advisory | severity | patched | what it is |
|---|---|---|---|
| GHSA-2v4p-qf9q-27wj | high | 1.83.2 | xDS servers: DoS crash on missing `:authority`/`Host` |
| GHSA-vp52-pcj8-j9qc | high | 1.83.1 | Heap exhaustion (OOM) via HTTP/2 DATA frame fragmentation |
| GHSA-qc2q-p7wx-3px3 | medium | 1.83.1 | xDS RBAC filter bypass via mixed-case header matching |

1.83.2 is the lowest version clearing all three.

### What it touches — measured, not assumed

`go mod why -m` gives the chain: `internal/oauth` → `ory/fosite` → `ory/x/otelx` → `otlptracehttp` → `grpc`. pad names grpc nowhere.

Then `go list -deps ./cmd/pad`, which answers what is actually LINKED rather than what is in the module graph:

- **66 grpc packages are in the graph**, so "indirect" does not mean absent. (`go list -deps` reports dependency-graph membership, not final linker inclusion — enough for the question here, and not the same claim.)
- **xDS: ZERO packages.** Both xDS advisories are absent from this build rather than merely unexercised.
- **`grpc/internal/transport`: 4 packages.** That is where the DATA-frame advisory lives. That package is the SHARED client and server transport, so its presence settles nothing on its own; what settles it is the advisory's attack model, which needs an inbound gRPC server stream. pad starts only its HTTP server and constructs no gRPC server.

Two greps close the remaining gap: pad contains no `grpc.*` call anywhere in `internal/` or `cmd/`, and wires no OTel exporter at all. The transport is linked because otlptracehttp pulls the client stack in, not because anything calls it.

**So the bump changes no behaviour pad can exercise TODAY** — a statement about the current call graph, not a promise about the next caller. I would rather say that plainly than dress it up as a fix.

### Why take it anyway

It costs one line; it clears three alerts that would otherwise sit open beside the one real one (the imaging TIFF alert you accepted as bounded), where a full alert list nobody can dismiss is how a real alert gets missed; and "unreachable today" is a property of the current call graph, not a guarantee about the next caller. The cheapest moment to be on a patched version is before someone wires an exporter.

### Gates

`go build ./...` 0 · `go test ./...` 0, no FAIL lines · `go vet` 0 · golangci-lint `0 issues.`

### The vendorHash, which this change invalidates

Any `go.mod` change invalidates the pinned `nix/package.nix` `vendorHash`, and **`nix` is not on PATH on this box**, so I cannot recompute it locally and am not going to guess one. The designed flow covers it: CI's Nix job recomputes in the working tree and the `push-vendor-hash` heal job fixes main after merge (BUG-2974's machinery). Flagging it rather than leaving it to surprise the Nix check.

### What I did NOT do

The imaging alert is untouched — your ruling stands that it is accepted-as-bounded with no fixed release, and dismissing it on GitHub is yours.


### Review

Codex CLEAN (CONVE-735). Its two precision corrections are folded in above and into the commit message, which is why the SHA moved from `07184aa1` to `5b882cb0`: `go list -deps` reports graph membership rather than linkage, and calling `internal/transport` a "server path" was imprecise since it is the shared client/server transport. Neither changes the conclusion; both change how much the sentence claims.
