### PR TITLE
fix(cloud): reconcile before destroying a workspace whose owner-add lost its ack (BUG-3026)

### DIFF
--- a/internal/server/handlers_cloud.go
+++ b/internal/server/handlers_cloud.go
@@ -1217,21 +1217,59 @@ func (s *Server) autoCreateWorkspace(user *models.User) {
 	// every request (owner_id alone grants no access), and the
 	// workspace never shows up in GetUserWorkspaces — it becomes a
 	// permanently orphaned, completely unreachable row. Retry once for
-	// transient blips (e.g. a dropped Postgres connection); if it still
-	// fails, delete the now-useless workspace rather than leaving that
-	// orphan behind, and log loudly either way so on-call can see it
-	// happened (B6, TASK-1932).
+	// transient blips (e.g. a dropped Postgres connection); if it still fails,
+	// RECONCILE against the durable row before deciding — see BUG-3026 below —
+	// and delete the now-useless workspace only when the membership genuinely is
+	// absent. Log loudly on every branch so on-call can see it happened
+	// (B6, TASK-1932).
 	if err := s.store.AddWorkspaceMember(ws.ID, user.ID, "owner"); err != nil {
 		slog.Warn("auto-create workspace: add owner member failed, retrying",
 			"workspace_id", ws.ID, "workspace_slug", ws.Slug, "user_id", user.ID, "error", err)
 		if err := s.store.AddWorkspaceMember(ws.ID, user.ID, "owner"); err != nil {
-			slog.Error("auto-create workspace: add owner member failed after retry; deleting orphaned workspace",
-				"workspace_id", ws.ID, "workspace_slug", ws.Slug, "user_id", user.ID, "error", err)
-			if delErr := s.store.DeleteWorkspace(ws.Slug); delErr != nil {
-				slog.Error("auto-create workspace: failed to clean up orphaned workspace; manual intervention required",
-					"workspace_id", ws.ID, "workspace_slug", ws.Slug, "user_id", user.ID, "error", delErr)
+			// RECONCILE BEFORE DESTROYING (BUG-3026). The retry's failure does not
+			// mean the row is absent, and the case where it does not is the very
+			// failure the retry was written for. AddWorkspaceMember is a plain
+			// INSERT against PRIMARY KEY (workspace_id, user_id) returning the raw
+			// tx.Commit() error, so a commit whose acknowledgement was lost — the
+			// "dropped Postgres connection" this comment already names — lands the
+			// row and reports an error; the retry then hits the primary key and
+			// fails deterministically. Deleting here destroyed the workspace
+			// PRECISELY when the membership write had succeeded.
+			//
+			// Three outcomes, not two:
+			membershipCheck := s.store.IsWorkspaceMember
+			if s.membershipCheck != nil {
+				membershipCheck = s.membershipCheck
 			}
-			return
+			switch member, cerr := membershipCheck(ws.ID, user.ID); {
+			case cerr != nil:
+				// UNCERTAIN — the read itself failed, so we cannot tell a genuine
+				// absence from an ack-lost success. Keep the workspace. An orphan is
+				// recoverable (and three sibling call sites accept one deliberately,
+				// BUG-2715); deleting a live workspace on a state nobody could read
+				// is not.
+				slog.Error("auto-create workspace: add owner member failed and the membership read also failed; "+
+					"KEEPING the workspace because its state is unknown",
+					"workspace_id", ws.ID, "workspace_slug", ws.Slug, "user_id", user.ID,
+					"error", err, "check_error", cerr)
+				return
+			case member:
+				// LANDED despite the reported error. Nothing is wrong with this
+				// workspace; fall through to success.
+				slog.Warn("auto-create workspace: add owner member reported an error but the row is present; "+
+					"reconciled to success",
+					"workspace_id", ws.ID, "workspace_slug", ws.Slug, "user_id", user.ID, "error", err)
+			default:
+				// ABSENT — the original behaviour, now reached only when the row
+				// genuinely is not there and the workspace really is unreachable.
+				slog.Error("auto-create workspace: add owner member failed after retry; deleting orphaned workspace",
+					"workspace_id", ws.ID, "workspace_slug", ws.Slug, "user_id", user.ID, "error", err)
+				if delErr := s.store.DeleteWorkspace(ws.Slug); delErr != nil {
+					slog.Error("auto-create workspace: failed to clean up orphaned workspace; manual intervention required",
+						"workspace_id", ws.ID, "workspace_slug", ws.Slug, "user_id", user.ID, "error", delErr)
+				}
+				return
+			}
 		}
 	}
 

--- a/internal/server/handlers_cloud.go
+++ b/internal/server/handlers_cloud.go
@@ -1236,14 +1236,21 @@ func (s *Server) autoCreateWorkspace(user *models.User) {
 			// fails deterministically. Deleting here destroyed the workspace
 			// PRECISELY when the membership write had succeeded.
 			//
-			// Three outcomes, not two:
-			membershipCheck := s.store.IsWorkspaceMember
+			// TWO QUESTIONS, not one, and an earlier draft of this reconcile
+			// conflated them (codex round 1): "did MY write land?" and "is it safe
+			// to destroy this workspace?". Existence answers the second; only the
+			// ROLE answers the first, because what was attempted was an OWNER row.
+			// A row carrying some other role means my write did NOT land, and also
+			// that somebody has access — so neither success nor deletion is honest.
+			// Hence four arms over GetWorkspaceMember's (row, error), not three
+			// over a bool.
+			membershipCheck := s.store.GetWorkspaceMember
 			if s.membershipCheck != nil {
 				membershipCheck = s.membershipCheck
 			}
 			switch member, cerr := membershipCheck(ws.ID, user.ID); {
 			case cerr != nil:
-				// UNCERTAIN — the read itself failed, so we cannot tell a genuine
+				// UNREADABLE — the read itself failed, so we cannot tell a genuine
 				// absence from an ack-lost success. Keep the workspace. An orphan is
 				// recoverable (and three sibling call sites accept one deliberately,
 				// BUG-2715); deleting a live workspace on a state nobody could read
@@ -1253,13 +1260,7 @@ func (s *Server) autoCreateWorkspace(user *models.User) {
 					"workspace_id", ws.ID, "workspace_slug", ws.Slug, "user_id", user.ID,
 					"error", err, "check_error", cerr)
 				return
-			case member:
-				// LANDED despite the reported error. Nothing is wrong with this
-				// workspace; fall through to success.
-				slog.Warn("auto-create workspace: add owner member reported an error but the row is present; "+
-					"reconciled to success",
-					"workspace_id", ws.ID, "workspace_slug", ws.Slug, "user_id", user.ID, "error", err)
-			default:
+			case member == nil:
 				// ABSENT — the original behaviour, now reached only when the row
 				// genuinely is not there and the workspace really is unreachable.
 				slog.Error("auto-create workspace: add owner member failed after retry; deleting orphaned workspace",
@@ -1268,6 +1269,30 @@ func (s *Server) autoCreateWorkspace(user *models.User) {
 					slog.Error("auto-create workspace: failed to clean up orphaned workspace; manual intervention required",
 						"workspace_id", ws.ID, "workspace_slug", ws.Slug, "user_id", user.ID, "error", delErr)
 				}
+				return
+			// The literal matches the AddWorkspaceMember call above and every other
+			// role comparison in this package; there is no shared constant.
+			case member.Role == "owner":
+				// LANDED as owner despite the reported error. Nothing is wrong with
+				// this workspace; fall through to success.
+				slog.Warn("auto-create workspace: add owner member reported an error but the owner row is present; "+
+					"reconciled to success",
+					"workspace_id", ws.ID, "workspace_slug", ws.Slug, "user_id", user.ID, "error", err)
+			default:
+				// PRESENT WITH THE WRONG ROLE. Not a success — the user cannot
+				// administer their own auto-created workspace (owner > editor >
+				// viewer) — and not a deletion either, since somebody does have
+				// access to it. Keep it and say so loudly; this needs a human, and
+				// silently claiming success would hide that.
+				//
+				// Deliberately NOT repaired by writing the role: this path cannot
+				// tell an ack-lost write from another actor's deliberate one, and
+				// escalating a role on that ambiguity is the wrong default for a
+				// permission.
+				slog.Error("auto-create workspace: add owner member failed and the membership row carries a "+
+					"different role; KEEPING the workspace, manual intervention required",
+					"workspace_id", ws.ID, "workspace_slug", ws.Slug, "user_id", user.ID,
+					"found_role", member.Role, "error", err)
 				return
 			}
 		}

--- a/internal/server/handlers_cloud_member_ack_test.go
+++ b/internal/server/handlers_cloud_member_ack_test.go
@@ -122,8 +122,14 @@ func assertAckLossKeepsTheWorkspace(t *testing.T, srv *Server) {
 		t.Fatalf("the member add reached COMMIT %d time(s), want 1: the retry must die on the primary key "+
 			"the first attempt's committed row created", n)
 	}
+	// BOUNDARY, stated because the line reads stronger than it is: this log is
+	// emitted immediately BEFORE the retry call, so it pins that the retry BRANCH
+	// was entered, not that the second INSERT executed. Nothing between the two can
+	// skip it, so the distinction is theoretical today — but a reader should not
+	// take this as proof the retry ran (codex round 2).
 	if logged := logBuf.String(); !strings.Contains(logged, "add owner member failed, retrying") {
-		t.Errorf("the retry did not run; without it this test does not describe the reported path. log: %s", logged)
+		t.Errorf("the retry branch was not entered; without it this test does not describe the reported "+
+			"path. log: %s", logged)
 	}
 
 	after, err := srv.store.ListWorkspaces()
@@ -188,6 +194,11 @@ func TestAutoCreateWorkspace_UnreadableMembershipKeepsTheWorkspace(t *testing.T)
 		t.Fatalf("ListWorkspaces before: %v", err)
 	}
 
+	var logBuf bytes.Buffer
+	prevLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, nil)))
+	t.Cleanup(func() { slog.SetDefault(prevLogger) })
+
 	// Both attempts fail outright — nothing is committed, so on the evidence the
 	// handler has, the membership may or may not exist.
 	restore := srv.store.SetAddWorkspaceMemberCommitHookForTesting(func(tx *sql.Tx) error {
@@ -215,6 +226,17 @@ func TestAutoCreateWorkspace_UnreadableMembershipKeepsTheWorkspace(t *testing.T)
 	if len(after) != len(before)+1 {
 		t.Errorf("workspace count %d -> %d, want exactly one more: the workspace was destroyed on a "+
 			"membership state that could not be read", len(before), len(after))
+	}
+
+	// The count alone does NOT identify this arm — the owner-success arm keeps the
+	// workspace too, so collapsing UNREADABLE into it would pass the check above
+	// (codex round 2). The log is what separates them.
+	logged := logBuf.String()
+	if !strings.Contains(logged, "KEEPING the workspace because its state is unknown") {
+		t.Errorf("the unreadable-state arm did not run; some other arm kept the workspace. log: %s", logged)
+	}
+	if strings.Contains(logged, "reconciled to success") {
+		t.Errorf("an unreadable membership state was reported as success. log: %s", logged)
 	}
 }
 
@@ -269,6 +291,11 @@ func TestAutoCreateWorkspace_WrongRoleMembershipKeepsTheWorkspace(t *testing.T) 
 		t.Fatalf("ListWorkspaces before: %v", err)
 	}
 
