### PR TITLE
test(agent): establish token-efficiency budgets (1/6)

### DIFF
--- a/internal/cli/agent_prompt_budget_test.go
+++ b/internal/cli/agent_prompt_budget_test.go
@@ -1,0 +1,32 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// This initially records the existing shared Cursor/Codex payload with modest
+// headroom. Later prompt-reduction changes should lower this budget, not spend it.
+const agentSkillPromptBudget = 40 * 1024
+
+func TestAgentSkillPromptBudget(t *testing.T) {
+	skill, err := os.ReadFile(filepath.Join("..", "..", "skills", "pad", "SKILL.md"))
+	if err != nil {
+		t.Fatalf("read embedded Pad skill: %v", err)
+	}
+
+	for _, agent := range []string{"cursor", "codex"} {
+		t.Run(agent, func(t *testing.T) {
+			tool := ResolveTool(agent)
+			if tool == nil {
+				t.Fatalf("ResolveTool(%q) returned nil", agent)
+			}
+			payload := FormatForTool(*tool, skill)
+			t.Logf("%s installed skill payload: %d bytes (budget %d)", agent, len(payload), agentSkillPromptBudget)
+			if len(payload) > agentSkillPromptBudget {
+				t.Fatalf("%s installed skill payload is %d bytes; budget is %d", agent, len(payload), agentSkillPromptBudget)
+			}
+		})
+	}
+}

