### PR TITLE
feat(items): content_state marks a body the server knows is stale (BUG-3000)

### DIFF
--- a/cmd/pad/cmd_item.go
+++ b/cmd/pad/cmd_item.go
@@ -758,6 +758,7 @@ func showCmd() *cobra.Command {
 				// it captures, `cat` included, before and after this change.)
 				// The human-facing surface is the default table format
 				// below, which still ends the body with a newline.
+				warnContentStale(item)
 				fmt.Print(item.Content)
 				return nil
 			}
@@ -792,6 +793,7 @@ func showCmd() *cobra.Command {
 			}
 
 			if item.Content != "" {
+				warnContentStale(item)
 				fmt.Println(item.Content)
 			}
 
@@ -3823,6 +3825,28 @@ func warnUndeclaredFields(item *models.Item) {
 		strings.Join(item.Warnings.UndeclaredFields, ", "))
 }
 
+// warnContentStale prints one line to STDERR when a READ served a body the server
+// knows is behind the item's live collaborative document (BUG-3000).
+//
+// The write-side twin above tells a caller that ITS OWN write has not reached the
+// row. This one is the other half, and it fires for a caller who wrote nothing: the
+// row can be behind because someone else's tab holds unflushed edits, and a read has
+// no way to notice that from the content alone.
+//
+// Stderr for the same reason as every other warning here — `--format json` and the
+// raw-content dump are both piped, and a line on stdout would corrupt them. That
+// matters more on this path than on the write path, because `pad item show
+// --format markdown` exists precisely to be redirected into a file.
+func warnContentStale(item *models.Item) {
+	if item == nil || item.ContentState != models.ContentOutcomeAppliedPendingFlush {
+		return
+	}
+	fmt.Fprintln(os.Stderr, "warning: this item's stored content is behind its live collaborative "+
+		"document — an editor holds edits that have not been written back yet, so what follows is "+
+		"the previous content. It catches up when a tab next flushes the item, and nothing on the "+
+		"server forces that to happen.")
+}
+
 // warnContentPendingFlush prints one line to STDERR when a content write reached
 // the collaborative document but not yet items.content (BUG-2995).
 //
