### PR TITLE
fix(items): a lost commit ack no longer writes the item twice (BUG-2994)

### DIFF
--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -1902,7 +1902,7 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 		// previously the only way to discover the applier path was to take it.
 		contentToApply := *input.Content
 
-		route, updated, routeErr := s.routeContentUpdate(w, r, item, &input, openChildrenPrecheck, parentLink, contentToApply)
+		route, updated := s.routeContentUpdate(w, r, item, &input, openChildrenPrecheck, parentLink, contentToApply)
 		switch route {
 		case contentRouteHandled:
 			// The refusal or the settling answer has already been written.
@@ -1923,9 +1923,8 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 			input.Content = nil
 		}
 		// No default and no fall-through arm: routeContentUpdate answers every
-		// failure itself (BUG-2994). routeErr is logged by the router and is kept
-		// only so the switch's failure arm stays named at this call site.
-		_ = routeErr
+		// failure itself and returns nothing for this caller to answer again
+		// (BUG-2994).
 	}
 
 	var updated *models.Item

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -1921,13 +1921,11 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 			fullWriteHandled = true
 			fullWriteUpdated = updated
 			input.Content = nil
-		case contentRouteFallThrough:
-			// A transient, non-deterministic failure that is NOT a lost-write
-			// hazard: no live writer holds a diverging Y.Doc, so the ordinary
-			// row write below still carries the content. routeErr is logged by
-			// the router.
-			_ = routeErr
 		}
+		// No default and no fall-through arm: routeContentUpdate answers every
+		// failure itself (BUG-2994). routeErr is logged by the router and is kept
+		// only so the switch's failure arm stays named at this call site.
+		_ = routeErr
 	}
 
 	var updated *models.Item

