### PR TITLE
fix(cli): refuse SQLite self-restore

### DIFF
--- a/cmd/pad/cmd_db.go
+++ b/cmd/pad/cmd_db.go
@@ -220,8 +220,12 @@ WARNING: This will overwrite the current database contents.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			inputFile := args[0]
-			if _, err := os.Stat(inputFile); os.IsNotExist(err) {
-				return fmt.Errorf("backup file not found: %s", inputFile)
+			inputInfo, err := os.Stat(inputFile)
+			if err != nil {
+				if os.IsNotExist(err) {
+					return fmt.Errorf("backup file not found: %s", inputFile)
+				}
+				return fmt.Errorf("stat backup file: %w", err)
 			}
 
 			dbDriver := os.Getenv("PAD_DB_DRIVER")
@@ -274,6 +278,13 @@ WARNING: This will overwrite the current database contents.`,
 				return fmt.Errorf("load config: %w", err)
 			}
 			dstPath := cfg.DBPath
+			if dstInfo, err := os.Stat(dstPath); err == nil {
+				if os.SameFile(inputInfo, dstInfo) {
+					return fmt.Errorf("backup file %s is the SQLite database being restored; choose a different backup file", inputFile)
+				}
+			} else if !os.IsNotExist(err) {
+				return fmt.Errorf("stat database: %w", err)
+			}
 
 			// Refuse to overwrite the database out from under a running server:
 			// the server holds it open and its background WAL checkpointer could

--- a/cmd/pad/cmd_db_restore_test.go
+++ b/cmd/pad/cmd_db_restore_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDBRestoreRejectsSameFile(t *testing.T) {
+	const contents = "database contents"
+
+	aliases := []struct {
+		name string
+		path func(t *testing.T, live string) string
+	}{
+		{"same path", func(_ *testing.T, live string) string { return live }},
+		{"symlink", func(t *testing.T, live string) string {
+			link := filepath.Join(filepath.Dir(live), "backup.db")
+			if err := os.Symlink(live, link); err != nil {
+				t.Skipf("symlinks unavailable: %v", err)
+			}
+			return link
+		}},
+		{"hard link", func(t *testing.T, live string) string {
+			link := filepath.Join(filepath.Dir(live), "backup.db")
+			if err := os.Link(live, link); err != nil {
+				t.Skipf("hard links unavailable: %v", err)
+			}
+			return link
+		}},
+	}
+
+	for _, tc := range aliases {
+		t.Run(tc.name, func(t *testing.T) {
+			dataDir := t.TempDir()
+			live := filepath.Join(dataDir, "pad.db")
+			if err := os.WriteFile(live, []byte(contents), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			setSQLiteRestoreEnv(t, dataDir)
+			cmd := dbRestoreCmd()
+			cmd.SetArgs([]string{"--force", tc.path(t, live)})
+			err := cmd.Execute()
+			if err == nil || !strings.Contains(err.Error(), "is the SQLite database being restored") {
+				t.Fatalf("restore error = %v, want same-file error", err)
+			}
+			if got, err := os.ReadFile(live); err != nil || string(got) != contents {
+				t.Fatalf("database after rejected restore = %q, %v", got, err)
+			}
+		})
+	}
+}
+
+func TestDBRestoreCopiesDistinctFile(t *testing.T) {
+	dataDir := t.TempDir()
+	backup := filepath.Join(dataDir, "backup.db")
+	if err := os.WriteFile(backup, []byte("backup contents"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	setSQLiteRestoreEnv(t, dataDir)
+	cmd := dbRestoreCmd()
+	cmd.SetArgs([]string{"--force", backup})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := os.ReadFile(filepath.Join(dataDir, "pad.db")); err != nil || string(got) != "backup contents" {
+		t.Fatalf("restored database = %q, %v", got, err)
+	}
+}
+
+func setSQLiteRestoreEnv(t *testing.T, dataDir string) {
+	t.Helper()
+	t.Setenv("PAD_DB_DRIVER", "")
+	t.Setenv("PAD_DATABASE_URL", "")
+	t.Setenv("PAD_DB_PATH", "")
+	t.Setenv("PAD_DATA_DIR", dataDir)
+	t.Setenv("PAD_PORT", "0")
+}


### PR DESCRIPTION
## What does this PR do?

Refuses a SQLite restore before opening the destination when the backup and live database identify the same underlying file.

The guard uses `os.Stat` and `os.SameFile`, so it covers:

- the exact same path
- a symlink alias
- a hard-link alias

The existing distinct-file restore behavior is unchanged. Regression tests prove that every same-file form returns an error without altering the database, and that a distinct backup still copies successfully.

Closes #1331

## How to test

```bash
go test ./cmd/pad -run '^TestDBRestore(RejectsSameFile|CopiesDistinctFile)$' -count=1

# macOS: use the canonical temp path and skip two existing Linux /proc-only assertions
TMPDIR=/private/tmp GOFLAGS='-skip=^TestOwnerLiveness_(Pid|Socket)$' make test

GOOS=linux make lint
make test-nix-hash

# With Node 24, matching .nvmrc and CI
make build
cd web && npm run check && npm run test
```

Local results:

- focused restore tests: pass
- full locally applicable Go suite: pass
- Linux-target golangci-lint suite: 0 issues
- Nix hash script tests: 60 passed, 0 failed
- full build: pass
- Svelte check: 0 errors
- Vitest: 172 files and 2,464 tests passed

Host note: an unmodified `make test` on macOS runs two assertions in `internal/cli/session_owner_test.go` that expect Linux `/proc` process-start tokens; both return `unknown` on non-Linux by design. An unmodified macOS `make lint` similarly sees the Linux-only `errProcStatMalformed` sentinel as unused. The commands above exercise every locally applicable test and run the full lint suite for the same Linux target as CI. No unrelated platform-test changes are included here.

## Checklist

- [x] `make build` passes
- [x] `make test` passes for all locally applicable tests (host exception documented above)
- [x] Regression tests added
- [x] TypeScript types updated (not applicable; no API change)
- [x] CLI help text updated (not applicable; no command or flag change)