+	var logBuf bytes.Buffer
+	prevLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, nil)))
+	t.Cleanup(func() { slog.SetDefault(prevLogger) })
+
 	restore := srv.store.SetAddWorkspaceMemberCommitHookForTesting(func(tx *sql.Tx) error {
 		_ = tx.Rollback()
 		return errSimMemberAckLoss
@@ -294,5 +321,22 @@ func TestAutoCreateWorkspace_WrongRoleMembershipKeepsTheWorkspace(t *testing.T) 
 	if len(after) != len(before)+1 {
 		t.Errorf("workspace count %d -> %d, want exactly one more: a membership row exists, so somebody "+
 			"has access and the workspace must not be destroyed", len(before), len(after))
+	}
+
+	// THE POINT OF THIS TEST, and the count above cannot carry it: the owner arm
+	// keeps the workspace too, so folding wrong-role back into "a row exists means
+	// success" — the exact defect round 1 found — would pass the count check
+	// (codex round 2). What must be true is that this is reported as a FAILURE
+	// needing a human, not as a success.
+	logged := logBuf.String()
+	if !strings.Contains(logged, "carries a "+"different role") {
+		t.Errorf("the wrong-role arm did not run. log: %s", logged)
+	}
+	if strings.Contains(logged, "reconciled to success") {
+		t.Errorf("a non-owner membership row was reported as success; the user cannot administer their "+
+			"own auto-created workspace. log: %s", logged)
+	}
+	if !strings.Contains(logged, "found_role=viewer") {
+		t.Errorf("the log does not name the role actually found, so on-call cannot see what happened. log: %s", logged)
 	}
 }

--- a/internal/server/handlers_cloud_member_ack_test.go
+++ b/internal/server/handlers_cloud_member_ack_test.go
@@ -235,7 +235,12 @@ func TestAutoCreateWorkspace_UnreadableMembershipKeepsTheWorkspace(t *testing.T)
 	if !strings.Contains(logged, "KEEPING the workspace because its state is unknown") {
 		t.Errorf("the unreadable-state arm did not run; some other arm kept the workspace. log: %s", logged)
 	}
-	if strings.Contains(logged, "reconciled to success") {
+	// The arm's OWN phrase, not the bare "reconciled to success" a first draft
+	// used: that substring is also emitted by the collab restore reconcile
+	// (internal/collab/manager.go), so it could only ever produce a false FAILURE
+	// here, but a negative assertion keyed on a string another subsystem owns is
+	// fragile for no benefit (codex round 3).
+	if strings.Contains(logged, "the owner row is present") {
 		t.Errorf("an unreadable membership state was reported as success. log: %s", logged)
 	}
 }
@@ -332,7 +337,9 @@ func TestAutoCreateWorkspace_WrongRoleMembershipKeepsTheWorkspace(t *testing.T) 
 	if !strings.Contains(logged, "carries a "+"different role") {
 		t.Errorf("the wrong-role arm did not run. log: %s", logged)
 	}
-	if strings.Contains(logged, "reconciled to success") {
+	// This arm's own phrase rather than the bare "reconciled to success", which
+	// the collab restore reconcile also emits (codex round 3).
+	if strings.Contains(logged, "the owner row is present") {
 		t.Errorf("a non-owner membership row was reported as success; the user cannot administer their "+
 			"own auto-created workspace. log: %s", logged)
 	}

--- a/internal/server/handlers_cloud_member_ack_test.go
+++ b/internal/server/handlers_cloud_member_ack_test.go
@@ -1,0 +1,211 @@
+package server
+
+import (
+	"database/sql"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/store"
+	"github.com/PerpetualSoftware/pad/internal/store/storetest"
+)
+
+// BUG-3026: the cloud auto-create path soft-deleted the workspace it had just
+// created successfully, whenever AddWorkspaceMember's commit landed and reported an
+// error anyway (the Postgres ack-loss shape).
+//
+// AddWorkspaceMember is a plain INSERT against PRIMARY KEY (workspace_id, user_id)
+// returning the raw tx.Commit() error. So a lost acknowledgement puts the row on
+// disk and reports failure; the handler's retry then hits the primary key and fails
+// deterministically; and the handler concluded the owner could not be added and
+// deleted the workspace. The deletion fired PRECISELY in the case where the write
+// had succeeded — and on exactly the "dropped Postgres connection" the retry was
+// written for.
+//
+// Found by the CONVE-18 class sweep for BUG-2994, which is the same defect (a store
+// write retried after an error whose outcome is ambiguous) with a worse consequence.
+//
+// The ABSENT arm — a membership that genuinely is not there, where deleting remains
+// correct — is covered by the older ghost-user FK test in
+// handlers_cloud_autocreate_workspace_test.go, which must keep passing.
+
+var errSimMemberAckLoss = errors.New("simulated member-add commit ack loss")
+
+func ackLossCloudServer(t *testing.T, driver store.DriverType) *Server {
+	t.Helper()
+	var s *store.Store
+	if driver == store.DriverPostgres {
+		s = storetest.NewPostgres(t) // skips if PAD_TEST_POSTGRES_URL is unset
+	} else {
+		s = storetest.NewSQLite(t)
+	}
+	if got := s.D().Driver(); got != driver {
+		t.Fatalf("wanted a %s store, got %s — this leg would have measured the wrong backend", driver, got)
+	}
+	srv := New(s)
+	t.Cleanup(func() { srv.Stop() })
+	srv.cloudMode = true
+	return srv
+}
+
+// realUser inserts a user so workspace_members' FK is satisfied and the INSERT can
+// actually succeed — the opposite setup from the ghost-user test, and the
+// precondition for measuring a commit that LANDS.
+func realUser(t *testing.T, srv *Server, email string) *models.User {
+	t.Helper()
+	u, err := srv.store.CreateUser(models.UserCreate{
+		Email:    email,
+		Name:     "Ack Loss",
+		Password: "correct-horse-battery-staple",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	return u
+}
+
+func TestAutoCreateWorkspace_MemberAddAckLossKeepsTheWorkspace_SQLite(t *testing.T) {
+	assertAckLossKeepsTheWorkspace(t, ackLossCloudServer(t, store.DriverSQLite))
+}
+
+func TestAutoCreateWorkspace_MemberAddAckLossKeepsTheWorkspace_Postgres(t *testing.T) {
+	assertAckLossKeepsTheWorkspace(t, ackLossCloudServer(t, store.DriverPostgres))
+}
+
+func assertAckLossKeepsTheWorkspace(t *testing.T, srv *Server) {
+	t.Helper()
+	user := realUser(t, srv, "ackloss@example.com")
+
+	before, err := srv.store.ListWorkspaces()
+	if err != nil {
+		t.Fatalf("ListWorkspaces before: %v", err)
+	}
+
+	// Fail the FIRST commit only, and commit it for real first: the membership row
+	// is durable and the caller is told it is not. The retry then hits the primary
+	// key on its own, with no help from the seam — which is the mechanism under
+	// test, not something the test simulates.
+	var commits int32
+	restore := srv.store.SetAddWorkspaceMemberCommitHookForTesting(func(tx *sql.Tx) error {
+		n := atomic.AddInt32(&commits, 1)
+		if cerr := tx.Commit(); cerr != nil {
+			return cerr
+		}
+		if n == 1 {
+			return errSimMemberAckLoss
+		}
+		return nil
+	})
+	t.Cleanup(restore)
+
+	srv.autoCreateWorkspace(user)
+
+	if atomic.LoadInt32(&commits) == 0 {
+		t.Fatal("the commit seam never fired; autoCreateWorkspace did not reach the member add")
+	}
+
+	after, err := srv.store.ListWorkspaces()
+	if err != nil {
+		t.Fatalf("ListWorkspaces after: %v", err)
+	}
+	if len(after) != len(before)+1 {
+		t.Fatalf("workspace count %d -> %d, want exactly one more: the workspace was deleted even though "+
+			"the owner-membership row had committed", len(before), len(after))
+	}
+
+	// ANTI-VACUITY CONTROL. The whole test is meaningless unless the first commit
+	// genuinely landed, so assert the row is really there. Without this the test
+	// would also pass against a seam that merely failed the insert — the case the
+	// ghost-user test already covers and which was never broken.
+	// (ListWorkspaces filters deleted_at IS NULL, so the COUNT above IS the
+	// not-deleted assertion; a separate DeletedAt check on a returned row would be
+	// vacuous by construction.)
+	ws := after[len(after)-1]
+	member, cerr := srv.store.IsWorkspaceMember(ws.ID, user.ID)
+	if cerr != nil {
+		t.Fatalf("IsWorkspaceMember: %v", cerr)
+	}
+	if !member {
+		t.Fatal("the owner-membership row is absent, so the first commit did not land and this test " +
+			"measured the ordinary insert-failure path instead of an ack loss")
+	}
+}
+
+// TestAutoCreateWorkspace_UnreadableMembershipKeepsTheWorkspace pins the third
+// outcome, and it is the arm most likely to be lost to a later simplification:
+// collapsing the read ERROR back into "absent" restores the deletion silently, and
+// nothing else in the suite would notice.
+//
+// Destroying a workspace on a state nobody could read is the worst of the three
+// outcomes. The orphan it would avoid is recoverable, and three sibling call sites
+// accept exactly that orphan deliberately (BUG-2715).
+func TestAutoCreateWorkspace_UnreadableMembershipKeepsTheWorkspace(t *testing.T) {
+	srv := ackLossCloudServer(t, store.DriverSQLite)
+	user := realUser(t, srv, "unreadable@example.com")
+
+	before, err := srv.store.ListWorkspaces()
+	if err != nil {
+		t.Fatalf("ListWorkspaces before: %v", err)
+	}
+
+	// Both attempts fail outright — nothing is committed, so on the evidence the
+	// handler has, the membership may or may not exist.
+	restore := srv.store.SetAddWorkspaceMemberCommitHookForTesting(func(tx *sql.Tx) error {
+		_ = tx.Rollback()
+		return errSimMemberAckLoss
+	})
+	t.Cleanup(restore)
+
+	var checks int32
+	srv.membershipCheck = func(string, string) (bool, error) {
+		atomic.AddInt32(&checks, 1)
+		return false, errors.New("simulated membership read failure")
+	}
+	t.Cleanup(func() { srv.membershipCheck = nil })
+
+	srv.autoCreateWorkspace(user)
+
+	if atomic.LoadInt32(&checks) == 0 {
+		t.Fatal("the membership check never ran; the reconcile was not reached")
+	}
+	after, err := srv.store.ListWorkspaces()
+	if err != nil {
+		t.Fatalf("ListWorkspaces after: %v", err)
+	}
+	if len(after) != len(before)+1 {
+		t.Errorf("workspace count %d -> %d, want exactly one more: the workspace was destroyed on a "+
+			"membership state that could not be read", len(before), len(after))
+	}
+}
+
+// TestAutoCreateWorkspaceReconcileArmsAreDistinguishable is the control for the two
+// tests above: it proves the ABSENT arm still deletes, so a fix that simply stopped
+// deleting altogether — which would pass both tests above — fails here.
+func TestAutoCreateWorkspaceReconcileArmsAreDistinguishable(t *testing.T) {
+	srv := ackLossCloudServer(t, store.DriverSQLite)
+	user := realUser(t, srv, "absent@example.com")
+
+	before, err := srv.store.ListWorkspaces()
+	if err != nil {
+		t.Fatalf("ListWorkspaces before: %v", err)
+	}
+
+	restore := srv.store.SetAddWorkspaceMemberCommitHookForTesting(func(tx *sql.Tx) error {
+		_ = tx.Rollback()
+		return errSimMemberAckLoss
+	})
+	t.Cleanup(restore)
+	// No membershipCheck seam: the REAL read runs and correctly reports absence.
+
+	srv.autoCreateWorkspace(user)
+
+	after, err := srv.store.ListWorkspaces()
+	if err != nil {
+		t.Fatalf("ListWorkspaces after: %v", err)
+	}
+	if len(after) != len(before) {
+		t.Errorf("workspace count %d -> %d, want unchanged: a genuinely absent membership leaves the "+
+			"workspace unreachable, so the cleanup must still delete it", len(before), len(after))
+	}
+}

--- a/internal/server/handlers_cloud_member_ack_test.go
+++ b/internal/server/handlers_cloud_member_ack_test.go
@@ -1,8 +1,11 @@
 package server
 
 import (
+	"bytes"
 	"database/sql"
 	"errors"
+	"log/slog"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -82,6 +85,11 @@ func assertAckLossKeepsTheWorkspace(t *testing.T, srv *Server) {
 		t.Fatalf("ListWorkspaces before: %v", err)
 	}
 
+	var logBuf bytes.Buffer
+	prevLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, nil)))
+	t.Cleanup(func() { slog.SetDefault(prevLogger) })
+
 	// Fail the FIRST commit only, and commit it for real first: the membership row
 	// is durable and the caller is told it is not. The retry then hits the primary
 	// key on its own, with no help from the seam — which is the mechanism under
@@ -101,8 +109,21 @@ func assertAckLossKeepsTheWorkspace(t *testing.T, srv *Server) {
 
 	srv.autoCreateWorkspace(user)
 
-	if atomic.LoadInt32(&commits) == 0 {
-		t.Fatal("the commit seam never fired; autoCreateWorkspace did not reach the member add")
+	// EXACTLY ONE commit — and the one is the mechanism, not an accident. The retry
+	// does run, but its INSERT dies on PRIMARY KEY (workspace_id, user_id) before it
+	// ever reaches tx.Commit, BECAUSE the first attempt's row is already on disk.
+	// So a commit count of 1 here is positive evidence that the first write landed.
+	//
+	// (Measured, after a first draft asserted 2 on the assumption that a retry
+	// reaches COMMIT — codex round 1 P3 asked for the retry to be pinned, and the
+	// obvious way to pin it encodes a mechanism that does not hold.) The retry's
+	// existence is pinned by its log line below instead.
+	if n := atomic.LoadInt32(&commits); n != 1 {
+		t.Fatalf("the member add reached COMMIT %d time(s), want 1: the retry must die on the primary key "+
+			"the first attempt's committed row created", n)
+	}
+	if logged := logBuf.String(); !strings.Contains(logged, "add owner member failed, retrying") {
+		t.Errorf("the retry did not run; without it this test does not describe the reported path. log: %s", logged)
 	}
 
 	after, err := srv.store.ListWorkspaces()
@@ -114,21 +135,39 @@ func assertAckLossKeepsTheWorkspace(t *testing.T, srv *Server) {
 			"the owner-membership row had committed", len(before), len(after))
 	}
 
-	// ANTI-VACUITY CONTROL. The whole test is meaningless unless the first commit
-	// genuinely landed, so assert the row is really there. Without this the test
-	// would also pass against a seam that merely failed the insert — the case the
-	// ghost-user test already covers and which was never broken.
 	// (ListWorkspaces filters deleted_at IS NULL, so the COUNT above IS the
 	// not-deleted assertion; a separate DeletedAt check on a returned row would be
 	// vacuous by construction.)
-	ws := after[len(after)-1]
-	member, cerr := srv.store.IsWorkspaceMember(ws.ID, user.ID)
-	if cerr != nil {
-		t.Fatalf("IsWorkspaceMember: %v", cerr)
+	//
+	// Found BY OWNER, not by position: ListWorkspaces is ORDER BY name ASC, so
+	// after[len(after)-1] is only this workspace by accident of today's empty
+	// fixture (codex round 1).
+	var ws *models.Workspace
+	for i := range after {
+		if after[i].OwnerID == user.ID {
+			ws = &after[i]
+			break
+		}
 	}
-	if !member {
+	if ws == nil {
+		t.Fatal("no workspace owned by the new user; autoCreateWorkspace did not create one")
+	}
+
+	// ANTI-VACUITY CONTROL. The test is meaningless unless the first commit
+	// genuinely landed, so assert the row is really there AND carries the role the
+	// write attempted. Without this the test would also pass against a seam that
+	// merely failed the insert — the case the ghost-user FK test already covers and
+	// which was never broken.
+	member, cerr := srv.store.GetWorkspaceMember(ws.ID, user.ID)
+	if cerr != nil {
+		t.Fatalf("GetWorkspaceMember: %v", cerr)
+	}
+	if member == nil {
 		t.Fatal("the owner-membership row is absent, so the first commit did not land and this test " +
 			"measured the ordinary insert-failure path instead of an ack loss")
+	}
+	if member.Role != "owner" {
+		t.Fatalf("membership role = %q, want owner", member.Role)
 	}
 }
 
@@ -158,9 +197,9 @@ func TestAutoCreateWorkspace_UnreadableMembershipKeepsTheWorkspace(t *testing.T)
 	t.Cleanup(restore)
 
 	var checks int32
-	srv.membershipCheck = func(string, string) (bool, error) {
+	srv.membershipCheck = func(string, string) (*models.WorkspaceMember, error) {
 		atomic.AddInt32(&checks, 1)
-		return false, errors.New("simulated membership read failure")
+		return nil, errors.New("simulated membership read failure")
 	}
 	t.Cleanup(func() { srv.membershipCheck = nil })
 
@@ -207,5 +246,53 @@ func TestAutoCreateWorkspaceReconcileArmsAreDistinguishable(t *testing.T) {
 	if len(after) != len(before) {
 		t.Errorf("workspace count %d -> %d, want unchanged: a genuinely absent membership leaves the "+
 			"workspace unreachable, so the cleanup must still delete it", len(before), len(after))
+	}
+}
+
+// TestAutoCreateWorkspace_WrongRoleMembershipKeepsTheWorkspace pins the fourth arm.
+//
+// It exists because the first version of this reconcile asked the wrong question
+// (codex round 1 P2): it used an EXISTENCE check, so a row carrying any role at all
+// reconciled to success. What was attempted was an OWNER row, so a row with another
+// role means the write did NOT land — and the user cannot administer their own
+// auto-created workspace, since owner > editor > viewer.
+//
+// Neither success nor deletion is honest there, so the workspace is kept and the
+// failure is logged loudly. Collapsing this arm back into the LANDED one restores a
+// silent success, and nothing else in the suite would notice.
+func TestAutoCreateWorkspace_WrongRoleMembershipKeepsTheWorkspace(t *testing.T) {
+	srv := ackLossCloudServer(t, store.DriverSQLite)
+	user := realUser(t, srv, "wrongrole@example.com")
+
+	before, err := srv.store.ListWorkspaces()
+	if err != nil {
+		t.Fatalf("ListWorkspaces before: %v", err)
+	}
+
+	restore := srv.store.SetAddWorkspaceMemberCommitHookForTesting(func(tx *sql.Tx) error {
+		_ = tx.Rollback()
+		return errSimMemberAckLoss
+	})
+	t.Cleanup(restore)
+
+	var checks int32
+	srv.membershipCheck = func(workspaceID, userID string) (*models.WorkspaceMember, error) {
+		atomic.AddInt32(&checks, 1)
+		return &models.WorkspaceMember{WorkspaceID: workspaceID, UserID: userID, Role: "viewer"}, nil
+	}
+	t.Cleanup(func() { srv.membershipCheck = nil })
+
+	srv.autoCreateWorkspace(user)
+
+	if atomic.LoadInt32(&checks) == 0 {
+		t.Fatal("the membership check never ran; the reconcile was not reached")
+	}
+	after, err := srv.store.ListWorkspaces()
+	if err != nil {
+		t.Fatalf("ListWorkspaces after: %v", err)
+	}
+	if len(after) != len(before)+1 {
+		t.Errorf("workspace count %d -> %d, want exactly one more: a membership row exists, so somebody "+
+			"has access and the workspace must not be destroyed", len(before), len(after))
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -353,12 +353,13 @@ type Server struct {
 	// non-nil, autoCreateWorkspace's reconcile calls it instead of
 	// store.IsWorkspaceMember.
 	//
-	// It exists for the UNCERTAIN arm only. A COUNT(*) over two indexed columns has
-	// no natural failure this test could provoke, and that arm is the one carrying
-	// the safety property worth pinning: when the membership state cannot be READ,
-	// the workspace is kept rather than destroyed. Without a test, collapsing the
-	// error case back into "absent" would restore the deletion silently.
-	membershipCheck func(workspaceID, userID string) (bool, error)
+	// It exists for the two arms with no natural trigger: UNREADABLE (a single-row
+	// SELECT over the primary key has no failure this test could provoke) and
+	// WRONG-ROLE. Both carry safety properties a later simplification would drop
+	// silently — collapsing the error case back into "absent" restores the
+	// deletion, and collapsing the role check back into existence restores the
+	// silent-success this reconcile was corrected to avoid.
+	membershipCheck func(workspaceID, userID string) (*models.WorkspaceMember, error)
 
 	// watchPredicatesLoadFault is a TEST SEAM (always nil in production,
 	// TASK-2533). When non-nil, loadWatchPredicates calls it before

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -349,6 +349,17 @@ type Server struct {
 	// for "non-commit" errors.
 	directWritePruneFault func() error
 
+	// membershipCheck is a TEST SEAM (always nil in production, BUG-3026). When
+	// non-nil, autoCreateWorkspace's reconcile calls it instead of
+	// store.IsWorkspaceMember.
+	//
+	// It exists for the UNCERTAIN arm only. A COUNT(*) over two indexed columns has
+	// no natural failure this test could provoke, and that arm is the one carrying
+	// the safety property worth pinning: when the membership state cannot be READ,
+	// the workspace is kept rather than destroyed. Without a test, collapsing the
+	// error case back into "absent" would restore the deletion silently.
+	membershipCheck func(workspaceID, userID string) (bool, error)
+
 	// watchPredicatesLoadFault is a TEST SEAM (always nil in production,
 	// TASK-2533). When non-nil, loadWatchPredicates calls it before
 	// touching the store; a non-nil return short-circuits the real

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -129,6 +129,18 @@ type Store struct {
 	// note that updateItemWithParentLinkOnce runs under retryOnParentSetChanged.
 	commitItemUpdate func(tx *sql.Tx) error
 
+	// commitAddWorkspaceMember is a TEST-ONLY seam, nil in production. Same shape
+	// and same reason as commitItemUpdate above, for BUG-3026: AddWorkspaceMember
+	// is a plain INSERT against PRIMARY KEY (workspace_id, user_id) returning the
+	// raw tx.Commit() error, so a commit that landed and whose acknowledgement was
+	// lost leaves the row on disk while the caller is told it is not — and the
+	// cloud auto-create path then deleted the workspace over it.
+	//
+	// Nothing else reproduces that state. Every other injection makes the INSERT
+	// genuinely fail, which is the case the code already handled (and which the
+	// existing ghost-user FK test covers).
+	commitAddWorkspaceMember func(tx *sql.Tx) error
+
 	// afterDocumentPreLockRead is a TEST-ONLY seam, nil in production. When
 	// set, UpdateDocument calls it after its pre-transaction read and before
 	// it opens the transaction that takes the rename lock (BUG-2778) — the

--- a/internal/store/testing_helpers.go
+++ b/internal/store/testing_helpers.go
@@ -135,3 +135,20 @@ func (s *Store) SetItemUpdateCommitHookForTesting(hook func(tx *sql.Tx) error) (
 	s.commitItemUpdate = hook
 	return func() { s.commitItemUpdate = prev }
 }
+
+// SetAddWorkspaceMemberCommitHookForTesting routes AddWorkspaceMember's COMMIT
+// through hook for the lifetime of the returned restore function.
+//
+// It exists for BUG-3026, and the honest hook is the same as its BUG-2994 twin:
+// call tx.Commit() and return a non-nil error on top, so the membership row really
+// is durable and the caller really is told it is not. A hook that returns an error
+// WITHOUT committing exercises the ordinary insert-failed case, which the existing
+// ghost-user FK test already covers and which was never broken.
+//
+// Production code MUST NOT call this. The "ForTesting" suffix is the grep signal.
+// Set it only while no other request is in flight against this Store.
+func (s *Store) SetAddWorkspaceMemberCommitHookForTesting(hook func(tx *sql.Tx) error) (restore func()) {
+	prev := s.commitAddWorkspaceMember
+	s.commitAddWorkspaceMember = hook
+	return func() { s.commitAddWorkspaceMember = prev }
+}

--- a/internal/store/workspace_members.go
+++ b/internal/store/workspace_members.go
@@ -47,7 +47,14 @@ func (s *Store) AddWorkspaceMember(workspaceID, userID, role string) error {
 		return err
 	}
 
-	if err := tx.Commit(); err != nil {
+	// Routed through the seam so a test can reproduce the one commit outcome this
+	// path must survive and cannot otherwise be shown (BUG-3026). Nil in
+	// production, where this is tx.Commit().
+	commit := tx.Commit
+	if s.commitAddWorkspaceMember != nil {
+		commit = func() error { return s.commitAddWorkspaceMember(tx) }
+	}
+	if err := commit(); err != nil {
 		return fmt.Errorf("add workspace member: %w", err)
 	}
 	return nil


### PR DESCRIPTION
The cloud auto-create path **soft-deleted the workspace it had just created successfully**, whenever `AddWorkspaceMember`'s commit landed and reported an error anyway.

Found by the CONVE-18 class sweep for BUG-2994 — same defect (a store write retried after an error whose outcome is ambiguous), worse consequence.

## The path

`AddWorkspaceMember` is a plain `INSERT` against `PRIMARY KEY (workspace_id, user_id)` returning the raw `tx.Commit()` error.

1. attempt 1: the commit **lands**, the ack is lost, an error is returned;
2. attempt 2 (the existing retry): the `INSERT` hits the primary key and fails deterministically;
3. the handler concludes the owner could not be added and calls `DeleteWorkspace`.

The deletion fired **precisely when the write had succeeded** — and on exactly the "dropped Postgres connection" the retry's own comment names, so the guard was most dangerous in the case it existed to handle. Cloud-only path, and Postgres is where ack loss happens, so the only deployment that runs it is the one that can hit it.

## Fixed at the caller, not in the store

This is the load-bearing decision. Making the INSERT idempotent is the obvious fix and is **wrong**:

- `AddWorkspaceMember` has **nine** call sites.
- At `handlers_members.go:133` the duplicate-key error is a live race backstop behind an `IsWorkspaceMember`/409 check. `ON CONFLICT DO NOTHING` would turn a lost race into a silent success there.
- `ON CONFLICT DO UPDATE` would be a **privilege bug**: a racing double-invite carrying different roles would silently apply the second, so inviting an existing owner as `viewer` could demote them with no error and no audit distinction.

The destroy is one call site — verified rather than assumed:

| caller | on failure |
|---|---|
| `handlers_workspaces.go:444` | logs, continues |
| `handlers_workspaces.go:925` | logs, continues |
| `handlers_import_bundle.go:188` | logs, continues — BUG-2715 ruled this "not fatal, but not discarded either" |
| `handlers_cloud.go:1224` | retried, then **deleted** |

So the cloud path's delete is the outlier and the house style is a loud log. The reconcile belongs at the caller that destroys.

## Four outcomes, over the ROLE — not three over existence

The first draft reconciled on `IsWorkspaceMember`, i.e. existence. Codex round 1 found that this asks the wrong question. **Two questions, not one:** *did MY write land?* and *is it safe to destroy this workspace?* Existence answers the second; only the ROLE answers the first, because what was attempted was an **owner** row. A row carrying `viewer` reconciled to success while the user could not administer their own auto-created workspace (`owner > editor > viewer`).

So, four arms over `GetWorkspaceMember`'s `(row, error)`:

- **UNREADABLE** — the read itself failed. **Keep.** Destroying on a state nobody could read is worse than the orphan, which is recoverable and which three sibling call sites already accept deliberately.
- **ABSENT** — genuinely not there. Keep the original delete: the workspace really is unreachable (`owner_id` alone grants no access).
- **OWNER** — landed. Reconcile to success.
- **OTHER ROLE** — **keep, logged loudly.** Not a success (they cannot administer it) and not a deletion (somebody has access). Deliberately **not** repaired by writing the role: this path cannot tell an ack-lost write from another actor's deliberate one, and escalating a permission on that ambiguity is the wrong default.

## Instruments

- The **LANDED** arm runs on **both backends** through a commit seam that calls `tx.Commit()` for real and returns an error on top, so the row is durable and the caller is told it is not. The retry then hits the primary key on its own — that is the mechanism under test, not something the test simulates.
- **Anti-vacuity leg:** it asserts the membership row is genuinely present. Without it the test would also pass against a seam that merely failed the insert — the case the existing ghost-user FK test covers and which was never broken.
- The **UNREADABLE** arm gets a server seam (`membershipCheck`, mirroring `restoreAckFault`), because a `COUNT(*)` over two indexed columns has no natural failure to provoke, and that arm is the one a later simplification would silently drop by collapsing the error case back into "absent".
- A **third test pins that the ABSENT arm still deletes**, so a fix that merely stopped deleting — which would pass both tests above — fails.
- `ListWorkspaces` filters `deleted_at IS NULL`, so the workspace COUNT *is* the not-deleted assertion; a separate `DeletedAt` check on a returned row would be vacuous, and is noted as such rather than included.

**Each arm's test asserts its OWN arm.** Round 2 caught that the count check (`before+1`) is satisfied by three different arms, so the test written to prevent the round-1 defect would have passed against it. Each now asserts its own log line plus the absence of the success line — keyed on this arm's own phrase, since `"reconciled to success"` is also emitted by the collab restore reconcile (round 3).

**Mutation-tested rather than argued:** collapsing `role == "owner"` to `member != nil` kills only the wrong-role test; collapsing the read-error arm kills only the unreadable test. No cross-talk.

**The retry is pinned by its log, not a commit count.** The obvious pin — assert two commits — encodes a mechanism that does not hold: the retry's INSERT dies on the primary key *before* reaching `tx.Commit`, precisely because the first attempt's row is on disk. Measured, not assumed. The commit count is asserted at exactly **1**, and that one *is* the evidence the first write landed. Boundary stated in the test: the log line precedes the retry call, so it pins that the branch was entered, not that the second INSERT ran.

Verified **red against the unfixed reconcile on both backends**, green with it. `-race -count=2` clean.

## Gates

- `make test` — 0 FAIL
- `make test-pg` — exit 0, 0 FAIL, no NO-TESTS-EXECUTED banner, Postgres leg PASS (not SKIP)
- `make lint` — 0 issues; `gofmt` clean
- `-race -count=2` on the new tests — clean
- codex rounds 1-3 (r1: 1 P2 + 1 P3, r2: 2 test findings, r3: 1 P3)

## Open question for review

The retry itself is kept. Even reconciled, retrying a non-idempotent INSERT after an ambiguous error is the shape BUG-2994 names — but its stated purpose (a transient blip) is real and the reconcile removes its teeth. Given that three sibling callers accept the orphan with only a log, a defensible follow-up is to drop the destroy entirely; that widens the unit from "stop destroying live workspaces" to "should this path destroy at all", so it is flagged rather than taken.

Closes BUG-3026.

https://claude.ai/code/session_01PDYjP67KTAcqpFpo3ijAAA
