### PR TITLE
feat(agent): add on-demand guidance (2/6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,6 +504,7 @@ pad library list                      Browse convention and playbook library
 pad library activate <title>          Activate a convention or playbook
 
 pad agent install [tool]              Install /pad skill for AI coding tools
+pad agent guide [topic]               Print one section of the canonical agent guide
 pad agent status                      Show supported tools and installation status
 pad agent update                      Update installed tool integrations
 

--- a/cmd/pad/agent_guide_test.go
+++ b/cmd/pad/agent_guide_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+const guideFixture = `# Pad
+
+## Context Loading
+
+Start here.
+
+### Why one call
+
+It is cheaper.
+
+## Role Awareness
+
+Pick a role.
+`
+
+func TestAgentGuideTopics(t *testing.T) {
+	got := strings.Join(agentGuideTopics(guideFixture), ",")
+	if got != "context-loading,why-one-call,role-awareness" {
+		t.Fatalf("topics = %q", got)
+	}
+}
+
+func TestAgentGuideSectionIncludesChildrenOnly(t *testing.T) {
+	got, ok := agentGuideSection(guideFixture, "Context Loading")
+	if !ok {
+		t.Fatal("context-loading topic not found")
+	}
+	if !strings.Contains(got, "### Why one call") {
+		t.Errorf("child section missing: %q", got)
+	}
+	if strings.Contains(got, "Role Awareness") {
+		t.Errorf("next peer section leaked into result: %q", got)
+	}
+}
+
+func TestAgentGuideSectionRejectsUnknownTopic(t *testing.T) {
+	if _, ok := agentGuideSection(guideFixture, "missing"); ok {
+		t.Fatal("unknown topic resolved")
+	}
+}

--- a/cmd/pad/cmd_agent.go
+++ b/cmd/pad/cmd_agent.go
@@ -4,12 +4,105 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"unicode"
 
 	"github.com/spf13/cobra"
 
 	pad "github.com/PerpetualSoftware/pad"
 	"github.com/PerpetualSoftware/pad/internal/cli"
 )
