### PR TITLE
feat(agent): install a compact shared skill (3/6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ pad server info                         # How this client is connected to Pad
 
 ### For AI Agents
 
-**Your agent becomes a project partner.** Install the `/pad` skill once, and your AI coding tool can read, create, and update project items through natural language.
+**Your agent becomes a project partner.** Install the `/pad` skill once, and your AI coding tool can read, create, and update project items through natural language. Cursor, Codex, Windsurf, and OpenCode receive a compact dispatcher and load detailed guidance by topic with `pad agent guide`, keeping routine turns small.
 
 ```bash
 pad agent install        # Auto-detects your tools and installs the skill

--- a/README.md
+++ b/README.md
@@ -504,6 +504,7 @@ pad library list                      Browse convention and playbook library
 pad library activate <title>          Activate a convention or playbook
 
 pad agent install [tool]              Install /pad skill for AI coding tools
+pad agent guide [topic]               Print one section of the canonical agent guide
 pad agent status                      Show supported tools and installation status
 pad agent update                      Update installed tool integrations
 

--- a/cmd/pad/agent_guide_test.go
+++ b/cmd/pad/agent_guide_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+const guideFixture = `# Pad
+
+## Context Loading
+
+Start here.
+
+### Why one call
+
+It is cheaper.
+
+## Role Awareness
+
+Pick a role.
+`
+
+func TestAgentGuideTopics(t *testing.T) {
+	got := strings.Join(agentGuideTopics(guideFixture), ",")
+	if got != "context-loading,why-one-call,role-awareness" {
+		t.Fatalf("topics = %q", got)
+	}
+}
+
+func TestAgentGuideSectionIncludesChildrenOnly(t *testing.T) {
+	got, ok := agentGuideSection(guideFixture, "Context Loading")
+	if !ok {
+		t.Fatal("context-loading topic not found")
+	}
+	if !strings.Contains(got, "### Why one call") {
+		t.Errorf("child section missing: %q", got)
+	}
+	if strings.Contains(got, "Role Awareness") {
+		t.Errorf("next peer section leaked into result: %q", got)
+	}
+}
+
+func TestAgentGuideSectionRejectsUnknownTopic(t *testing.T) {
+	if _, ok := agentGuideSection(guideFixture, "missing"); ok {
+		t.Fatal("unknown topic resolved")
+	}
+}

--- a/cmd/pad/cmd_agent.go
+++ b/cmd/pad/cmd_agent.go
@@ -4,12 +4,105 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"unicode"
 
 	"github.com/spf13/cobra"
 
 	pad "github.com/PerpetualSoftware/pad"
 	"github.com/PerpetualSoftware/pad/internal/cli"
 )
+
+func agentGuideCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "guide [topic]",
+		Short: "Print Pad agent guidance on demand",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			body := string(cli.StripFrontmatter(pad.PadSkill))
+			if len(args) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "Available Pad agent guide topics:")
+				for _, topic := range agentGuideTopics(body) {
+					fmt.Fprintf(cmd.OutOrStdout(), "  %s\n", topic)
+				}
+				fmt.Fprintln(cmd.OutOrStdout(), "\nUse `pad agent guide <topic>` for one section or `pad agent guide all` for the full guide.")
+				return nil
+			}
+
+			if args[0] == "all" {
+				fmt.Fprint(cmd.OutOrStdout(), body)
+				return nil
+			}
+			section, ok := agentGuideSection(body, args[0])
+			if !ok {
+				return fmt.Errorf("unknown guide topic %q; run `pad agent guide` to list topics", args[0])
+			}
+			fmt.Fprint(cmd.OutOrStdout(), section)
+			return nil
+		},
+	}
+}
+
+func agentGuideTopics(markdown string) []string {
+	var topics []string
+	for _, line := range strings.Split(markdown, "\n") {
+		_, topic, ok := agentGuideHeading(line)
+		if ok {
+			topics = append(topics, topic)
+		}
+	}
+	return topics
+}
+
+func agentGuideSection(markdown, topic string) (string, bool) {
+	want := agentGuideSlug(topic)
+	lines := strings.Split(markdown, "\n")
+	start, level := -1, 0
+	for i, line := range lines {
+		lineLevel, lineTopic, ok := agentGuideHeading(line)
+		if start < 0 {
+			if ok && lineTopic == want {
+				start, level = i, lineLevel
+			}
+			continue
+		}
+		if ok && lineLevel <= level {
+			return strings.Join(lines[start:i], "\n") + "\n", true
+		}
+	}
+	if start >= 0 {
+		return strings.Join(lines[start:], "\n"), true
+	}
+	return "", false
+}
+
+func agentGuideHeading(line string) (level int, topic string, ok bool) {
+	line = strings.TrimSpace(line)
+	for level < len(line) && line[level] == '#' {
+		level++
+	}
+	if level < 2 || level >= len(line) || line[level] != ' ' {
+		return 0, "", false
+	}
+	topic = agentGuideSlug(line[level+1:])
+	return level, topic, topic != ""
+}
+
+func agentGuideSlug(s string) string {
+	var out strings.Builder
+	dash := false
+	for _, r := range strings.ToLower(strings.TrimSpace(s)) {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			if dash && out.Len() > 0 {
+				out.WriteByte('-')
+			}
+			out.WriteRune(r)
+			dash = false
+		} else {
+			dash = true
+		}
+	}
+	return out.String()
+}
 
 func installCmd() *cobra.Command {
 	cmd := &cobra.Command{

--- a/cmd/pad/groups.go
+++ b/cmd/pad/groups.go
@@ -187,6 +187,7 @@ func agentCmd() *cobra.Command {
 	}
 	cmd.AddCommand(
 		installCmd(),
+		agentGuideCmd(),
 		agentUpdateCmd(),
 		agentStatusCmd(),
 	)

--- a/internal/cli/agent_prompt_budget_test.go
+++ b/internal/cli/agent_prompt_budget_test.go
@@ -1,0 +1,32 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// This initially records the existing shared Cursor/Codex payload with modest
+// headroom. Later prompt-reduction changes should lower this budget, not spend it.
+const agentSkillPromptBudget = 40 * 1024
+
+func TestAgentSkillPromptBudget(t *testing.T) {
+	skill, err := os.ReadFile(filepath.Join("..", "..", "skills", "pad", "SKILL.md"))
+	if err != nil {
+		t.Fatalf("read embedded Pad skill: %v", err)
+	}
+
+	for _, agent := range []string{"cursor", "codex"} {
+		t.Run(agent, func(t *testing.T) {
+			tool := ResolveTool(agent)
+			if tool == nil {
+				t.Fatalf("ResolveTool(%q) returned nil", agent)
+			}
+			payload := FormatForTool(*tool, skill)
+			t.Logf("%s installed skill payload: %d bytes (budget %d)", agent, len(payload), agentSkillPromptBudget)
+			if len(payload) > agentSkillPromptBudget {
+				t.Fatalf("%s installed skill payload is %d bytes; budget is %d", agent, len(payload), agentSkillPromptBudget)
+			}
+		})
+	}
+}

--- a/internal/cli/agent_prompt_budget_test.go
+++ b/internal/cli/agent_prompt_budget_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 )
 
-// This initially records the existing shared Cursor/Codex payload with modest
-// headroom. Later prompt-reduction changes should lower this budget, not spend it.
-const agentSkillPromptBudget = 40 * 1024
+// The compact dispatcher should stay small enough to load eagerly. Detailed
+// reference material belongs behind `pad agent guide`, not in this payload.
+const agentSkillPromptBudget = 5 * 1024
 
 func TestAgentSkillPromptBudget(t *testing.T) {
 	skill, err := os.ReadFile(filepath.Join("..", "..", "skills", "pad", "SKILL.md"))
@@ -26,6 +26,11 @@ func TestAgentSkillPromptBudget(t *testing.T) {
 			t.Logf("%s installed skill payload: %d bytes (budget %d)", agent, len(payload), agentSkillPromptBudget)
 			if len(payload) > agentSkillPromptBudget {
 				t.Fatalf("%s installed skill payload is %d bytes; budget is %d", agent, len(payload), agentSkillPromptBudget)
+			}
+			for _, required := range []string{"pad bootstrap", "issue IDs", "convention_index", "pad agent guide"} {
+				if !contains(string(payload), required) {
+					t.Errorf("%s installed skill is missing core guidance %q", agent, required)
+				}
 			}
 		})
 	}

--- a/internal/cli/agents.go
+++ b/internal/cli/agents.go
@@ -82,6 +82,68 @@ var SupportedTools = []AgentTool{
 	},
 }
 
+// agentsSkillBody is the eager dispatcher installed for tools that share the
+// .agents skill format. The full, canonical guide stays embedded in Pad and is
+// available by topic through `pad agent guide`; repeating it here would charge
+// Cursor and Codex for reference material on every skill load.
+const agentsSkillBody = `# Pad — Talk to Your Project
+
+Use Pad when the user discusses project work: issues, tasks, plans, ideas,
+progress, dependencies, conventions, roles, standups, or retrospectives.
+
+## Start every invocation
+
+Run ` + "`pad bootstrap --format json`" + ` before acting. It returns the workspace,
+user, collections and schemas, always-on conventions, convention index, roles,
+playbooks, dashboard, and recent activity in one call.
+
+- If ` + "`pad`" + ` is missing, ask the user to install it or add it to PATH.
+- If bootstrap fails, run ` + "`pad agent guide context-loading`" + ` and follow that
+  section. Never initialize authentication blindly.
+- Follow every body in ` + "`conventions`" + `. Before meaningful work, inspect
+  ` + "`convention_index`" + ` and load bodies for the matching trigger.
+- If ` + "`needs_onboarding`" + ` is true, offer setup and wait for consent.
+- If roles exist and none was chosen in this conversation, ask once; do not block
+  if the user declines.
+
+## Act safely
+
+- Use issue IDs such as ` + "`TASK-5`" + `, never slugs.
+- Read an item before updating it. Send only changed fields and include a comment
+  with status changes.
+- Read collection schemas instead of guessing field names or terminal statuses.
+- Confirm each mutation from the returned object before saying it succeeded.
+- Use active playbooks when intent or an invocation slug matches; never run draft
+  or deprecated playbooks unless the user explicitly asks.
+- Prefer summary reads and bounded lists. Fetch full bodies only when needed.
+
+## Common commands
+
+` + "```bash" + `
+pad project dashboard --format json
+pad item show TASK-5 --format json
+pad item list [collection] --format json
+pad item create <collection> "Title" [flags]
+pad item update TASK-5 [flags]
+pad item comment TASK-5 -m "Message"
+pad playbook list --format json
+pad playbook show <slug> --format markdown
+` + "```" + `
+
+Use ` + "`pad <group> <command> --help`" + ` for exact flags.
+
+## Load details only when needed
+
+` + "```bash" + `
+pad agent guide                         # list available topics
+pad agent guide items                   # item commands and contracts
+pad agent guide before-performing-work  # convention routing
+pad agent guide role-awareness          # role behavior
+pad agent guide multi-step-workflows    # planning, ideation, retro, onboarding
+pad agent guide all                     # explicit full reference
+` + "```" + `
+`
+
 // ResolveTool finds an AgentTool by name or alias. Returns nil if not found.
 func ResolveTool(nameOrAlias string) *AgentTool {
 	lower := strings.ToLower(nameOrAlias)
@@ -206,15 +268,15 @@ func FormatForTool(tool AgentTool, embeddedContent []byte) []byte {
 		return embeddedContent
 
 	case "agents":
-		// Codex/Cursor/Windsurf/OpenCode use name + description frontmatter
-		body := StripFrontmatter(embeddedContent)
+		// Codex/Cursor/Windsurf/OpenCode use a compact eager dispatcher.
+		// Detailed guidance remains available through `pad agent guide`.
 		fm := `---
 name: pad
 description: "Talk to your project. Natural-language project management — create items, check status, create plans, brainstorm ideas, and more."
 ---
 
 `
-		return append([]byte(fm), body...)
+		return []byte(fm + agentsSkillBody)
 
 	case "copilot":
 		// GitHub Copilot uses applyTo frontmatter

--- a/internal/cli/agents_test.go
+++ b/internal/cli/agents_test.go
@@ -101,7 +101,7 @@ Body content here.
 		}
 	})
 
-	t.Run("agents has name+description frontmatter", func(t *testing.T) {
+	t.Run("agents has compact dispatcher", func(t *testing.T) {
 		tool := *ResolveTool("agents")
 		got := string(FormatForTool(tool, embedded))
 		if got[:4] != "---\n" {
@@ -116,8 +116,11 @@ Body content here.
 		if contains(got, "allowed-tools") {
 			t.Error("Agents format should NOT contain allowed-tools")
 		}
-		if !contains(got, "# Pad Skill") {
-			t.Error("Agents format should contain body")
+		if !contains(got, "pad agent guide") {
+			t.Error("Agents format should point to on-demand guidance")
+		}
+		if contains(got, "Body content here") {
+			t.Error("Agents format should not eagerly copy the full embedded guide")
 		}
 	})
 

--- a/internal/mcp/prompt_budget_test.go
+++ b/internal/mcp/prompt_budget_test.go
@@ -1,0 +1,57 @@
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+
+	protocol "github.com/mark3labs/mcp-go/mcp"
+)
+
+// These budgets record the existing prompt-bearing MCP payloads with modest
+// headroom. Later prompt-reduction changes should lower them, not spend them.
+const (
+	mcpInitializePromptBudget = 20 * 1024
+	mcpToolListPromptBudget   = 54 * 1024
+)
+
+func TestMCPPromptBudgets(t *testing.T) {
+	srv := NewServer(Options{Version: "prompt-budget-test"})
+	registered, err := Register(srv.MCP(), RegistryOptions{
+		Doc:        fixtureDoc(),
+		Workspace:  NewWorkspaceState(""),
+		Dispatcher: &fakeDispatcher{},
+		PadVersion: "test",
+	})
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	client, initialize, cleanup := runClientSession(t, srv)
+	defer cleanup()
+
+	tools, err := client.ListTools(t.Context(), protocol.ListToolsRequest{})
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	if len(tools.Tools) != registered {
+		t.Fatalf("ListTools returned %d tools; registered %d", len(tools.Tools), registered)
+	}
+
+	initializeJSON, err := json.Marshal(initialize)
+	if err != nil {
+		t.Fatalf("marshal initialize result: %v", err)
+	}
+	toolsJSON, err := json.Marshal(tools)
+	if err != nil {
+		t.Fatalf("marshal tools/list result: %v", err)
+	}
+
+	t.Logf("MCP initialize payload: %d bytes (budget %d)", len(initializeJSON), mcpInitializePromptBudget)
+	t.Logf("MCP tools/list payload: %d bytes (budget %d)", len(toolsJSON), mcpToolListPromptBudget)
+	if len(initializeJSON) > mcpInitializePromptBudget {
+		t.Errorf("MCP initialize payload is %d bytes; budget is %d", len(initializeJSON), mcpInitializePromptBudget)
+	}
+	if len(toolsJSON) > mcpToolListPromptBudget {
+		t.Errorf("MCP tools/list payload is %d bytes; budget is %d", len(toolsJSON), mcpToolListPromptBudget)
+	}
+}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -190,6 +190,14 @@ func TestServer_GracefulShutdownOnContextCancel(t *testing.T) {
 // the wiring stays in one place.
 func runHandshake(t *testing.T, srv *Server) (*mcp.InitializeResult, func()) {
 	t.Helper()
+	_, res, cleanup := runClientSession(t, srv)
+	return res, cleanup
+}
+
+// runClientSession returns the initialized client as well as the handshake
+// result so tests can inspect later protocol responses on the same session.
+func runClientSession(t *testing.T, srv *Server) (*client.Client, *mcp.InitializeResult, func()) {
+	t.Helper()
 
 	serverIn, clientOut := io.Pipe()
 	clientIn, serverOut := io.Pipe()
@@ -238,5 +246,5 @@ func runHandshake(t *testing.T, srv *Server) (*mcp.InitializeResult, func()) {
 		_ = serverOut.Close()
 		wg.Wait()
 	}
-	return res, cleanup
+	return c, res, cleanup
 }


### PR DESCRIPTION
## Tracking issue

Part of #1339. Umbrella: [#1339 — Reduce Pad token overhead for Cursor and Codex agents](https://github.com/PerpetualSoftware/pad/issues/1339).

## Stack containment

> **PR 3 of 6. Adds the compact installed skill on top of #1334.**

1. [#1333](https://github.com/PerpetualSoftware/pad/pull/1333) — test(agent): establish token-efficiency budgets
2. [#1334](https://github.com/PerpetualSoftware/pad/pull/1334) — feat(agent): add on-demand guidance
3. **[#1335](https://github.com/PerpetualSoftware/pad/pull/1335) — feat(agent): install a compact shared skill ← this PR**
4. [#1336](https://github.com/PerpetualSoftware/pad/pull/1336) — perf(agent): reuse bootstrapped session context
5. [#1337](https://github.com/PerpetualSoftware/pad/pull/1337) — feat(agent): add a compact item projection
6. [#1338](https://github.com/PerpetualSoftware/pad/pull/1338) — feat(mcp): add client-compatible compact results

**Includes:** [#1334](https://github.com/PerpetualSoftware/pad/pull/1334)  
**Next layer:** [#1336](https://github.com/PerpetualSoftware/pad/pull/1336)

All six PRs target `main` and are cumulative. Per maintainer direction, #1338 is the single rebase-merge target once feedback on the lower review layers is satisfied; the lower PRs remain focused review anchors.

## Why

Cursor and Codex eagerly load the installed Pad skill, so the full operating manual consumes context even when a task needs only one workflow. The compact skill keeps the safety-critical contract in context and retrieves detail through `pad agent guide` only when needed.

## Changes

- replace the eager shared Cursor/Codex/Windsurf/OpenCode guide with a compact dispatcher
- retain bootstrap, conventions, schema, issue-reference, read-before-write, confirmation, and playbook safeguards
- route detailed workflow questions to the canonical on-demand guide from #1334
- keep Claude on the full-guide installation path
- ratchet the installed-skill budget from 40 KiB to 5 KiB

## Measured impact

At this PR, the installed shared skill falls from 37,691 to 2,532 bytes (**93.28% smaller**). The completed stack remains at 2,777 bytes (**92.63% smaller**) after adding the later session and compact-read guidance.

## Compatibility

No Pad command or MCP schema changes. The installed guidance becomes shorter, while the complete canonical guide remains available on demand.

## Rollout

Existing Cursor and Codex skill installations are copied files and do not change merely because Pad is upgraded. After this ships, existing users must run `pad agent update` (or reinstall with `pad agent install`) to receive the compact dispatcher. New installations receive it automatically.

## Validation

- Cursor and Codex installed-skill budget tests pass locally
- agent-guide and agent-formatting tests pass locally
- `git diff --check`, `go vet ./...`, and the final Go build pass
- full macOS `go test ./...` retains only four pre-existing session/PID failures, reproduced on exact base `9aa6c7b762e5b784990c2fe4c1456ba5f70f8101`
- GitHub Actions CI and Nix runs are awaiting maintainer approval (`action_required`) and have not executed


## Completed-stack validation

The rebased cumulative stack at `072483e0853804bf1b2cacf42c2b8a381efc7eeb` passes `git diff --check`, `go vet ./...`, `go build ./cmd/pad`, the focused agent, guide, projection, and compact-result tests, and the complete `internal/mcp` package locally. Full macOS `go test ./...` has four failures in process/session liveness tests; all four reproduce unchanged on the exact base `9aa6c7b762e5b784990c2fe4c1456ba5f70f8101`, so they are not introduced by this stack.

The pre-rebase cumulative stack at `4a3e6b8c457bf762ac508530f5f90fb7e961a823` previously passed the full Linux CI-equivalent matrix, macOS native CLI smoke, and Windows cross-compile. Those remain historical results, not exact-head validation after the rebase. Current per-head GitHub CI and Nix runs are `action_required` pending maintainer approval; Windows runtime smoke remains remote-only.