### PR TITLE
test: no test request goes through the process-global default transport (BUG-3008, closes BUG-2949)

### DIFF
--- a/internal/cli/client_stream_identity_test.go
+++ b/internal/cli/client_stream_identity_test.go
@@ -95,7 +95,12 @@ func TestNewWatchEventsStreamRequest_UnsendableLabelStillConnects(t *testing.T) 
 		t.Fatalf("build request: %v", err)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	// srv.Client(), not http.DefaultClient: httptest.Server.Close() closes idle
+	// connections on the PROCESS-WIDE default transport (the standard library
+	// does it deliberately, calling it "not part of httptest.Server's
+	// correctness"), so with several parallel tests in this package any one of
+	// them finishing could break this request mid-flight. BUG-3008.
+	resp, err := srv.Client().Do(req)
 	if err != nil {
 		t.Fatalf("request was not sendable — the monitor would retry forever and deliver nothing: %v", err)
 	}
@@ -130,7 +135,8 @@ func TestNewWatchEventsStreamRequest_ArmedSendsQueryParam(t *testing.T) {
 	if err != nil {
 		t.Fatalf("build request: %v", err)
 	}
-	resp, err := http.DefaultClient.Do(req)
+	// srv.Client() rather than http.DefaultClient, for the reason above (BUG-3008).
+	resp, err := srv.Client().Do(req)
 	if err != nil {
 		t.Fatalf("request not sendable: %v", err)
 	}

--- a/internal/server/handlers_collab_test.go
+++ b/internal/server/handlers_collab_test.go
@@ -554,7 +554,7 @@ func TestCollabUpgradeRejectsSchemaVersionMismatch(t *testing.T) {
 	// Server's RoomManager is at "1" (DefaultSchemaVersion); send "9"
 	// to force a mismatch. We hit the HTTP path directly rather than
 	// through dialCollab so we can read the JSON error body.
-	resp, err := http.Get(ts.URL + "/api/v1/collab/" + itemID + "?schema_version=9")
+	resp, err := isolatedTestClient().Get(ts.URL + "/api/v1/collab/" + itemID + "?schema_version=9")
 	if err != nil {
 		t.Fatalf("http get: %v", err)
 	}
@@ -614,7 +614,7 @@ func TestCollabUpgradeMissingItemIDBadRequest(t *testing.T) {
 	ts := httptest.NewServer(srv)
 	defer ts.Close()
 
-	resp, err := http.Get(ts.URL + "/api/v1/collab/")
+	resp, err := isolatedTestClient().Get(ts.URL + "/api/v1/collab/")
 	if err != nil {
 		t.Fatalf("http get: %v", err)
 	}

--- a/internal/server/handlers_events_access_epoch_stream_test.go
+++ b/internal/server/handlers_events_access_epoch_stream_test.go
@@ -90,7 +90,7 @@ func TestSSEStream_AnnouncesAnAccessChangeButStaysQuietOtherwise(t *testing.T) {
 	}
 	req.Header.Set("User-Agent", testSessionUA)
 	req.AddCookie(&http.Cookie{Name: sessionCookieName(srv.secureCookies), Value: token})
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := isolatedTestClient().Do(req)
 	if err != nil {
 		t.Fatalf("open stream: %v", err)
 	}

--- a/internal/server/handlers_events_cancel_test.go
+++ b/internal/server/handlers_events_cancel_test.go
@@ -91,7 +91,7 @@ func TestDisconnectDuringEstablishmentReleasesTheAdmissionSlot(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := isolatedTestClient().Do(req)
 		if err == nil {
 			_ = resp.Body.Close()
 		}

--- a/internal/server/handlers_events_failed_test.go
+++ b/internal/server/handlers_events_failed_test.go
@@ -59,7 +59,7 @@ func TestAFailedSubscriptionIsRefusedWithARetryableStatus(t *testing.T) {
 		if lastID != "" {
 			req.Header.Set("Last-Event-ID", lastID)
 		}
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := isolatedTestClient().Do(req)
 		if err != nil {
 			t.Fatalf("%s: GET: %v", name, err)
 		}

--- a/internal/server/handlers_events_resume_test.go
+++ b/internal/server/handlers_events_resume_test.go
@@ -34,7 +34,9 @@ func readRawSSEFramesAuthed(t *testing.T, ctx context.Context, url, lastEventID,
 	if token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
-	resp, err := http.DefaultClient.Do(req)
+	// isolatedTestClient(), not http.DefaultClient — same helper reasoning as
+	// connectSSE (BUG-3008).
+	resp, err := isolatedTestClient().Do(req)
 	if err != nil {
 		t.Fatalf("connecting: %v", err)
 	}

--- a/internal/server/handlers_events_test.go
+++ b/internal/server/handlers_events_test.go
@@ -386,7 +386,7 @@ func TestSSEGlobalConnectionLimit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := isolatedTestClient().Do(req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -417,7 +417,7 @@ func TestSSEPerWorkspaceLimit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := isolatedTestClient().Do(req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -451,7 +451,7 @@ func TestSSELimitsExistingConnectionsUnaffected(t *testing.T) {
 
 	// Try (and fail) to get a second connection
 	req, _ := http.NewRequest("GET", ts.URL+"/api/v1/events?workspace="+slug, nil)
-	resp, _ := http.DefaultClient.Do(req)
+	resp, _ := isolatedTestClient().Do(req)
 	resp.Body.Close()
 
 	// The existing connection should still work — publish an event

--- a/internal/server/handlers_events_test.go
+++ b/internal/server/handlers_events_test.go
@@ -41,7 +41,10 @@ func connectSSE(ctx context.Context, t *testing.T, baseURL, workspaceSlug string
 		t.Fatalf("failed to create SSE request: %v", err)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	// isolatedTestClient(), not http.DefaultClient: this helper's request lives
+	// for the whole test, and a caller may be parallel (BUG-3008). A helper cannot
+	// know which of its callers is exposed, so it does not try to.
+	resp, err := isolatedTestClient().Do(req)
 	if err != nil {
 		t.Fatalf("failed to connect to SSE: %v", err)
 	}
@@ -102,7 +105,9 @@ func apiRequest(t *testing.T, baseURL, method, path string, body interface{}) *h
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	resp, err := http.DefaultClient.Do(req)
+	// isolatedTestClient() for the reason on connectSSE above (BUG-3008): callers
+	// include parallel tests, and the helper cannot tell them apart.
+	resp, err := isolatedTestClient().Do(req)
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
 	}

--- a/internal/server/handlers_sessions_test.go
+++ b/internal/server/handlers_sessions_test.go
@@ -29,7 +29,7 @@ func getSessions(t *testing.T, baseURL, token string) (int, sessionsResponse) {
 	if token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := isolatedTestClient().Do(req)
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
 	}
@@ -101,7 +101,7 @@ func TestListSessions_IsNotCacheable(t *testing.T) {
 
 	req, _ := http.NewRequest("GET", ts.URL+"/api/v1/sessions", nil)
 	req.Header.Set("Authorization", "Bearer "+tok.Token)
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := isolatedTestClient().Do(req)
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
 	}

--- a/internal/server/handlers_stream_gap_test.go
+++ b/internal/server/handlers_stream_gap_test.go
@@ -351,7 +351,7 @@ func TestRefusedConnectionDoesNotCountASyncRequired(t *testing.T) {
 		t.Fatalf("building the request: %v", err)
 	}
 	req.Header.Set("Last-Event-ID", "not-a-number")
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := isolatedTestClient().Do(req)
 	if err != nil {
 		t.Fatalf("connecting: %v", err)
 	}

--- a/internal/server/handlers_watch_events_cancel_test.go
+++ b/internal/server/handlers_watch_events_cancel_test.go
@@ -86,7 +86,7 @@ func TestDisconnectDuringTheResumeSettleReleasesTheAdmissionSlot(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := isolatedTestClient().Do(req)
 		if err == nil {
 			_ = resp.Body.Close()
 		}

--- a/internal/server/handlers_watch_events_test.go
+++ b/internal/server/handlers_watch_events_test.go
@@ -81,7 +81,7 @@ func connectWatchStreamWithHeadersAndQuery(ctx context.Context, t *testing.T, ba
 		req.Header.Set(k, v)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := isolatedTestClient().Do(req)
 	if err != nil {
 		t.Fatalf("failed to connect: %v", err)
 	}
@@ -156,7 +156,7 @@ func TestWatchEventsStream_RequiresAuth(t *testing.T) {
 	defer ts.Close()
 
 	req, _ := http.NewRequest("GET", ts.URL+"/api/v1/events/stream", nil)
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := isolatedTestClient().Do(req)
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
 	}

--- a/internal/server/isolated_client_test.go
+++ b/internal/server/isolated_client_test.go
@@ -2,9 +2,11 @@ package server
 
 import "net/http"
 
-// isolatedTestClient returns an HTTP client with a transport of its own. Test
-// requests in this package go through it (or through srv.Client()), never
-// through http.DefaultClient (BUG-3008).
+// isolatedTestClient returns an HTTP client with a transport of its own.
+// Outbound requests in this package's tests go through it — or through the
+// httptest server's own `ts.Client()` where the test holds the server value —
+// and never through `http.DefaultClient`, `http.Get`, or an `http.Client`
+// literal with a nil Transport, which is `http.DefaultTransport` (BUG-3008).
 //
 // WHY THIS EXISTS. `httptest.Server.Close()` reaches into the PROCESS-WIDE
 // default transport — the standard library says so in its own comment, calling
@@ -22,14 +24,18 @@ import "net/http"
 // the server that closed belonged to a different test entirely.
 //
 // WHAT IS AND IS NOT CLAIMED HERE. Read out of `net/http/transport.go`,
-// `Transport.CloseIdleConnections` closes each pooled connection with
-// `errCloseIdleConns` — the error in that message — and sets `closeIdle`, so
-// connections going idle afterwards are closed instead of pooled until the next
-// `queueForIdleConn` clears the flag. It also cancels dials in progress that
-// are not waiting. Its doc comment states that it "does not interrupt any
-// connections currently in use", and the idle pool is mutated under `idleMu`,
-// so the precise interleaving by which that error reached a caller's `Do()` is
-// NOT reconstructed here.
+// `Transport.CloseIdleConnections` closes each pooled HTTP/1 connection with
+// `errCloseIdleConns` — the error in that message; HTTP/2 connections go
+// through `h2transport.CloseIdleConnections()` separately. It sets
+// `closeIdle`, so connections going idle afterwards are closed instead of
+// pooled, until a later `queueForIdleConn` clears it (which it does not reach
+// when `DisableKeepAlives` is set). It also cancels the dials in progress that
+// have a `cancelCtx` and are not waiting.
+//
+// Its doc comment states that it "does not interrupt any connections currently
+// in use", and the idle pool is mutated under `idleMu`, so the precise
+// interleaving by which that error reached a caller's `Do()` is NOT
+// reconstructed here.
 //
 // That unknown is the argument for isolation rather than a narrower repair: a
 // client with its own transport is outside the reach of another test's
@@ -38,8 +44,16 @@ import "net/http"
 //
 // It is deliberately not a shared package-level var: two tests holding one
 // transport would reintroduce a smaller version of the same coupling.
+//
+// NOT A GENERAL RULE FOR EVERY PACKAGE. `internal/cli`'s tests drive the
+// PRODUCTION client from `NewClientFromURL`, which has a nil Transport by
+// design, so its sends cannot be isolated without changing what the shipped
+// CLI does. There the boundary really is parallel-vs-serial: the two
+// `t.Parallel()` tests that build their own requests use `srv.Client()`, and
+// the rest are serial, which a parallel test's teardown cannot overlap.
 func isolatedTestClient() *http.Client {
 	// No Timeout on purpose. These are SSE and long-poll requests; a timeout
-	// here would cancel the stream the test is measuring.
+	// here would cancel the stream the test is measuring. A caller that wants
+	// one sets it on the returned client.
 	return &http.Client{Transport: &http.Transport{}}
 }

--- a/internal/server/isolated_client_test.go
+++ b/internal/server/isolated_client_test.go
@@ -27,8 +27,9 @@ import "net/http"
 // `Transport.CloseIdleConnections` closes each pooled HTTP/1 connection with
 // `errCloseIdleConns` — the error in that message; HTTP/2 connections go
 // through `h2transport.CloseIdleConnections()` separately. It sets
-// `closeIdle`, so connections going idle afterwards are closed instead of
-// pooled, until a later `queueForIdleConn` clears it (which it does not reach
+// `closeIdle`, so a connection going idle afterwards is closed rather than
+// pooled when no request is waiting for one — a waiter is still handed it —
+// until a later `queueForIdleConn` clears the flag (which it does not reach
 // when `DisableKeepAlives` is set). It also cancels the dials in progress that
 // have a `cancelCtx` and are not waiting.
 //

--- a/internal/server/isolated_client_test.go
+++ b/internal/server/isolated_client_test.go
@@ -15,17 +15,28 @@ import "net/http"
 //	}
 //
 // So in a package where several PARALLEL tests each stand up an httptest
-// server, any one of them finishing can break an in-flight request another one
-// is making through `http.DefaultClient`. The symptom is
-// "transport connection broken: http: CloseIdleConnections called" on a request
-// that had nothing to do with the server that closed, and it reproduces only
-// when two tests interleave inside a window of microseconds — so it reads as
+// server, any one of them finishing reaches into a transport every other test
+// is sharing. `Transport.CloseIdleConnections` does three things there, and the
+// first two can land on a request that is already under way:
+//
+//   - it closes every pooled connection with `errCloseIdleConns`, which a
+//     concurrent `getConn` may have just handed to a request;
+//   - it cancels the dials in progress that are not waiting
+//     (`w.cancelCtx()` over `t.dialsInProgress`);
+//   - it sets `closeIdle`, so connections that go idle later close too.
+//
+// The symptom is "transport connection broken: http: CloseIdleConnections
+// called" on a request that had nothing to do with the server that closed. It
+// needs two tests to interleave inside a window of microseconds, so it reads as
 // infrastructure noise and survives local `-count` runs.
 //
 // A client with its own transport cannot be reached that way.
 //
 // It is deliberately not a shared package-level var: two tests holding one
-// transport would reintroduce a smaller version of the same coupling.
+// transport would reintroduce a smaller version of the same coupling. The
+// per-call transport does not accumulate anything, either — `httptest.Server.Close`
+// waits for outstanding requests and closes every connection it accepted, so
+// the client's pool is dead by the time the test returns.
 func isolatedTestClient() *http.Client {
 	// No Timeout on purpose. These are SSE and long-poll requests; a timeout
 	// here would cancel the stream the test is measuring.

--- a/internal/server/isolated_client_test.go
+++ b/internal/server/isolated_client_test.go
@@ -2,41 +2,42 @@ package server
 
 import "net/http"
 
-// isolatedTestClient returns an HTTP client with a transport of its own, for
-// tests that must survive another test's teardown (BUG-3008).
+// isolatedTestClient returns an HTTP client with a transport of its own. Test
+// requests in this package go through it (or through srv.Client()), never
+// through http.DefaultClient (BUG-3008).
 //
-// WHY THIS EXISTS. `httptest.Server.Close()` closes idle connections on the
-// PROCESS-WIDE default transport — the standard library says so in its own
-// comment, calling it "not part of httptest.Server's correctness" and doing it
-// to help out users who are on the standard transport:
+// WHY THIS EXISTS. `httptest.Server.Close()` reaches into the PROCESS-WIDE
+// default transport — the standard library says so in its own comment, calling
+// it "not part of httptest.Server's correctness" and doing it to help out
+// users who are on the standard transport:
 //
 //	if t, ok := http.DefaultTransport.(closeIdleTransport); ok {
 //	    t.CloseIdleConnections()
 //	}
 //
-// So in a package where several PARALLEL tests each stand up an httptest
-// server, any one of them finishing reaches into a transport every other test
-// is sharing. `Transport.CloseIdleConnections` does three things there, and the
-// first two can land on a request that is already under way:
+// So in a package where many tests each stand up an httptest server, every
+// `defer ts.Close()` mutates state that every other test's requests depend on.
+// What CI observed (BUG-2949, then BUG-3008) is a request in one test failing
+// with "transport connection broken: http: CloseIdleConnections called" while
+// the server that closed belonged to a different test entirely.
 //
-//   - it closes every pooled connection with `errCloseIdleConns`, which a
-//     concurrent `getConn` may have just handed to a request;
-//   - it cancels the dials in progress that are not waiting
-//     (`w.cancelCtx()` over `t.dialsInProgress`);
-//   - it sets `closeIdle`, so connections that go idle later close too.
+// WHAT IS AND IS NOT CLAIMED HERE. Read out of `net/http/transport.go`,
+// `Transport.CloseIdleConnections` closes each pooled connection with
+// `errCloseIdleConns` — the error in that message — and sets `closeIdle`, so
+// connections going idle afterwards are closed instead of pooled until the next
+// `queueForIdleConn` clears the flag. It also cancels dials in progress that
+// are not waiting. Its doc comment states that it "does not interrupt any
+// connections currently in use", and the idle pool is mutated under `idleMu`,
+// so the precise interleaving by which that error reached a caller's `Do()` is
+// NOT reconstructed here.
 //
-// The symptom is "transport connection broken: http: CloseIdleConnections
-// called" on a request that had nothing to do with the server that closed. It
-// needs two tests to interleave inside a window of microseconds, so it reads as
-// infrastructure noise and survives local `-count` runs.
-//
-// A client with its own transport cannot be reached that way.
+// That unknown is the argument for isolation rather than a narrower repair: a
+// client with its own transport is outside the reach of another test's
+// teardown whichever window it was. Guessing at the window and fixing only
+// that would leave the next seat to rediscover this from a worse position.
 //
 // It is deliberately not a shared package-level var: two tests holding one
-// transport would reintroduce a smaller version of the same coupling. The
-// per-call transport does not accumulate anything, either — `httptest.Server.Close`
-// waits for outstanding requests and closes every connection it accepted, so
-// the client's pool is dead by the time the test returns.
+// transport would reintroduce a smaller version of the same coupling.
 func isolatedTestClient() *http.Client {
 	// No Timeout on purpose. These are SSE and long-poll requests; a timeout
 	// here would cancel the stream the test is measuring.

--- a/internal/server/isolated_client_test.go
+++ b/internal/server/isolated_client_test.go
@@ -1,0 +1,33 @@
+package server
+
+import "net/http"
+
+// isolatedTestClient returns an HTTP client with a transport of its own, for
+// tests that must survive another test's teardown (BUG-3008).
+//
+// WHY THIS EXISTS. `httptest.Server.Close()` closes idle connections on the
+// PROCESS-WIDE default transport — the standard library says so in its own
+// comment, calling it "not part of httptest.Server's correctness" and doing it
+// to help out users who are on the standard transport:
+//
+//	if t, ok := http.DefaultTransport.(closeIdleTransport); ok {
+//	    t.CloseIdleConnections()
+//	}
+//
+// So in a package where several PARALLEL tests each stand up an httptest
+// server, any one of them finishing can break an in-flight request another one
+// is making through `http.DefaultClient`. The symptom is
+// "transport connection broken: http: CloseIdleConnections called" on a request
+// that had nothing to do with the server that closed, and it reproduces only
+// when two tests interleave inside a window of microseconds — so it reads as
+// infrastructure noise and survives local `-count` runs.
+//
+// A client with its own transport cannot be reached that way.
+//
+// It is deliberately not a shared package-level var: two tests holding one
+// transport would reintroduce a smaller version of the same coupling.
+func isolatedTestClient() *http.Client {
+	// No Timeout on purpose. These are SSE and long-poll requests; a timeout
+	// here would cancel the stream the test is measuring.
+	return &http.Client{Transport: &http.Transport{}}
+}

--- a/internal/server/listen_serve_test.go
+++ b/internal/server/listen_serve_test.go
@@ -42,7 +42,11 @@ func TestListenAndServe_StillServes(t *testing.T) {
 	t.Cleanup(func() { _ = ln.Close() })
 
 	// The split must not have changed what a bound server does: it answers.
-	client := &http.Client{Timeout: 2 * time.Second}
+	// A nil Transport means http.DefaultTransport, which another test's
+	// httptest server teardown reaches into (BUG-3008). The timeout is the
+	// reason this is not a bare isolatedTestClient() call.
+	client := isolatedTestClient()
+	client.Timeout = 2 * time.Second
 	var resp *http.Response
 	for i := 0; i < 20; i++ {
 		resp, err = client.Get("http://" + ln.Addr().String() + "/api/v1/health")

--- a/internal/server/stream_admission_test.go
+++ b/internal/server/stream_admission_test.go
@@ -30,7 +30,7 @@ func rawWatchStreamStatus(t *testing.T, baseURL, token string) int {
 		t.Fatalf("build request: %v", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := isolatedTestClient().Do(req)
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
 	}
@@ -56,7 +56,7 @@ func holdAuthedSSE(ctx context.Context, t *testing.T, baseURL, slug, token strin
 		t.Fatalf("build request: %v", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := isolatedTestClient().Do(req)
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
 	}
@@ -459,7 +459,7 @@ func rawSSEStatus(t *testing.T, baseURL, slug string) int {
 	if err != nil {
 		t.Fatalf("build request: %v", err)
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := isolatedTestClient().Do(req)
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
 	}
@@ -724,7 +724,7 @@ func TestStreamLimitRefusalContractIsIdenticalOnBothEndpoints(t *testing.T) {
 			t.Fatalf("%s: build request: %v", tc.name, err)
 		}
 		req.Header.Set("Authorization", "Bearer "+tc.token)
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := isolatedTestClient().Do(req)
 		if err != nil {
 			t.Fatalf("%s: request failed: %v", tc.name, err)
 		}


### PR DESCRIPTION
Closes BUG-3008. Also closes BUG-2949, which filed this same failure on 09-07 with the mechanism explicitly undiagnosed.

## The failure

```
--- FAIL: TestNewWatchEventsStreamRequest_ArmedSendsQueryParam
    client_stream_identity_test.go:135: request not sendable:
      Get "http://127.0.0.1:45521/api/v1/events/stream?armed=true":
      net/http: HTTP/1.x transport connection broken: http: CloseIdleConnections called
```

It surfaced on the grpc bump's PG job (#1322). `internal/cli` imports no grpc and that diff is three lines of go.mod/go.sum, so the change could not reach it.

## The coupling

`httptest.Server.Close()` reaches into the **process-wide** default transport, deliberately, and says so in the standard library's own comment:

```go
// Not part of httptest.Server's correctness, but assume most
// users of httptest.Server will be using the standard
// transport, so help them out and close any idle connections for them.
if t, ok := http.DefaultTransport.(closeIdleTransport); ok {
    t.CloseIdleConnections()
}
```

So in a package where many tests each stand up a server, every `defer ts.Close()` mutates transport state that every other test's requests depend on. What CI observed is a request failing in one test while the server that closed belonged to a different test entirely.

BUG-2949's filing did everything right and stopped in the correct place: it refuted the obvious candidate (`CopyItem`'s `CloseIdleConnections`, which clones a client and cannot reach the default pool), noted that a repo-wide grep found no other caller, and listed three hypotheses rather than guessing. This is its hypothesis (1) — and the caller is the standard library, not this repo, which is why grepping the repo found nothing.

## What is NOT claimed

`Transport.CloseIdleConnections`'s own doc comment says it "does not interrupt any connections currently in use", and the idle pool is mutated under `idleMu`. The precise interleaving by which `errCloseIdleConns` reached a caller's `Do()` is **not reconstructed** here, and `isolatedTestClient`'s comment says so rather than inventing one. That unknown is the argument for isolation over a narrower repair: a client with its own transport is out of reach whichever window it was.

An earlier revision of this branch did claim a mechanism ("closes a pooled conn a concurrent `getConn` may have just handed to a request"). Codex round 2 disputed it against the source and was right; the claim is gone.

## Scope

**Every test request in the affected packages**, not just the ones that are parallel today.

The first revision scoped this to the six `t.Parallel()` tests with a direct `http.DefaultClient` call. That was wrong twice over:

1. **It missed shared helpers.** `connectSSE`, `apiRequest` (handlers_events_test.go) and `readRawSSEFramesAuthed` (handlers_events_resume_test.go) sent through the default transport, and their callers include parallel tests. `TestWorkspaceStreamBoundsAnonymousCallersPerWorkspace` is `t.Parallel()` and reaches the first two via `createTestWorkspace`; `connectSSE` holds its request open for the whole test, the longest window in the package for another test's teardown to land in. A helper cannot know which of its callers is exposed, so it no longer tries to.
2. **"Serial is safe" is the wrong boundary.** It is true — a parallel test does not resume until the package's serial tests finish — but serial-ness is one `t.Parallel()` away, and CONVE-2086 instructs the next author to add exactly that line.

3. **A nil `Transport` is the default transport too.** `listen_serve_test.go`'s health probe built `&http.Client{Timeout: 2*time.Second}`, which is `http.DefaultTransport` and was exposed identically — and does not appear in any grep for `DefaultClient`. Codex round 3 found it; the rule in `isolatedTestClient`'s doc comment now names this third form explicitly.

After this PR, no test in `internal/server` sends through the default transport: no `http.DefaultClient`, no `http.Get`/`Post`/`Head`, and no `http.Client` literal with a nil `Transport`. The only non-test outbound client the package's tests reach (the webhooks dispatcher) builds its own.

**`internal/cli` is deliberately different.** Its tests drive the PRODUCTION client from `NewClientFromURL`, which has a nil `Transport` by design, so those sends cannot be isolated without changing what the shipped CLI does. There the boundary really is parallel-vs-serial: the two `t.Parallel()` tests build their own requests and use `srv.Client()`; the rest are serial. That asymmetry is recorded in the doc comment rather than left for the next reader to infer.

- `internal/cli` uses `srv.Client()`, the client `httptest` hands out for its own server.
- `internal/server`'s sites reach the URL through helpers that never see the server value, so they use `isolatedTestClient()`, which carries the mechanism in its doc comment. Fresh per call on purpose: one shared transport across tests would be a smaller version of the same coupling.
- **CONVE-2086 amended** with the clause, so the convention that creates the exposure also carries the rule.

## Verification

A local green proves nothing about this class of flake — it needs two tests to interleave inside a window of microseconds, and `-count=3` runs were green before any of this was written. The evidence is the coupling read out of `$GOROOT/src/net/http/httptest/server.go`, plus an enumeration instrument that walks enclosing functions and helper call graphs rather than grepping test bodies (grepping bodies is what produced the first revision's wrong count).

Codex: four rounds, findings applied each time (the wrong class enumeration, two overstated stdlib claims, the nil-Transport site and three more comment corrections).

Gates on the final SHA: `go test ./...` 0, `go vet ./...` 0, `gofmt` clean, `make lint` 0 issues.