@@ -3835,9 +3859,13 @@ func warnUndeclaredFields(item *models.Item) {
 // Stderr for warnUndeclaredFields's reason: --format json output is piped into
 // scripts and a warning on stdout would corrupt the JSON they parse.
 //
-// It deliberately states no duration. It is not established that the flush
-// always lands — see BUG-3000 — so a number here would be a claim this command
-// cannot support.
+// It deliberately states no duration, and BUG-3000's day-64 measurement is why
+// that must stay: the flush is NOT guaranteed to land at all. Nothing server-side
+// moves applier content into items.content — the op-log GC's flush-coverage guard
+// deliberately retains those rows rather than flushing them — so the row catches up
+// only when a tab next opens the item. Any number here would be a claim this
+// command cannot support. (This comment previously said the question was "not
+// established"; it now is.)
 func warnContentPendingFlush(item *models.Item) {
 	if item == nil || item.Warnings == nil {
 		return

--- a/cmd/pad/cmd_item.go
+++ b/cmd/pad/cmd_item.go
@@ -792,8 +792,12 @@ func showCmd() *cobra.Command {
 				}
 			}
 
+			// Before the empty-body check, not inside it: an item whose STORED
+			// body is empty while its document holds the real text is exactly
+			// this bug's shape, and it is the case where a reader has least to
+			// go on — they see nothing at all (codex round 3).
+			warnContentStale(item)
 			if item.Content != "" {
-				warnContentStale(item)
 				fmt.Println(item.Content)
 			}
 

--- a/internal/cli/item_summary.go
+++ b/internal/cli/item_summary.go
@@ -35,10 +35,15 @@ type ItemSummary struct {
 	Tags           json.RawMessage `json:"tags,omitempty"`
 	Pinned         bool            `json:"pinned,omitempty"`
 	ContentPreview string          `json:"content_preview,omitempty"`
-	ParentRef      string          `json:"parent_ref,omitempty"`
-	AssignedUser   string          `json:"assigned_user,omitempty"`
-	AgentRole      string          `json:"agent_role,omitempty"`
-	HasChildren    bool            `json:"has_children,omitempty"`
+	// ContentState rides the PREVIEW for the same reason it rides the full body
+	// (BUG-3000): a preview is content, so a stale row yields a stale preview and
+	// a consumer reading only this shape would otherwise have no signal at all.
+	// Same values as models.Item.ContentState; omitted when the row is current.
+	ContentState string `json:"content_state,omitempty"`
+	ParentRef    string `json:"parent_ref,omitempty"`
+	AssignedUser string `json:"assigned_user,omitempty"`
+	AgentRole    string `json:"agent_role,omitempty"`
+	HasChildren  bool   `json:"has_children,omitempty"`
 
 	// RelationTargets carries the hydrated `relation` values (PLAN-2857 U6).
 	//
@@ -125,6 +130,7 @@ func ToItemSummary(item models.Item) ItemSummary {
 		Tags:            rawJSONOrNil(item.Tags),
 		Pinned:          item.Pinned,
 		ContentPreview:  contentPreview(item.Content),
+		ContentState:    item.ContentState,
 		ParentRef:       item.ParentRef,
 		AssignedUser:    item.AssignedUserName,
 		AgentRole:       item.AgentRoleSlug,

--- a/internal/models/item.go
+++ b/internal/models/item.go
@@ -181,13 +181,36 @@ func ReservedItemFieldKeys() []string {
 }
 
 type Item struct {
-	ID             string     `json:"id"`
-	WorkspaceID    string     `json:"workspace_id"`
-	CollectionID   string     `json:"collection_id"`
-	Title          string     `json:"title"`
-	Slug           string     `json:"slug"`
-	Ref            string     `json:"ref,omitempty"` // computed: e.g. "TASK-5", "BUG-8"
-	Content        string     `json:"content"`
+	ID           string `json:"id"`
+	WorkspaceID  string `json:"workspace_id"`
+	CollectionID string `json:"collection_id"`
+	Title        string `json:"title"`
+	Slug         string `json:"slug"`
+	Ref          string `json:"ref,omitempty"` // computed: e.g. "TASK-5", "BUG-8"
+	Content      string `json:"content"`
+
+	// ContentState reports that the `Content` above is known to be BEHIND the
+	// item's live collaborative document (BUG-3000). Empty — and so omitted —
+	// whenever the row is current, which is the overwhelmingly common case, so a
+	// consumer that does not know this field sees byte-identical responses.
+	//
+	// It takes the same values as ItemWriteWarnings.ContentOutcome, deliberately:
+	// a caller should have ONE story about where content is, whether it learned it
+	// from a write response or from a read. The name differs because a write
+	// warning describes what a REQUEST did, while this describes what the ROW is.
+	//
+	// The predicate is "the op-log holds a row above items.content_flushed_op_log_id",
+	// i.e. the document is ahead of the row. That is deliberately broader than "an
+	// applier-path API write is pending flush": it also covers a user typing in an
+	// open tab whose edits have not flushed. Both serve stale content, the row does
+	// not record WHY the op-log is ahead, and the narrow reading is therefore not
+	// expressible — see the BUG-3000 trail.
+	//
+	// It is emitted ONLY where a real `content` value is, and is built alongside
+	// that column for exactly that reason: a query selecting an empty-string literal
+	// for content must not claim its empty body is stale.
+	ContentState string `json:"content_state,omitempty"`
+
 	Fields         string     `json:"fields"` // JSON string
 	Tags           string     `json:"tags"`   // JSON array string
 	Pinned         bool       `json:"pinned"`

--- a/internal/server/handlers_items_content_state_test.go
+++ b/internal/server/handlers_items_content_state_test.go
@@ -1,0 +1,90 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// BUG-3000 at the HTTP door. The store test proves the predicate; this proves the
+// marker actually REACHES a caller, which is a separate claim — a field can be
+// computed correctly and dropped by a projection on the way out, and this codebase
+// has a summary projection that deliberately drops `content`.
+//
+// The population is enumerated on the BUG-3000 trail. The doors driven here are the
+// ones a caller reaches for first: the single-item read and the list.
+func TestContentStateReachesTheHTTPReadDoors(t *testing.T) {
+	srv := testServerWithCollab(t)
+	slug := createWSWithCollections(t, srv)
+	item := createTaskWithFields(t, srv, slug, "Stale body", `{"status":"open"}`)
+
+	decodeItem := func(t *testing.T, path string) models.Item {
+		t.Helper()
+		rr := doRequest(srv, "GET", path, nil)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("GET %s: %d: %s", path, rr.Code, rr.Body.String())
+		}
+		var got models.Item
+		if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+			t.Fatalf("decode %s: %v", path, err)
+		}
+		return got
+	}
+
+	itemPath := "/api/v1/workspaces/" + slug + "/items/" + item.Slug
+
+	// CONTROL FIRST, so the assertion below cannot be read as an always-on marker.
+	if got := decodeItem(t, itemPath); got.ContentState != "" {
+		t.Fatalf("a fresh item is marked %q over HTTP; everything below would prove nothing", got.ContentState)
+	}
+
+	// Put the document ahead of the row — the state an applier-path write leaves.
+	if _, err := srv.store.AppendYjsUpdate(item.ID, []byte{1, 2, 3}, "1"); err != nil {
+		t.Fatalf("AppendYjsUpdate: %v", err)
+	}
+
+	got := decodeItem(t, itemPath)
+	if got.ContentState != models.ContentOutcomeAppliedPendingFlush {
+		t.Errorf("GET item content_state = %q, want %q — the caller is served a stale body with no signal",
+			got.ContentState, models.ContentOutcomeAppliedPendingFlush)
+	}
+
+	// The raw JSON must carry the key, not merely the decoded struct: a Go struct
+	// round-trip would pass even if the field were never serialised.
+	rr := doRequest(srv, "GET", itemPath, nil)
+	var raw map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("decode raw: %v", err)
+	}
+	if raw["content_state"] != models.ContentOutcomeAppliedPendingFlush {
+		t.Errorf("wire JSON content_state = %v, want %q", raw["content_state"],
+			models.ContentOutcomeAppliedPendingFlush)
+	}
+
+	// The list door must agree. A marker on one door and not another is exactly the
+	// failure the enumeration exists to prevent.
+	listRR := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/collections/tasks/items", nil)
+	if listRR.Code != http.StatusOK {
+		t.Fatalf("list: %d: %s", listRR.Code, listRR.Body.String())
+	}
+	var listed []models.Item
+	if err := json.Unmarshal(listRR.Body.Bytes(), &listed); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	var seen bool
+	for _, li := range listed {
+		if li.ID != item.ID {
+			continue
+		}
+		seen = true
+		if li.ContentState != models.ContentOutcomeAppliedPendingFlush {
+			t.Errorf("list content_state = %q, want %q", li.ContentState,
+				models.ContentOutcomeAppliedPendingFlush)
+		}
+	}
+	if !seen {
+		t.Fatal("the item did not come back from the list door; that leg measured nothing")
+	}
+}

--- a/internal/server/handlers_share_links.go
+++ b/internal/server/handlers_share_links.go
@@ -391,7 +391,7 @@ func (s *Server) requireShareLinkTargetVisible(w http.ResponseWriter, r *http.Re
 // link. TestMovedTo_ShareLinkNeverCarriesPointer pins both the key set and
 // that specific omission.
 func publicShareItemDTO(item *models.Item) map[string]interface{} {
-	return map[string]interface{}{
+	dto := map[string]interface{}{
 		"title":           item.Title,
 		"content":         item.Content,
 		"fields":          item.Fields,
@@ -399,6 +399,19 @@ func publicShareItemDTO(item *models.Item) map[string]interface{} {
 		"collection_name": item.CollectionName,
 		"collection_icon": item.CollectionIcon,
 	}
+	// BUG-3000. This DTO is an explicit allow-list, so it does NOT inherit
+	// models.Item's staleness marker the way every struct-serialising door does —
+	// and a public share is the door whose reader is LEAST able to notice on their
+	// own: an anonymous viewer has no editor, no op-log, and nothing to compare
+	// against.
+	//
+	// Added only when set, which keeps the key set byte-identical in the common
+	// case — the property TestMovedTo_ShareLinkNeverCarriesPointer pins, and which
+	// this must not disturb.
+	if item.ContentState != "" {
+		dto["content_state"] = item.ContentState
+	}
+	return dto
 }
 
 // handleResolveShareLink is the /s/{token} route. It resolves a share link

--- a/internal/store/item_content_state_test.go
+++ b/internal/store/item_content_state_test.go
@@ -192,7 +192,26 @@ func TestContentStateClearsOnceTheFlushWatermarkCatchesUp(t *testing.T) {
 // So this is a column/Scan alignment guard first and a behaviour test second. A door
 // that returns the right marker has, necessarily, a matching destination.
 func TestEveryContentBearingReadDoorCarriesTheMarker(t *testing.T) {
-	s := storetest.NewSQLite(t)
+	for _, backend := range []struct {
+		name string
+		open func(*testing.T) *store.Store
+	}{
+		{"SQLite", storetest.NewSQLite},
+		{"Postgres", storetest.NewPostgres}, // skips unless PAD_TEST_POSTGRES_URL is set
+	} {
+		t.Run(backend.name, func(t *testing.T) {
+			everyContentBearingReadDoor(t, backend.open(t))
+		})
+	}
+}
+
+// everyContentBearingReadDoor is the body, parameterised over the backend because
+// the FTS branches are DIALECT-SPECIFIC: ListItems(search) and Search take different
+// SELECTs on SQLite and Postgres, so a SQLite-only enumeration leaves the Postgres
+// variants of those spliced queries unexercised — and an unexercised spliced query
+// is precisely the runtime-mismatch hazard this test exists for (codex round 3).
+func everyContentBearingReadDoor(t *testing.T, s *store.Store) {
+	t.Helper()
 	wsID, _, item := seedStaleItem(t, s)
 	if _, err := s.AppendYjsUpdate(item.ID, []byte{7}, "1"); err != nil {
 		t.Fatalf("AppendYjsUpdate: %v", err)
@@ -259,8 +278,15 @@ func TestEveryContentBearingReadDoorCarriesTheMarker(t *testing.T) {
 		return s.GetItemBySlugIncludeDeleted(wsID, item.Slug)
 	})
 	one("ResolveItem", func() (*models.Item, error) { return s.ResolveItem(wsID, item.Slug) })
-	one("ResolveItemIncludeDeleted", func() (*models.Item, error) {
-		return s.ResolveItemIncludeDeleted(wsID, item.Slug)
+	// By REF, not slug: a slug falls through to GetItemBySlugIncludeDeleted and
+	// leaves this function's own ref SELECT — a separately spliced query —
+	// unexercised. Passing the slug here made this leg pass while measuring the
+	// wrong query (codex round 3).
+	one("ResolveItemIncludeDeleted(by ref)", func() (*models.Item, error) {
+		return s.ResolveItemIncludeDeleted(wsID, item.Ref)
+	})
+	one("ResolveItem(by ref)", func() (*models.Item, error) {
+		return s.ResolveItem(wsID, item.Ref)
 	})
 
 	first("ListItems", func() ([]models.Item, error) {

--- a/internal/store/item_content_state_test.go
+++ b/internal/store/item_content_state_test.go
@@ -2,6 +2,7 @@ package store_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/PerpetualSoftware/pad/internal/models"
 	"github.com/PerpetualSoftware/pad/internal/store"
@@ -176,4 +177,166 @@ func TestContentStateClearsOnceTheFlushWatermarkCatchesUp(t *testing.T) {
 		t.Errorf("content_state = %q after the watermark caught up, want empty: the row is current "+
 			"and a permanent marker would be worse than none", got.ContentState)
 	}
+}
+
+// TestEveryContentBearingReadDoorCarriesTheMarker drives EVERY store function whose
+// query was spliced, against one item in the stale state.
+//
+// It exists because of how the first implementation pass failed. A column added to a
+// SELECT without its matching Scan destination is a RUNTIME error, not a compile
+// error: `go build` stayed green across a half-applied edit, and the mismatch
+// surfaced only when a test happened to exercise the query. Two of the fifteen
+// spliced queries were reachable only through paths no content-state test touched,
+// so "the suite is green" was not evidence that all fifteen were aligned.
+//
+// So this is a column/Scan alignment guard first and a behaviour test second. A door
+// that returns the right marker has, necessarily, a matching destination.
+func TestEveryContentBearingReadDoorCarriesTheMarker(t *testing.T) {
+	s := storetest.NewSQLite(t)
+	wsID, _, item := seedStaleItem(t, s)
+	if _, err := s.AppendYjsUpdate(item.ID, []byte{7}, "1"); err != nil {
+		t.Fatalf("AppendYjsUpdate: %v", err)
+	}
+	want := models.ContentOutcomeAppliedPendingFlush
+
+	// A child so the child-item doors have something to return.
+	child, err := s.CreateItem(wsID, item.CollectionID, models.ItemCreate{
+		Title: "Child", Content: "child body",
+	})
+	if err != nil {
+		t.Fatalf("create child: %v", err)
+	}
+	// The hierarchy lives in item_links, not in a parent_id column, so the link has
+	// to be created explicitly — a ParentID on ItemCreate leaves GetChildItems
+	// empty and the leg below would report "measured nothing" rather than a marker
+	// failure. (It did, first time round.)
+	if _, err := s.CreateItemLink(wsID, models.ItemLinkCreate{
+		TargetID: item.ID, LinkType: "parent",
+	}, child.ID); err != nil {
+		t.Fatalf("link child to parent: %v", err)
+	}
+	if _, err := s.AppendYjsUpdate(child.ID, []byte{8}, "1"); err != nil {
+		t.Fatalf("AppendYjsUpdate(child): %v", err)
+	}
+
+	one := func(name string, get func() (*models.Item, error)) {
+		t.Run(name, func(t *testing.T) {
+			got, err := get()
+			if err != nil {
+				t.Fatalf("%s: %v", name, err)
+			}
+			if got == nil {
+				t.Fatalf("%s returned no item; this leg measured nothing", name)
+			}
+			if got.ContentState != want {
+				t.Errorf("%s content_state = %q, want %q", name, got.ContentState, want)
+			}
+		})
+	}
+	first := func(name string, get func() ([]models.Item, error), id string) {
+		t.Run(name, func(t *testing.T) {
+			items, err := get()
+			if err != nil {
+				t.Fatalf("%s: %v", name, err)
+			}
+			for _, it := range items {
+				if it.ID != id {
+					continue
+				}
+				if it.ContentState != want {
+					t.Errorf("%s content_state = %q, want %q", name, it.ContentState, want)
+				}
+				return
+			}
+			t.Fatalf("%s did not return the item; this leg measured nothing", name)
+		})
+	}
+
+	one("GetItem", func() (*models.Item, error) { return s.GetItem(item.ID) })
+	one("GetItemIncludeDeleted", func() (*models.Item, error) { return s.GetItemIncludeDeleted(item.ID) })
+	one("GetItemBySlug", func() (*models.Item, error) { return s.GetItemBySlug(wsID, item.Slug) })
+	one("GetItemBySlugIncludeDeleted", func() (*models.Item, error) {
+		return s.GetItemBySlugIncludeDeleted(wsID, item.Slug)
+	})
+	one("ResolveItem", func() (*models.Item, error) { return s.ResolveItem(wsID, item.Slug) })
+	one("ResolveItemIncludeDeleted", func() (*models.Item, error) {
+		return s.ResolveItemIncludeDeleted(wsID, item.Slug)
+	})
+
+	first("ListItems", func() ([]models.Item, error) {
+		return s.ListItems(wsID, models.ItemListParams{})
+	}, item.ID)
+	first("ListItems(search→FTS)", func() ([]models.Item, error) {
+		return s.ListItems(wsID, models.ItemListParams{Search: "Stale"})
+	}, item.ID)
+	first("GetChildItems", func() ([]models.Item, error) { return s.GetChildItems(item.ID) }, child.ID)
+	first("ItemsModifiedSince", func() ([]models.Item, error) {
+		updated, _, err := s.ItemsModifiedSince(wsID, time.Time{})
+		return updated, err
+	}, item.ID)
+
+	// The starred door specifically: it lives in item_stars.go and reaches the
+	// SHARED scanItems helper from outside items.go, which is exactly how the first
+	// implementation pass broke — and it broke at runtime, with the build green.
+	t.Run("ListStarredItems", func(t *testing.T) {
+		// A real user row: item_stars carries an FK on user_id, so a synthetic id
+		// fails the insert rather than the assertion.
+		u, err := s.CreateUser(models.UserCreate{
+			Email: "star@example.com", Name: "Star", Password: "correct-horse-battery-staple",
+		})
+		if err != nil {
+			t.Fatalf("CreateUser: %v", err)
+		}
+		if err := s.StarItem(u.ID, item.ID); err != nil {
+			t.Fatalf("StarItem: %v", err)
+		}
+		items, err := s.ListStarredItems(u.ID, wsID, true)
+		if err != nil {
+			t.Fatalf("ListStarredItems: %v", err)
+		}
+		for _, it := range items {
+			if it.ID != item.ID {
+				continue
+			}
+			if it.ContentState != want {
+				t.Errorf("ListStarredItems content_state = %q, want %q", it.ContentState, want)
+			}
+			return
+		}
+		t.Fatal("ListStarredItems did not return the item; this leg measured nothing")
+	})
+
+	t.Run("SearchItems", func(t *testing.T) {
+		results, err := s.SearchItems(wsID, "Stale")
+		if err != nil {
+			t.Fatalf("SearchItems: %v", err)
+		}
+		for _, r := range results {
+			if r.Item.ID != item.ID {
+				continue
+			}
+			if r.Item.ContentState != want {
+				t.Errorf("SearchItems content_state = %q, want %q", r.Item.ContentState, want)
+			}
+			return
+		}
+		t.Fatal("SearchItems did not return the item; this leg measured nothing")
+	})
+
+	t.Run("Search", func(t *testing.T) {
+		resp, err := s.Search(store.SearchParams{WorkspaceIDs: []string{wsID}, Query: "Stale"})
+		if err != nil {
+			t.Fatalf("Search: %v", err)
+		}
+		for _, r := range resp.Results {
+			if r.Item.ID != item.ID {
+				continue
+			}
+			if r.Item.ContentState != want {
+				t.Errorf("Search content_state = %q, want %q", r.Item.ContentState, want)
+			}
+			return
+		}
+		t.Fatal("Search did not return the item; this leg measured nothing")
+	})
 }

--- a/internal/store/item_content_state_test.go
+++ b/internal/store/item_content_state_test.go
@@ -1,0 +1,179 @@
+package store_test
+
+import (
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/store"
+	"github.com/PerpetualSoftware/pad/internal/store/storetest"
+)
+
+// BUG-3000: a read that serves items.content must say so when that content is
+// behind the item's live collaborative document.
+//
+// The window is UNBOUNDED, which is what makes the marker worth having rather than
+// a documentation note: nothing server-side moves applier content into the row.
+// PruneSweep's candidate query requires MAX(op-log.id) <= content_flushed_op_log_id,
+// so an item in exactly this state is EXCLUDED from the sweep — its op-log rows are
+// retained (the content is durable) and the row stays behind until a tab next opens
+// the item and flushes.
+//
+// THE CONTROL THAT MATTERS is the absence leg. A marker that is always on is
+// indistinguishable from a marker that is always right, and the population is large
+// enough that a blanket stamp would look like success at every door. Every case
+// below therefore asserts both directions on the same item.
+
+func seedStaleItem(t *testing.T, s *store.Store) (wsID, collID string, item *models.Item) {
+	t.Helper()
+	ws, err := s.CreateWorkspace(models.WorkspaceCreate{Name: "CS", Slug: "cs"})
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	if err := s.SeedCollectionsFromTemplate(ws.ID, "startup"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	colls, err := s.ListCollections(ws.ID)
+	if err != nil || len(colls) == 0 {
+		t.Fatalf("ListCollections: %v", err)
+	}
+	var tasks string
+	for _, c := range colls {
+		if c.Slug == "tasks" {
+			tasks = c.ID
+		}
+	}
+	if tasks == "" {
+		t.Fatal("no tasks collection")
+	}
+	it, err := s.CreateItem(ws.ID, tasks, models.ItemCreate{Title: "Stale", Content: "stored body"})
+	if err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+	return ws.ID, tasks, it
+}
+
+func TestContentStateMarksOnlyItemsWhoseDocumentIsAhead(t *testing.T) {
+	for _, backend := range []struct {
+		name string
+		open func(*testing.T) *store.Store
+	}{
+		{"SQLite", storetest.NewSQLite},
+		{"Postgres", storetest.NewPostgres}, // skips unless PAD_TEST_POSTGRES_URL is set
+	} {
+		t.Run(backend.name, func(t *testing.T) {
+			s := backend.open(t)
+			wsID, _, item := seedStaleItem(t, s)
+
+			// CONTROL, and it runs FIRST so the later assertion cannot be read as
+			// "the marker is simply always set". A freshly created item has no
+			// op-log at all.
+			got, err := s.GetItem(item.ID)
+			if err != nil {
+				t.Fatalf("GetItem: %v", err)
+			}
+			if got.ContentState != "" {
+				t.Fatalf("a fresh item with no op-log is marked %q; the marker is firing "+
+					"unconditionally and proves nothing below", got.ContentState)
+			}
+
+			// Now put a row in the op-log ABOVE the (NULL) flush watermark: the
+			// document is ahead of the row, which is exactly the state an
+			// applier-path write leaves behind before any tab flushes.
+			if _, err := s.AppendYjsUpdate(item.ID, []byte{1, 2, 3}, "1"); err != nil {
+				t.Fatalf("AppendYjsUpdate: %v", err)
+			}
+
+			got, err = s.GetItem(item.ID)
+			if err != nil {
+				t.Fatalf("GetItem: %v", err)
+			}
+			if got.ContentState != models.ContentOutcomeAppliedPendingFlush {
+				t.Errorf("GetItem content_state = %q, want %q: the op-log is ahead of the row, so "+
+					"this body is stale and a caller has no other way to learn that",
+					got.ContentState, models.ContentOutcomeAppliedPendingFlush)
+			}
+			// The body itself is unchanged — the marker describes the row, it does
+			// not repair it. Stated so nobody reads the marker as a fix.
+			if got.Content != "stored body" {
+				t.Errorf("content = %q, want the stored body unchanged", got.Content)
+			}
+
+			// EVERY read door that serves a body must agree with GetItem. A marker
+			// present on one door and missing on another is the failure this
+			// enumeration exists to prevent.
+			items, err := s.ListItems(wsID, models.ItemListParams{})
+			if err != nil {
+				t.Fatalf("ListItems: %v", err)
+			}
+			var found bool
+			for _, li := range items {
+				if li.ID != item.ID {
+					continue
+				}
+				found = true
+				if li.ContentState != models.ContentOutcomeAppliedPendingFlush {
+					t.Errorf("ListItems content_state = %q, want %q", li.ContentState,
+						models.ContentOutcomeAppliedPendingFlush)
+				}
+			}
+			if !found {
+				t.Fatal("the item did not come back from ListItems; this leg measured nothing")
+			}
+
+			// NoContent asks for the body to be omitted. The marker must go with it:
+			// claiming an omitted body is stale is a false signal about content this
+			// query never returned.
+			noBody, err := s.ListItems(wsID, models.ItemListParams{NoContent: true})
+			if err != nil {
+				t.Fatalf("ListItems(NoContent): %v", err)
+			}
+			for _, li := range noBody {
+				if li.ID != item.ID {
+					continue
+				}
+				if li.Content != "" {
+					t.Fatalf("NoContent returned a body (%q); this leg cannot measure what it claims", li.Content)
+				}
+				if li.ContentState != "" {
+					t.Errorf("NoContent omitted the body but still marked it %q", li.ContentState)
+				}
+			}
+		})
+	}
+}
+
+// TestContentStateClearsOnceTheFlushWatermarkCatchesUp is the other half of the
+// control: the marker must go AWAY, not merely appear. A predicate that latches on
+// once an op-log row exists would pass every assertion above and still be wrong for
+// every item that has ever been edited collaboratively — which, on this deployment,
+// is most of them.
+func TestContentStateClearsOnceTheFlushWatermarkCatchesUp(t *testing.T) {
+	s := storetest.NewSQLite(t)
+	_, _, item := seedStaleItem(t, s)
+
+	opID, err := s.AppendYjsUpdate(item.ID, []byte{9}, "1")
+	if err != nil {
+		t.Fatalf("AppendYjsUpdate: %v", err)
+	}
+	got, err := s.GetItem(item.ID)
+	if err != nil {
+		t.Fatalf("GetItem: %v", err)
+	}
+	if got.ContentState == "" {
+		t.Fatal("precondition failed: the item is not marked stale, so clearing it proves nothing")
+	}
+
+	// Advance the watermark to cover the op-log, which is what a flush does.
+	if err := s.SetItemContentFlushedOpLogIDForTesting(item.ID, opID); err != nil {
+		t.Fatalf("advance watermark: %v", err)
+	}
+
+	got, err = s.GetItem(item.ID)
+	if err != nil {
+		t.Fatalf("GetItem: %v", err)
+	}
+	if got.ContentState != "" {
+		t.Errorf("content_state = %q after the watermark caught up, want empty: the row is current "+
+			"and a permanent marker would be worse than none", got.ContentState)
+	}
+}

--- a/internal/store/item_stars.go
+++ b/internal/store/item_stars.go
@@ -95,7 +95,7 @@ func (s *Store) AreItemsStarred(userID string, itemIDs []string) (map[string]boo
 // If includeTerminal is false, items in terminal statuses are excluded.
 func (s *Store) ListStarredItems(userID, workspaceID string, includeTerminal bool) ([]models.Item, error) {
 	query := `
-		SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, i.fields, i.tags,
+		SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, ` + contentStateSQL + `, i.fields, i.tags,
 		       i.pinned, i.sort_order, i.parent_id, i.assigned_user_id, i.agent_role_id, i.role_sort_order,
 		       i.created_by, i.last_modified_by, i.source,
 		       i.item_number, i.seq, i.created_at, i.updated_at,

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -655,6 +655,53 @@ func (s *Store) getItemTx(tx *sql.Tx, id string) (*models.Item, error) {
 // getItemScanQ is the one item-row scan behind GetItem, getItemTx and
 // GetItemIncludeDeleted — identical SELECT and hydration, differing only in
 // executor and in whether soft-deleted rows are visible. (nil, nil) on no row.
+// contentStateSQL is the SELECT-list expression behind models.Item.ContentState
+// (BUG-3000): it reports that items.content is BEHIND the item's live
+// collaborative document.
+//
+// EXISTS, not MAX. The op-log's (item_id, id) index (migration 050) makes this a
+// seek that stops at the FIRST qualifying row, where the sweeper's
+// ListDormantOpLogItemsBefore has to aggregate MAX(u.id) across the whole per-item
+// range. Same index, different cost class — which is why the sweeper's shape is the
+// wrong precedent to copy here even though it is the obvious one. That distinction
+// is what makes this affordable on a LIST, where an aggregate would not be.
+//
+// COALESCE(..., 0) treats a NULL watermark — never flushed — as "everything in the
+// op-log is unflushed", which is what it means: ids are positive.
+//
+// It requires the items table aliased as `i`, which every query using it already
+// does. It is spliced ONLY where a real content column is selected; see
+// models.Item.ContentState for why a query selecting an empty-string literal for
+// content must not carry it.
+//
+// RECEIPT (BUG-3000, day 64). ListItems over 200 items, SQLite, best-of-5 per shape,
+// measured WITH the predicate and again with it replaced by an empty-string literal
+// — the counterfactual, because a one-armed timing cannot attribute cost:
+//
+//	op-log rows   with        without
+//	0             2.44ms      3.58ms
+//	2,000         4.00ms      2.86ms
+//	20,000        3.81ms      3.27ms
+//
+// The arms are INDISTINGUISHABLE: they overlap, and at 0 rows the arm without the
+// predicate was the slower one. Run-to-run variance (~1.5ms) exceeds any systematic
+// difference, so the honest statement is that the cost is BELOW THE NOISE FLOOR at
+// this scale — not that it is zero.
+//
+// What the measurement does NOT cover, and where it would be worth redoing: SQLite
+// rather than Postgres; per-item op-logs far beyond 100 rows (the EXISTS stops at
+// the first qualifying row, so depth should not matter, but that is the argument
+// rather than the measurement); a store under concurrent load; and lists far larger
+// than 200 items.
+//
+// Error direction is benign either way: the predicate is read-only and its only
+// consequence is an extra index seek per row.
+const contentStateSQL = `CASE WHEN EXISTS (
+			SELECT 1 FROM item_yjs_updates u
+			WHERE u.item_id = i.id
+			  AND u.id > COALESCE(i.content_flushed_op_log_id, 0)
+		) THEN 'applied_pending_flush' ELSE '' END`
+
 func (s *Store) getItemScanQ(q Queryer, id string, includeDeleted bool) (*models.Item, error) {
 	var item models.Item
 	var createdAt, updatedAt string
@@ -662,7 +709,7 @@ func (s *Store) getItemScanQ(q Queryer, id string, includeDeleted bool) (*models
 	var pinned bool
 
 	query := `
-		SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, i.fields, i.tags,
+		SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, ` + contentStateSQL + `, i.fields, i.tags,
 		       i.pinned, i.sort_order, i.parent_id, i.assigned_user_id, i.agent_role_id, i.role_sort_order,
 		       i.created_by, i.last_modified_by, i.source,
 		       i.item_number, i.seq, i.created_at, i.updated_at, i.deleted_at,
@@ -679,7 +726,7 @@ func (s *Store) getItemScanQ(q Queryer, id string, includeDeleted bool) (*models
 	}
 	err := q.QueryRow(s.q(query), id).Scan(
 		&item.ID, &item.WorkspaceID, &item.CollectionID, &item.Title, &item.Slug,
-		&item.Content, &item.Fields, &item.Tags,
+		&item.Content, &item.ContentState, &item.Fields, &item.Tags,
 		&pinned, &item.SortOrder, &item.ParentID, &item.AssignedUserID, &item.AgentRoleID, &item.RoleSortOrder,
 		&item.CreatedBy, &item.LastModifiedBy, &item.Source,
 		&item.ItemNumber, &item.Seq, &createdAt, &updatedAt, &deletedAt,
@@ -828,7 +875,7 @@ func (s *Store) ResolveItemIncludeDeleted(workspaceID, slugOrRef string) (*model
 		var pinned bool
 
 		err := s.db.QueryRow(s.q(`
-			SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, i.fields, i.tags,
+			SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, `+contentStateSQL+`, i.fields, i.tags,
 			       i.pinned, i.sort_order, i.parent_id, i.assigned_user_id, i.agent_role_id, i.role_sort_order,
 			       i.created_by, i.last_modified_by, i.source,
 			       i.item_number, i.seq, i.created_at, i.updated_at, i.deleted_at,
@@ -842,7 +889,7 @@ func (s *Store) ResolveItemIncludeDeleted(workspaceID, slugOrRef string) (*model
 			WHERE i.workspace_id = ? AND c.prefix = ? AND i.item_number = ?
 		`), workspaceID, prefix, number).Scan(
 			&item.ID, &item.WorkspaceID, &item.CollectionID, &item.Title, &item.Slug,
-			&item.Content, &item.Fields, &item.Tags,
+			&item.Content, &item.ContentState, &item.Fields, &item.Tags,
 			&pinned, &item.SortOrder, &item.ParentID, &item.AssignedUserID, &item.AgentRoleID, &item.RoleSortOrder,
 			&item.CreatedBy, &item.LastModifiedBy, &item.Source,
 			&item.ItemNumber, &item.Seq, &createdAt, &updatedAt, &deletedAt,
@@ -986,6 +1033,10 @@ func (s *Store) GetItemsByIDsIncludeDeleted(ids []string) (map[string]*models.It
 		args[i] = id
 	}
 	rows, err := s.db.Query(s.q(fmt.Sprintf(`
+		-- BUG-3000: NO contentStateSQL here. This query selects '' for content
+		-- (dashboard batching needs the metadata, not the body), and a staleness marker
+		-- on an empty body would be a false signal about content this query never
+		-- returns. The marker is spliced only where a real content column is.
 		SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, '', i.fields, i.tags,
 		       i.pinned, i.sort_order, i.parent_id, i.assigned_user_id, i.agent_role_id, i.role_sort_order,
 		       i.created_by, i.last_modified_by, i.source,
@@ -1041,7 +1092,7 @@ func (s *Store) GetItemBySlugIncludeDeleted(workspaceID, slug string) (*models.I
 	var pinned bool
 
 	err := s.db.QueryRow(s.q(`
-		SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, i.fields, i.tags,
+		SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, `+contentStateSQL+`, i.fields, i.tags,
 		       i.pinned, i.sort_order, i.parent_id, i.assigned_user_id, i.agent_role_id, i.role_sort_order,
 		       i.created_by, i.last_modified_by, i.source,
 		       i.item_number, i.seq, i.created_at, i.updated_at, i.deleted_at,
@@ -1055,7 +1106,7 @@ func (s *Store) GetItemBySlugIncludeDeleted(workspaceID, slug string) (*models.I
 		WHERE i.workspace_id = ? AND i.slug = ?
 	`), workspaceID, slug).Scan(
 		&item.ID, &item.WorkspaceID, &item.CollectionID, &item.Title, &item.Slug,
-		&item.Content, &item.Fields, &item.Tags,
+		&item.Content, &item.ContentState, &item.Fields, &item.Tags,
 		&pinned, &item.SortOrder, &item.ParentID, &item.AssignedUserID, &item.AgentRoleID, &item.RoleSortOrder,
 		&item.CreatedBy, &item.LastModifiedBy, &item.Source,
 		&item.ItemNumber, &item.Seq, &createdAt, &updatedAt, &deletedAt,
@@ -1099,11 +1150,16 @@ func (s *Store) ListItems(workspaceID string, params models.ItemListParams) ([]m
 	// item's full markdown. scanItems still scans the same column count;
 	// item.Content just comes back empty (BUG-2002).
 	contentCol := "i.content"
+	// The marker tracks the CONTENT column, not the row (BUG-3000). When this
+	// query is asked to omit the body, it must not claim the omitted body is
+	// stale — so the two are set together and can never disagree.
+	stateCol := contentStateSQL
 	if params.NoContent {
 		contentCol = "''"
+		stateCol = "''"
 	}
 	query := `
-		SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, ` + contentCol + `, i.fields, i.tags,
+		SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, ` + contentCol + `, ` + stateCol + `, i.fields, i.tags,
 		       i.pinned, i.sort_order, i.parent_id, i.assigned_user_id, i.agent_role_id, i.role_sort_order,
 		       i.created_by, i.last_modified_by, i.source,
 		       i.item_number, i.seq, i.created_at, i.updated_at,
@@ -1854,7 +1910,7 @@ func (s *Store) listItemsFTS(workspaceID string, params models.ItemListParams) (
 		ftsRank = s.dialect.FTSRank("i", "search_vector")
 
 		query = fmt.Sprintf(`
-			SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, i.fields, i.tags,
+			SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, `+contentStateSQL+`, i.fields, i.tags,
 			       i.pinned, i.sort_order, i.parent_id, i.assigned_user_id, i.agent_role_id, i.role_sort_order,
 			       i.created_by, i.last_modified_by, i.source,
 			       i.item_number, i.seq, i.created_at, i.updated_at,
@@ -1880,7 +1936,7 @@ func (s *Store) listItemsFTS(workspaceID string, params models.ItemListParams) (
 		ftsRank = s.dialect.FTSRank("items_fts", "search_vector")
 
 		query = fmt.Sprintf(`
-			SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, i.fields, i.tags,
+			SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, `+contentStateSQL+`, i.fields, i.tags,
 			       i.pinned, i.sort_order, i.parent_id, i.assigned_user_id, i.agent_role_id, i.role_sort_order,
 			       i.created_by, i.last_modified_by, i.source,
 			       i.item_number, i.seq, i.created_at, i.updated_at,
@@ -3116,7 +3172,7 @@ func (s *Store) SearchItems(workspaceID, query string) ([]ItemSearchResult, erro
 		ftsRank := s.dialect.FTSRank("i", "search_vector")
 
 		sqlQuery = fmt.Sprintf(`
-			SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, i.fields, i.tags,
+			SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, `+contentStateSQL+`, i.fields, i.tags,
 			       i.pinned, i.sort_order, i.parent_id, i.assigned_user_id, i.agent_role_id, i.role_sort_order,
 			       i.created_by, i.last_modified_by, i.source,
 			       i.item_number, i.seq, i.created_at, i.updated_at,
@@ -3144,7 +3200,7 @@ func (s *Store) SearchItems(workspaceID, query string) ([]ItemSearchResult, erro
 		ftsRank := s.dialect.FTSRank("items_fts", "search_vector")
 
 		sqlQuery = fmt.Sprintf(`
-			SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, i.fields, i.tags,
+			SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, `+contentStateSQL+`, i.fields, i.tags,
 			       i.pinned, i.sort_order, i.parent_id, i.assigned_user_id, i.agent_role_id, i.role_sort_order,
 			       i.created_by, i.last_modified_by, i.source,
 			       i.item_number, i.seq, i.created_at, i.updated_at,
@@ -3190,7 +3246,7 @@ func (s *Store) SearchItems(workspaceID, query string) ([]ItemSearchResult, erro
 		var pinned bool
 		if err := rows.Scan(
 			&r.Item.ID, &r.Item.WorkspaceID, &r.Item.CollectionID, &r.Item.Title, &r.Item.Slug,
-			&r.Item.Content, &r.Item.Fields, &r.Item.Tags,
+			&r.Item.Content, &r.Item.ContentState, &r.Item.Fields, &r.Item.Tags,
 			&pinned, &r.Item.SortOrder, &r.Item.ParentID, &r.Item.AssignedUserID, &r.Item.AgentRoleID, &r.Item.RoleSortOrder,
 			&r.Item.CreatedBy, &r.Item.LastModifiedBy,
 			&r.Item.Source, &r.Item.ItemNumber, &r.Item.Seq, &createdAt, &updatedAt,
@@ -4622,7 +4678,7 @@ type childQueryer interface {
 
 func (s *Store) getChildItems(q childQueryer, parentItemID string) ([]models.Item, error) {
 	rows, err := q.Query(s.q(fmt.Sprintf(`
-		SELECT DISTINCT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, i.fields, i.tags,
+		SELECT DISTINCT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, `+contentStateSQL+`, i.fields, i.tags,
 		       i.pinned, i.sort_order, i.parent_id, i.assigned_user_id, i.agent_role_id, i.role_sort_order,
 		       i.created_by, i.last_modified_by, i.source,
 		       i.item_number, i.seq, i.created_at, i.updated_at,
@@ -5309,7 +5365,7 @@ func scanItems(rows *sql.Rows) ([]models.Item, error) {
 		var pinned bool
 		if err := rows.Scan(
 			&item.ID, &item.WorkspaceID, &item.CollectionID, &item.Title, &item.Slug,
-			&item.Content, &item.Fields, &item.Tags,
+			&item.Content, &item.ContentState, &item.Fields, &item.Tags,
 			&pinned, &item.SortOrder, &item.ParentID, &item.AssignedUserID, &item.AgentRoleID, &item.RoleSortOrder,
 			&item.CreatedBy, &item.LastModifiedBy, &item.Source,
 			&item.ItemNumber, &item.Seq, &createdAt, &updatedAt,
@@ -5367,7 +5423,11 @@ func (s *Store) ItemsModifiedSince(workspaceID string, since time.Time) (updated
 	// Fetch updated items: active items modified since the timestamp,
 	// PLUS items archived since the timestamp (so archived views can update).
 	query := s.q(`
-		SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, i.fields, i.tags,
+		-- BUG-3000: NO contentStateSQL here. This query selects '' for content
+		-- (child batching needs the metadata, not the body), and a staleness marker
+		-- on an empty body would be a false signal about content this query never
+		-- returns. The marker is spliced only where a real content column is.
+		SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, ` + contentStateSQL + `, i.fields, i.tags,
 		       i.pinned, i.sort_order, i.parent_id, i.assigned_user_id, i.agent_role_id, i.role_sort_order,
 		       i.created_by, i.last_modified_by, i.source,
 		       i.item_number, i.seq, i.created_at, i.updated_at,

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -4724,6 +4724,10 @@ func (s *Store) GetChildItemsForParents(parentIDs []string) (map[string][]models
 		args[i] = id
 	}
 	rows, err := s.db.Query(s.q(fmt.Sprintf(`
+		-- BUG-3000: NO contentStateSQL here. This query selects an empty-string
+		-- literal for content (child batching needs the metadata, not the body), and
+		-- a staleness marker on an empty body would be a false signal about content
+		-- this query never returns.
 		SELECT DISTINCT il.target_id,
 		       i.id, i.workspace_id, i.collection_id, i.title, i.slug, '', i.fields, i.tags,
 		       i.pinned, i.sort_order, i.parent_id, i.assigned_user_id, i.agent_role_id, i.role_sort_order,
@@ -5423,10 +5427,6 @@ func (s *Store) ItemsModifiedSince(workspaceID string, since time.Time) (updated
 	// Fetch updated items: active items modified since the timestamp,
 	// PLUS items archived since the timestamp (so archived views can update).
 	query := s.q(`
-		-- BUG-3000: NO contentStateSQL here. This query selects '' for content
-		-- (child batching needs the metadata, not the body), and a staleness marker
-		-- on an empty body would be a false signal about content this query never
-		-- returns. The marker is spliced only where a real content column is.
 		SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, ` + contentStateSQL + `, i.fields, i.tags,
 		       i.pinned, i.sort_order, i.parent_id, i.assigned_user_id, i.agent_role_id, i.role_sort_order,
 		       i.created_by, i.last_modified_by, i.source,

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -652,9 +652,6 @@ func (s *Store) getItemTx(tx *sql.Tx, id string) (*models.Item, error) {
 	return item, nil
 }
 
-// getItemScanQ is the one item-row scan behind GetItem, getItemTx and
-// GetItemIncludeDeleted — identical SELECT and hydration, differing only in
-// executor and in whether soft-deleted rows are visible. (nil, nil) on no row.
 // contentStateSQL is the SELECT-list expression behind models.Item.ContentState
 // (BUG-3000): it reports that items.content is BEHIND the item's live
 // collaborative document.
@@ -702,6 +699,9 @@ const contentStateSQL = `CASE WHEN EXISTS (
 			  AND u.id > COALESCE(i.content_flushed_op_log_id, 0)
 		) THEN 'applied_pending_flush' ELSE '' END`
 
+// getItemScanQ is the one item-row scan behind GetItem, getItemTx and
+// GetItemIncludeDeleted — identical SELECT and hydration, differing only in
+// executor and in whether soft-deleted rows are visible. (nil, nil) on no row.
 func (s *Store) getItemScanQ(q Queryer, id string, includeDeleted bool) (*models.Item, error) {
 	var item models.Item
 	var createdAt, updatedAt string

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -110,7 +110,7 @@ func (s *Store) Search(params SearchParams) (*SearchResponse, error) {
 	// and do a direct lookup first so refs are always findable.
 	if prefix, number, ok := parseItemRef(strings.TrimSpace(params.Query)); ok {
 		refQuery := `
-			SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, i.fields, i.tags,
+			SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, ` + contentStateSQL + `, i.fields, i.tags,
 			       i.pinned, i.sort_order, i.parent_id, i.assigned_user_id, i.agent_role_id, i.role_sort_order,
 			       i.created_by, i.last_modified_by, i.source,
 			       i.item_number, i.seq, i.created_at, i.updated_at,
@@ -182,7 +182,7 @@ func (s *Store) Search(params SearchParams) (*SearchResponse, error) {
 				var pinned bool
 				if err := refRows.Scan(
 					&r.Item.ID, &r.Item.WorkspaceID, &r.Item.CollectionID, &r.Item.Title, &r.Item.Slug,
-					&r.Item.Content, &r.Item.Fields, &r.Item.Tags,
+					&r.Item.Content, &r.Item.ContentState, &r.Item.Fields, &r.Item.Tags,
 					&pinned, &r.Item.SortOrder, &r.Item.ParentID, &r.Item.AssignedUserID, &r.Item.AgentRoleID, &r.Item.RoleSortOrder,
 					&r.Item.CreatedBy, &r.Item.LastModifiedBy,
 					&r.Item.Source, &r.Item.ItemNumber, &r.Item.Seq, &createdAt, &updatedAt,
@@ -212,7 +212,7 @@ func (s *Store) Search(params SearchParams) (*SearchResponse, error) {
 	// Lets the search palette double as a quick "go to item N" jump. See BUG-910.
 	if number, ok := parseItemNumber(strings.TrimSpace(params.Query)); ok {
 		numQuery := `
-			SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, i.fields, i.tags,
+			SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, ` + contentStateSQL + `, i.fields, i.tags,
 			       i.pinned, i.sort_order, i.parent_id, i.assigned_user_id, i.agent_role_id, i.role_sort_order,
 			       i.created_by, i.last_modified_by, i.source,
 			       i.item_number, i.seq, i.created_at, i.updated_at,
@@ -290,7 +290,7 @@ func (s *Store) Search(params SearchParams) (*SearchResponse, error) {
 				var pinned bool
 				if err := numRows.Scan(
 					&r.Item.ID, &r.Item.WorkspaceID, &r.Item.CollectionID, &r.Item.Title, &r.Item.Slug,
-					&r.Item.Content, &r.Item.Fields, &r.Item.Tags,
+					&r.Item.Content, &r.Item.ContentState, &r.Item.Fields, &r.Item.Tags,
 					&pinned, &r.Item.SortOrder, &r.Item.ParentID, &r.Item.AssignedUserID, &r.Item.AgentRoleID, &r.Item.RoleSortOrder,
 					&r.Item.CreatedBy, &r.Item.LastModifiedBy,
 					&r.Item.Source, &r.Item.ItemNumber, &r.Item.Seq, &createdAt, &updatedAt,
@@ -348,7 +348,7 @@ func (s *Store) Search(params SearchParams) (*SearchResponse, error) {
 		// (raw query + hyphen-sanitized query) for the OR-combined
 		// plainto_tsquery — see dialect.go and BUG-842.
 		query = fmt.Sprintf(`
-			SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, i.fields, i.tags,
+			SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, `+contentStateSQL+`, i.fields, i.tags,
 			       i.pinned, i.sort_order, i.parent_id, i.assigned_user_id, i.agent_role_id, i.role_sort_order,
 			       i.created_by, i.last_modified_by, i.source,
 			       i.item_number, i.seq, i.created_at, i.updated_at,
@@ -378,7 +378,7 @@ func (s *Store) Search(params SearchParams) (*SearchResponse, error) {
 		ftsMatch := s.dialect.FTSMatch("items_fts", "search_vector")
 
 		query = fmt.Sprintf(`
-			SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, i.fields, i.tags,
+			SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, `+contentStateSQL+`, i.fields, i.tags,
 			       i.pinned, i.sort_order, i.parent_id, i.assigned_user_id, i.agent_role_id, i.role_sort_order,
 			       i.created_by, i.last_modified_by, i.source,
 			       i.item_number, i.seq, i.created_at, i.updated_at,
@@ -575,7 +575,7 @@ func (s *Store) Search(params SearchParams) (*SearchResponse, error) {
 
 		if err := rows.Scan(
 			&r.Item.ID, &r.Item.WorkspaceID, &r.Item.CollectionID, &r.Item.Title, &r.Item.Slug,
-			&r.Item.Content, &r.Item.Fields, &r.Item.Tags,
+			&r.Item.Content, &r.Item.ContentState, &r.Item.Fields, &r.Item.Tags,
 			&pinned, &r.Item.SortOrder, &r.Item.ParentID, &r.Item.AssignedUserID, &r.Item.AgentRoleID, &r.Item.RoleSortOrder,
 			&r.Item.CreatedBy, &r.Item.LastModifiedBy,
 			&r.Item.Source, &r.Item.ItemNumber, &r.Item.Seq, &createdAt, &updatedAt,

--- a/internal/store/testing_helpers.go
+++ b/internal/store/testing_helpers.go
@@ -152,3 +152,18 @@ func (s *Store) SetAddWorkspaceMemberCommitHookForTesting(hook func(tx *sql.Tx) 
 	s.commitAddWorkspaceMember = hook
 	return func() { s.commitAddWorkspaceMember = prev }
 }
+
+// SetItemContentFlushedOpLogIDForTesting advances items.content_flushed_op_log_id
+// directly, standing in for the collab-snapshot flush that normally moves it.
+//
+// It exists for BUG-3000's clearing leg. The marker must go AWAY once the row
+// catches up, not merely appear when it falls behind — a predicate that latched on
+// at the first op-log row would satisfy every "is it marked?" assertion and still be
+// wrong for every item that has ever been edited collaboratively. Driving a real
+// flush would need a browser; this writes the one column that flush advances.
+//
+// Production code MUST NOT call this. The "ForTesting" suffix is the grep signal.
+func (s *Store) SetItemContentFlushedOpLogIDForTesting(itemID string, opLogID int64) error {
+	_, err := s.db.Exec(s.q(`UPDATE items SET content_flushed_op_log_id = ? WHERE id = ?`), opLogID, itemID)
+	return err
+}

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -641,6 +641,18 @@ export interface Item {
 	title: string;
 	slug: string;
 	content: string;
+	/**
+	 * Set when `content` above is known to be BEHIND the item's live
+	 * collaborative document (BUG-3000) — absent whenever the row is current,
+	 * which is the common case. Takes the same values as a write response's
+	 * `warnings.content_outcome`, so a caller has one story about where content
+	 * is whether it learned from a write or a read.
+	 *
+	 * The web editor rarely needs it: an open tab reads the Y.Doc, not this
+	 * field. It matters for surfaces that render `content` straight from the
+	 * API without joining the room.
+	 */
+	content_state?: string;
 	fields: string;
 	tags: string;
 	pinned: boolean;

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -652,7 +652,7 @@ export interface Item {
 	 * field. It matters for surfaces that render `content` straight from the
 	 * API without joining the room.
 	 */
-	content_state?: string;
+	content_state?: 'applied_pending_flush';
 	fields: string;
 	tags: string;
 	pinned: boolean;


### PR DESCRIPTION
A read of `items.content` could serve a body the server **knew** was behind the item's live collaborative document, with no way for the caller to tell. BUG-2995 fixed the write response; this is the read side, which that unit deliberately did not fold in.

## The window is UNBOUNDED (measured; the body said "about five seconds")

That measurement is what makes this a marker rather than a documentation note.

**Nothing server-side moves applier content into `items.content`.** `RoomManager.PruneSweep` is the only periodic process touching the op-log, and it prunes — it never flushes. Its candidate query ends:

```sql
HAVING MAX(u.created_at) < ?
   AND MAX(u.id) <= i.content_flushed_op_log_id
```

That flush-coverage guard (TASK-1309 r4 P1) means an item in exactly this state is **excluded from the sweep**. Two halves of one design:

- **Durable** — those op-log rows are retained *because* they are unflushed; the GC deliberately refuses to delete them. Nothing is lost.
- **Permanently stale** — the row catches up only when a tab opens the item, replays the op-log, and its flusher fires.

It is also **not crash-only**: the only teardown flush is on `beforeunload`, with no `pagehide` (filed separately as BUG-3030), so mobile backgrounding — ordinary use — can be the closing tab.

A server-side reconciler would bound the window rather than merely reveal it, and is **rejected on the record**: the relay is deliberately dumb and cannot derive markdown from Yjs updates without a Go Yjs port, which CLAUDE.md rules out. That is why a read-side marker is the honest ceiling, not a compromise.

## On the item, not the door

Reads return a **bare item or array** — there is no warnings envelope on the read side, unlike writes. A per-door marker would be N changes across a population that grows silently whenever someone adds a handler returning a `models.Item`.

An additive `omitempty` field on the struct is inherited by every door by construction — HTTP, MCP resources, CLI, web — and a consumer that does not know it sees byte-identical responses.

## EXISTS, not MAX

```sql
EXISTS (SELECT 1 FROM item_yjs_updates u
        WHERE u.item_id = i.id
          AND u.id > COALESCE(i.content_flushed_op_log_id, 0))
```

The op-log's `(item_id, id)` index (migration 050) makes this a **seek that stops at the first qualifying row**, where the sweeper's `MAX(u.id)` must aggregate the whole per-item range. Same index, different cost class — which is why the sweeper is the wrong precedent to copy here even though it is the obvious one. No migration needed.

## The marker tracks the CONTENT COLUMN, not the row

Four queries select an empty-string literal for content (dashboard batching, child batching, the index and changes readers). Marking those would be a false signal about a body they never return, so they are exempt and say so at the site. `ListItems` builds `contentCol` and `stateCol` **together**, so `NoContent` can never mark an omitted body.

## The population was bigger than any single sweep found

Three sweeps, each widening the last, and that history is the point rather than an embarrassment — it is why the coverage guard below exists.

**15 SELECT sites, not 10.** `search.go` (4) and `item_stars.go` (1) carry content too — and `ListStarredItems` reaches the shared `scanItems` helper from *outside* `items.go`, across the population boundary. That is how the first pass failed, and it failed at **runtime, not compile time**: a column/Scan mismatch leaves `go build` green.

Then review found five more doors that build their own shape and so inherit nothing:

- **Public share DTO — FOLDED IN.** An anonymous viewer has no editor, no op-log, and nothing to compare against; it is the door whose reader is least able to notice. Added only when set, so the key set stays byte-identical in the common case and the existing exact-shape pin is undisturbed.
- **Workspace export → `models.ItemExport`** — filed as **BUG-3032**. Marking it is a portable bundle-format change the import path must tolerate, and `ImportWorkspace` writes the body back as canonical in the destination, where the op-log that held the real content does not exist.
- **Artifact export, playbook run, bootstrap convention bodies, MCP item resource** — filed as **BUG-3033**. Each needs a rendering decision rather than a field copy. The playbook and bootstrap halves rank first: an agent *acts* on those bodies. (The MCP one verified directly — the JSON it fetches does carry the field; `formatItemAsMarkdown` re-renders without it.)

`ItemSummary` gets the field too: it carries `content_preview`, and a preview is content.

## Receipt (CONVE-20)

Measured **with a counterfactual arm**, because a one-armed timing cannot attribute cost. 200 items, SQLite, best-of-5:

| op-log rows | with | without |
|---|---|---|
| 0 | 2.44ms | 3.58ms |
| 2,000 | 4.00ms | 2.86ms |
| 20,000 | 3.81ms | 3.27ms |

The arms are **indistinguishable**, and at 0 rows the arm *without* the predicate was slower. Run-to-run variance (~1.5ms) exceeds any systematic difference, so the honest statement is **below the noise floor at this scale** — not "free". Untested scales (Postgres, very deep per-item op-logs, concurrent load, larger lists) are named in the comment.

## The coverage guard

The content-state tests originally exercised **two of fifteen** spliced queries, so "the suite is green" was never evidence the other thirteen were aligned. `TestEveryContentBearingReadDoorCarriesTheMarker` now drives **all fourteen reachable store doors on both backends**. It is an alignment guard first and a behaviour test second: a door returning the right marker necessarily has a matching Scan destination.

Two of its own legs were found measuring nothing and fixed: `ResolveItemIncludeDeleted` was called with a slug, which falls through to another function and left its own ref SELECT unexercised; and the enumeration ran SQLite-only, leaving the *dialect-specific* FTS variants of `ListItems(search)` and `Search` uncovered.

## Instruments

Every case asserts **both directions on the same item** — a marker that is always on is indistinguishable from one that is always right, and the population is large enough that a blanket stamp would look like success at every door.

Mutation-tested, with no cross-talk:

- an always-true predicate → killed only by the clearing leg
- a `NoContent` leak → killed only by the omitted-body leg
- a never-set marker → killed by all three

The HTTP test asserts the **raw wire JSON**, not just the decoded struct: a Go round-trip would pass even if the field were never serialised. Both backends, and the Postgres leg verified to RUN rather than skip.

## Also corrected

- `warnContentPendingFlush`'s comment said the flush question was "not established". It now is (CONVE-23).
- A scripted exemption comment landed on `ItemsModifiedSince` instead of `GetChildItemsForParents`, so a comment reading "NO contentStateSQL here, this query selects an empty-string literal" sat directly above a query that has the predicate and selects `i.content`. A non-unique anchor edited the wrong match.
- The CLI warning now fires *before* the empty-body check: an item whose stored body is empty while the document holds the real text is exactly this bug's shape, and it is the case where a reader has least to go on.
- The TypeScript type is the literal `'applied_pending_flush'`, not `string`.

## Gates

- `make test` — 0 FAIL
- `make test-pg` — exit 0, 0 FAIL, no NO-TESTS-EXECUTED banner, Postgres legs PASS not SKIP
- `make lint` — 0 issues; `gofmt` clean
- codex rounds 1-3 (r1: population miss; r2: 1 P1 + 2 P2 + my own misplaced comment; r3: 2 P2 coverage holes + 2 P3)

Closes BUG-3000.

https://claude.ai/code/session_01PDYjP67KTAcqpFpo3ijAAA