--- a/internal/mcp/prompt_budget_test.go
+++ b/internal/mcp/prompt_budget_test.go
@@ -1,0 +1,57 @@
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+
+	protocol "github.com/mark3labs/mcp-go/mcp"
+)
+
+// These budgets record the existing prompt-bearing MCP payloads with modest
+// headroom. Later prompt-reduction changes should lower them, not spend them.
+const (
+	mcpInitializePromptBudget = 20 * 1024
+	mcpToolListPromptBudget   = 54 * 1024
+)
+
+func TestMCPPromptBudgets(t *testing.T) {
+	srv := NewServer(Options{Version: "prompt-budget-test"})
+	registered, err := Register(srv.MCP(), RegistryOptions{
+		Doc:        fixtureDoc(),
+		Workspace:  NewWorkspaceState(""),
+		Dispatcher: &fakeDispatcher{},
+		PadVersion: "test",
+	})
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	client, initialize, cleanup := runClientSession(t, srv)
+	defer cleanup()
+
+	tools, err := client.ListTools(t.Context(), protocol.ListToolsRequest{})
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	if len(tools.Tools) != registered {
+		t.Fatalf("ListTools returned %d tools; registered %d", len(tools.Tools), registered)
+	}
+
+	initializeJSON, err := json.Marshal(initialize)
+	if err != nil {
+		t.Fatalf("marshal initialize result: %v", err)
+	}
+	toolsJSON, err := json.Marshal(tools)
+	if err != nil {
+		t.Fatalf("marshal tools/list result: %v", err)
+	}
+
+	t.Logf("MCP initialize payload: %d bytes (budget %d)", len(initializeJSON), mcpInitializePromptBudget)
+	t.Logf("MCP tools/list payload: %d bytes (budget %d)", len(toolsJSON), mcpToolListPromptBudget)
+	if len(initializeJSON) > mcpInitializePromptBudget {
+		t.Errorf("MCP initialize payload is %d bytes; budget is %d", len(initializeJSON), mcpInitializePromptBudget)
+	}
+	if len(toolsJSON) > mcpToolListPromptBudget {
+		t.Errorf("MCP tools/list payload is %d bytes; budget is %d", len(toolsJSON), mcpToolListPromptBudget)
+	}
+}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -190,6 +190,14 @@ func TestServer_GracefulShutdownOnContextCancel(t *testing.T) {
 // the wiring stays in one place.
 func runHandshake(t *testing.T, srv *Server) (*mcp.InitializeResult, func()) {
 	t.Helper()
+	_, res, cleanup := runClientSession(t, srv)
+	return res, cleanup
+}
+
+// runClientSession returns the initialized client as well as the handshake
+// result so tests can inspect later protocol responses on the same session.
+func runClientSession(t *testing.T, srv *Server) (*client.Client, *mcp.InitializeResult, func()) {
+	t.Helper()
 
 	serverIn, clientOut := io.Pipe()
 	clientIn, serverOut := io.Pipe()
@@ -238,5 +246,5 @@ func runHandshake(t *testing.T, srv *Server) (*mcp.InitializeResult, func()) {
 		_ = serverOut.Close()
 		wg.Wait()
 	}
-	return res, cleanup
+	return c, res, cleanup
 }


### PR DESCRIPTION
## Tracking issue

Part of #1339. Umbrella: [#1339 — Reduce Pad token overhead for Cursor and Codex agents](https://github.com/PerpetualSoftware/pad/issues/1339).

## Stack containment

> **PR 1 of 6. Review anchor for the baseline measurement layer.**

1. **[#1333](https://github.com/PerpetualSoftware/pad/pull/1333) — test(agent): establish token-efficiency budgets ← this PR**
2. [#1334](https://github.com/PerpetualSoftware/pad/pull/1334) — feat(agent): add on-demand guidance
3. [#1335](https://github.com/PerpetualSoftware/pad/pull/1335) — feat(agent): install a compact shared skill
4. [#1336](https://github.com/PerpetualSoftware/pad/pull/1336) — perf(agent): reuse bootstrapped session context
5. [#1337](https://github.com/PerpetualSoftware/pad/pull/1337) — feat(agent): add a compact item projection
6. [#1338](https://github.com/PerpetualSoftware/pad/pull/1338) — feat(mcp): add client-compatible compact results

**Includes:** none  
**Next layer:** [#1334](https://github.com/PerpetualSoftware/pad/pull/1334)

All six PRs target `main` and are cumulative. Per maintainer direction, #1338 is the single rebase-merge target once feedback on the lower review layers is satisfied; the lower PRs remain focused review anchors.

## Why

Pad had no executable limits on the instruction and MCP discovery payloads that Cursor and Codex load before doing useful work. This baseline makes token growth measurable and prevents later regressions.

## Changes

- measure the fully formatted shared Cursor/Codex skill
- measure MCP initialization after a real handshake
- measure `tools/list` with the complete registered catalog
- enforce explicit byte budgets in tests without changing runtime behavior

## Recorded baseline

| Surface | Measured payload | Initial budget |
| --- | ---: | ---: |
| Installed Cursor/Codex skill | 37,691 bytes | 40,960 bytes |
| MCP initialize | 22,804 bytes | 24,576 bytes |
| MCP tools/list | 53,134 bytes | 55,296 bytes |
| **Combined eager surface** | **113,629 bytes** | — |

## Completed-stack outcome

After all six PRs, the same combined eager surface is 79,484 bytes: **34,145 bytes / 30.05% smaller**. At roughly four bytes per token, that is approximately **8–9K fewer tokens**, but actual token counts vary by model and tokenizer. Later PRs add on-demand guidance, session reuse, compact item reads, and opt-in client-compatible compact MCP results.

## Compatibility

Test-only change. No CLI, MCP, storage, or agent behavior changes.

## Validation

- targeted CLI and MCP prompt-budget/handshake tests pass locally
- `git diff --check`, `go vet ./...`, and the final Go build pass
- full macOS `go test ./...` retains only four pre-existing session/PID failures, reproduced on exact base `9aa6c7b762e5b784990c2fe4c1456ba5f70f8101`
- GitHub Actions CI and Nix runs are awaiting maintainer approval (`action_required`) and have not executed


## Completed-stack validation

The rebased cumulative stack at `072483e0853804bf1b2cacf42c2b8a381efc7eeb` passes `git diff --check`, `go vet ./...`, `go build ./cmd/pad`, the focused agent, guide, projection, and compact-result tests, and the complete `internal/mcp` package locally. Full macOS `go test ./...` has four failures in process/session liveness tests; all four reproduce unchanged on the exact base `9aa6c7b762e5b784990c2fe4c1456ba5f70f8101`, so they are not introduced by this stack.

The pre-rebase cumulative stack at `4a3e6b8c457bf762ac508530f5f90fb7e961a823` previously passed the full Linux CI-equivalent matrix, macOS native CLI smoke, and Windows cross-compile. Those remain historical results, not exact-head validation after the rebase. Current per-head GitHub CI and Nix runs are `action_required` pending maintainer approval; Windows runtime smoke remains remote-only.