### PR TITLE
fix(cli): `pad token create --scopes` validates and JSON-encodes (#1237 review option b)

### DIFF
--- a/cmd/pad/cmd_token.go
+++ b/cmd/pad/cmd_token.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
+	"slices"
+	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -54,11 +57,16 @@ func tokenCreateCmd() *cobra.Command {
 		Short: "Mint a new API token (secret shown once)",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			scopes, err := encodeTokenScopes(scopesFlag)
+			if err != nil {
+				return err
+			}
+
 			client, _ := getClient()
 
 			input := models.APITokenCreate{
 				Name:      nameFlag,
-				Scopes:    scopesFlag,
+				Scopes:    scopes,
 				ExpiresIn: expiresInFlag,
 			}
 
@@ -95,7 +103,7 @@ func tokenCreateCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&nameFlag, "name", "", "token name (required; shown in list and audit log)")
 	cmd.Flags().IntVar(&expiresInFlag, "expires-in", 0, "expiry in days (0 = platform default)")
-	cmd.Flags().StringVar(&scopesFlag, "scopes", "", "optional scopes string")
+	cmd.Flags().StringVar(&scopesFlag, "scopes", "", "comma-separated scopes: *, read, write, pad:read, pad:write, pad:admin (default: full access)")
 	_ = cmd.MarkFlagRequired("name")
 
 	return cmd
@@ -175,6 +183,39 @@ typo is a not-found error rather than a wrong token revoked.`,
 			return nil
 		},
 	}
+}
+
+// tokenScopeVocabulary is the server's recognized scope set
+// (internal/server/middleware_auth.go tokenScopeAllows). Anything else
+// is stored verbatim and then denied on every request, so the CLI
+// refuses it locally rather than minting a dead token.
+var tokenScopeVocabulary = []string{"*", "read", "write", "pad:read", "pad:write", "pad:admin"}
+
+// encodeTokenScopes turns the --scopes flag's comma-separated value into
+// the JSON-array string the server's scope check parses. Empty stays
+// empty (the server records full access). Values are trimmed; an empty
+// element or one outside the vocabulary is refused with the allowed
+// list named.
+func encodeTokenScopes(raw string) (string, error) {
+	if raw == "" {
+		return "", nil
+	}
+	var scopes []string
+	for _, part := range strings.Split(raw, ",") {
+		scope := strings.TrimSpace(part)
+		if scope == "" {
+			return "", fmt.Errorf("--scopes has an empty entry in %q; allowed values: %s", raw, strings.Join(tokenScopeVocabulary, ", "))
+		}
+		if !slices.Contains(tokenScopeVocabulary, scope) {
+			return "", fmt.Errorf("unknown scope %q; allowed values: %s", scope, strings.Join(tokenScopeVocabulary, ", "))
+		}
+		scopes = append(scopes, scope)
+	}
+	encoded, err := json.Marshal(scopes)
+	if err != nil {
+		return "", fmt.Errorf("encode scopes: %w", err)
+	}
+	return string(encoded), nil
 }
 
 // formatTokenExpiry renders an expiry timestamp for display; a nil

--- a/cmd/pad/cmd_token_test.go
+++ b/cmd/pad/cmd_token_test.go
@@ -47,12 +47,18 @@ func newStubTokenServer(t *testing.T, wantToken string) *stubTokenServer {
 		switch r.Method {
 		case http.MethodGet:
 			s.listHits++
+			// The first row deliberately carries a "token" key the real
+			// server never sends on list: the renderer must print known
+			// metadata columns only, so this secret-shaped value must not
+			// reach stdout even from a buggy or hostile server. That is
+			// what makes the no-secret assertion below falsifiable.
 			_ = json.NewEncoder(w).Encode([]map[string]any{
 				{
 					"id": "tok-1111", "name": "ci-agent", "prefix": "pad_abc1",
 					"created_at":   "2026-08-01T10:00:00Z",
 					"last_used_at": "2026-09-01T09:00:00Z",
 					"expires_at":   "2026-11-01T10:00:00Z",
+					"token":        "pad_leakedsecretmaterial",
 				},
 				{
 					"id": "tok-2222", "name": "sweep", "prefix": "pad_def2",
@@ -191,8 +197,70 @@ func TestTokenList_RendersMetadataWithoutSecret(t *testing.T) {
 			t.Errorf("list output missing %q:\n%s", want, out)
 		}
 	}
-	if strings.Contains(out, "secret") {
-		t.Errorf("list output must never carry secret material:\n%s", out)
+	if strings.Contains(out, "pad_leaked") {
+		t.Errorf("list output must never carry secret material, even when the server response does:\n%s", out)
+	}
+}
+
+// --scopes values are validated locally and posted as the JSON array the
+// server's tokenScopeAllows requires — the raw string was stored verbatim
+// before, minting a token every request refused (#1237 review).
+func TestTokenCreate_ScopesPostedAsJSONArray(t *testing.T) {
+	srv := setupTokenEnv(t)
+
+	cases := []struct {
+		flag string
+		want string
+	}{
+		{"read", `["read"]`},
+		{"read,write", `["read","write"]`},
+		{" pad:read , pad:write ", `["pad:read","pad:write"]`},
+		{"*", `["*"]`},
+	}
+	for i, tc := range cases {
+		cmd := tokenCreateCmd()
+		cmd.SetArgs([]string{"--name", "scoped", "--scopes", tc.flag})
+		var runErr error
+		captureStdout(t, func() {
+			runErr = cmd.Execute()
+		})
+		if runErr != nil {
+			t.Fatalf("token create --scopes %q: %v", tc.flag, runErr)
+		}
+		if len(srv.createBodies) != i+1 {
+			t.Fatalf("expected %d POSTs after case %q, got %d", i+1, tc.flag, len(srv.createBodies))
+		}
+		got, _ := srv.createBodies[i]["scopes"].(string)
+		if got != tc.want {
+			t.Errorf("--scopes %q posted scopes %q, want %q", tc.flag, got, tc.want)
+		}
+	}
+}
+
+// A scope outside the server's vocabulary is refused locally, naming the
+// allowed values, before any request — the server would store it verbatim
+// and then deny every call made with the token.
+func TestTokenCreate_UnknownScopeRefusedLocally(t *testing.T) {
+	srv := setupTokenEnv(t)
+
+	for _, bad := range []string{"read-only", "read,,write", "admin"} {
+		cmd := tokenCreateCmd()
+		cmd.SetArgs([]string{"--name", "scoped", "--scopes", bad})
+		cmd.SilenceUsage = true
+		cmd.SilenceErrors = true
+		var runErr error
+		captureStdout(t, func() {
+			runErr = cmd.Execute()
+		})
+		if runErr == nil {
+			t.Fatalf("--scopes %q must be refused", bad)
+		}
+		if !strings.Contains(runErr.Error(), "pad:admin") {
+			t.Errorf("--scopes %q error should name the allowed vocabulary, got %q", bad, runErr.Error())
+		}
+		if len(srv.createBodies) != 0 {
+			t.Fatalf("no POST should reach the server for --scopes %q, got %d", bad, len(srv.createBodies))
+		}
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

Closes out the one real finding from [the #1237 review](https://github.com/PerpetualSoftware/pad/pull/1237#pullrequestreview-5118132360), which merged before I got back to it: `--scopes` passed its raw string into `APITokenCreate.Scopes`, the store writes it verbatim, and `tokenScopeAllows` requires a JSON array — so `pad token create --name x --scopes read` minted a token every request refused, with only a server-side slog warning the CLI user never sees. This is your option (b):

- **Comma-separated values**, trimmed, **validated against the server's recognized vocabulary** (`*`, `read`, `write`, `pad:read`, `pad:write`, `pad:admin` — read from `tokenScopeAllows`, cited in a comment next to the CLI's copy of the list). An unknown or empty entry is refused locally with the allowed list named, before any request — same disposition as `--name`'s local requirement.
- **Valid values are JSON-encoded**: `--scopes read` posts `"scopes": "[\"read\"]"`, test-pinned against the stub server's recorded body (four cases including whitespace-padded multi-value and `*`).
- Help text no longer says "optional scopes string".

**Folded in, per the review's minor note:** `TestTokenList_RendersMetadataWithoutSecret`'s no-secret guard could not fail for the reason it named, because the list stub never carried a secret. The stub's first row now carries a `token` field the real server never sends on list, so the assertion is falsifiable: the renderer must keep printing known metadata columns only, even from a buggy or hostile server. Verified it bites by reintroducing exactly that leak (a `Token` field on `models.APIToken` plus a renderer column) and watching the test fail on the leaked value before reverting.

No server changes. The README's session-required section (#1267) already covers the other loose end from the merge comment, so nothing to add there.

## How to test

1. `pad token create --name scoped --scopes read` → token minted; a request with it succeeds on GET and is refused on POST (the scope finally does what it says).
2. `pad token create --name scoped --scopes read-only` → refused locally: `unknown scope "read-only"; allowed values: *, read, write, pad:read, pad:write, pad:admin`; no request sent.
3. `pad token create --name scoped` (no flag) → unchanged: no `scopes` key posted, server records full access.

## Checklist

- [x] `go build ./...` passes
- [x] `go test ./cmd/pad/` — zero new failures by name vs the same-day clean-`main` run on this Windows box (the pre-existing HOME-assumption set, unchanged; all `TestToken*` pass)
- [x] New features have tests — written first and watched fail against the pass-through (`posted scopes "read", want "[\"read\"]"`)
- [ ] TypeScript types updated — n/a, no API change
- [x] CLI help text updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)