--- a/internal/server/handlers_items_ack_loss_test.go
+++ b/internal/server/handlers_items_ack_loss_test.go
@@ -16,26 +16,29 @@ import (
 // BUG-2994: a content PATCH whose transaction COMMITS but whose tx.Commit()
 // reports an error must not be written a second time.
 //
-// The path, enumerated rather than assumed: handleUpdateItem writes twice iff
-// routeContentUpdate returns contentRouteFallThrough, and that return had exactly
+// The path, enumerated rather than assumed: handleUpdateItem wrote twice iff
+// routeContentUpdate returned contentRouteFallThrough, and that return had exactly
 // one producer — the settleDirectFailed arm, reached when PruneAndApply's applyFn
-// (the store write) fails and writeTypedItemRefusal does not recognise the error.
+// (the store call) fails and writeTypedItemRefusal does not recognise the error.
 // PruneAndApply's only other error, ErrRoomActiveDuringPrune, is consumed by the
-// settle loop above and never reaches that arm, so EVERY error arriving there is a
-// store write-transaction error. The fall-through's premise — "nothing was written"
-// — is an inference from rollback semantics, and a lost commit ack falsifies it.
+// settle loop above and never reaches that arm.
 //
-// WHY THE OBVIOUS INSTRUMENT DOES NOT WORK. Counting item_versions rows does not
-// discriminate here, and a test built on it would pass against the defect. The
-// version INSERT is gated on `*input.Content != existing.Content` (items.go), and
-// the second write re-reads `existing` AFTER the first commit landed — so it sees
-// the content it is about to write and mints no row. One version row is what BOTH
-// the broken and the fixed code produce.
+// The fall-through's premise was "nothing was written", inferred from rollback
+// semantics. A commit that reported an error falsifies it: the outcome is ambiguous,
+// and a lost acknowledgement means the row already changed. (An earlier wording here
+// said every error arriving at that arm came out of a write TRANSACTION. It does
+// not — GetItem, validateAssignmentScope and db.Begin all fail before one is opened
+// — and the enum comment in handlers_items_content_route.go carries the three-way
+// split. Corrected in codex round 2, having been corrected wrongly in round 1: the
+// round-1 edit fixed the enum comment and left this one contradicting it.)
+//
+// WHY THE OBVIOUS INSTRUMENTS DO NOT WORK — see the note above the commit-count
+// assertion below, which names each and what it actually measures.
 //
 // What does discriminate: how many transactions reached COMMIT (counted at the seam
-// itself, which is the property stated directly), the number of item_updated events
-// the request emits, and the status code — a second write that succeeds answers 200
-// about a request whose first write's outcome was never established.
+// itself, which is the property stated directly), and the status code — a second
+// write that succeeds answers 200 about a request whose first write's outcome was
+// never established.
 
 var errSimItemAckLoss = errors.New("simulated commit ack loss")
 
@@ -129,15 +132,19 @@ func assertContentPatchAckLossCommitsOnce(t *testing.T, srv *Server) {
 	//     existing.Content, and the replayed write re-reads `existing` AFTER the
 	//     first commit landed, so it finds the content already at its target value
 	//     and mints nothing.
-	//   - item_updated events. The store's outbox emit is gated on
-	//     itemUpdatedSliceChanged and finds nothing changed for the same reason; the
-	//     handler's SSE publish fires once per successful REQUEST, not once per
-	//     write. Stated carefully because an earlier draft of this comment said
-	//     "events do not discriminate" full stop, and that is wrong in the other
-	//     direction (codex round 1): the fixed tree emits ZERO, because 500 returns
-	//     before the publish. That distinguishes fixed from unfixed — but it is the
-	//     same fact the status assertion below already pins, and it says nothing
-	//     about how many times the row was written, which is the property here.
+	//   - item_updated events, on EITHER of the two surfaces that carry that name,
+	//     which are worth separating because an earlier draft of this comment ran
+	//     them together (codex rounds 1 and 2):
+	//
+	//     The DURABLE OUTBOX row, written in-transaction by emitItemUpdateEventsTx
+	//     and gated on itemUpdatedSliceChanged. One write produces one; the replay
+	//     produces none, for the same reason the version INSERT mints none.
+	//
+	//     The SSE publish, which the HANDLER makes once per successful request, not
+	//     once per write. It fires once on the unfixed tree and not at all on the
+	//     fixed one, since a 500 returns before it — so it separates fixed from
+	//     unfixed, but it is the same fact the status assertion below pins, and it
+	//     is silent on how many times the row was written, which is the property.
 	//
 	// Measured against the unfixed tree, not reasoned about.
 	if n := atomic.LoadInt32(&commits); n != 1 {

--- a/internal/server/handlers_items_ack_loss_test.go
+++ b/internal/server/handlers_items_ack_loss_test.go
@@ -121,13 +121,25 @@ func assertContentPatchAckLossCommitsOnce(t *testing.T, srv *Server) {
 
 	// THE PROPERTY. One request, at most one committed transaction.
 	//
-	// Counted at the seam because the two instruments a reader reaches for first do
-	// NOT discriminate, and a test built on either passes against the defect. Both
-	// fail for one reason: the replayed write re-reads `existing` AFTER the first
-	// commit landed, so it finds every field already at its target value. The
-	// item_versions INSERT is gated on *input.Content != existing.Content and mints
-	// nothing; emitItemUpdateEventsTx gates on itemUpdatedSliceChanged and emits
-	// nothing. Measured against the unfixed tree, not reasoned about.
+	// Counted at the seam because the two instruments a reader reaches for first
+	// cannot tell ONE committed write from TWO, so a test built on either passes
+	// against the defect:
+	//
+	//   - item_versions rows. The INSERT is gated on *input.Content !=
+	//     existing.Content, and the replayed write re-reads `existing` AFTER the
+	//     first commit landed, so it finds the content already at its target value
+	//     and mints nothing.
+	//   - item_updated events. The store's outbox emit is gated on
+	//     itemUpdatedSliceChanged and finds nothing changed for the same reason; the
+	//     handler's SSE publish fires once per successful REQUEST, not once per
+	//     write. Stated carefully because an earlier draft of this comment said
+	//     "events do not discriminate" full stop, and that is wrong in the other
+	//     direction (codex round 1): the fixed tree emits ZERO, because 500 returns
+	//     before the publish. That distinguishes fixed from unfixed — but it is the
+	//     same fact the status assertion below already pins, and it says nothing
+	//     about how many times the row was written, which is the property here.
+	//
+	// Measured against the unfixed tree, not reasoned about.
 	if n := atomic.LoadInt32(&commits); n != 1 {
 		t.Errorf("one PATCH drove %d transactions to COMMIT, want 1: the lost ack was read as a rollback "+
 			"and the write was replayed against the row it had already changed", n)

--- a/internal/server/handlers_items_ack_loss_test.go
+++ b/internal/server/handlers_items_ack_loss_test.go
@@ -154,3 +154,80 @@ func assertContentPatchAckLossCommitsOnce(t *testing.T, srv *Server) {
 			"(body %s)", rr.Code, rr.Body.String())
 	}
 }
+
+var errSimPruneFailure = errors.New("simulated op-log prune failure")
+
+// TestDirectWritePruneFailureDoesNotReplayWithoutThePrune is the SECOND defect of
+// the same removed fall-through (BUG-2994), and it is a different error shape on
+// purpose.
+//
+// The direct write rides the op-log prune inside its own transaction
+// (composePruneWithPrecheck) so a refusal from either half rolls the other back.
+// The handler's ordinary write does NOT carry that composition. So a prune failure
+// — an honest rollback, nothing committed, no double write — fell through to a
+// write that set items.content while the per-item op-log still held exactly the ops
+// the prune existed to remove. PruneAndApply has already established under appendMu
+// that no live writer holds the room, so those rows belong to departed peers and a
+// reconnecting client replays them over the content just seeded.
+//
+// WHY THIS EXISTS ALONGSIDE THE ACK-LOSS TEST rather than being folded into it: the
+// two errors are terminal for different reasons, and the arm must be terminal for
+// ALL of them. Re-opening the fall-through for "non-commit" errors only — the
+// plausible shape of a future regression, since a transient error looks retryable —
+// leaves the ack-loss test green and is caught only here.
+func TestDirectWritePruneFailureDoesNotReplayWithoutThePrune(t *testing.T) {
+	srv := ackLossServer(t, store.DriverSQLite)
+	slug := createWSWithCollections(t, srv)
+	item := createTaskWithFields(t, srv, slug, "Prune failure", `{"status":"open"}`)
+
+	// Op-log rows standing in for a departed peer's unflushed edits: content that
+	// exists ONLY in the op-log, which is what the prune is there to discard.
+	seedOpLog(t, srv, item.ID, 3)
+	if got := countOpLog(t, srv, item.ID); got != 3 {
+		t.Fatalf("seeded op-log = %d rows, want 3", got)
+	}
+	if srv.collab.HasElectableApplier(item.ID) {
+		t.Fatal("an applier is electable; this test would have measured the applier path instead")
+	}
+
+	before, err := srv.store.GetItem(item.ID)
+	if err != nil || before == nil {
+		t.Fatalf("GetItem: %v", err)
+	}
+
+	var faults int32
+	srv.directWritePruneFault = func() error {
+		atomic.AddInt32(&faults, 1)
+		return errSimPruneFailure
+	}
+	t.Cleanup(func() { srv.directWritePruneFault = nil })
+
+	rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+item.Slug,
+		map[string]interface{}{"content": "content that must not outrun the prune"})
+
+	if atomic.LoadInt32(&faults) == 0 {
+		t.Fatal("the prune seam never fired; the request did not reach the direct write this test measures")
+	}
+	if rr.Code != http.StatusInternalServerError {
+		t.Errorf("PATCH answered %d, want 500: a write that could not prune the op-log must be refused, "+
+			"not retried without the prune (body %s)", rr.Code, rr.Body.String())
+	}
+
+	after, err := srv.store.GetItem(item.ID)
+	if err != nil || after == nil {
+		t.Fatalf("GetItem: %v", err)
+	}
+	if after.Content != before.Content {
+		t.Errorf("items.content moved to %q despite the prune failing: the replayed write did not carry "+
+			"composePruneWithPrecheck, so it seeded content the surviving op-log will be replayed over",
+			after.Content)
+	}
+	// PRECONDITION, not a discriminator — it holds either way, and saying so keeps
+	// it from reading as coverage it does not provide. The rows survive in BOTH
+	// trees (the replayed write carried no prune at all), which is precisely what
+	// makes the content move above harmful: there is something left to replay over
+	// it. Measured against the unfixed tree.
+	if got := countOpLog(t, srv, item.ID); got != 3 {
+		t.Errorf("op-log = %d rows, want the 3 seeded: the prune must roll back with its transaction", got)
+	}
+}

--- a/internal/server/handlers_items_ack_loss_test.go
+++ b/internal/server/handlers_items_ack_loss_test.go
@@ -1,0 +1,156 @@
+package server
+
+import (
+	"database/sql"
+	"errors"
+	"net/http"
+	"sync/atomic"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/collab"
+	"github.com/PerpetualSoftware/pad/internal/events"
+	"github.com/PerpetualSoftware/pad/internal/store"
+	"github.com/PerpetualSoftware/pad/internal/store/storetest"
+)
+
+// BUG-2994: a content PATCH whose transaction COMMITS but whose tx.Commit()
+// reports an error must not be written a second time.
+//
+// The path, enumerated rather than assumed: handleUpdateItem writes twice iff
+// routeContentUpdate returns contentRouteFallThrough, and that return had exactly
+// one producer — the settleDirectFailed arm, reached when PruneAndApply's applyFn
+// (the store write) fails and writeTypedItemRefusal does not recognise the error.
+// PruneAndApply's only other error, ErrRoomActiveDuringPrune, is consumed by the
+// settle loop above and never reaches that arm, so EVERY error arriving there is a
+// store write-transaction error. The fall-through's premise — "nothing was written"
+// — is an inference from rollback semantics, and a lost commit ack falsifies it.
+//
+// WHY THE OBVIOUS INSTRUMENT DOES NOT WORK. Counting item_versions rows does not
+// discriminate here, and a test built on it would pass against the defect. The
+// version INSERT is gated on `*input.Content != existing.Content` (items.go), and
+// the second write re-reads `existing` AFTER the first commit landed — so it sees
+// the content it is about to write and mints no row. One version row is what BOTH
+// the broken and the fixed code produce.
+//
+// What does discriminate: how many transactions reached COMMIT (counted at the seam
+// itself, which is the property stated directly), the number of item_updated events
+// the request emits, and the status code — a second write that succeeds answers 200
+// about a request whose first write's outcome was never established.
+
+var errSimItemAckLoss = errors.New("simulated commit ack loss")
+
+// ackLossServer builds a *Server on the named backend with collab and an event bus
+// wired. The Postgres leg skips unless PAD_TEST_POSTGRES_URL is set (make test-pg).
+//
+// It exists because testServer is hardwired to storetest.NewSQLite, so a test built
+// on that helper measures SQLite whatever gate is running it — the trap recorded on
+// this bug's sibling unit. testServerPostgres is the precedent for the other leg.
+func ackLossServer(t *testing.T, driver store.DriverType) *Server {
+	t.Helper()
+	var s *store.Store
+	if driver == store.DriverPostgres {
+		s = storetest.NewPostgres(t) // skips if PAD_TEST_POSTGRES_URL is unset
+	} else {
+		s = storetest.NewSQLite(t)
+	}
+	if got := s.D().Driver(); got != driver {
+		t.Fatalf("wanted a %s store, got %s — this leg would have measured the wrong backend", driver, got)
+	}
+	srv := New(s)
+	t.Cleanup(func() { srv.Stop() })
+
+	obus := collab.NewMemoryOpBus()
+	t.Cleanup(obus.Close)
+	rm := collab.NewRoomManager(srv.store, obus)
+	t.Cleanup(rm.Close)
+	srv.SetCollabRoomManager(rm)
+
+	srv.SetEventBus(events.New())
+	return srv
+}
+
+func TestContentPatchAckLossCommitsOnce_SQLite(t *testing.T) {
+	assertContentPatchAckLossCommitsOnce(t, ackLossServer(t, store.DriverSQLite))
+}
+
+func TestContentPatchAckLossCommitsOnce_Postgres(t *testing.T) {
+	assertContentPatchAckLossCommitsOnce(t, ackLossServer(t, store.DriverPostgres))
+}
+
+func assertContentPatchAckLossCommitsOnce(t *testing.T, srv *Server) {
+	t.Helper()
+
+	slug := createWSWithCollections(t, srv)
+	item := createTaskWithFields(t, srv, slug, "Ack loss", `{"status":"open"}`)
+
+	// PRECONDITION, not decoration: with no conn dialled there is no electable
+	// applier, so routeContentUpdate takes the DIRECT-WRITE route — the only route
+	// that can reach the fall-through. Without this the test could pass by never
+	// visiting the path it exists to measure.
+	if srv.collab.HasElectableApplier(item.ID) {
+		t.Fatal("an applier is electable; this test would have measured the applier path instead")
+	}
+
+	// Fail the FIRST commit only, and commit it for real first. That is the whole
+	// point: the transaction's effects are durable and the caller is told they are
+	// not. A hook that returned an error WITHOUT committing would exercise the
+	// ordinary rollback case, which was never broken.
+	var commits int32
+	restore := srv.store.SetItemUpdateCommitHookForTesting(func(tx *sql.Tx) error {
+		n := atomic.AddInt32(&commits, 1)
+		if cerr := tx.Commit(); cerr != nil {
+			return cerr
+		}
+		if n == 1 {
+			return errSimItemAckLoss
+		}
+		return nil
+	})
+	t.Cleanup(restore)
+
+	rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+item.Slug,
+		map[string]interface{}{
+			"title":   "Renamed by the one request",
+			"content": "content written once",
+		})
+
+	// The seam must have fired, or nothing below means anything.
+	if atomic.LoadInt32(&commits) == 0 {
+		t.Fatal("the commit seam never fired; the request did not reach the store write this test measures")
+	}
+
+	// THE PROPERTY. One request, at most one committed transaction.
+	//
+	// Counted at the seam because the two instruments a reader reaches for first do
+	// NOT discriminate, and a test built on either passes against the defect. Both
+	// fail for one reason: the replayed write re-reads `existing` AFTER the first
+	// commit landed, so it finds every field already at its target value. The
+	// item_versions INSERT is gated on *input.Content != existing.Content and mints
+	// nothing; emitItemUpdateEventsTx gates on itemUpdatedSliceChanged and emits
+	// nothing. Measured against the unfixed tree, not reasoned about.
+	if n := atomic.LoadInt32(&commits); n != 1 {
+		t.Errorf("one PATCH drove %d transactions to COMMIT, want 1: the lost ack was read as a rollback "+
+			"and the write was replayed against the row it had already changed", n)
+	}
+
+	// ANTI-VACUITY CONTROL. The seam is only honest if the first transaction really
+	// did land, so assert the effects are on disk even though the caller was told
+	// they were not. Without this the whole test could pass against a seam that
+	// merely failed the commit, which is the case the code already handled.
+	after, gerr := srv.store.GetItem(item.ID)
+	if gerr != nil || after == nil {
+		t.Fatalf("re-read item: %v", gerr)
+	}
+	if after.Title != "Renamed by the one request" || after.Content != "content written once" {
+		t.Fatalf("the first transaction did not durably land (title=%q content=%q); the seam did not "+
+			"reproduce a lost ack and nothing above measures this bug", after.Title, after.Content)
+	}
+
+	// A commit whose outcome was never established must not be answered as success.
+	// 500 is what the plain path already answers for the same unrecognised store
+	// error, so this is parity rather than a new refusal.
+	if rr.Code != http.StatusInternalServerError {
+		t.Errorf("PATCH answered %d; a write whose commit outcome is unknown must not read as success "+
+			"(body %s)", rr.Code, rr.Body.String())
+	}
+}

--- a/internal/server/handlers_items_content_echo_test.go
+++ b/internal/server/handlers_items_content_echo_test.go
@@ -144,8 +144,10 @@ func keysOf(m map[string]any) []string {
 //
 // WHAT IT ESTABLISHES, stated exactly (codex round 1 P2). The precondition it checks
 // is that items.content holds the sent value — which is true of the direct-write
-// path, and equally true of contentRouteFallThrough or any ordinary non-routed
-// write. It therefore does NOT prove which route ran, and an earlier name
+// path, and equally true of any ordinary non-routed write. (It named
+// contentRouteFallThrough as a third case until BUG-2994 removed that route; the
+// point the sentence makes is unchanged, since it never depended on which of them
+// ran.) It therefore does NOT prove which route ran, and an earlier name
 // ("DirectPath") claimed that it did. The invariant is the one worth pinning and is
 // route-independent: wherever the content reached the row, there is nothing pending,
 // so the marker must be absent.

--- a/internal/server/handlers_items_content_route.go
+++ b/internal/server/handlers_items_content_route.go
@@ -40,11 +40,30 @@ const (
 	// contentRouteDirectWrote — PruneAndApply ran the full write for a room with no
 	// live writer.
 	contentRouteDirectWrote
-	// contentRouteFallThrough — nothing was written and no live writer holds a
-	// diverging document, so the caller's ordinary row write should carry the
-	// content as it always did.
-	contentRouteFallThrough
 )
+
+// There is deliberately no fall-through route (BUG-2994). One used to exist, on the
+// premise that a failed direct write left nothing behind and the handler's ordinary
+// row write could carry the content instead. That premise came from the store's
+// rollback semantics and is false for the case it mattered most in: a transaction
+// that COMMITTED and whose tx.Commit() reported an error anyway, which is what
+// Postgres does when the acknowledgement is lost at the connection boundary. The
+// handler then wrote the item a SECOND time, re-running the open-children precheck
+// against the row it had already changed.
+//
+// The population is what settles it. settleDirectFailed carries only applyFn's
+// error, because PruneAndApply's own ErrRoomActiveDuringPrune is consumed by the
+// settle loop before it can reach that arm — so EVERY error arriving there comes out
+// of a store write transaction, and there is no member of the set for which
+// re-running the same write is both safe and useful. The second defect makes that
+// concrete: the ordinary write does NOT carry composePruneWithPrecheck, so a
+// PruneItemOpLogTx failure — an honest rollback, no double write — fell through to a
+// write that set items.content while the op-log still held the ops the prune existed
+// to remove, which a reconnecting peer then replays over it.
+//
+// So the direct write is terminal, and answers with the same classification the
+// ordinary path gives the same error (writeTypedItemRefusal's five arms, then
+// writeInternalError). Parity, not a new refusal.
 
 // applierSettleBudget bounds the wait for a room that is neither settled enough to
 // elect an applier nor empty enough to write directly.
@@ -138,11 +157,14 @@ func (s *Server) routeContentUpdate(
 		if s.writeTypedItemRefusal(w, item, paErr) {
 			return contentRouteHandled, nil, nil
 		}
-		slog.Warn("collab: direct-write path failed; falling through to the ordinary row write",
+		// Terminal: no second write. The first attempt's outcome is unknown — it may
+		// have durably committed — so replaying it is the defect, not the recovery.
+		slog.Error("collab: the direct-write transaction failed; answering without a second write",
 			"item_id", item.ID,
 			"error", paErr,
 		)
-		return contentRouteFallThrough, nil, paErr
+		writeInternalError(w, paErr)
+		return contentRouteHandled, nil, paErr
 	}
 }
 

--- a/internal/server/handlers_items_content_route.go
+++ b/internal/server/handlers_items_content_route.go
@@ -53,17 +53,32 @@ const (
 //
 // The population is what settles it. settleDirectFailed carries only applyFn's
 // error, because PruneAndApply's own ErrRoomActiveDuringPrune is consumed by the
-// settle loop before it can reach that arm — so EVERY error arriving there comes out
-// of a store write transaction, and there is no member of the set for which
-// re-running the same write is both safe and useful. The second defect makes that
-// concrete: the ordinary write does NOT carry composePruneWithPrecheck, so a
-// PruneItemOpLogTx failure — an honest rollback, no double write — fell through to a
-// write that set items.content while the op-log still held the ops the prune existed
-// to remove, which a reconnecting peer then replays over it.
+// settle loop before it can reach that arm. That error splits three ways, and the
+// split is worth stating because an earlier draft of this comment claimed all of it
+// came out of a write transaction, which is not true (codex round 1):
+//
+//   - BEFORE any transaction — GetItem, validateAssignmentScope, or db.Begin
+//     failing. Nothing was written.
+//   - INSIDE the transaction, rolled back. Nothing was written.
+//   - The COMMIT, whose acknowledgement was lost. The effects ARE on disk.
+//
+// Terminal is right for all three, for two different reasons. The third is BUG-2994
+// itself: a replay writes the item twice. The first two are the second defect, and
+// it is the one that makes a "transient failures may retry" carve-out unsafe — the
+// ordinary write does NOT carry composePruneWithPrecheck, so a rolled-back direct
+// write fell through to a write that set items.content while the per-item op-log
+// still held the ops the prune existed to remove, which a reconnecting peer then
+// replays over it.
 //
 // So the direct write is terminal, and answers with the same classification the
 // ordinary path gives the same error (writeTypedItemRefusal's five arms, then
 // writeInternalError). Parity, not a new refusal.
+//
+// THE COST, named rather than left for someone to discover: a one-shot transient
+// failure in the first bucket used to get a second attempt that could answer 200,
+// and now answers 500. That is precisely what the ordinary path already answers for
+// the same error, so this makes the two orderings agree rather than singling this
+// one out — but it is an availability change and not only a correctness fix.
 
 // applierSettleBudget bounds the wait for a room that is neither settled enough to
 // elect an applier nor empty enough to write directly.

--- a/internal/server/handlers_items_content_route.go
+++ b/internal/server/handlers_items_content_route.go
@@ -60,10 +60,15 @@ const (
 //   - BEFORE any transaction — GetItem, validateAssignmentScope, or db.Begin
 //     failing. Nothing was written.
 //   - INSIDE the transaction, rolled back. Nothing was written.
-//   - The COMMIT, whose acknowledgement was lost. The effects ARE on disk.
+//   - The COMMIT reported an error. The outcome is AMBIGUOUS: a serialization or
+//     deferred-constraint failure wrote nothing, while a lost acknowledgement means
+//     the effects ARE on disk. Nothing at this layer can tell the two apart, which
+//     is the whole difficulty rather than an aside (codex round 2 — an earlier
+//     wording asserted the effects had landed, which is only one of the cases).
 //
 // Terminal is right for all three, for two different reasons. The third is BUG-2994
-// itself: a replay writes the item twice. The first two are the second defect, and
+// itself: the replay may write the item twice, and no caller can know whether it
+// did. The first two are the second defect, and
 // it is the one that makes a "transient failures may retry" carve-out unsafe — the
 // ordinary write does NOT carry composePruneWithPrecheck, so a rolled-back direct
 // write fell through to a write that set items.content while the per-item op-log
@@ -120,6 +125,11 @@ const applierSettlePoll = 10 * time.Millisecond
 
 // routeContentUpdate decides which ordering a content PATCH takes and executes it.
 //
+// It returns no error, deliberately (BUG-2994, codex round 2). Every failure is
+// ANSWERED here, so an error returned alongside a response that has already been
+// written is a contract inviting a future caller to answer it twice. The error is
+// logged at the arm that owns it.
+//
 // It owns the re-decision deliberately. The predecessor helper retried
 // ErrRoomActiveDuringPrune INSIDE applyContentViaCollab and re-called
 // ApplyExternalContent, which could succeed through a freshly-joined applier and
@@ -134,7 +144,7 @@ func (s *Server) routeContentUpdate(
 	openChildrenPrecheck func(*sql.Tx, *models.Item) error,
 	parentLink *store.ParentLinkUpdate,
 	content string,
-) (contentRoute, *models.Item, error) {
+) (contentRoute, *models.Item) {
 	var updated *models.Item
 	outcome, paErr := settleContentRoute(
 		r.Context(),
@@ -158,7 +168,7 @@ func (s *Server) routeContentUpdate(
 		return s.applierFirstWrite(w, item, input, openChildrenPrecheck, parentLink, content)
 
 	case settleDirectWrote:
-		return contentRouteDirectWrote, updated, nil
+		return contentRouteDirectWrote, updated
 
 	case settleUnsettled:
 		slog.Info("collab: room neither electable nor peerless within the settle budget; refusing",
@@ -166,11 +176,11 @@ func (s *Server) routeContentUpdate(
 			"budget", applierSettleBudget,
 		)
 		writeRoomSettlingError(w, itemRefOrSlug(*item))
-		return contentRouteHandled, nil, nil
+		return contentRouteHandled, nil
 
 	default: // settleDirectFailed
 		if s.writeTypedItemRefusal(w, item, paErr) {
-			return contentRouteHandled, nil, nil
+			return contentRouteHandled, nil
 		}
 		// Terminal: no second write. The first attempt's outcome is unknown — it may
 		// have durably committed — so replaying it is the defect, not the recovery.
@@ -179,7 +189,7 @@ func (s *Server) routeContentUpdate(
 			"error", paErr,
 		)
 		writeInternalError(w, paErr)
-		return contentRouteHandled, nil, paErr
+		return contentRouteHandled, nil
 	}
 }
 
@@ -265,7 +275,7 @@ func (s *Server) applierFirstWrite(
 	openChildrenPrecheck func(*sql.Tx, *models.Item) error,
 	parentLink *store.ParentLinkUpdate,
 	content string,
-) (contentRoute, *models.Item, error) {
+) (contentRoute, *models.Item) {
 	rowInput := *input
 	// The content half travels through the applier, not the row. Every store content
 	// write is gated on Content != nil, so a nil here means the row write touches
@@ -278,10 +288,10 @@ func (s *Server) applierFirstWrite(
 		// ApplyExternalContent is ever called, so there is no Y.Doc write, no
 		// op-log row, and nothing for a later flush to carry.
 		if s.writeTypedItemRefusal(w, item, uerr) {
-			return contentRouteHandled, nil, nil
+			return contentRouteHandled, nil
 		}
 		writeInternalError(w, uerr)
-		return contentRouteHandled, nil, nil
+		return contentRouteHandled, nil
 	}
 
 	if aerr := s.collab.ApplyExternalContent(item.ID, content); aerr != nil {
@@ -291,7 +301,7 @@ func (s *Server) applierFirstWrite(
 			// would be a false statement, so it keeps its own retryable answer.
 			writeError(w, http.StatusConflict, "applier_ambiguous",
 				"A concurrent version restore made this edit's outcome ambiguous; please retry.")
-			return contentRouteHandled, nil, nil
+			return contentRouteHandled, nil
 		}
 		outcome := classifyApplyOutcome(aerr)
 		slog.Warn("collab: row write landed but the apply did not confirm; answering content_not_applied",
@@ -300,10 +310,10 @@ func (s *Server) applierFirstWrite(
 			"error", aerr,
 		)
 		writeContentNotAppliedError(w, itemRefOrSlug(*item), landedFieldNames(input), updated.UpdatedAt, outcome, aerr.Error())
-		return contentRouteHandled, nil, nil
+		return contentRouteHandled, nil
 	}
 
-	return contentRouteApplierWrote, updated, nil
+	return contentRouteApplierWrote, updated
 }
 
 // classifyApplyOutcome decides whether a failed apply DEMONSTRABLY left the content

--- a/internal/server/handlers_items_content_route.go
+++ b/internal/server/handlers_items_content_route.go
@@ -329,6 +329,9 @@ func composePruneWithPrecheck(s *Server, itemID string, inner func(*sql.Tx, *mod
 				return err
 			}
 		}
+		if s.directWritePruneFault != nil {
+			return s.directWritePruneFault()
+		}
 		return s.store.PruneItemOpLogTx(tx, itemID)
 	}
 }

--- a/internal/server/handlers_items_rename_cascade_test.go
+++ b/internal/server/handlers_items_rename_cascade_test.go
@@ -207,11 +207,18 @@ func TestItemRenameCascadeTooLarge_MappedOnTheCollabSnapshotPath(t *testing.T) {
 // TestItemRenameCascadeTooLarge_CollabEditPathDoesNotRunTheCascadeTwice closes
 // the other half of codex R2's second finding.
 //
-// The collab-edit path treats most callback errors as recoverable and falls
-// through to a direct write — graceful degradation for applier timeouts. A
-// cascade refusal is NOT recoverable: it is deterministic, so the fall-through
-// re-reads every linking body, re-charges the projection, and refuses
-// identically. The caller waits twice for one answer.
+// The collab-edit path USED TO treat most callback errors as recoverable and fall
+// through to a direct write — graceful degradation for applier timeouts. A cascade
+// refusal is NOT recoverable: it is deterministic, so the fall-through re-read every
+// linking body, re-charged the projection, and refused identically. The caller
+// waited twice for one answer.
+//
+// BUG-2994 removed that fall-through entirely, so the double cascade now has two
+// independent guards rather than one. This test still pins the first and the older
+// of them: a cascade refusal is TYPED, so writeTypedItemRefusal answers it and the
+// route returns handled — it never reached the fall-through even while one existed.
+// Drop that arm and the refusal goes untyped, answering 500 instead of 413, which
+// this test's status assertion catches.
 //
 // STATUS CANNOT PIN THIS. Both behaviours end in 413 — the fall-through reaches
 // the plain path's arm — so a status assertion passes either way. The

--- a/internal/server/handlers_items_title_test.go
+++ b/internal/server/handlers_items_title_test.go
@@ -314,8 +314,14 @@ func TestWriteTypedItemRefusalIncludesTitleRefusal(t *testing.T) {
 	if refused(nil) {
 		t.Error("nil is not a failure")
 	}
+	// The wording here used to say an unrecognised error must "stay recoverable so
+	// the route still degrades gracefully". That rationale died with BUG-2994: the
+	// route no longer degrades, it answers. The ASSERTION is unchanged and still
+	// load-bearing, for the reason underneath it — an unrecognised error must not be
+	// dressed up as a typed 4xx refusal, so it reaches writeInternalError and the
+	// caller is told the server failed rather than that the request was declined.
 	if refused(errors.New("transient prune failure")) {
-		t.Error("an unrecognised error must stay recoverable so the route still degrades gracefully")
+		t.Error("an unrecognised error must not be mapped to a typed refusal; it belongs to writeInternalError")
 	}
 
 	// The FIFTH arm. Before PLAN-2975 the applier path's row write fell through the

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -335,6 +335,20 @@ type Server struct {
 	// reconciliation end-to-end through the real handler.
 	restoreAckFault func() error
 
+	// directWritePruneFault is a TEST SEAM (always nil in production, BUG-2994).
+	// When non-nil, composePruneWithPrecheck invokes it in place of the op-log
+	// prune; a non-nil return is an untyped store error raised INSIDE the direct
+	// write's transaction, so the transaction rolls back and nothing is written.
+	//
+	// It exists because that error shape is the one the removed fall-through was
+	// WORST for and the one no other injection reaches: an honest rollback, no
+	// double write, but a second attempt that does NOT carry the prune — so the
+	// replay set items.content while the per-item op-log still held the ops the
+	// prune existed to remove. The ack-loss seam cannot produce it, and a test
+	// built only on that seam stays green if someone re-opens the fall-through
+	// for "non-commit" errors.
+	directWritePruneFault func() error
+
 	// watchPredicatesLoadFault is a TEST SEAM (always nil in production,
 	// TASK-2533). When non-nil, loadWatchPredicates calls it before
 	// touching the store; a non-nil return short-circuits the real

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -2888,7 +2888,15 @@ func (s *Store) updateItemWithParentLinkOnce(
 		return nil, err
 	}
 
-	if err := tx.Commit(); err != nil {
+	// Routed through the seam so a test can reproduce the ONE commit outcome
+	// this path must survive and cannot otherwise be shown: a transaction that
+	// durably landed whose acknowledgement was lost, which surfaces here as an
+	// ordinary error (BUG-2994). Nil in production, where this is tx.Commit().
+	commit := tx.Commit
+	if s.commitItemUpdate != nil {
+		commit = func() error { return s.commitItemUpdate(tx) }
+	}
+	if err := commit(); err != nil {
 		return nil, err
 	}
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -111,6 +111,24 @@ type Store struct {
 	// (codex round 3).
 	afterItemPreLockRead func(itemID string)
 
+	// commitItemUpdate is a TEST-ONLY seam, nil in production. When set,
+	// updateItemWithParentLinkOnce routes its final COMMIT through it instead
+	// of calling tx.Commit directly.
+	//
+	// It exists for BUG-2994, whose whole subject is the one outcome no other
+	// seam can produce: a transaction that DURABLY COMMITTED and whose
+	// tx.Commit() nevertheless reported an error, which is what Postgres does
+	// when the acknowledgement is lost at the connection boundary. A hook that
+	// calls tx.Commit itself and then returns a non-nil error reproduces that
+	// exactly — the effects are on disk, the caller is told they are not — and
+	// it does so without faking a commit the store never ran, which is the
+	// distinction that keeps the resulting test from being vacuous.
+	//
+	// Same usage constraint as the seams above: set it only while no other
+	// request is in flight against this Store. It fires once per ATTEMPT, so
+	// note that updateItemWithParentLinkOnce runs under retryOnParentSetChanged.
+	commitItemUpdate func(tx *sql.Tx) error
+
 	// afterDocumentPreLockRead is a TEST-ONLY seam, nil in production. When
 	// set, UpdateDocument calls it after its pre-transaction read and before
 	// it opens the transaction that takes the rename lock (BUG-2778) — the

--- a/internal/store/testing_helpers.go
+++ b/internal/store/testing_helpers.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"database/sql"
 	"fmt"
 	"strings"
 )
@@ -110,4 +111,27 @@ func traitUniquenessIndexDDL(driver DriverType) ([]string, error) {
 		return nil, fmt.Errorf("expected 2 CREATE UNIQUE INDEX statements in %s, found %d", path, len(out))
 	}
 	return out, nil
+}
+
+// SetItemUpdateCommitHookForTesting routes updateItemWithParentLinkOnce's final
+// COMMIT through hook for the lifetime of the returned restore function.
+//
+// It exists for BUG-2994. The defect is that an item update whose transaction
+// COMMITTED but whose tx.Commit() reported an error anyway — the Postgres
+// ack-loss shape — was written a second time by the handler above. Nothing else
+// in the tree can produce that outcome: every other failure injection makes the
+// commit actually fail, which is the case the code already handles.
+//
+// The honest hook calls tx.Commit() itself and returns a non-nil error on top,
+// so the transaction's effects really are durable and the caller really is told
+// they are not. A hook that returns an error WITHOUT committing is a different
+// (already-covered) case and will not exercise the double write.
+//
+// Production code MUST NOT call this. The "ForTesting" suffix is the grep
+// signal — any non-test caller is a bug. Set it only while no other request is
+// in flight against this Store.
+func (s *Store) SetItemUpdateCommitHookForTesting(hook func(tx *sql.Tx) error) (restore func()) {
+	prev := s.commitItemUpdate
+	s.commitItemUpdate = hook
+	return func() { s.commitItemUpdate = prev }
 }


### PR DESCRIPTION
A content PATCH whose store transaction COMMITTED but whose `tx.Commit()` reported an error anyway — the Postgres ack-loss shape — was written a SECOND time. The replay re-ran the open-children precheck against the row it had already changed, bumped the workspace seq again, and answered **200** about a first write whose outcome was never established.

Not introduced by PLAN-2975; the reorder moved the code and preserved the behaviour. Confirmed on `main` during TASK-2989 codex round 2.

## The path, enumerated rather than assumed

`handleUpdateItem` wrote twice iff `routeContentUpdate` returned `contentRouteFallThrough`, and that return had exactly one producer: the `settleDirectFailed` arm, reached when the direct write fails and `writeTypedItemRefusal` does not recognise the error. `PruneAndApply`'s own `ErrRoomActiveDuringPrune` is consumed by the settle loop before it can reach that arm.

The errors that DO reach it split three ways, and the split matters because the terminal conclusion rests on different reasons in each:

| bucket | where | state |
|---|---|---|
| pre-transaction | `GetItem`, `validateAssignmentScope`, `db.Begin` | nothing written |
| in-transaction | precheck, prune, the write itself | rolled back |
| the commit | `tx.Commit()` returned an error | **ambiguous** — a serialization failure wrote nothing, a lost ack means the row already changed, and nothing at this layer can tell them apart |

`retryOnParentSetChanged` was checked and cleared as a second site — all four raise sites are pre-commit.

## The fix

The direct write is terminal. No fall-through, and the error is answered with the same classification the ordinary path gives the same error — `writeTypedItemRefusal`'s five arms, then `writeInternalError`. **Parity, not a new refusal**: the two orderings now agree where they used to diverge.

`routeContentUpdate` no longer returns an error either (codex r2). It returned one alongside a response it had already written, and the caller could only discard it — a contract inviting a future caller to answer the same failure twice.

`BUG-2276` residual 1 / `ForceRefreshRoom`'s three-way reconcile was measured for fit, as the bug body proposes, and does not fit. That three-way exists because its success continuation consumes values the transaction produced (`boundary = MAX+1`, `restoredSeq`) and must recover them from durable stamps. This path has no continuation — it only picks a response — so the property is satisfied by deleting the second write.

### The cost, named

A one-shot transient failure in the first bucket used to get a second attempt that could answer 200, and now answers 500. That is exactly what the ordinary path already answers for the same error, so this makes the two orderings agree rather than singling this one out — but it is an availability change, not only a correctness fix.

## Second defect, same fall-through, folded in

The ordinary write does **not** carry `composePruneWithPrecheck`. So a rolled-back direct write fell through to a write that set `items.content` while the per-item op-log still held exactly the ops the prune existed to remove. `PruneAndApply` has already established under `appendMu` that no live writer holds the room, so those rows belong to departed peers and a reconnecting client replays them over the content just seeded. This is also why a "transient errors may still retry" carve-out would be unsafe. Given its own test, with its own seam.

## Instruments

Both tests were run against the unfixed tree and **failed** — the ack-loss one on both backends — and re-verified after round 2 changed the signature, since a green binds to the tree that produced it.

**Neither obvious instrument can tell ONE committed write from TWO**, and a test built on either passes against the defect. Both fail because the replayed write re-reads `existing` AFTER the first commit landed and finds every field already at its target value:

- `item_versions` rows — the INSERT is gated on `*input.Content != existing.Content`.
- the durable outbox `item.updated` row — gated on `itemUpdatedSliceChanged`.

(The handler's SSE publish is a *third* surface and behaves differently again: once per successful request, so zero on the fixed tree. That separates fixed from unfixed, but says nothing about how many times the row was written, which is the property. The comment history here is itself a finding — the first draft claimed "events don't discriminate" on the strength of reading one of the three.)

What discriminates: **committed transactions counted at the commit seam** — the property stated directly — and the status code.

The ack-loss seam is honest: it calls `tx.Commit()` for real and returns an error on top. An anti-vacuity leg re-reads the row and asserts the first transaction's effects are on disk; without it the test would pass against a seam that merely failed the commit, which is the case the code already handled. The prune seam mirrors `restoreAckFault`.

`testServer` is hardwired to `storetest.NewSQLite`, so the ack-loss test builds its own server per backend. Verified the Postgres leg RAN rather than skipped.

## Class sweep (CONVE-18)

Swept for the defect class — a store write retried after an error whose outcome is ambiguous. One other instance found and **filed separately as BUG-3026**: the cloud auto-create path retries `AddWorkspaceMember` once and, if the retry fails, soft-deletes the workspace. `workspace_members` is `PRIMARY KEY (workspace_id, user_id)` and the insert has no `ON CONFLICT`, so a lost ack lands the row, the retry hits the primary key, and the workspace is deleted *because the write succeeded*. Not fixed here; it is a different call site with a different fix.

Also checked and clean: the collab-snapshot branch writes once (`fullWriteHandled` guards the later write), and the version-restore path's two write sites are mutually exclusive branches.

## Residual, deliberately open

A commit-ack loss on the single remaining write is still ambiguous to the caller — 500 about a write that may have landed, and no SSE event. True on `main` today for every non-collab PATCH; not what this bug reports. Ruled out of scope.

## Gates

- `make test` — 0 FAIL
- `make test-pg` — exit 0, 0 FAIL, no NO-TESTS-EXECUTED banner, both new Postgres legs PASS (not SKIP)
- `make lint` — 0 issues; `gofmt` clean
- new tests under `-race -count=3` — clean, no data races
- codex rounds 1-3 (r1: 3 findings, r2: 5, r3: none)

Closes BUG-2994.

https://claude.ai/code/session_01PDYjP67KTAcqpFpo3ijAAA