+
+func agentGuideCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "guide [topic]",
+		Short: "Print Pad agent guidance on demand",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			body := string(cli.StripFrontmatter(pad.PadSkill))
+			if len(args) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "Available Pad agent guide topics:")
+				for _, topic := range agentGuideTopics(body) {
+					fmt.Fprintf(cmd.OutOrStdout(), "  %s\n", topic)
+				}
+				fmt.Fprintln(cmd.OutOrStdout(), "\nUse `pad agent guide <topic>` for one section or `pad agent guide all` for the full guide.")
+				return nil
+			}
+
+			if args[0] == "all" {
+				fmt.Fprint(cmd.OutOrStdout(), body)
+				return nil
+			}
+			section, ok := agentGuideSection(body, args[0])
+			if !ok {
+				return fmt.Errorf("unknown guide topic %q; run `pad agent guide` to list topics", args[0])
+			}
+			fmt.Fprint(cmd.OutOrStdout(), section)
+			return nil
+		},
+	}
+}
+
+func agentGuideTopics(markdown string) []string {
+	var topics []string
+	for _, line := range strings.Split(markdown, "\n") {
+		_, topic, ok := agentGuideHeading(line)
+		if ok {
+			topics = append(topics, topic)
+		}
+	}
+	return topics
+}
+
+func agentGuideSection(markdown, topic string) (string, bool) {
+	want := agentGuideSlug(topic)
+	lines := strings.Split(markdown, "\n")
+	start, level := -1, 0
+	for i, line := range lines {
+		lineLevel, lineTopic, ok := agentGuideHeading(line)
+		if start < 0 {
+			if ok && lineTopic == want {
+				start, level = i, lineLevel
+			}
+			continue
+		}
+		if ok && lineLevel <= level {
+			return strings.Join(lines[start:i], "\n") + "\n", true
+		}
+	}
+	if start >= 0 {
+		return strings.Join(lines[start:], "\n"), true
+	}
+	return "", false
+}
+
+func agentGuideHeading(line string) (level int, topic string, ok bool) {
+	line = strings.TrimSpace(line)
+	for level < len(line) && line[level] == '#' {
+		level++
+	}
+	if level < 2 || level >= len(line) || line[level] != ' ' {
+		return 0, "", false
+	}
+	topic = agentGuideSlug(line[level+1:])
+	return level, topic, topic != ""
+}
+
+func agentGuideSlug(s string) string {
+	var out strings.Builder
+	dash := false
+	for _, r := range strings.ToLower(strings.TrimSpace(s)) {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			if dash && out.Len() > 0 {
+				out.WriteByte('-')
+			}
+			out.WriteRune(r)
+			dash = false
+		} else {
+			dash = true
+		}
+	}
+	return out.String()
+}
 
 func installCmd() *cobra.Command {
 	cmd := &cobra.Command{

--- a/cmd/pad/groups.go
+++ b/cmd/pad/groups.go
@@ -187,6 +187,7 @@ func agentCmd() *cobra.Command {
 	}
 	cmd.AddCommand(
 		installCmd(),
+		agentGuideCmd(),
 		agentUpdateCmd(),
 		agentStatusCmd(),
 	)

--- a/internal/cli/agent_prompt_budget_test.go
+++ b/internal/cli/agent_prompt_budget_test.go
@@ -1,0 +1,32 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// This initially records the existing shared Cursor/Codex payload with modest
+// headroom. Later prompt-reduction changes should lower this budget, not spend it.
+const agentSkillPromptBudget = 40 * 1024
+
+func TestAgentSkillPromptBudget(t *testing.T) {
+	skill, err := os.ReadFile(filepath.Join("..", "..", "skills", "pad", "SKILL.md"))
+	if err != nil {
+		t.Fatalf("read embedded Pad skill: %v", err)
+	}
+
+	for _, agent := range []string{"cursor", "codex"} {
+		t.Run(agent, func(t *testing.T) {
+			tool := ResolveTool(agent)
+			if tool == nil {
+				t.Fatalf("ResolveTool(%q) returned nil", agent)
+			}
+			payload := FormatForTool(*tool, skill)
+			t.Logf("%s installed skill payload: %d bytes (budget %d)", agent, len(payload), agentSkillPromptBudget)
+			if len(payload) > agentSkillPromptBudget {
+				t.Fatalf("%s installed skill payload is %d bytes; budget is %d", agent, len(payload), agentSkillPromptBudget)
+			}
+		})
+	}
+}

--- a/internal/mcp/prompt_budget_test.go
+++ b/internal/mcp/prompt_budget_test.go
@@ -1,0 +1,57 @@
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+
+	protocol "github.com/mark3labs/mcp-go/mcp"
+)
+
+// These budgets record the existing prompt-bearing MCP payloads with modest
+// headroom. Later prompt-reduction changes should lower them, not spend them.
+const (
+	mcpInitializePromptBudget = 20 * 1024
+	mcpToolListPromptBudget   = 54 * 1024
+)
+
+func TestMCPPromptBudgets(t *testing.T) {
+	srv := NewServer(Options{Version: "prompt-budget-test"})
+	registered, err := Register(srv.MCP(), RegistryOptions{
+		Doc:        fixtureDoc(),
+		Workspace:  NewWorkspaceState(""),
+		Dispatcher: &fakeDispatcher{},
+		PadVersion: "test",
+	})
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	client, initialize, cleanup := runClientSession(t, srv)
+	defer cleanup()
+
+	tools, err := client.ListTools(t.Context(), protocol.ListToolsRequest{})
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	if len(tools.Tools) != registered {
+		t.Fatalf("ListTools returned %d tools; registered %d", len(tools.Tools), registered)
+	}
+
+	initializeJSON, err := json.Marshal(initialize)
+	if err != nil {
+		t.Fatalf("marshal initialize result: %v", err)
+	}
+	toolsJSON, err := json.Marshal(tools)
+	if err != nil {
+		t.Fatalf("marshal tools/list result: %v", err)
+	}
+
+	t.Logf("MCP initialize payload: %d bytes (budget %d)", len(initializeJSON), mcpInitializePromptBudget)
+	t.Logf("MCP tools/list payload: %d bytes (budget %d)", len(toolsJSON), mcpToolListPromptBudget)
+	if len(initializeJSON) > mcpInitializePromptBudget {
+		t.Errorf("MCP initialize payload is %d bytes; budget is %d", len(initializeJSON), mcpInitializePromptBudget)
+	}
+	if len(toolsJSON) > mcpToolListPromptBudget {
+		t.Errorf("MCP tools/list payload is %d bytes; budget is %d", len(toolsJSON), mcpToolListPromptBudget)
+	}
+}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -190,6 +190,14 @@ func TestServer_GracefulShutdownOnContextCancel(t *testing.T) {
 // the wiring stays in one place.
 func runHandshake(t *testing.T, srv *Server) (*mcp.InitializeResult, func()) {
 	t.Helper()
+	_, res, cleanup := runClientSession(t, srv)
+	return res, cleanup
+}
+
+// runClientSession returns the initialized client as well as the handshake
+// result so tests can inspect later protocol responses on the same session.
+func runClientSession(t *testing.T, srv *Server) (*client.Client, *mcp.InitializeResult, func()) {
+	t.Helper()
 
 	serverIn, clientOut := io.Pipe()
 	clientIn, serverOut := io.Pipe()
@@ -238,5 +246,5 @@ func runHandshake(t *testing.T, srv *Server) (*mcp.InitializeResult, func()) {
 		_ = serverOut.Close()
 		wg.Wait()
 	}
-	return res, cleanup
+	return c, res, cleanup
 }


### PR DESCRIPTION
## Tracking issue

Part of #1339. Umbrella: [#1339 — Reduce Pad token overhead for Cursor and Codex agents](https://github.com/PerpetualSoftware/pad/issues/1339).

## Stack containment

> **PR 2 of 6. Adds on-demand guidance on top of #1333.**

1. [#1333](https://github.com/PerpetualSoftware/pad/pull/1333) — test(agent): establish token-efficiency budgets
2. **[#1334](https://github.com/PerpetualSoftware/pad/pull/1334) — feat(agent): add on-demand guidance ← this PR**
3. [#1335](https://github.com/PerpetualSoftware/pad/pull/1335) — feat(agent): install a compact shared skill
4. [#1336](https://github.com/PerpetualSoftware/pad/pull/1336) — perf(agent): reuse bootstrapped session context
5. [#1337](https://github.com/PerpetualSoftware/pad/pull/1337) — feat(agent): add a compact item projection
6. [#1338](https://github.com/PerpetualSoftware/pad/pull/1338) — feat(mcp): add client-compatible compact results

**Includes:** [#1333](https://github.com/PerpetualSoftware/pad/pull/1333)  
**Next layer:** [#1335](https://github.com/PerpetualSoftware/pad/pull/1335)

All six PRs target `main` and are cumulative. Per maintainer direction, #1338 is the single rebase-merge target once feedback on the lower review layers is satisfied; the lower PRs remain focused review anchors.

## Why

Agents should not receive the entire operating manual on every conversation. They need a compact index first and detailed instructions only for the topic involved in the current task.

## Changes

- add `pad agent guide` as a small topic index
- add `pad agent guide <topic>` to return one canonical section and its child sections
- keep `pad agent guide all` as an explicit full-guide escape hatch
- derive every response from the existing canonical `skills/pad/SKILL.md` rather than maintaining a second guide

## Measured impact

On the completed stack:

- topic index: 731 bytes
- `items` topic: 1,883 bytes
- index plus `items`: 2,614 bytes versus 37,991 bytes for `all`
- representative lookup reduction: **35,377 bytes / 93.12%**

The full-guide escape hatch is intentionally not the efficient path. After the 2,777-byte compact dispatcher is loaded, `pad agent guide all` adds 37,991 bytes for a 40,768-byte total: **3,077 bytes / 8.16% more** than the old 37,691-byte eager skill. It exists for exceptional comprehensive lookups; normal agent workflows should request only the relevant topic.

## Compatibility

Additive CLI command only. Existing skill installation and commands remain unchanged in this PR.

## Validation

- agent-guide topic, section-boundary, unknown-topic, formatting, and prompt-budget tests pass locally
- `git diff --check`, `go vet ./...`, and the final Go build pass
- full macOS `go test ./...` retains only four pre-existing session/PID failures, reproduced on exact base `9aa6c7b762e5b784990c2fe4c1456ba5f70f8101`
- GitHub Actions CI and Nix runs are awaiting maintainer approval (`action_required`) and have not executed


## Completed-stack validation

The rebased cumulative stack at `072483e0853804bf1b2cacf42c2b8a381efc7eeb` passes `git diff --check`, `go vet ./...`, `go build ./cmd/pad`, the focused agent, guide, projection, and compact-result tests, and the complete `internal/mcp` package locally. Full macOS `go test ./...` has four failures in process/session liveness tests; all four reproduce unchanged on the exact base `9aa6c7b762e5b784990c2fe4c1456ba5f70f8101`, so they are not introduced by this stack.

The pre-rebase cumulative stack at `4a3e6b8c457bf762ac508530f5f90fb7e961a823` previously passed the full Linux CI-equivalent matrix, macOS native CLI smoke, and Windows cross-compile. Those remain historical results, not exact-head validation after the rebase. Current per-head GitHub CI and Nix runs are `action_required` pending maintainer approval; Windows runtime smoke remains remote-only.